### PR TITLE
Add typography.

### DIFF
--- a/components/typography/typography.js
+++ b/components/typography/typography.js
@@ -1,0 +1,189 @@
+import '@webcomponents/shadycss/custom-style-interface.min.js';
+
+/* TODO: deal with the mixins. */
+
+const importUrl = 'https://s.brightspace.com/lib/fonts/0.4.0/assets/';
+
+const head = document.getElementsByTagName('head')[0];
+if (!head.querySelector('#d2l-typography-font-face')) {
+	const style = document.createElement('style');
+	style.id = 'd2l-typography-font-face';
+	style.textContent = `
+		@font-face {
+			font-family: 'Lato';
+			font-style: normal;
+			font-weight: 400;
+			src: local('Lato Regular'), local('Lato-Regular'), url(${new URL('Lato-400.woff2', importUrl)}) format('woff2'), url(${new URL('Lato-400.woff', importUrl)}) format('woff'), url(${new URL('Lato-400.ttf', importUrl)}) format('truetype');
+		}
+		@font-face {
+			font-family: 'Lato';
+			font-style: normal;
+			font-weight: 700;
+			src: local('Lato Bold'), local('Lato-Bold'), url(${new URL('Lato-700.woff2', importUrl)}) format('woff2'), url(${new URL('Lato-700.woff', importUrl)}) format('woff'), url(${new URL('Lato-700.ttf', importUrl)}) format('truetype');
+		}
+		@font-face {
+			font-family: 'Open Dyslexic';
+			font-style: normal;
+			font-weight: 400;
+			src: local('Open Dyslexic Regular'), local('OpenDyslexic-Regular'), url(${new URL('OpenDyslexic.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic.ttf', importUrl)}) format('truetype');
+		}
+		@font-face {
+			font-family: 'Open Dyslexic';
+			font-style: italic;
+			font-weight: 400;
+			src: local('Open Dyslexic Italic'), local('OpenDyslexic-Italic'), url(${new URL('OpenDyslexic-Italic.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic-Italic.ttf', importUrl)}) format('truetype');
+		}
+		@font-face {
+			font-family: 'Open Dyslexic';
+			font-style: normal;
+			font-weight: 700;
+			src: local('Open Dyslexic Bold'), local('OpenDyslexic-Bold'), url(${new URL('OpenDyslexic-700.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic-700.ttf', importUrl)}) format('truetype');
+		}
+		@font-face {
+			font-family: 'Open Dyslexic';
+			font-style: italic;
+			font-weight: 700;
+			src: local('Open Dyslexic Bold Italic'), local('OpenDyslexic-BoldItalic'), url(${new URL('OpenDyslexic-700-Italic.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic-700-Italic.ttf', importUrl)}) format('truetype');
+		}
+
+		.d2l-typography,
+		.vui-typography {
+			color: var(--d2l-color-ferrite);
+			display: block;
+			font-family: 'Lato', 'Lucida Sans Unicode', 'Lucida Grande', sans-serif;
+			letter-spacing: 0.01rem;
+			font-size: 0.95rem;
+			font-weight: 400;
+			line-height: 1.4rem;
+			/*@apply --d2l-font-custom;*/
+		}
+
+		/*
+		.d2l-typography .d2l-body-standard {
+			@apply --d2l-body-standard-text;
+		}
+
+		.d2l-typography .d2l-body-compact {
+			@apply --d2l-body-compact-text;
+		}
+
+		.d2l-typography .d2l-body-small {
+			@apply --d2l-body-small-text;
+		}
+
+		.d2l-typography .d2l-label-text {
+			@apply --d2l-label-text;
+		}
+		*/
+
+		.d2l-typography p,
+		.vui-typography p {
+			margin: 1rem 0;
+			/*@apply --d2l-font-paragraph-custom;*/
+		}
+
+		.d2l-typography.d2l-dyslexic,
+		.d2l-typography .d2l-dyslexic,
+		.vui-typography.vui-dyslexic,
+		.vui-typography .vui-dyslexic {
+			font-family: 'Open Dyslexic', sans-serif;
+			font-weight: 400;
+			/*@apply --d2l-font-dyslexic-custom;*/
+		}
+
+		.d2l-typography:lang(ar),
+		.d2l-typography :lang(ar),
+		.vui-typography:lang(ar),
+		.vui-typography :lang(ar) {
+			font-family: 'Arabic Transparent', 'Arabic Typesetting', 'Geeza Pro', sans-serif;
+		}
+
+		.d2l-typography:lang(zh),
+		.d2l-typography :lang(zh),
+		.vui-typography:lang(zh),
+		.vui-typography :lang(zh) {
+			font-family: 'Microsoft YaHei', 'Hiragino Sans GB', sans-serif;
+		}
+
+		.d2l-typography:lang(ko),
+		.d2l-typography :lang(ko),
+		.vui-typography:lang(ko),
+		.vui-typography :lang(ko) {
+			font-family: 'Apple SD Gothic Neo', Dotum, sans-serif;
+		}
+
+		.d2l-typography:lang(ja),
+		.d2l-typography :lang(ja),
+		.vui-typography:lang(ja),
+		.vui-typography :lang(ja) {
+			font-family: 'Hiragino Kaku Gothic Pro', 'Meiyro', sans-serif;
+		}
+
+		/*
+		.vui-typography .vui-heading-1,
+		.d2l-typography .d2l-heading-1 {
+			@apply --d2l-heading-1;
+			@apply --d2l-heading-1-custom;
+		}
+
+		.vui-typography .vui-heading-2,
+		.d2l-typography .d2l-heading-2 {
+			@apply --d2l-heading-2;
+			@apply --d2l-heading-2-custom;
+		}
+
+		.vui-typography .vui-heading-3,
+		.d2l-typography .d2l-heading-3 {
+			@apply --d2l-heading-3;
+			@apply --d2l-heading-3-custom;
+		}
+
+		.vui-typography .vui-heading-4,
+		.d2l-typography .d2l-heading-4 {
+			@apply --d2l-heading-4;
+			@apply --d2l-heading-4-custom;
+		}
+		*/
+
+		@media (max-width: 615px) {
+			.d2l-typography .d2l-heading-1,
+			.d2l-typography .vui-heading-1 {
+				font-size: 1.5rem;
+				font-weight: 400;
+				line-height: 1.8rem;
+			}
+			.d2l-typography .d2l-heading-2,
+			.d2l-typography .vui-heading-2 {
+				font-size: 1rem;
+				font-weight: 700;
+				line-height: 1.5rem;
+			}
+			.d2l-typography .d2l-heading-3,
+			.d2l-typography .vui-heading-3,
+			.d2l-typography .d2l-heading-4,
+			.d2l-typography .vui-heading-4 {
+				font-size: 0.8rem;
+				font-weight: 700;
+				line-height: 1.2rem;
+			}
+			.d2l-typography .d2l-body-standard {
+				font-size: 0.8rem;
+				line-height: 1.2rem;
+			}
+			.d2l-typography .d2l-body-compact {
+				font-size: 0.8rem;
+				line-height: 1.2rem;
+			}
+			.d2l-typography .d2l-body-small {
+				font-size: 0.6rem;
+				line-height: 0.9rem;
+			}
+			.d2l-typography .d2l-label-text {
+				font-size: 0.6rem;
+				line-height: 0.9rem;
+			}
+		}
+	`;
+	head.appendChild(style);
+	window.ShadyCSS.CustomStyleInterface.addCustomStyle(style);
+}

--- a/index.html
+++ b/index.html
@@ -3,12 +3,18 @@
 <head>
 	<script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
 	<script type="module">
+		document.body.style.opacity = 0;
 		window.WebComponents = window.WebComponents || {
 			waitFor(cb) { addEventListener('WebComponentsReady', cb); }
 		};
 		window.WebComponents.waitFor(async() => {
-			import('./components/colors/colors.js');
-			import('./components/hello-world/hello-world.js');
+			return Promise.all([
+				import('./components/colors/colors.js'),
+				import('./components/typography/typography.js'),
+				import('./components/hello-world/hello-world.js')
+			]).then(() => {
+				document.body.style.opacity = 1;
+			});
 		});
 	</script>
 	<title>core sample</title>
@@ -16,7 +22,7 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
-<body>
+<body class="d2l-typography">
 
 	<h1>Sample</h1>
 


### PR DESCRIPTION
The excluded (commented in code) style blocks contain mixins that we should deal with since the `@apply` is deprecated.  I will leave that for a future PR.  Two possible options (other ideas welcome!) are:

1. replace the mixins with global CSS properties.  Advantages: consumers have flexibility to exclude properties that are not needed for their use-case; consumers code is tidy.  Disadvantages: consumer may accidentally exclude a property; if changes are made to typography in the future, it will be a pain to update all the places.

2. factor the style selectors and associated properties out (from the font-faces) into one or more shared css templates that can be imported by consumers into their components, and have them use those class names in their local DOM.  Advantages: consumers don't need to know all the properties to include, and if there are future changes, they will automatically get them when they get a new version of typography.  Disadvantages: the consumer markup gets a bit bloated with typography classes; consumers occasionally need to override (ex margins), however this is something we deal with today with the mixins.