### PR TITLE
Make demos a little more informative.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 		document.body.style.opacity = 0;
 	</script>
 	<script type="module">
+		import 'demo-transfigurator/demo-transfigurator.js';
 		import './components/colors/colors.js';
 		import './components/typography/typography.js';
 		import './components/button/button-subtle.js';
@@ -21,14 +22,23 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
+	<style>
+		demo-transfigurator {
+			margin-bottom: 24px;
+		}
+	</style>
 </head>
 <body class="d2l-typography">
 
 	<h1>Sample</h1>
 
-	<d2l-button-subtle text="Do not press this button!" icon="d2l-tier1:gear"></d2l-button-subtle>
+	<demo-transfigurator>
+		<d2l-button-subtle text="Do not press this button!" icon="d2l-tier1:gear"></d2l-button-subtle>
+	</demo-transfigurator>
 
-	<d2l-more-less></d2l-more-less>
+	<demo-transfigurator>
+		<d2l-more-less></d2l-more-less>
+	</demo-transfigurator>
 
 	<script>
 		document.querySelector('d2l-button-subtle').addEventListener('click', () => {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "babel-eslint": "latest",
+    "demo-transfigurator": "dbatiste/demo-transfigurator",
     "eslint": "latest",
     "eslint-config-brightspace": "latest",
     "eslint-plugin-html": "latest",


### PR DESCRIPTION
This uses a simple little demo container that will render demo code with syntax highlighting sorta like the old Polymer demo-snippet.  Helpful for the time being, and we can pick out some of it's code if it's helpful once we decide what we want longer term for demos & docs.

![demo-transfigurator](https://user-images.githubusercontent.com/9042472/54546470-16457800-497a-11e9-9d38-168dc7b1ebbb.png)
