### PR TITLE
Dbatiste/tweak fouc

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 		}
 	</style>
 </head>
-<body class="d2l-typography" unresolved>
+<body class="d2l-typography" unresolved="unresolved">
 
 	<h1>Sample</h1>
 

--- a/index.html
+++ b/index.html
@@ -8,12 +8,6 @@
 		import './components/typography/typography.js';
 		import './components/button/button-subtle.js';
 		import './components/more-less/more-less.js';
-		window.WebComponents = window.WebComponents || {
-			waitFor(cb) { addEventListener('WebComponentsReady', cb); }
-		};
-		window.WebComponents.waitFor(() => {
-			document.body.removeAttribute('unresolved');
-		});
 	</script>
 	<title>core sample</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 		window.WebComponents = window.WebComponents || {
 			waitFor(cb) { addEventListener('WebComponentsReady', cb); }
 		};
-		window.WebComponents.waitFor(async() => {
+		window.WebComponents.waitFor(() => {
 			document.body.removeAttribute('unresolved');
 		});
 	</script>

--- a/index.html
+++ b/index.html
@@ -3,9 +3,6 @@
 <head>
 	<script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
-		document.body.style.opacity = 0;
-	</script>
-	<script type="module">
 		import 'demo-transfigurator/demo-transfigurator.js';
 		import './components/colors/colors.js';
 		import './components/typography/typography.js';
@@ -15,7 +12,7 @@
 			waitFor(cb) { addEventListener('WebComponentsReady', cb); }
 		};
 		window.WebComponents.waitFor(async() => {
-			document.body.style.opacity = 1;
+			document.body.removeAttribute('unresolved');
 		});
 	</script>
 	<title>core sample</title>
@@ -23,12 +20,15 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
+		body[unresolved] {
+			opacity: 0;
+		}
 		demo-transfigurator {
 			margin-bottom: 24px;
 		}
 	</style>
 </head>
-<body class="d2l-typography">
+<body class="d2l-typography" unresolved>
 
 	<h1>Sample</h1>
 
@@ -46,5 +46,6 @@
 			console.log('You are a risk taker.');
 		});
 	</script>
+
 </body>
 </html>


### PR DESCRIPTION
I tried a bunch of different things here.  It looks like `unresolved` will be removed for us, but we need to define the style for it (which I don't recall us having to do previously).  Omitting the style for `unresolved` results in FOUC in all browsers.  This also avoids dynamically setting opacity via JavaScript at the earliest possible time.  So far it's not needed, but if we need to remove it ourselves, the following can be used, which seems to nicely handle timing of WCR event:
```
window.WebComponents = window.WebComponents || {
	waitFor(cb) { addEventListener('WebComponentsReady', cb); }
};
window.WebComponents.waitFor(() => {
	document.body.removeAttribute('unresolved');
});
```