### PR TITLE
fix ResizeObserver

### DIFF
--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -7,8 +7,8 @@ import { getComposedChildren, isComposedAncestor } from '../helpers/d2l-dom.js';
 import { classMap} from 'lit-html/directives/class-map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeMixin } from '../localize/localize-mixin.js';
-import { ResizeObserver } from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { styleMap} from 'lit-html/directives/style-map.js';
+import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 
 export class D2LMoreLess extends LocalizeMixin(LitElement)  {
 

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -7,8 +7,8 @@ import { getComposedChildren, isComposedAncestor } from '../helpers/d2l-dom.js';
 import { classMap} from 'lit-html/directives/class-map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeMixin } from '../localize/localize-mixin.js';
-import { styleMap} from 'lit-html/directives/style-map.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
+import { styleMap} from 'lit-html/directives/style-map.js';
 
 export class D2LMoreLess extends LocalizeMixin(LitElement)  {
 


### PR DESCRIPTION
Otherwise I get the error `Uncaught SyntaxError: The requested module '../../../resize-observer-polyfill/dist/ResizeObserver.es.js' does not provide an export named 'ResizeObserver'`. Is this the correct order though?