### PR TITLE
localization: example of using dynamically imported locale files [DO NOT MERGE]

### DIFF
--- a/components/more-less/locales/ar.js
+++ b/components/more-less/locales/ar.js
@@ -1,0 +1,4 @@
+export const val = {
+	'more': 'المزيد',
+	'less': 'أقل'
+};

--- a/components/more-less/locales/en.js
+++ b/components/more-less/locales/en.js
@@ -1,0 +1,4 @@
+export const val = {
+	'more': 'more',
+	'less': 'less'
+};

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -59,56 +59,6 @@ export class D2LMoreLess extends LocalizeMixin(LitElement)  {
 
 		this.__blurBackground = 'linear-gradient(rgba(255, 255, 255, 0) 0%, rgb(255, 255, 255) 100%)';
 		this.__transitionAdded = false;
-		this.__langResources = {
-			'ar': {
-				more: 'المزيد',
-				less: 'أقل'
-			},
-			'en': {
-				more: 'more',
-				less: 'less'
-			},
-			'es': {
-				more: 'más',
-				less: 'menos'
-			},
-			'fr': {
-				more: 'plus',
-				less: 'moins'
-			},
-			'ja': {
-				more: 'より多い',
-				less: 'より少ない'
-			},
-			'ko': {
-				more: '더 보기',
-				less: '축소'
-			},
-			'nl': {
-				more: 'meer',
-				less: 'minder'
-			},
-			'pt': {
-				more: 'mais',
-				less: 'menos'
-			},
-			'sv': {
-				more: 'mer',
-				less: 'mindre'
-			},
-			'tr': {
-				more: 'diğer',
-				less: 'daha az'
-			},
-			'zh': {
-				more: '更多',
-				less: '更少'
-			},
-			'zh-tw': {
-				more: '較多',
-				less: '較少'
-			}
-		};
 
 		this.height = '4em';
 
@@ -181,8 +131,9 @@ export class D2LMoreLess extends LocalizeMixin(LitElement)  {
 	}
 
 	getLanguage(langs) {
+		const locales = ['en', 'ar'];
 		for (let i = 0; i < langs.length; i++) {
-			if (this.__langResources[langs[i]]) {
+			if (locales.indexOf(langs[i]) !== -1) {
 				return langs[i];
 			}
 		}
@@ -200,7 +151,18 @@ export class D2LMoreLess extends LocalizeMixin(LitElement)  {
 			return proto.__localizationCache.requests[namespace];
 		}
 
-		const result = this.__langResources[lang];
+		let translations;
+
+		switch (lang) {
+			case 'en':
+				translations = await import('./locales/en.js');
+				break;
+			case 'ar':
+				translations = await import('./locales/ar.js');
+				break;
+		}
+
+		const result = translations.val;
 
 		proto.__localizationCache.requests[namespace] = result;
 		return result;


### PR DESCRIPTION
This PR is just to get an example up for future us and/or others who may need to implement this, as well as to get any feedback on this.

This approach works with BSI. It is not necessary to do anything extra to get this to work (in BSI I just changed `webcomponents/d2l-more-less.js` to contain `import 'd2l-core-ui/components/more-less/more-less.js';` and there was a small modification necessary for now for getting `d2l-button-subtle` to work).

Note that (at this time) it is not possible to use a `${lang}` variable for the file name to import in the BSI build. For example ```translations = await import(`./locales/${lang}.js`);``` instead of the case/switch section in `getLangResources` would not work.