### PR TITLE
Dbatiste/rtl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
 - npm run lint
 - |
   if [ $TRAVIS_PULL_REQUEST != false ] && [ $TRAVIS_SECURE_ENV_VARS == true ]; then
-    npm run test:diff;
+    npm run test:diff || travis_terminate 1;
     echo "Pull request with secure environment variables, running Sauce tests...";
     npm run test:sauce || travis_terminate 1;
   else

--- a/components/button/button-subtle-styles.js
+++ b/components/button/button-subtle-styles.js
@@ -19,8 +19,7 @@ export const buttonSubtleStyles = css`
 	:host([h-align="text"]) button {
 		left: -0.6rem;
 	}
-	:host(:dir(rtl)):host([h-align="text"]) button,
-	:host(:dir(rtl))[h-align="text"] button {
+	:host([dir="rtl"][h-align="text"]) button {
 		left: 0;
 		right: -0.6rem;
 	}
@@ -52,14 +51,12 @@ export const buttonSubtleStyles = css`
 		padding-right: 1.2rem;
 	}
 
-	:host(:dir(rtl)):host([icon]) .d2l-button-subtle-content,
-	:host(:dir(rtl))[icon] .d2l-button-subtle-content {
+	:host([dir="rtl"][icon]) .d2l-button-subtle-content {
 		padding-left: 0;
 		padding-right: 1.2rem;
 	}
 
-	:host(:dir(rtl)):host([icon]):host([icon-right]) .d2l-button-subtle-content,
-	:host(:dir(rtl))[icon][icon-right] .d2l-button-subtle-content {
+	:host([dir="rtl"][icon][icon-right]) .d2l-button-subtle-content {
 		padding-left: 1.2rem;
 		padding-right: 0;
 	}
@@ -79,8 +76,7 @@ export const buttonSubtleStyles = css`
 	:host([icon][icon-right]) d2l-icon.d2l-button-subtle-icon {
 		right: 0.6rem;
 	}
-	:host([dir="rtl"][icon][icon-right]) d2l-icon.d2l-button-subtle-icon,
-	:host(:dir(rtl))[icon][icon-right] d2l-icon.d2l-button-subtle-icon {
+	:host([dir="rtl"][icon][icon-right]) d2l-icon.d2l-button-subtle-icon {
 		left: 0.6rem;
 		right: auto;
 	}

--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -6,12 +6,13 @@ import { buttonSubtleStyles } from './button-subtle-styles.js';
 import { D2LButtonMixin } from './button-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { labelStyles } from '../typography/styles.js';
+import { RtlMixin } from '../localize/rtl-mixin.js';
 
 /* TODO: convert icons to Lit and update these imports */
 /* TODO: move tier1-icons.js out of here and figure out correct path for it */
 /* TODO: check to make sure nothing was missed */
 
-export class D2LButtonSubtle extends D2LButtonMixin(LitElement) {
+export class D2LButtonSubtle extends D2LButtonMixin(RtlMixin(LitElement)) {
 
 	static get properties() {
 		return {

--- a/components/localize/rtl-mixin.js
+++ b/components/localize/rtl-mixin.js
@@ -8,7 +8,8 @@ export const RtlMixin = superclass => class extends superclass {
 
 	constructor() {
 		super();
-		this._dir = document.documentElement.getAttribute('dir');
+		const dir = document.documentElement.getAttribute('dir');
+		if (dir) this._dir = dir;
 	}
 
 };

--- a/components/localize/rtl-mixin.js
+++ b/components/localize/rtl-mixin.js
@@ -1,0 +1,14 @@
+export const RtlMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			_dir: { type: String, reflect: true, attribute: 'dir' }
+		};
+	}
+
+	constructor() {
+		super();
+		this._dir = document.documentElement.getAttribute('dir');
+	}
+
+};

--- a/test/button/button-subtle.visual-diff.html
+++ b/test/button/button-subtle.visual-diff.html
@@ -26,5 +26,11 @@
 	<div class="visual-diff">
 		<d2l-button-subtle id="icon-right" icon="d2l-tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
 	</div>
+	<div class="visual-diff">
+		<d2l-button-subtle id="with-icon-rtl" dir="rtl" icon="d2l-tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
+	</div>
+	<div class="visual-diff">
+		<d2l-button-subtle id="icon-right-rtl" dir="rtl" icon="d2l-tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
+	</div>
 </body>
 </html>

--- a/test/button/button-subtle.visual-diff.js
+++ b/test/button/button-subtle.visual-diff.js
@@ -51,8 +51,18 @@ describe('d2l-button-subtle', function() {
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
+	it('with-icon-rtl', async function() {
+		const rect = await visualDiff.getRect(page, '#with-icon-rtl');
+		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+	});
+
 	it('icon-right', async function() {
 		const rect = await visualDiff.getRect(page, '#icon-right');
+		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+	});
+
+	it('icon-right-rtl', async function() {
+		const rect = await visualDiff.getRect(page, '#icon-right-rtl');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 


### PR DESCRIPTION
This PR creates an RtlMixin that will sprout `dir` attributes on elements before they are attached to the DOM.  I have confirmed that this approach works in all browsers, and that it also does not cause any additional render calls.  I made this a mixin (as opposed to having the consuming element do this) as to leave open the option of observing changes to the document's `dir` attribute.  I was also able to clean-up the old RTL styles considerably.

For demos/tests, it's possible for the consumer to simply specify `dir="rtl"` on the element - it will take precedence over the reflected `_dir` value.  For tests however, I think the RTL scenario is better captured with the visual-diff.

The background: with Polymer 1 we were able to use `:host-context`.  For Polymer 3, it created these  `dir` in the same way at runtime, with the addition of an observer to detect changes.  It would be a simple addition to the mixin but I did not include it because in order to use a shared observer, a shared list of elements needs to be maintained in order to notify them when the document's dir changes.  (this is exactly how the Polymer 3 DirMixin works).