### PR TITLE
Dbatiste/test cleanup

### DIFF
--- a/test/button/button-icon.visual-diff.js
+++ b/test/button/button-icon.visual-diff.js
@@ -11,7 +11,7 @@ describe('d2l-button-icon', function() {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/button/button-icon.visual-diff.html`, {waitUntil: ['networkidle2', 'load']});
+		await page.goto(`${visualDiff.getBaseUrl()}/test/button/button-icon.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 		await page.bringToFront();
 	});
 

--- a/test/button/button-icon.visual-diff.js
+++ b/test/button/button-icon.visual-diff.js
@@ -35,14 +35,7 @@ describe('d2l-button-icon', function() {
 		});
 
 		it('focus', async function() {
-			await page.evaluate(() => {
-				const promise = new Promise((resolve) => {
-					const elem = document.querySelector('#normal');
-					elem.shadowRoot.querySelector('button').addEventListener('transitionend', resolve);
-					elem.focus();
-				});
-				return promise;
-			});
+			await focus(page, '#normal');
 			const rect = await visualDiff.getRect(page, '#normal');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
@@ -62,28 +55,13 @@ describe('d2l-button-icon', function() {
 		});
 
 		it('focus', async function() {
-			await page.evaluate(() => {
-				const promise = new Promise((resolve) => {
-					const elem = document.querySelector('#translucent-enabled > d2l-button-icon');
-					elem.shadowRoot.querySelector('button').addEventListener('transitionend', resolve);
-					elem.focus();
-				});
-				return promise;
-			});
+			await focus(page, '#translucent-enabled > d2l-button-icon');
 			const rect = await visualDiff.getRect(page, '#translucent-enabled');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 
 		it('hover', async function() {
-			const p = page.evaluate(() => {
-				const promise = new Promise((resolve) => {
-					const elem = document.querySelector('#translucent-enabled > d2l-button-icon');
-					elem.shadowRoot.querySelector('button').addEventListener('transitionend', resolve);
-				});
-				return promise;
-			});
 			await page.hover('#translucent-enabled > d2l-button-icon');
-			await p;
 			const rect = await visualDiff.getRect(page, '#translucent-enabled');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
@@ -94,5 +72,15 @@ describe('d2l-button-icon', function() {
 		});
 
 	});
+
+	const focus = async(page, selector) => {
+		return page.evaluate((selector) => {
+			return new Promise((resolve) => {
+				const elem = document.querySelector(selector);
+				elem.shadowRoot.querySelector('button').addEventListener('transitionend', resolve);
+				elem.focus();
+			});
+		}, selector);
+	};
 
 });

--- a/test/button/button-subtle.html
+++ b/test/button/button-subtle.html
@@ -3,28 +3,28 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-
-		<title>subtle button tests</title>
-
+		<title>d2l-button-subtle unit tests</title>
 		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="../../../mocha/mocha.js"></script>
 		<script src="../../../chai/chai.js"></script>
 		<script src="../../../@polymer/test-fixture/test-fixture.js"></script>
 		<script src="../../../wct-mocha/wct-mocha.js"></script>
-
 		<script type="module" src="../../components/button/button-subtle.js"></script>
 	</head>
 	<body>
+
 		<test-fixture id="basic">
 			<template>
 				<d2l-button-subtle text="Subtle Button"></d2l-button-subtle>
 			</template>
 		</test-fixture>
+
 		<test-fixture id="with-icon">
 			<template>
 				<d2l-button-subtle text="Subtle Button with Icon" icon="d2l-tier1:gear"></d2l-button-subtle>
 			</template>
 		</test-fixture>
+
 		<test-fixture id="disabled">
 			<template>
 				<d2l-button-subtle disabled text="Disabled Subtle Button"></d2l-button-subtle>
@@ -34,22 +34,27 @@
 		<script type="module">
 			import { runAxe } from '../../tools/a11y-test-helper.js';
 
-			describe('subtle button', () => {
+			describe('d2l-button-subtle', () => {
 				let button;
+
 				describe('basic', () => {
+
 					beforeEach(async() => {
 						button = fixture('basic');
 						await button.updateComplete;
 					});
+
 					it('should execute onclick when clicked', async() => {
 						return new Promise(resolve => {
 							button.addEventListener('click', resolve, {once: true});
 							button.click();
 						});
 					});
+
 					it('should pass all axe tests', async() => {
 						await runAxe(button);
 					});
+
 					// TODO: Fix contrast of focussed buttons to meet WCAG 2 standards
 					it.skip('should pass all axe tests when focussed', async() => {
 						return new Promise((resolve, reject) => {
@@ -64,22 +69,27 @@
 							button.shadowRoot.querySelector('button').focus();
 						});
 					});
+
 				});
 
 				describe('with icon', () => {
+
 					beforeEach(async() => {
 						button = fixture('with-icon');
 						await button.updateComplete;
 					});
+
 					it('should execute onclick when clicked', async() => {
 						return new Promise(resolve => {
 							button.addEventListener('click', resolve, {once: true});
 							button.click();
 						});
 					});
+
 					it('should pass all axe tests', async() => {
 						await runAxe(button);
 					});
+
 					// TODO: Fix contrast of focussed buttons to meet WCAG 2 standards
 					it.skip('should pass all axe tests when focussed', async() => {
 						return new Promise((resolve, reject) => {
@@ -94,17 +104,22 @@
 							button.shadowRoot.querySelector('button').focus();
 						});
 					});
+
 				});
 
 				describe('disabled', () => {
+
 					beforeEach(async() => {
 						button = fixture('disabled');
 						await button.updateComplete;
 					});
+
 					it('should pass all axe tests', async() => {
 						await runAxe(button);
 					});
+
 				});
+
 			});
 		</script>
 	</body>

--- a/test/button/button-subtle.visual-diff.js
+++ b/test/button/button-subtle.visual-diff.js
@@ -11,7 +11,7 @@ describe('d2l-button-subtle', function() {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/button/button-subtle.visual-diff.html`, {waitUntil: ['networkidle2', 'load']});
+		await page.goto(`${visualDiff.getBaseUrl()}/test/button/button-subtle.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 		await page.bringToFront();
 	});
 

--- a/test/button/button-subtle.visual-diff.js
+++ b/test/button/button-subtle.visual-diff.js
@@ -29,14 +29,7 @@ describe('d2l-button-subtle', function() {
 	});
 
 	it('focus', async function() {
-		await page.evaluate(() => {
-			const promise = new Promise((resolve) => {
-				const elem = document.querySelector('#normal');
-				elem.shadowRoot.querySelector('button').addEventListener('transitionend', resolve);
-				elem.focus();
-			});
-			return promise;
-		});
+		await focus(page, '#normal');
 		const rect = await visualDiff.getRect(page, '#normal');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
@@ -65,5 +58,15 @@ describe('d2l-button-subtle', function() {
 		const rect = await visualDiff.getRect(page, '#icon-right-rtl');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
+
+	const focus = async(page, selector) => {
+		return page.evaluate((selector) => {
+			return new Promise((resolve) => {
+				const elem = document.querySelector(selector);
+				elem.shadowRoot.querySelector('button').addEventListener('transitionend', resolve);
+				elem.focus();
+			});
+		}, selector);
+	};
 
 });

--- a/test/more-less/more-less.html
+++ b/test/more-less/more-less.html
@@ -3,18 +3,16 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-
-		<title>more-less tests</title>
-
+		<title>d2l-more-less unit tests</title>
 		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="../../../mocha/mocha.js"></script>
 		<script src="../../../chai/chai.js"></script>
 		<script src="../../../@polymer/test-fixture/test-fixture.js"></script>
 		<script src="../../../wct-mocha/wct-mocha.js"></script>
-
 		<script type="module" src="../../components/more-less/more-less.js"></script>
 	</head>
 	<body>
+
 		<test-fixture id="basic">
 			<template>
 				<d2l-more-less>
@@ -30,6 +28,7 @@
 				</d2l-more-less>
 			</template>
 		</test-fixture>
+
 		<test-fixture id="expanded-dynamic">
 			<template>
 				<d2l-more-less expanded>
@@ -41,7 +40,7 @@
 		<script type="module">
 			import { runAxe } from '../../tools/a11y-test-helper.js';
 
-			describe('more-less', () => {
+			describe('d2l-more-less', () => {
 				let moreless, content;
 
 				function waitForInitialization(callback) {
@@ -55,6 +54,7 @@
 				}
 
 				describe('basic', () => {
+
 					beforeEach(async() => {
 						moreless = fixture('basic');
 						await moreless.updateComplete;
@@ -63,13 +63,16 @@
 							waitForInitialization(resolve);
 						});
 					});
+
 					// TODO: come up with a different solution for hiding the button from the screenreader
 					it.skip('should pass all axe tests', async() => {
 						await runAxe(moreless);
 					});
+
 				});
 
 				describe('expanded', () => {
+
 					beforeEach(async() => {
 						moreless = fixture('expanded-dynamic');
 						await moreless.updateComplete;
@@ -78,10 +81,12 @@
 							waitForInitialization(resolve);
 						});
 					});
+
 					// TODO: come up with a different solution for hiding the button from the screenreader
 					it.skip('should pass all axe tests when expanded', async() => {
 						await runAxe(moreless);
 					});
+
 					it('should expand when more content is dynamically added', async() => {
 						const previousContentHeight = content.scrollHeight;
 						expect(moreless.offsetHeight).to.be.above(content.scrollHeight);
@@ -97,7 +102,9 @@
 							});
 						});
 					});
+
 				});
+
 			});
 		</script>
 	</body>

--- a/test/typography/typography.visual-diff.js
+++ b/test/typography/typography.visual-diff.js
@@ -67,7 +67,7 @@ describe('d2l-typography', function() {
 
 		before(async() => {
 			await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
-			await page.goto(`${visualDiff.getBaseUrl()}/test/typography/typography.visual-diff.html`, {waitUntil: ['networkidle2', 'load']});
+			await page.goto(`${visualDiff.getBaseUrl()}/test/typography/typography.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 			await page.bringToFront();
 		});
 
@@ -79,7 +79,7 @@ describe('d2l-typography', function() {
 
 		before(async() => {
 			await page.setViewport({width: 600, height: 800, deviceScaleFactor: 2});
-			await page.goto(`${visualDiff.getBaseUrl()}/test/typography/typography.visual-diff.html`, {waitUntil: ['networkidle2', 'load']});
+			await page.goto(`${visualDiff.getBaseUrl()}/test/typography/typography.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 			await page.bringToFront();
 		});
 


### PR DESCRIPTION
To summarize:

* switched to waiting for 0 connections for 500ms - this seems safer
* moved focus / wait for transitionend logic to eliminate a few lines, and make test easier to read
* added some whitespace to unit tests to make a little easier to read
* update a couple titles for consistency
