### PR TITLE
don't render icon if it's not set

### DIFF
--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -110,6 +110,8 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 	}
 
 	render() {
+		const icon = this.icon ?
+			html`<d2l-icon icon="${this.icon}" class="d2l-button-subtle-icon"></d2l-icon>` : '';
 		return html`
 			<button
 				aria-expanded="${ifDefined(this.ariaExpanded)}"
@@ -126,7 +128,7 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 				formtarget="${ifDefined(this.formtarget)}"
 				name="${ifDefined(this.name)}"
 				type="${this.type}">
-				<d2l-icon icon="${ifDefined(this.icon)}" class="d2l-button-subtle-icon"></d2l-icon>
+				${icon}
 				<span class="d2l-button-subtle-content">${this.text}</span>
 				<slot></slot>
 		</button>


### PR DESCRIPTION
I noticed that even when subtle button's `icon` attribute isn't set, the underlying `<d2l-icon>` was still getting rendered, just with no `icon` attribute itself.

This change only renders the icon if the attribute is set, saving us outputting a web component.