### PR TITLE
Import test-helper functions.

### DIFF
--- a/test/button/button-icon.visual-diff.html
+++ b/test/button/button-icon.visual-diff.html
@@ -7,7 +7,6 @@
 		import '../../components/colors/colors.js';
 		import '../../components/typography/typography.js';
 		import '../../components/button/button-icon.js';
-		import '../../tools/test-helpers/helpers.js';
 	</script>
 	<title>d2l-button-icon</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/test/button/button-icon.visual-diff.js
+++ b/test/button/button-icon.visual-diff.js
@@ -12,6 +12,13 @@ describe('d2l-button-icon', function() {
 		page = await browser.newPage();
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
 		await page.goto(`${visualDiff.getBaseUrl()}/test/button/button-icon.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.addScriptTag({
+			type: 'module',
+			content: `
+				import { focus } from '../../tools/test-helpers/helpers.js';
+				window.MyCustomFocus = focus;
+			`
+		});
 		await page.bringToFront();
 	});
 
@@ -35,9 +42,7 @@ describe('d2l-button-icon', function() {
 		});
 
 		it('focus', async function() {
-			await page.evaluate(() => D2L.TestHelpers.focus(
-				'#normal', { waitFor: { selector: ['#normal', 'button'], eventName: 'transitionend' } }
-			));
+			await page.evaluate(async() => window.MyCustomFocus('#normal', { waitFor: { selector: ['#normal', 'button'], eventName: 'transitionend' } }));
 			const rect = await visualDiff.getRect(page, '#normal');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});


### PR DESCRIPTION
A follow-up to your https://github.com/BrightspaceUI/core/pull/51#discussion_r276683098.

I did a bunch of different experiments in attempt to avoid adding these helpers to the `window`.  Imports are scoped to their module, so in order to use these helper functions outside of the module (in this case inside of a Puppeteer `evaluate()` callback) they must be added to the `window` somewhere.  

If we want to avoid adding them to the window where they are exported, we could either have the consumer add them to the window in their test `html` file, or we could have them inject it into the page as I've shown in this PR.  We could also wrap up these helpers in a "global" export that handles this.  I'm not sure I like either.  At this point I almost think the existing code is preferred... at least in it's case, it's really clear what's being done.  

Thoughts?