### PR TITLE
Use icons

### DIFF
--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -1,5 +1,4 @@
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier1-icons.js';
+import '../icons/icon.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { VisibleOnAncestorMixin, visibleOnAncestorStyles } from '../../mixins/visible-on-ancestor-mixin.js';
 import { ButtonMixin } from './button-mixin.js';

--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -1,5 +1,4 @@
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier1-icons.js';
+import '../icons/icon.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ButtonMixin } from './button-mixin.js';
 import { buttonStyles } from './button-styles.js';

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -1,6 +1,4 @@
 import '../button/button-subtle.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier1-icons.js';
 import 'fastdom/fastdom.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { getComposedChildren, isComposedAncestor } from '../../helpers/dom.js';

--- a/demo/button/button-icon.html
+++ b/demo/button/button-icon.html
@@ -60,7 +60,7 @@
 		}
 	</style>
 </head>
-<body class="d2l-typography" unresolved="unresolved">
+<body class="d2l-typography">
 
 	<h3>Icon Button</h3>
 

--- a/demo/button/button-subtle.html
+++ b/demo/button/button-subtle.html
@@ -14,7 +14,7 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
-<body class="d2l-typography" unresolved="unresolved">
+<body class="d2l-typography">
 
 	<h3>Subtle Button with Text Only</h3>
 

--- a/demo/icons/icon.html
+++ b/demo/icons/icon.html
@@ -28,16 +28,16 @@
 
 		<h3>Preset (icon attribute)</h3>
 		<d2l-demo-snippet>
-			<d2l-icon icon="d2l-tier1:gear"></d2l-icon>
-			<d2l-icon icon="d2l-tier2:gear"></d2l-icon>
-			<d2l-icon icon="d2l-tier3:gear"></d2l-icon>
+			<d2l-icon icon="d2l-tier1:calendar"></d2l-icon>
+			<d2l-icon icon="d2l-tier2:calendar"></d2l-icon>
+			<d2l-icon icon="d2l-tier3:calendar"></d2l-icon>
 		</d2l-demo-snippet>
 
 		<h3>Custom SVG (src attribute)</h3>
 		<d2l-demo-snippet>
-			<d2l-icon src="../../components/icons/images/tier1/gear.svg" size="tier1"></d2l-icon>
-			<d2l-icon src="../../components/icons/images/tier2/gear.svg" size="tier2"></d2l-icon>
-			<d2l-icon src="../../components/icons/images/tier3/gear.svg" size="tier3"></d2l-icon>
+			<d2l-icon src="../../components/icons/images/tier1/calendar.svg" size="tier1"></d2l-icon>
+			<d2l-icon src="../../components/icons/images/tier2/calendar.svg" size="tier2"></d2l-icon>
+			<d2l-icon src="../../components/icons/images/tier3/calendar.svg" size="tier3"></d2l-icon>
 		</d2l-demo-snippet>
 
 		<h3>Custom non-SVG (src attribute)</h3>
@@ -50,16 +50,16 @@
 		<h3>Color Override</h3>
 		<d2l-demo-snippet>
 			<div class="color-override">
-				<d2l-icon icon="d2l-tier3:gear"></d2l-icon>
-				<d2l-icon src="../../components/icons/images/tier3/gear.svg" size="tier3"></d2l-icon>
+				<d2l-icon icon="d2l-tier3:calendar"></d2l-icon>
+				<d2l-icon src="../../components/icons/images/tier3/calendar.svg" size="tier3"></d2l-icon>
 			</div>
 		</d2l-demo-snippet>
 
 		<h3>Size Override</h3>
 		<d2l-demo-snippet>
 			<div class="size-override">
-				<d2l-icon icon="d2l-tier3:gear"></d2l-icon>
-				<d2l-icon src="../../components/icons/images/tier3/gear.svg" size="tier3"></d2l-icon>
+				<d2l-icon icon="d2l-tier3:calendar"></d2l-icon>
+				<d2l-icon src="../../components/icons/images/tier3/calendar.svg" size="tier3"></d2l-icon>
 				<d2l-icon src="calendar-tier3.png" size="tier3"></d2l-icon>
 			</div>
 		</d2l-demo-snippet>

--- a/demo/more-less/more-less.html
+++ b/demo/more-less/more-less.html
@@ -14,7 +14,7 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
-<body class="d2l-typography" unresolved="unresolved">
+<body class="d2l-typography">
 
 	<h3>More-less collapsed</h3>
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@webcomponents/shadycss": "latest",
     "@webcomponents/webcomponentsjs": "latest",
-    "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-intl": "^2.0.0",
     "fastdom": "^1.0.9",
     "intl-messageformat": "^2.2.0",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -14,24 +14,9 @@
 					"version": ""
 				},
 				{
-					"browserName": "firefox",
-					"platform": "OS X 10.13",
-					"version": ""
-				},
-				{
 					"browserName": "safari",
 					"platform": "OS X 10.13",
 					"version": ""
-				},
-				{
-					"browserName": "microsoftedge",
-					"platform": "Windows 10",
-					"version": ""
-				},
-				{
-					"browserName": "internet explorer",
-					"platform": "Windows 10",
-					"version": "11"
 				}
 			]
 		}


### PR DESCRIPTION
This PR abandons our Polymer-based icons and uses the fancy Lit ones. In doing so, the demo pages are making a lot fewer requests.

With Polymer icons:

Page | Requests | Download
------------ | ------------- | -------------
Subtle Button | 97 | 367 KB 
Icon Button | 99 | 427 KB
More/Less | 156 | 440 KB

With Lit icons 🔥:

Page | Requests | Download
------------ | ------------- | -------------
Subtle Button | 42 | 161 KB
Icon Button | 44 | 221 KB
More/Less | 100 | 232 KB

So a savings of 55 requests and 206 KB by not including Polymer and the crazy huge icon bundles.