### PR TITLE
Dbatiste/demo snippet rtl tweak

### DIFF
--- a/components/demo-snippet/demo-snippet.js
+++ b/components/demo-snippet/demo-snippet.js
@@ -96,18 +96,23 @@ class DemoSnippet extends LitElement {
 		this._dirButton = this._dir === 'rtl' ? 'ltr' : 'rtl';
 		const nodes = this.shadowRoot.querySelector('slot').assignedNodes();
 		if (nodes.length === 0) return;
-		const applyDir = (nodes) => {
+		const applyDir = (nodes, isRoot) => {
 			for (let i = 0; i < nodes.length; i++) {
 				if (nodes[i].nodeType === Node.ELEMENT_NODE) {
-					nodes[i].setAttribute('dir', this._dir);
-					if (nodes[i].shadowRoot) {
-						applyDir(nodes[i].shadowRoot.children);
+					/* only sprout dir on root or custom element so devs don't think that
+					[dir="rtl"].some-class will work. they must use :host([dir="rtl"]) in their
+					custom element's CSS since RTLMixin only sprouts [dir="rtl"] on host */
+					if (isRoot || nodes[i].tagName.indexOf('-') !== -1) {
+						nodes[i].setAttribute('dir', this._dir);
 					}
-					applyDir(nodes[i].children);
+					if (nodes[i].shadowRoot) {
+						applyDir(nodes[i].shadowRoot.children, false);
+					}
+					applyDir(nodes[i].children, false);
 				}
 			}
 		};
-		applyDir(nodes);
+		applyDir(nodes, true);
 	}
 
 	_handleSlotChange(e) {

--- a/demo/button/button-icon.html
+++ b/demo/button/button-icon.html
@@ -14,9 +14,6 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
-		d2l-button-icon {
-			margin-right: 1.2rem;
-		}
 		.ancestor-container {
 			padding: 0.5rem;
 			position: relative;


### PR DESCRIPTION
The `d2l-demo-snippet` RTL handler recurses through demo element's children to apply `dir="rtl"`.  In contrast, the [RTLMixin](https://github.com/BrightspaceUI/core/blob/master/mixins/rtl-mixin.js) only sprouts `dir="rtl"` on the host element.  This difference could lead developers to believe that selectors such as the following would work:
```
:host > [dir="rtl"].some-class { ... }
```
This change updates the demo-snippet RTL logic to more closely match the behavior of the RTLMixin, which requires devs to define their RTL selector on the host for custom elements:
```
:host([dir="rtl"]) .some-class { ... }
```