### PR TITLE
Refactor d2l-demo-snippet so that code-view can be used for non-HTML code.

### DIFF
--- a/components/demo/code-dark-plus-styles.js
+++ b/components/demo/code-dark-plus-styles.js
@@ -1,10 +1,9 @@
 import { css } from 'lit-element/lit-element.js';
 
-export const codeStyles = css`
+export const themeStyles = css`
 	/**
-	 * prism.js tomorrow night eighties for JavaScript, CoffeeScript, CSS and HTML
-	 * Based on https://github.com/chriskempson/tomorrow-theme
-	 * @author Rose Pritchard
+	 * prism.js VSCode's Dark+ theme for JavaScript, CSS and HTML
+	 * Modelled after https://github.com/dunstontc/atom-vscode-syntax
 	 */
 
 	code[class*="language-"],
@@ -54,57 +53,56 @@ export const codeStyles = css`
 	.token.prolog,
 	.token.doctype,
 	.token.cdata {
-		color: #999;
+		color: #808080;
 	}
 
-	.token.punctuation {
-		color: #ccc;
+	.token.punctuation,
+	.token.number,
+	.token.url,
+	.token.operator {
+		color: #D4D4D4;
+	}
+
+	.token.interpolation,
+	.token.attr-name,
+	.token.constant,
+	.token.property {
+		color: #9CDCFE;
 	}
 
 	.token.tag,
-	.token.attr-name,
-	.token.namespace,
-	.token.deleted {
-		color: #e2777a;
-	}
-
-	.token.function-name {
-		color: #6196cc;
-	}
-
 	.token.boolean,
-	.token.number,
+	.token.entity,
+	.token.interpolation-punctuation {
+		color: #569CD6;
+	}
+
 	.token.function {
-		color: #f08d49;
+		color: #DCDCAA;
 	}
 
-	.token.property,
-	.token.class-name,
-	.token.constant,
-	.token.symbol {
-		color: #f8c555;
+	.token.class-name {
+		color: #4EC9B0;
 	}
 
-	.token.selector,
-	.token.important,
-	.token.atrule,
 	.token.keyword,
-	.token.builtin {
-		color: #cc99cd;
+	.token.atrule {
+		color: #C586C0;
+	}
+
+	.token.selector {
+		color: #D7BA7D;
+	}
+
+	.token.important,
+	.token.regex {
+		color: #D16969;
 	}
 
 	.token.string,
 	.token.char,
-	.token.attr-value,
-	.token.regex,
-	.token.variable {
-		color: #7ec699;
-	}
-
-	.token.operator,
-	.token.entity,
-	.token.url {
-		color: #67cdcc;
+	.token.attr-value {
+		color: #CE9178;
 	}
 
 	.token.important,

--- a/components/demo/code-tomorrow-styles.js
+++ b/components/demo/code-tomorrow-styles.js
@@ -1,9 +1,10 @@
 import { css } from 'lit-element/lit-element.js';
 
-export const codeStyles = css`
+export const themeStyles = css`
 	/**
-	 * prism.js VSCode's Dark+ theme for JavaScript, CSS and HTML
-	 * Modelled after https://github.com/dunstontc/atom-vscode-syntax
+	 * prism.js tomorrow night eighties for JavaScript, CoffeeScript, CSS and HTML
+	 * Based on https://github.com/chriskempson/tomorrow-theme
+	 * @author Rose Pritchard
 	 */
 
 	code[class*="language-"],
@@ -53,56 +54,57 @@ export const codeStyles = css`
 	.token.prolog,
 	.token.doctype,
 	.token.cdata {
-		color: #808080;
+		color: #999;
 	}
 
-	.token.punctuation,
-	.token.number,
-	.token.url,
-	.token.operator {
-		color: #D4D4D4;
-	}
-
-	.token.interpolation,
-	.token.attr-name,
-	.token.constant,
-	.token.property {
-		color: #9CDCFE;
+	.token.punctuation {
+		color: #ccc;
 	}
 
 	.token.tag,
+	.token.attr-name,
+	.token.namespace,
+	.token.deleted {
+		color: #e2777a;
+	}
+
+	.token.function-name {
+		color: #6196cc;
+	}
+
 	.token.boolean,
-	.token.entity,
-	.token.interpolation-punctuation {
-		color: #569CD6;
-	}
-
+	.token.number,
 	.token.function {
-		color: #DCDCAA;
+		color: #f08d49;
 	}
 
-	.token.class-name {
-		color: #4EC9B0;
+	.token.property,
+	.token.class-name,
+	.token.constant,
+	.token.symbol {
+		color: #f8c555;
 	}
 
-	.token.keyword,
-	.token.atrule {
-		color: #C586C0;
-	}
-
-	.token.selector {
-		color: #D7BA7D;
-	}
-
+	.token.selector,
 	.token.important,
-	.token.regex {
-		color: #D16969;
+	.token.atrule,
+	.token.keyword,
+	.token.builtin {
+		color: #cc99cd;
 	}
 
 	.token.string,
 	.token.char,
-	.token.attr-value {
-		color: #CE9178;
+	.token.attr-value,
+	.token.regex,
+	.token.variable {
+		color: #7ec699;
+	}
+
+	.token.operator,
+	.token.entity,
+	.token.url {
+		color: #67cdcc;
 	}
 
 	.token.important,

--- a/components/demo/code-view-styles.js
+++ b/components/demo/code-view-styles.js
@@ -1,0 +1,40 @@
+import { css } from 'lit-element/lit-element.js';
+
+export const styles = css`
+	:host {
+		border: 1px solid var(--d2l-color-tungsten);
+		border-radius: 6px;
+		box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
+		display: block;
+		max-width: 900px;
+		position: relative;
+	}
+	:host([hidden]) {
+		display: none;
+	}
+	:host .d2l-code-view-code {
+		font-size: 14px;
+	}
+	:host .d2l-code-view-code::before {
+		box-sizing: border-box;
+		color: var(--d2l-color-tungsten);
+		content: attr(language);
+		font-size: 0.7rem;
+		padding: 0;
+		position: absolute;
+		margin: 0 0.4rem;
+		right: 0;
+		top: 0;
+	}
+	:host([hide-language]) .d2l-code-view-code::before {
+		display: none;
+	}
+	:host slot {
+		display: none;
+	}
+	pre[class*="language-"] {
+		border-radius: 5px;
+		margin: 0;
+		padding: 18px;
+	}
+`;

--- a/components/demo/code-view-styles.js
+++ b/components/demo/code-view-styles.js
@@ -29,7 +29,7 @@ export const styles = css`
 	:host([hide-language]) .d2l-code-view-code::before {
 		display: none;
 	}
-	:host slot {
+	:host .d2l-code-view-src {
 		display: none;
 	}
 	pre[class*="language-"] {

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -27,7 +27,7 @@ class CodeView extends LitElement {
 
 	render() {
 		return html`
-			<slot @slotchange="${this._handleSlotChange}"></slot>
+			<div class="d2l-code-view-src"><slot @slotchange="${this._handleSlotChange}"></slot></div>
 			<div language="${this.language}" class="d2l-code-view-code">${this._codeTemplate}</div>
 		`;
 	}

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -1,5 +1,6 @@
 import 'prismjs/prism.js';
 import 'prismjs/components/prism-json.min.js';
+import 'prismjs/components/prism-bash.min.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { styles } from './code-view-styles.js';
 import { themeStyles } from './code-dark-plus-styles.js';
@@ -72,11 +73,13 @@ class CodeView extends LitElement {
 
 	_getPrismGrammar(language) {
 		switch (language) {
+			case 'bash': return Prism.languages.bash;
 			case 'css': return Prism.languages.css;
 			case 'html': return Prism.languages.html;
 			case 'javascript': return Prism.languages.javascript;
 			case 'js': return Prism.languages.javascript;
 			case 'json': return Prism.languages.json;
+			case 'shell': return Prism.languages.bash;
 			default: return Prism.languages.html;
 		}
 	}

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -81,7 +81,7 @@ class CodeView extends LitElement {
 	}
 
 	_getLanguage(language) {
-		const aliases = {shell: "bash"};
+		const aliases = {shell: 'bash'};
 		return aliases[language] ? aliases[language] : language;
 	}
 
@@ -113,7 +113,7 @@ class CodeView extends LitElement {
 			code = Prism.highlight(code, this._getPrismGrammar(this.language), this.language);
 			this._code = code;
 
-		}).catch((reason) => {
+		}).catch(() => {
 			this._code = code;
 		});
 

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -1,0 +1,102 @@
+import 'prismjs/prism.js';
+import 'prismjs/components/prism-json.min.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
+import { styles } from './code-view-styles.js';
+import { themeStyles } from './code-dark-plus-styles.js';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+
+class CodeView extends LitElement {
+
+	static get properties() {
+		return {
+			hideLanguage: { type: Boolean, reflect: true, attribute: 'hide-language' },
+			language: { type: String, reflect: true },
+			_code: { type: String }
+		};
+	}
+
+	static get styles() {
+		return [ themeStyles, styles ];
+	}
+
+	constructor() {
+		super();
+		this.language = 'html';
+	}
+
+	render() {
+		return html`
+			<slot @slotchange="${this._handleSlotChange}"></slot>
+			<div language="${this.language}" class="d2l-code-view-code">${this._codeTemplate}</div>
+		`;
+	}
+
+	firstUpdated() {
+		this._updateCode(this.shadowRoot.querySelector('slot'));
+	}
+
+	get _codeTemplate() {
+		return html`<pre class="language-${this.language}"><code class="language-${this.language}">${unsafeHTML(this._code)}</code></pre>`;
+	}
+
+	_formatCode(text) {
+
+		if (!text) return text;
+
+		let lines = text.replace(/\t/g, '  ').split('\n');
+
+		// Shift indent left if possible, modified from:
+		// https://github.com/PolymerElements/marked-element/blob/master/marked-element.js#L340-359
+
+		const indent = lines.reduce((prev, line) => {
+
+			// completely ignore blank lines
+			if (/^\s*$/.test(line)) return prev;
+
+			const lineIndent = line.match(/^(\s*)/)[0].length;
+			if (prev === null) return lineIndent;
+			return lineIndent < prev ? lineIndent : prev;
+
+		}, null);
+
+		// remove leading or trailing blank lines
+		lines = lines.filter((line, index) => {
+			if (index === 0 || index === lines.length - 1) return !/^\s*$/.test(line);
+			return true;
+		});
+
+		return lines.map((l) => {
+			return l.substr(indent);
+		}).join('\n');
+	}
+
+	_getPrismGrammar(language) {
+		switch (language) {
+			case 'css': return Prism.languages.css;
+			case 'html': return Prism.languages.html;
+			case 'javascript': return Prism.languages.javascript;
+			case 'js': return Prism.languages.javascript;
+			case 'json': return Prism.languages.json;
+			default: return Prism.languages.html;
+		}
+	}
+
+	_handleSlotChange(e) {
+		this._updateCode(e.target);
+	}
+
+	_updateCode(slot) {
+		const nodes = slot.assignedNodes();
+		if (nodes.length === 0) {
+			this._code = '';
+			return;
+		}
+		const code = Prism.highlight(
+			this._formatCode(nodes[0].textContent),
+			this._getPrismGrammar(this.language), this.language
+		);
+		this._code = code;
+	}
+}
+
+customElements.define('d2l-code-view', CodeView);

--- a/components/demo/demo-snippet-styles.js
+++ b/components/demo/demo-snippet-styles.js
@@ -37,4 +37,7 @@ export const styles = css`
 	:host .d2l-demo-snippet-actions button {
 		cursor: pointer;
 	}
+	:host d2l-code-view {
+		margin: 0;
+	}
 `;

--- a/components/demo/demo-snippet-styles.js
+++ b/components/demo/demo-snippet-styles.js
@@ -37,12 +37,4 @@ export const styles = css`
 	:host .d2l-demo-snippet-actions button {
 		cursor: pointer;
 	}
-	:host .d2l-demo-snippet-code {
-		font-size: 14px;
-	}
-	pre[class*="language-"] {
-		border-radius: 5px;
-		margin: 0;
-		padding: 18px;
-	}
 `;

--- a/demo/button/button-icon.html
+++ b/demo/button/button-icon.html
@@ -4,7 +4,7 @@
 	<link rel="stylesheet" href="../styles.css" type="text/css">
 	<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
-		import '../../components/demo-snippet/demo-snippet.js';
+		import '../../components/demo/demo-snippet.js';
 		import '../../components/colors/colors.js';
 		import '../../components/typography/typography.js';
 		import '../../components/button/button-icon.js';

--- a/demo/button/button-subtle.html
+++ b/demo/button/button-subtle.html
@@ -4,7 +4,7 @@
 	<link rel="stylesheet" href="../styles.css" type="text/css">
 	<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
-		import '../../components/demo-snippet/demo-snippet.js';
+		import '../../components/demo/demo-snippet.js';
 		import '../../components/colors/colors.js';
 		import '../../components/typography/typography.js';
 		import '../../components/button/button-subtle.js';

--- a/demo/icons/icon.html
+++ b/demo/icons/icon.html
@@ -5,7 +5,7 @@
 		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import 'whatwg-fetch';
-			import '../../components/demo-snippet/demo-snippet.js';
+			import '../../components/demo/demo-snippet.js';
 			import '../../components/colors/colors.js';
 			import '../../components/typography/typography.js';
 			import '../../components/icons/icon.js';

--- a/demo/more-less/more-less.html
+++ b/demo/more-less/more-less.html
@@ -4,7 +4,7 @@
 	<link rel="stylesheet" href="../styles.css" type="text/css">
 	<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
-		import '../../components/demo-snippet/demo-snippet.js';
+		import '../../components/demo/demo-snippet.js';
 		import '../../components/colors/colors.js';
 		import '../../components/typography/typography.js';
 		import '../../components/more-less/more-less.js';

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -13,6 +13,7 @@ h3 {
 	margin-top: 36px;
 	margin-bottom: 18px;
 }
+d2l-code-view,
 d2l-demo-snippet {
 	margin-bottom: 36px;
 }


### PR DESCRIPTION
This moves the "code-view" code out of `d2l-demo-snippet` into a new `d2l-code-view` so that it can be used for more than just demoing and formatting HTML.  The `d2l-code-view` is configured to support `html`, `javascript`, `css`, `json`, and `bash`/`shell`.  We can configure it to load other language grammars if the need arises (Prism supports 176 languages).

![d2l-demo-snippet](https://user-images.githubusercontent.com/9042472/56464065-65cef780-63af-11e9-8733-b8b3cd89aaa3.png)

