### PR TITLE
Wrap common demo imports in demo page and handle FOUC.

### DIFF
--- a/components/demo/demo-page.js
+++ b/components/demo/demo-page.js
@@ -2,12 +2,46 @@ import './demo-snippet.js';
 import './code-view.js';
 import '../colors/colors.js';
 import '../typography/typography.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 
 document.body.classList.add('d2l-typography');
 
-export const showPage = async() => {
-	if (document.fonts) {
-		await document.fonts.ready;
-	}
+(async() => {
+	const fontsPromise = document.fonts ? document.fonts.ready : Promise.resolve();
+	await Promise.all([
+		customElements.whenDefined('d2l-demo-page'),
+		fontsPromise
+	]);
 	document.body.removeAttribute('unresolved');
-};
+})();
+
+class DemoPage extends LitElement {
+
+	static get properties() {
+		return {
+			title: { type: String, reflect: true }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+		`;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		const title = document.createElement('title');
+		title.textContent = this.title;
+		document.head.insertBefore(title, document.head.firstChild);
+	}
+
+	render() {
+		return html`<slot></slot>`;
+	}
+
+}
+
+customElements.define('d2l-demo-page', DemoPage);

--- a/components/demo/demo-page.js
+++ b/components/demo/demo-page.js
@@ -1,0 +1,13 @@
+import './demo-snippet.js';
+import './code-view.js';
+import '../colors/colors.js';
+import '../typography/typography.js';
+
+document.body.classList.add('d2l-typography');
+
+export const showPage = async() => {
+	if (document.fonts) {
+		await document.fonts.ready;
+	}
+	document.body.removeAttribute('unresolved');
+};

--- a/components/demo/demo-page.js
+++ b/components/demo/demo-page.js
@@ -3,6 +3,7 @@ import './code-view.js';
 import '../colors/colors.js';
 import '../typography/typography.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { heading2Styles } from '../typography/styles.js';
 
 document.body.classList.add('d2l-typography');
 
@@ -24,11 +25,27 @@ class DemoPage extends LitElement {
 	}
 
 	static get styles() {
-		return css`
+		return [ heading2Styles, css`
 			:host {
+				background-color: #f2f3f5;
 				display: block;
+				padding: 30px;
 			}
-		`;
+			.d2l-heading-2 {
+				margin-top: 0;
+			}
+			:host > div > ::slotted(h2),
+			:host > div > ::slotted(h3) {
+				font-size: 0.8rem;
+				font-weight: 700;
+				line-height: 1.2rem;
+				margin: 1.5rem 0 1.5rem 0;
+			}
+			:host > div > ::slotted(d2l-code-view),
+			:host > div > ::slotted(d2l-demo-snippet) {
+				margin-bottom: 36px;
+			}
+		`];
 	}
 
 	connectedCallback() {
@@ -39,7 +56,10 @@ class DemoPage extends LitElement {
 	}
 
 	render() {
-		return html`<slot></slot>`;
+		return html`
+			<h1 class="d2l-heading-2">${this.title}</h1>
+			<div><slot></slot></div>
+		`;
 	}
 
 }

--- a/demo/button/button-icon.html
+++ b/demo/button/button-icon.html
@@ -58,19 +58,19 @@
 
 	<d2l-demo-page title="d2l-button-icon">
 
-		<h3>Icon Button</h3>
+		<h2>Icon Button</h2>
 
 		<d2l-demo-snippet>
 			<d2l-button-icon id="normal" icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
 		</d2l-demo-snippet>
 
-		<h3>Icon Button Disabled</h3>
+		<h2>Icon Button Disabled</h2>
 
 		<d2l-demo-snippet>
 			<d2l-button-icon id="disabled" icon="d2l-tier1:gear" text="Icon Button" disabled></d2l-button-icon>
 		</d2l-demo-snippet>
 
-		<h3>Icon Button Translucent</h3>
+		<h2>Icon Button Translucent</h2>
 
 		<d2l-demo-snippet>
 			<div class="translucent-container">
@@ -79,7 +79,7 @@
 			</div>
 		</d2l-demo-snippet>
 
-		<h3>Icon Button with Horizontal Align</h3>
+		<h2>Icon Button with Horizontal Align</h2>
 
 		<d2l-demo-snippet>
 			<d2l-button-icon icon="d2l-tier1:gear" text="Button Edge Aligned (default)"></d2l-button-icon>
@@ -87,7 +87,7 @@
 			<d2l-button-icon icon="d2l-tier1:gear" text="Button Content Aligned" h-align="text"></d2l-button-icon>
 		</d2l-demo-snippet>
 
-		<h3>Icon Button with Visible on Ancestor</h3>
+		<h2>Icon Button with Visible on Ancestor</h2>
 
 		<d2l-demo-snippet>
 			<div class="ancestor-container d2l-visible-on-ancestor-target">
@@ -97,7 +97,7 @@
 			</div>
 		</d2l-demo-snippet>
 
-		<h3>Icon Button with Translucent + Visible on Ancestor</h3>
+		<h2>Icon Button with Translucent + Visible on Ancestor</h2>
 
 		<d2l-demo-snippet>
 			<div class="translucent-container d2l-visible-on-ancestor-target">

--- a/demo/button/button-icon.html
+++ b/demo/button/button-icon.html
@@ -56,7 +56,7 @@
 </head>
 <body unresolved>
 
-	<d2l-demo-page title="d2l-button-icon demo">
+	<d2l-demo-page title="d2l-button-icon">
 
 		<h3>Icon Button</h3>
 

--- a/demo/button/button-icon.html
+++ b/demo/button/button-icon.html
@@ -1,18 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<link rel="stylesheet" href="../styles.css" type="text/css">
-	<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-	<script type="module">
-		import '../../components/demo/demo-snippet.js';
-		import '../../components/colors/colors.js';
-		import '../../components/typography/typography.js';
-		import '../../components/button/button-icon.js';
-	</script>
 	<title>d2l-button-icon demo</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
+	<link rel="stylesheet" href="../styles.css" type="text/css">
+	<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script type="module">
+		import '../../components/button/button-icon.js';
+		import { showPage } from '../../components/demo/demo-page.js';
+		showPage();
+	</script>
 	<style>
 		.ancestor-container {
 			padding: 0.5rem;
@@ -57,7 +56,7 @@
 		}
 	</style>
 </head>
-<body class="d2l-typography">
+<body unresolved>
 
 	<h3>Icon Button</h3>
 

--- a/demo/button/button-icon.html
+++ b/demo/button/button-icon.html
@@ -1,16 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<title>d2l-button-icon demo</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../styles.css" type="text/css">
 	<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
+		import '../../components/demo/demo-page.js';
 		import '../../components/button/button-icon.js';
-		import { showPage } from '../../components/demo/demo-page.js';
-		showPage();
 	</script>
 	<style>
 		.ancestor-container {
@@ -58,53 +56,57 @@
 </head>
 <body unresolved>
 
-	<h3>Icon Button</h3>
+	<d2l-demo-page title="d2l-button-icon demo">
 
-	<d2l-demo-snippet>
-		<d2l-button-icon id="normal" icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
-	</d2l-demo-snippet>
+		<h3>Icon Button</h3>
 
-	<h3>Icon Button Disabled</h3>
+		<d2l-demo-snippet>
+			<d2l-button-icon id="normal" icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
+		</d2l-demo-snippet>
 
-	<d2l-demo-snippet>
-		<d2l-button-icon id="disabled" icon="d2l-tier1:gear" text="Icon Button" disabled></d2l-button-icon>
-	</d2l-demo-snippet>
+		<h3>Icon Button Disabled</h3>
 
-	<h3>Icon Button Translucent</h3>
+		<d2l-demo-snippet>
+			<d2l-button-icon id="disabled" icon="d2l-tier1:gear" text="Icon Button" disabled></d2l-button-icon>
+		</d2l-demo-snippet>
 
-	<d2l-demo-snippet>
-		<div class="translucent-container">
-			<img alt="" src="https://s.brightspace.com/course-images/images/e4fbb461-4cd9-4512-8304-44f2c2b741f1/tile-low-density-max-size.jpg">
-			<d2l-button-icon id="translucent" icon="d2l-tier1:gear" text="Icon Button" translucent></d2l-button-icon>
-		</div>
-	</d2l-demo-snippet>
+		<h3>Icon Button Translucent</h3>
 
-	<h3>Icon Button with Horizontal Align</h3>
+		<d2l-demo-snippet>
+			<div class="translucent-container">
+				<img alt="" src="https://s.brightspace.com/course-images/images/e4fbb461-4cd9-4512-8304-44f2c2b741f1/tile-low-density-max-size.jpg">
+				<d2l-button-icon id="translucent" icon="d2l-tier1:gear" text="Icon Button" translucent></d2l-button-icon>
+			</div>
+		</d2l-demo-snippet>
 
-	<d2l-demo-snippet>
-		<d2l-button-icon icon="d2l-tier1:gear" text="Button Edge Aligned (default)"></d2l-button-icon>
-		<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
-		<d2l-button-icon icon="d2l-tier1:gear" text="Button Content Aligned" h-align="text"></d2l-button-icon>
-	</d2l-demo-snippet>
+		<h3>Icon Button with Horizontal Align</h3>
 
-	<h3>Icon Button with Visible on Ancestor</h3>
+		<d2l-demo-snippet>
+			<d2l-button-icon icon="d2l-tier1:gear" text="Button Edge Aligned (default)"></d2l-button-icon>
+			<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
+			<d2l-button-icon icon="d2l-tier1:gear" text="Button Content Aligned" h-align="text"></d2l-button-icon>
+		</d2l-demo-snippet>
 
-	<d2l-demo-snippet>
-		<div class="ancestor-container d2l-visible-on-ancestor-target">
-			<d2l-button-icon icon="d2l-tier1:home" text="Home"></d2l-button-icon>
-			<d2l-button-icon icon="d2l-tier1:bookmark-hollow" text="Bookmark"></d2l-button-icon>
-			<d2l-button-icon icon="d2l-tier1:gear" text="Gear" visible-on-ancestor></d2l-button-icon>
-		</div>
-	</d2l-demo-snippet>
+		<h3>Icon Button with Visible on Ancestor</h3>
 
-	<h3>Icon Button with Translucent + Visible on Ancestor</h3>
+		<d2l-demo-snippet>
+			<div class="ancestor-container d2l-visible-on-ancestor-target">
+				<d2l-button-icon icon="d2l-tier1:home" text="Home"></d2l-button-icon>
+				<d2l-button-icon icon="d2l-tier1:bookmark-hollow" text="Bookmark"></d2l-button-icon>
+				<d2l-button-icon icon="d2l-tier1:gear" text="Gear" visible-on-ancestor></d2l-button-icon>
+			</div>
+		</d2l-demo-snippet>
 
-	<d2l-demo-snippet>
-		<div class="translucent-container d2l-visible-on-ancestor-target">
-			<img alt="" src="https://s.brightspace.com/course-images/images/e4fbb461-4cd9-4512-8304-44f2c2b741f1/tile-low-density-max-size.jpg">
-			<d2l-button-icon icon="d2l-tier1:gear" text="Settings" translucent visible-on-ancestor></d2l-button-icon>
-		</div>
-	</d2l-demo-snippet>
+		<h3>Icon Button with Translucent + Visible on Ancestor</h3>
+
+		<d2l-demo-snippet>
+			<div class="translucent-container d2l-visible-on-ancestor-target">
+				<img alt="" src="https://s.brightspace.com/course-images/images/e4fbb461-4cd9-4512-8304-44f2c2b741f1/tile-low-density-max-size.jpg">
+				<d2l-button-icon icon="d2l-tier1:gear" text="Settings" translucent visible-on-ancestor></d2l-button-icon>
+			</div>
+		</d2l-demo-snippet>
+
+	</d2l-demo-page>
 
 	<script>
 		document.querySelector('d2l-button-icon').addEventListener('click', () => {

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -2,19 +2,10 @@ html {
 	font-size: 20px;
 }
 body {
-	background-color: #f2f3f5;
-	margin: 30px;
+	margin: 0;
+	padding: 0;
 	transition: opacity 0.2s ease-in-out;
 }
 body[unresolved] {
 	opacity: 0;
-}
-h3 {
-	font-size: 1rem;
-	margin-top: 36px;
-	margin-bottom: 18px;
-}
-d2l-code-view,
-d2l-demo-snippet {
-	margin-bottom: 36px;
 }

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -4,6 +4,7 @@ html {
 body {
 	background-color: #f2f3f5;
 	margin: 30px;
+	transition: opacity 0.2s ease-in-out;
 }
 body[unresolved] {
 	opacity: 0;


### PR DESCRIPTION
This PR does a couple of things for demo pages:

1. factors common imports into `demo-page.js`
2. adds the `d2l-typography` class to the body
3. handle FOUC using `unresolved`

It only saves one line of code, but flash of unwanted content is handled as well.

The `unresolved` styles must be included in the document synchronously in order to effectively avoid FOUC.  They cannot be placed in `demo-page.js` since it's a module, and all modules are deferred by browsers.  

The `demo-page.js` doesn't really know what other imports are going to be loaded, so it simply exposes a `showPage` function for the page to call after its imports.  It is worth noting that the WCR  event is also insufficient since it may be dispatched before module scripts are executed.

For flash of unwanted text: Chrome, Safari, and IE will render the rest of the page, but until the font has loaded, it displays a blank space in place of the text that uses the font.  Firefox first displays the text in the default font, and then re-renders text in the font once it has loaded, resulting in flash of unwanted text.  Edge appears to do this also, but is [not mentioned](https://developers.google.com/fonts/docs/technical_considerations).
 
The `showPage` function also waits for fonts to be ready by using `document.fonts` API.  This nicely avoids flash of unwanted text in FireFox, but does nothing for Edge since it does not support the `document.fonts` API yet.  This means that for Chrome and Safari, the page doesn't show until the font is loaded, when technically it could have been displayed with invisible text slightly earlier.
