### PR TITLE
Fixed progress bar not being limited to container

### DIFF
--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -19,9 +19,6 @@ class MeterLinear extends LitElement  {
 			.d2l-meter-linear-full-bar, .d2l-meter-linear-inner-bar {
 				border-radius: 32px;
 				height: 9px;
-				left: 0;
-				position: absolute;
-				top: 0;
 				width: 100%;
 			}
 
@@ -31,6 +28,9 @@ class MeterLinear extends LitElement  {
 
 			.d2l-meter-linear-inner-bar {
 				background-color: var(--d2l-color-celestine);
+				left: 0;
+				position: absolute;
+				top: 0;
 			}
 		`];
 	}

--- a/test/meter/meter-linear.visual-diff.html
+++ b/test/meter/meter-linear.visual-diff.html
@@ -14,13 +14,13 @@
 </head>
 <body class="d2l-typography">
 	<div class="visual-diff" style="width: 170px;">
-		<d2l-meter-linear id="no-progress" value="0" max="10" style="display: block;"></d2l-meter-linear>
+		<d2l-meter-linear id="no-progress" value="0" max="10"></d2l-meter-linear>
 	</div>
 	<div class="visual-diff" style="width: 170px;">
-		<d2l-meter-linear id="has-progress" value="3" max="10" style="display: block;"></d2l-meter-linear>
+		<d2l-meter-linear id="has-progress" value="3" max="10"></d2l-meter-linear>
 	</div>
 	<div class="visual-diff" style="width: 170px;">
-		<d2l-meter-linear id="completed" value="10" max="10" style="display: block;"></d2l-meter-linear>
+		<d2l-meter-linear id="completed" value="10" max="10"></d2l-meter-linear>
 	</div>
 </body>
 </html>


### PR DESCRIPTION
I noticed an issue where the second box was using the `width: 100%` to the previous box that had an absolute position so it wasn't bounded. So with this change it is bounded by the `:host` that has the relative position.