### PR TITLE
wcag: update button color when focus/hover

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
     npm run test:sauce || travis_terminate 1;
   else
     echo "Not a pull request and/or no secure environment variables, running headless tests...";
-    npm run test:local || travis_terminate 1;
+    npm run test:travis || travis_terminate 1;
   fi
 env:
   global:

--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -62,6 +62,11 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 					color: var(--d2l-color-celestine);
 					vertical-align: middle;
 				}
+				button:hover:not([disabled]) .d2l-button-subtle-content,
+				button:focus:not([disabled]) .d2l-button-subtle-content,
+				:host([active]:not([disabled])) button .d2l-button-subtle-content {
+					color: var(--d2l-color-celestine-minus-1);
+				}
 				:host([icon]) .d2l-button-subtle-content {
 					padding-left: 1.2rem;
 				}
@@ -88,6 +93,11 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 					top: 50%;
 					transform: translateY(-50%);
 					width: 0.9rem;
+				}
+				button:hover:not([disabled]) d2l-icon.d2l-button-subtle-icon,
+				button:focus:not([disabled]) d2l-icon.d2l-button-subtle-icon,
+				:host([active]:not([disabled])) button d2l-icon.d2l-button-subtle-icon {
+					color: var(--d2l-color-celestine-minus-1);
 				}
 				:host([icon]) d2l-icon.d2l-button-subtle-icon {
 					display: inline-block;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:diff": "mocha './test/**/*.visual-diff.js' -t 10000",
     "test:diff:golden": "mocha './test/**/*.visual-diff.js' -t 10000 --golden",
     "test:local": "polymer test --skip-plugin sauce",
-    "test:sauce": "polymer test --skip-plugin local"
+    "test:sauce": "polymer test --skip-plugin local",
+    "test:travis": "polymer test --config-file wct.conf-travis.json"
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",

--- a/test/button/button-icon.html
+++ b/test/button/button-icon.html
@@ -50,8 +50,7 @@
 						await runAxe(button);
 					});
 
-					// TODO: Fix contrast of focussed buttons to meet WCAG 2 standards
-					it.skip('passes all axe tests when focussed', async() => {
+					it('passes all axe tests when focused', async() => {
 						return new Promise((resolve, reject) => {
 							button.addEventListener('focus', async() => {
 								try {

--- a/test/button/button-subtle.html
+++ b/test/button/button-subtle.html
@@ -55,8 +55,7 @@
 						await runAxe(button);
 					});
 
-					// TODO: Fix contrast of focussed buttons to meet WCAG 2 standards
-					it.skip('should pass all axe tests when focussed', async() => {
+					it('should pass all axe tests when focused', async() => {
 						return new Promise((resolve, reject) => {
 							button.addEventListener('focus', async() => {
 								try {
@@ -90,8 +89,7 @@
 						await runAxe(button);
 					});
 
-					// TODO: Fix contrast of focussed buttons to meet WCAG 2 standards
-					it.skip('should pass all axe tests when focussed', async() => {
+					it('should pass all axe tests when focused', async() => {
 						return new Promise((resolve, reject) => {
 							button.addEventListener('focus', async() => {
 								try {

--- a/wct.conf-travis.json
+++ b/wct.conf-travis.json
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "local": {
+      "browsers": ["chrome"],
+      "browserOptions": {
+        "chrome": ["headless", "disable-gpu", "no-sandbox"]
+      }
+    }
+	}
+}

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -3,7 +3,7 @@
     "local": {
       "browsers": ["chrome"],
       "browserOptions": {
-        "chrome": ["disable-gpu", "no-sandbox"]
+        "chrome": ["headless", "disable-gpu", "no-sandbox"]
       }
     },
 		"sauce": {

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -3,7 +3,7 @@
     "local": {
       "browsers": ["chrome"],
       "browserOptions": {
-        "chrome": ["headless", "disable-gpu", "no-sandbox"]
+        "chrome": ["disable-gpu", "no-sandbox"]
       }
     },
 		"sauce": {


### PR DESCRIPTION
Improve the contrast ratio for button text when button is hovered/focused.

`headless` was removed from running tests locally because of an issue with browser window focus causing `.focus()` to not run when `headless` and for the tests with `.focus()` to timeout. A travis wct config was added to run the tests headlessly, since they fail on travis when not run with `headless`.

I tried to use `MockInteractions.focus` here instead of `.focus()` but that seemed to not actually trigger the styles.