### PR TITLE
Text for the d2l-meter-circle now shows up on edge and ie11

### DIFF
--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -31,7 +31,6 @@ class MeterCircle extends LitElement {
 		.d2l-meter-circle-text {
 			fill: var(--d2l-color-ferrite);
 			font-size: 0.6rem;
-			line-height: 0;
 		}
 	` ];
 	}
@@ -42,7 +41,7 @@ class MeterCircle extends LitElement {
 		const space = lengthOfLine - progressFill;
 		const dashOffset = 7 * Math.PI * 2 - 10; // approximation perimeter of circle divide by 3 subtract the rounded edges (5 pixels each)
 		return html `
-			<svg viewBox="0 0 48 48" >
+			<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision">
 				<circle class="d2l-meter-circle-full-bar" cx="24" cy="24" r="21"/>
 				<circle
 					class="d2l-meter-circle-progress-bar"
@@ -50,8 +49,8 @@ class MeterCircle extends LitElement {
 					stroke-dasharray="${progressFill} ${space}"
 					stroke-dashoffset="${dashOffset}"
 					visibility="${this.value ? 'visible' : 'hidden'}" />
-				<text class="d2l-body-standard d2l-meter-circle-text" x="24" y="25" text-anchor="middle" dominant-baseline="middle">
-					${this.value}/${this.max}
+				<text class="d2l-body-standard d2l-meter-circle-text" x="24" y="28" text-anchor="middle">
+						${this.value}/${this.max}
 				</text>
 			</svg>
 		`;

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -1,5 +1,5 @@
 import d2lIntl from 'd2l-intl';
-import IntlMessageFormat from 'intl-messageformat/src/main.js';
+import IntlMessageFormat from 'intl-messageformat/lib/index.js';
 window.IntlMessageFormat = IntlMessageFormat;
 
 const assign =

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "test:travis": "polymer test --config-file wct.conf-travis.json"
   },
   "files": [
-     "/components",
-     "/helpers",
-     "/mixins",
-     "/tools",
-     "!demo",
-     "!test",
-     "/components/demo",
-     "!/components/demo/demo"
+    "/components",
+    "/helpers",
+    "/mixins",
+    "/tools",
+    "!demo",
+    "!test",
+    "/components/demo",
+    "!/components/demo/demo"
   ],
   "author": "D2L Corporation",
   "license": "Apache-2.0",
@@ -51,7 +51,7 @@
     "@webcomponents/shadycss": "latest",
     "@webcomponents/webcomponentsjs": "latest",
     "d2l-intl": "^2.0.0",
-    "intl-messageformat": "^3.0.0",
+    "intl-messageformat": "3.0.0",
     "lit-element": "latest",
     "resize-observer-polyfill": "^1.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@webcomponents/shadycss": "latest",
     "@webcomponents/webcomponentsjs": "latest",
     "d2l-intl": "^2.0.0",
-    "intl-messageformat": "3.0.0",
+    "intl-messageformat": "^3.0.0",
     "lit-element": "latest",
     "resize-observer-polyfill": "^1.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@webcomponents/shadycss": "latest",
     "@webcomponents/webcomponentsjs": "latest",
     "d2l-intl": "^2.0.0",
-    "intl-messageformat": "^3.0.0",
+    "intl-messageformat": "^3.1.0",
     "lit-element": "latest",
     "resize-observer-polyfill": "^1.5.1"
   },


### PR DESCRIPTION
Edge:
![image](https://user-images.githubusercontent.com/13232226/58272135-d1640600-7d5b-11e9-8c0f-9019ffa5aaed.png)
Chrome:
![image](https://user-images.githubusercontent.com/13232226/58272204-ffe1e100-7d5b-11e9-975e-9d71fb7c46b7.png)

I am still having issues where Edge and IE11 don't agree on how to position the text so as seen in the photo the text isn't quite in the middle. 