### PR TITLE
labels should no longer have a responsive breakpoint

### DIFF
--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -100,10 +100,4 @@ export const labelStyles = css`
 		font-weight: 700;
 		letter-spacing: 0.2px;
 	}
-	@media (max-width: 615px) {
-		.d2l-label-text {
-			font-size: 0.6rem;
-			line-height: 0.9rem;
-		}
-	}
 `;

--- a/components/typography/typography.js
+++ b/components/typography/typography.js
@@ -166,11 +166,6 @@ if (!document.head.querySelector('#d2l-typography-font-face')) {
 				line-height: 1.2rem;
 			}
 
-			.d2l-typography .d2l-label-text {
-				font-size: 0.6rem;
-				line-height: 0.9rem;
-			}
-
 		}
 	`;
 	document.head.appendChild(style);


### PR DESCRIPTION
Mirrors [change in typography](https://github.com/BrightspaceUI/typography/pull/134). Will require new goldens.