### PR TITLE
Dbatiste/more docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Coming soon!
 * [More/less](components/more-less/): constrain long bits of content
 * [Typography](components/typography/): typography styles and components
 
+## Helpers
+
+* [Helpers](helpers/): helpers for composed DOM, unique ids, etc.
+
+## Mixins
+
+* [Mixins](mixins/): mixins for localization, RTL styles, etc.
+
 ## Usage
 
 ### Structure

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,0 +1,36 @@
+# Helpers
+
+## DOM
+
+DOM helper functions to make your life easier.
+
+### Usage
+
+```js
+import { ... } from '@brightspace-ui/core/helpers/dom.js';
+
+// returns null or the closest ancestor that fulfills the specified predicate fxn
+findComposedAncestor(node, predicate);
+
+// gets the composed children (including shadow children & distributed children)
+getComposedChildren(element);
+
+// gets the composed parent (including shadow host & insertion points)
+getComposedParent(node);
+
+// returns true/false whether the specified ancestorNode is an ancestor of node
+isComposedAncestor(ancestorNode, node);
+```
+
+## UniqueId
+
+A simple helper that returns a unique id.
+
+### Usage
+
+```js
+import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
+
+// gets a unique indexed id (for lifetime of page)
+getUniqueId();
+```

--- a/mixins/README.md
+++ b/mixins/README.md
@@ -1,0 +1,58 @@
+# Mixins
+
+## LocalizeMixin
+
+### Usage
+
+```js
+  import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+```
+
+## RtlMixin
+
+The `RtlMixin` creates `dir` attributes on host elements based on the document's `dir`, enabling components to define RTL styles for elements within their shadow-DOMs via `:host([dir="rtl"])`. It is possible to opt-out our this behavior by explicitly setting a `dir` attribute (ex. for testing).
+
+### Usage
+
+Apply the mixin and defined RTL styles.
+
+```js
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+class MyComponent extends RtlMixin(LitElement) {
+  static get styles() {
+    return css`
+      :host([dir="rtl"]) .some-elem {
+        /* some RTL styles */
+      }
+    `;
+  }
+}
+```
+
+## VisibleOnAncestorMixin
+
+The `VisibleOnAncestorMixin` adds a behavior to a component so that it is initially hidden, and becomes visible when a hovers or focuses within an ancestor marked with the `d2l-visible-on-ancestor-target` class. It includes styles that must be included with the component. If the device does not support hovering, the element will be visible regardless of whether the user is hovering or focusing within the target.
+
+### Usage
+
+Apply the mixin and include the required `visibleOnAncestorStyles`.
+
+```js
+import { VisibleOnAncestorMixin, visibleOnAncestorStyles } from '@brightspace-ui/core/mixins/visible-on-ancestor-mixin.js';
+class MyComponent extends VisibleOnAncestorMixin(LitElement) {
+  static get styles() {
+    return [ visibleOnAncestorStyles, css`/* MyComponent styles */` ];
+  }
+}
+```
+
+The consumer turns on the behavior using the `visible-on-ancestor` attribute and adding the `d2l-visible-on-ancestor-target` to the element in which hovering/focusing will show the element.
+
+```html
+<div class="d2l-visible-on-ancestor-target">
+  ...
+  <my-component visible-on-ancestor></my-component>
+  ...
+</div>
+```

--- a/mixins/README.md
+++ b/mixins/README.md
@@ -15,7 +15,7 @@ The `RtlMixin` creates `dir` attributes on host elements based on the document's
 
 ### Usage
 
-Apply the mixin and defined RTL styles.
+Apply the mixin and define RTL styles.
 
 ```js
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -32,7 +32,7 @@ class MyComponent extends RtlMixin(LitElement) {
 
 ## VisibleOnAncestorMixin
 
-The `VisibleOnAncestorMixin` adds a behavior to a component so that it is initially hidden, and becomes visible when a hovers or focuses within an ancestor marked with the `d2l-visible-on-ancestor-target` class. It includes styles that must be included with the component. If the device does not support hovering, the element will be visible regardless of whether the user is hovering or focusing within the target.
+The `VisibleOnAncestorMixin` adds a behavior to a component so that it is initially hidden, and becomes visible when user hovers or focuses within an ancestor marked with the `d2l-visible-on-ancestor-target` class. It includes styles that must be included with the component. If the device does not support hovering, the element will be visible regardless of whether the user is hovering or focusing within the target.
 
 ### Usage
 
@@ -47,7 +47,7 @@ class MyComponent extends VisibleOnAncestorMixin(LitElement) {
 }
 ```
 
-The consumer turns on the behavior using the `visible-on-ancestor` attribute and adding the `d2l-visible-on-ancestor-target` to the element in which hovering/focusing will show the element.
+The consumer turns on the behavior using the `visible-on-ancestor` attribute and adds the `d2l-visible-on-ancestor-target` to the element in which hovering/focusing should show the element.
 
 ```html
 <div class="d2l-visible-on-ancestor-target">

--- a/mixins/README.md
+++ b/mixins/README.md
@@ -1,14 +1,5 @@
 # Mixins
 
-## LocalizeMixin
-
-### Usage
-
-```js
-  import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-
-```
-
 ## RtlMixin
 
 The `RtlMixin` creates `dir` attributes on host elements based on the document's `dir`, enabling components to define RTL styles for elements within their shadow-DOMs via `:host([dir="rtl"])`. It is possible to opt-out our this behavior by explicitly setting a `dir` attribute (ex. for testing).


### PR DESCRIPTION
This adds README docs for our `helpers` and `mixins`. Much of this is copied forward from the original in polymer-behaviors.

This includes a placeholder for the localization mixin.  I don't mind putting that together, but I think @margaree is more familiar with the expected API, so I'd like to defer that until she returns.