### PR TITLE
Aria to work with NVDA and Firefox and Move text

### DIFF
--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -1,7 +1,5 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { bodySmallStyles } from '../typography/styles.js';
-import { getUniqueId } from '../../helpers/uniqueId.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 class MeterLinear extends LitElement  {
 	static get properties() {
@@ -56,8 +54,11 @@ class MeterLinear extends LitElement  {
 				color: var(--d2l-color-ferrite);
 				display: flex;
 				flex-direction: row;
-				justify-content: space-between;
 				margin: 0 6px;
+			}
+
+			.d2l-meter-linear-text-space-between {
+				justify-content: space-between;
 			}
 
 			.d2l-meter-linear-secondary {
@@ -75,25 +76,20 @@ class MeterLinear extends LitElement  {
 	}
 
 	render() {
-		const primaryTextId = getUniqueId();
-		const secondaryTextId = getUniqueId();
-
 		const percentage = this.max > 0 ? this.value / this.max * 100 : 0;
 		const primary = this.percent ? `${Math.floor(percentage)}%` : `${this.value}/${this.max}`;
 		const secondaryText = this._formatContext(this.text, this.value, this.max);
-		const secondaryTextElement = secondaryText ? html`<div id="${secondaryTextId}" class="d2l-meter-linear-secondary">${secondaryText}</div>` : html``;
+		const addSpace = !this.textInline && secondaryText !== this.text ? 'd2l-meter-linear-text-space-between' : '';
+		const secondaryTextElement = secondaryText ? html`<div class="d2l-meter-linear-secondary">${secondaryText}</div>` : html``;
 		return html `
 			<div
-				role="progressBar"
-				aria-valuenow="${this.value}"
-				aria-valuemax="${this.max}"
-				aria-valuetext="${ifDefined(secondaryText)}"
-				aria-describedby="${primaryTextId} ${secondaryTextId}">
+				role="img"
+				aria-label="${secondaryText}, ${primary}, progress indicator">
 				<div class="d2l-meter-linear-full-bar">
 					<div class="d2l-meter-linear-inner-bar" style="width:${percentage}%;"></div>
 				</div>
-				<div class="d2l-body-small d2l-meter-linear-text">
-					<div id="${primaryTextId}" class="d2l-meter-linear-primary">${primary}&nbsp;</div>
+				<div class="d2l-body-small d2l-meter-linear-text ${addSpace}">
+					<div class="d2l-meter-linear-primary">${primary}&nbsp;</div>
 					${secondaryTextElement}
 				</div>
 			</div>

--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { bodySmallStyles } from '../typography/styles.js';
+import { classMap } from 'lit-html/directives/class-map.js';
 
 class MeterLinear extends LitElement  {
 	static get properties() {
@@ -79,7 +80,11 @@ class MeterLinear extends LitElement  {
 		const percentage = this.max > 0 ? this.value / this.max * 100 : 0;
 		const primary = this.percent ? `${Math.floor(percentage)}%` : `${this.value}/${this.max}`;
 		const secondaryText = this._formatContext(this.text, this.value, this.max);
-		const addSpace = !this.textInline && secondaryText !== this.text ? 'd2l-meter-linear-text-space-between' : '';
+		const textClasses =  {
+			'd2l-meter-linear-text-space-between': !this.textInline && secondaryText !== this.text,
+			'd2l-body-small': true,
+			'd2l-meter-linear-text': true
+		};
 		const secondaryTextElement = secondaryText ? html`<div class="d2l-meter-linear-secondary">${secondaryText}</div>` : html``;
 		return html `
 			<div
@@ -88,7 +93,7 @@ class MeterLinear extends LitElement  {
 				<div class="d2l-meter-linear-full-bar">
 					<div class="d2l-meter-linear-inner-bar" style="width:${percentage}%;"></div>
 				</div>
-				<div class="d2l-body-small d2l-meter-linear-text ${addSpace}">
+				<div class=${classMap(textClasses)}>
 					<div class="d2l-meter-linear-primary">${primary}&nbsp;</div>
 					${secondaryTextElement}
 				</div>


### PR DESCRIPTION
Here is what happens with the text:
![image](https://user-images.githubusercontent.com/13232226/58907831-0e75b400-86dd-11e9-866f-78b6be6b5e47.png)

When text doesn't contain either {x/y} or {%} then it will move the text beside the number.

This is done to fit with the designs.

I also, switch to image route for screen reader support. NVDA and firefox don't support the progressBar role.

Out of scope:
Lang term for 'progress indicator'
