### PR TITLE
Option 1 - Fix icon property update

### DIFF
--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -25,11 +25,6 @@ class Icon extends RtlMixin(LitElement) {
 		};
 	}
 
-	constructor() {
-		super();
-		this.size = 'tier1';
-	}
-
 	static get styles() {
 		return css`
 			:host {

--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -81,6 +81,27 @@ class Icon extends RtlMixin(LitElement) {
 		`;
 	}
 
+	set icon(val) {
+		this._icon = val;
+		this.setAttribute('icon', this._icon);
+	}
+
+	get icon() { return this._icon; }
+
+	set size(val) {
+		this._size = val;
+		this.setAttribute('size', this._size);
+	}
+
+	get size() { return this._size; }
+
+	set src(val) {
+		this._src = val;
+		this.setAttribute('src', this._src);
+	}
+
+	get src() { return this._src; }
+
 	attributeChangedCallback(name, oldval, newval) {
 		if (name === 'icon') {
 			this._fetchSvg(newval);


### PR DESCRIPTION
This PR added custom property setters/getters for `icon`, `src`, and `size` properties so that their values are reflected to attributes, thereby triggering the existing `attributeChangedCallback` which is responsible for kicking off a new request/update.  The clunky part of this is that it can result in 2 property updates - one when someone calls it, and again as a result of the attribute being updated.