### PR TITLE
Option 2 - Fix icon property update

### DIFF
--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -25,11 +25,6 @@ class Icon extends RtlMixin(LitElement) {
 		};
 	}
 
-	constructor() {
-		super();
-		this.size = 'tier1';
-	}
-
 	static get styles() {
 		return css`
 			:host {

--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -100,12 +100,6 @@ class Icon extends RtlMixin(LitElement) {
 		super.attributeChangedCallback(name, oldval, newval);
 	}
 
-	shouldUpdate(changedProperties) {
-		const shouldUpdate = changedProperties.has('_svg')
-			|| changedProperties.has('_imgSrc');
-		return shouldUpdate;
-	}
-
 	render() {
 		if (this._svg) {
 			return this._svg;


### PR DESCRIPTION
This PR simply omits the custom `shouldUpdate`, resulting in `render` being called 2x.  The first time `render` is called, it simply returns undefined.  It's unfortunate, but I don't think it's a performance concern since the real concern would be unnecessary DOM updates, which this would only have when there's something to render.