### PR TITLE
Option 3 - Fix icon property update

### DIFF
--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -86,17 +86,6 @@ class Icon extends RtlMixin(LitElement) {
 		})}`;
 	}
 
-	async _fetchSvg(icon) {
-		const svg = await loadSvg(icon);
-		return this._fixSvg(svg ? svg.val : undefined);
-	}
-
-	async _fetchSrcSvg(src) {
-		const response = await fetch(src);
-		if (!response.ok) return;
-		return this._fixSvg(await response.text());
-	}
-
 	_fixSvg(svgStr) {
 
 		if (svgStr === undefined) {
@@ -121,9 +110,14 @@ class Icon extends RtlMixin(LitElement) {
 	}
 
 	async _getIcon() {
-		if (this.icon) return this._fetchSvg(this.icon);
+		if (this.icon) {
+			const svg = await loadSvg(this.icon);
+			return this._fixSvg(svg ? svg.val : undefined);
+		}
 		if (this.src && this.src.substr(this.src.length - 4) === '.svg') {
-			return this._fetchSrcSvg(this.src);
+			const response = await fetch(this.src);
+			if (!response.ok) return;
+			return this._fixSvg(await response.text());
 		} else {
 			return html`<img src="${this.src}" alt="">`;
 		}

--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -24,11 +24,6 @@ class Icon extends RtlMixin(LitElement) {
 		};
 	}
 
-	constructor() {
-		super();
-		this.size = 'tier1';
-	}
-
 	static get styles() {
 		return css`
 			:host {

--- a/directives/run-async.js
+++ b/directives/run-async.js
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import { directive } from 'lit-html/lit-html.js';
+const hasAbortController = typeof AbortController === 'function';
+const runs = new WeakMap();
+/**
+ * Runs an async function whenever the key changes, and calls one of several
+ * lit-html template functions depending on the state of the async call:
+ *
+ *  - success() is called when the result of the function resolves.
+ *  - pending() is called immediately
+ *  - initial() is called if the function rejects with a InitialStateError,
+ *    which lets the function indicate that it couldn't proceed with the
+ *    provided key. This is usually the case when there isn't data to load.
+ *  - failure() is called if the function rejects.
+ *
+ * @param key A parameter passed to the task function. The task function is only
+ *     called when they key changes.
+ * @param task An async function to run when the key changes
+ * @param templates The templates to render for each state of the task
+ */
+export const runAsync = directive((key, task, templates) => (part) => {
+	const { success, pending, initial, failure } = templates;
+	const currentRunState = runs.get(part);
+	// The first time we see a value we save and await the work function.
+	// TODO(justinfagnani): allow a custom invalidate function
+	if (currentRunState === undefined || currentRunState.key !== key) {
+		// Abort a pending request if there is one
+		if (currentRunState !== undefined && currentRunState.state === 'pending') {
+			if (currentRunState.abortController !== undefined) {
+				currentRunState.abortController.abort();
+			}
+			// TODO(justinfagnani): This should be an AbortError, but it's not
+			// implemented yet
+			currentRunState.rejectPending(new Error());
+		}
+		const abortController = hasAbortController ? new AbortController() : undefined;
+		const abortSignal = hasAbortController ? abortController.signal : undefined;
+		let resolvePending;
+		let rejectPending;
+		const pendingPromise = new Promise((res, rej) => {
+			resolvePending = res;
+			rejectPending = rej;
+		});
+		const promise = task(key, { signal: abortSignal });
+		// The state is immediately 'pending', since the function has been
+		// executed, but if the function throws an InitialStateError to
+		// indicate that it couldn't even start processing, then we will set
+		// the state to 'initial'.
+		const runState = {
+			key,
+			promise,
+			state: 'pending',
+			abortController,
+			resolvePending,
+			rejectPending,
+		};
+		runs.set(part, runState);
+		Promise.resolve(promise).then((value) => {
+			runState.state = 'success';
+			const currentRunState = runs.get(part);
+			runState.resolvePending();
+			if (currentRunState !== runState) {
+				return;
+			}
+			part.setValue(success(value));
+			part.commit();
+		}, (error) => {
+			const currentRunState = runs.get(part);
+			runState.rejectPending(new Error());
+			if (currentRunState !== runState) {
+				return;
+			}
+			if (error instanceof InitialStateError && typeof initial === 'function') {
+				runState.state = 'initial';
+				part.setValue(initial());
+				part.commit();
+			} else {
+				runState.state = 'failure';
+				if (typeof failure === 'function') {
+					// render success callback
+					part.setValue(failure(error));
+					part.commit();
+				}
+			}
+		});
+		(async() => {
+			// Wait a microtask for the initial render of the Part to complete
+			await 0;
+			const currentRunState = runs.get(part);
+			if (currentRunState === runState && currentRunState.state === 'pending') {
+				part.startNode.parentNode.dispatchEvent(new CustomEvent('pending-state', {
+					composed: true,
+					bubbles: true,
+					detail: { promise: pendingPromise }
+				}));
+			}
+		})();
+	}
+	// If the promise has not yet resolved, set/update the defaultContent
+	const latestRunState = currentRunState;
+	if ((latestRunState === undefined || latestRunState.state === 'pending') && typeof pending === 'function') {
+		part.setValue(pending());
+	}
+});
+/**
+ * Error thrown by async tasks when the task couldn't be started based on the
+ * key passed to it.
+ */
+export class InitialStateError extends Error {}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "files": [
     "/cli",
     "/components",
+    "/directives",
     "/helpers",
     "/mixins",
     "/tools",


### PR DESCRIPTION
This PR uses the async rendering directive proposed by @justinfagnani, copied from his [runAsync PR](https://github.com/Polymer/lit-html/pull/657).  It cleans up the properties by avoiding the need for the private properties.  The rest of the logic is the same.

The async directive has potential use elsewhere with our hyper-media components, both for displaying alternative content while async state is pending, but also for visual-diff testing since the directive dispatches a promise-carrying event `pending-state`.

Per the directive comments, alternate views can be provided by the consumer for other states:
```
render() {
   return html`${runAsync(this.icon ? this.icon : this.src, (term) => this._getIcon(term), {
      success: (icon) => icon,
      pending: () => 'Pending',
      initial: () => 'Initial',
      failure: (e) => `Error: ${e}`
   })};
}
```