### PR TITLE
Add icon source check to fetch/inline logic.

### DIFF
--- a/components/icons/demo/icon.html
+++ b/components/icons/demo/icon.html
@@ -44,6 +44,7 @@
 				<d2l-icon-demo-color-override>
 					<d2l-icon icon="d2l-tier3:assignments"></d2l-icon>
 					<d2l-icon src="https://s.brightspace.com/lib/bsi/20.19.7-39/images/tier3/assignments.svg" size="tier3"></d2l-icon>
+					<d2l-icon src="../images/tier3/assignments.svg" size="tier3"></d2l-icon>
 				</d2l-icon-demo-color-override>
 			</d2l-demo-snippet>
 

--- a/components/icons/demo/icon.html
+++ b/components/icons/demo/icon.html
@@ -43,7 +43,7 @@
 			<d2l-demo-snippet>
 				<d2l-icon-demo-color-override>
 					<d2l-icon icon="d2l-tier3:assignments"></d2l-icon>
-					<d2l-icon src="../images/tier3/assignments.svg" size="tier3"></d2l-icon>
+					<d2l-icon src="https://s.brightspace.com/lib/bsi/20.19.7-39/images/tier3/assignments.svg" size="tier3"></d2l-icon>
 				</d2l-icon-demo-color-override>
 			</d2l-demo-snippet>
 

--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -114,12 +114,14 @@ class Icon extends RtlMixin(LitElement) {
 			const svg = await loadSvg(this.icon);
 			return this._fixSvg(svg ? svg.val : undefined);
 		}
-		if (this.src && this.src.substr(this.src.length - 4) === '.svg') {
-			const response = await fetch(this.src);
-			if (!response.ok) return;
-			return this._fixSvg(await response.text());
-		} else {
-			return html`<img src="${this.src}" alt="">`;
+		if (this.src) {
+			if (this.src.substr(this.src.length - 4) === '.svg' && this.src.startsWith('https://s.brightspace.com/')) {
+				const response = await fetch(this.src);
+				if (!response.ok) return;
+				return this._fixSvg(await response.text());
+			} else {
+				return html`<img src="${this.src}" alt="">`;
+			}
 		}
 	}
 

--- a/components/icons/test/icon.visual-diff.html
+++ b/components/icons/test/icon.visual-diff.html
@@ -44,7 +44,12 @@
 		</div>
 		<div class="visual-diff">
 			<d2l-icon-demo-color-override>
-				<d2l-icon src="../images/tier3/assignments.svg" size="tier3" id="color-override-custom-svg"></d2l-icon>
+				<d2l-icon src="../images/tier3/assignments.svg" size="tier3" id="color-override-untrusted-svg"></d2l-icon>
+			</d2l-icon-demo-color-override>
+		</div>
+		<div class="visual-diff">
+			<d2l-icon-demo-color-override>
+				<d2l-icon src="https://s.brightspace.com/lib/bsi/20.19.7-39/images/tier3/assignments.svg" size="tier3" id="color-override-trusted-svg"></d2l-icon>
 			</d2l-icon-demo-color-override>
 		</div>
 		<div class="visual-diff">

--- a/components/icons/test/icon.visual-diff.js
+++ b/components/icons/test/icon.visual-diff.js
@@ -21,7 +21,7 @@ describe('d2l-icon', function() {
 		{category: 'preset', tests: ['tier1', 'tier2', 'tier3']},
 		{category: 'custom-svg', tests: ['tier1', 'tier2', 'tier3']},
 		{category: 'fill', tests: ['none']},
-		{category: 'color-override', tests: ['preset', 'custom-svg']},
+		{category: 'color-override', tests: ['preset', 'trusted-svg', 'untrusted-svg']},
 		{category: 'size-override', tests: ['preset', 'custom-svg', 'custom-other']},
 		{category: 'rtl', tests: ['preset-tier1', 'preset-tier2', 'preset-tier3', 'custom-svg-tier1', 'custom-svg-tier2', 'custom-svg-tier3']}
 	].forEach((entry) => {


### PR DESCRIPTION
This PR updates the condition for inlining the SVG so that it will only do so provided the src is on the CDN.  Otherwise it will fallback to standard `img`.  The consequence to this is that any color overrides would not be applied.