### PR TITLE
Use latest eslint plugin for lit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "latest",
     "eslint-config-brightspace": "latest",
     "eslint-plugin-html": "latest",
-    "eslint-plugin-lit": "1.0.0",
+    "eslint-plugin-lit": "latest",
     "eslint-plugin-sort-class-members": "latest",
     "mocha": "latest",
     "polymer-cli": "latest",


### PR DESCRIPTION
Switch back to use the latest version of `eslint-plugin-lit` since `viewBox` attribute parsing has been fixed with recent v1.1.1.