### PR TITLE
Update the shadyCSS import path.

### DIFF
--- a/components/colors/colors.js
+++ b/components/colors/colors.js
@@ -1,4 +1,4 @@
-import '@webcomponents/shadycss/custom-style-interface.min.js';
+import '@webcomponents/shadycss/entrypoints/custom-style-interface.js';
 
 if (!document.head.querySelector('#d2l-colors')) {
 	const style = document.createElement('style');

--- a/components/typography/typography.js
+++ b/components/typography/typography.js
@@ -1,4 +1,4 @@
-import '@webcomponents/shadycss/custom-style-interface.min.js';
+import '@webcomponents/shadycss/entrypoints/custom-style-interface.js';
 
 const importUrl = 'https://s.brightspace.com/lib/fonts/0.4.0/assets/';
 


### PR DESCRIPTION
This will make the path consistent with polymer's `custom-style` element ensuring they get deduplicated as expected.