### PR TITLE
script to update the version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,8 @@ script:
     echo "Not a pull request and/or no secure environment variables, running headless tests...";
     npm run test:travis || travis_terminate 1;
   fi
-- |
-  if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_EVENT_TYPE != "cron" ]; then
-    echo "Not a pull request and on master branch, so bumping version...";
-    frauci-update-version --ownerName=BrightspaceUI --repoName=core;
-    export TRAVIS_TAG=$(frauci-get-version)
-  fi
+after_success:
+- npm run update-version
 env:
   global:
   - SAUCE_USERNAME: Desire2Learn
@@ -33,10 +29,6 @@ env:
   # GITHUB_RELEASE_TOKEN (2374......46ed)
   - secure: Q0Nl6PYZhAvS2rUprp7yxAnFmaaWlRJ7Vek1y8uQ0h2Rm4hraRDTwmcFSKOdOgHnI75Wzn5qCcTDHnQMVu1tHUf7/Z1Fnk/2cG5Y5G/R877jihoaaSNdhlbBPV92EZ5+tSc51H3hmChoK4FePKv45KQLsz59txOYmsVzKd8ryKTXzrDSH5IA3ssyBLfRTT6RbRDdTRBOpoTR4zPBkWCj9vB1Pd4g01jZPk2oP1bd8sIfJp1vrEzRCOrR7FiuDIBNArKTqOoLt3rlNry4uZpwrZmmA5b0L7xNM1C1PUxMjCKZV7mT5MthVx9R2NVOrddxAE0P7z/6PK1V86oJYwoSySOedLM4AYCwddpZNzqIR5aEAM33rvbRYuyCURt/1w59SXb5zftigdjbVg7wbvxb7sxWOEbhg+LHlno0+8U1r2WU1OY3BZBvsEKCV4jGGJpSyhvQpJ0gyWfsNk3Kt37OFgG0ZBNdXgIfQ+jSzan8puoR8wUbz4DyuYOV/z5Y4LdswFR3q4/eo1FjjzBBz+fXDodXxUm2XT/lxz5uL23y5EUqfT6vIBXd2XhlQ/izS0PCckzPILSz+nOL/I4Hq/q2Zfzu+9kD/sL6G3n1c28LbQnNOsuXyfoBozVZvwPc8wXWf4jIJlWGUXCoyG2zRJkN5D64GnSDvzu6+TThOYU8ZNQ=
 deploy:
-  - provider: releases
-    api_key: "$GITHUB_RELEASE_TOKEN"
-    on:
-      tags: true
   - provider: npm
     email: d2ltravisdeploy@d2l.com
     skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -108,6 +108,4 @@ npm test
 
 All version changes should obey [semantic versioning](https://semver.org/) rules.
 
-Commits and pull request merges to `master` will use [frau-ci](https://github.com/Brightspace/frau-ci) to automatically increment the `package.json` version and create a tag, which will subsequently trigger a deployment to NPM.
-
-By default, the minor version will be bumped. To increment the major or patch version instead, use `[increment major]` or `[increment patch]` in your merge message.
+Include either `[increment major]`, `[increment minor]` or `[increment patch]` in your merge commit message to automatically increment the `package.json` version, create a tag, and trigger a deployment to NPM.

--- a/cli/update-version.js
+++ b/cli/update-version.js
@@ -1,0 +1,95 @@
+const chalk = require('chalk'),
+	git = require('simple-git/promise')(),
+	spawn = require('child_process');
+
+const remote = `https://${process.env.GITHUB_RELEASE_TOKEN}@github.com/BrightspaceUI/core`;
+
+function getIncrementType() {
+
+	const commitMessage = process.env.TRAVIS_COMMIT_MESSAGE;
+
+	let incrementType = 'none';
+	if (commitMessage.indexOf('[increment patch]') > -1) {
+		incrementType = 'patch';
+	} else if (commitMessage.indexOf('[increment minor]') > -1) {
+		incrementType = 'minor';
+	} else if (commitMessage.indexOf('[increment major]') > -1) {
+		incrementType = 'major';
+	}
+
+	return incrementType;
+
+}
+
+function updateVersion(incrementType) {
+
+	console.log(chalk.blue(`Incrementing ${incrementType} version.`));
+
+	try {
+		spawn.execSync(`npm version ${incrementType} --no-git-tag-version`);
+	} catch (err) {
+		console.error(chalk.red(err));
+		return null;
+	}
+
+	let newVersion = require('../package.json').version;
+	newVersion = `v${newVersion}`;
+	console.log(chalk.blue(`New version: ${newVersion}`));
+
+	return newVersion;
+
+}
+
+function commit(newVersion) {
+
+	git.addConfig('user.name', 'BrightspaceGitHubReader');
+	git.addConfig('user.email', 'brightspacegithubreader@d2l.com');
+	git.addConfig('push.default', 'simple');
+
+	console.log(chalk.blue('Committing, tagging and pushing...'));
+	const commitMessage = `[skip ci] Updated version to ${newVersion}`;
+	return git.commit(commitMessage, 'package.json')
+		.then(() => {
+			git.addTag(newVersion);
+		}).then(() => {
+			git.push(remote, 'master');
+		}).then(() => {
+			git.pushTags(remote);
+		}).then(() => {
+			process.env.TRAVIS_TAG = newVersion;
+		});
+
+}
+
+console.log(chalk.yellow('Checking whether package.json version update is required...'));
+console.group();
+
+if (process.env.TRAVIS_BRANCH !== 'master' || process.env.TRAVIS_PULL_REQUEST !== 'false') {
+	console.log('Pull request or not on master branch, skipping version update.');
+	console.groupEnd();
+	process.exit(0);
+}
+
+const incrementType = getIncrementType();
+if (incrementType === 'none') {
+	console.log('No [increment major/minor/patch] found in commit message, skipping version update.');
+	console.groupEnd();
+	process.exit(0);
+}
+
+const newVersion = updateVersion(incrementType);
+if (newVersion === null) {
+	console.groupEnd();
+	process.exit(1);
+}
+
+commit(newVersion)
+	.then(() => {
+		console.groupEnd();
+		console.log(chalk.green('Version updated successfully.'));
+		process.exit(0);
+	}).catch((err) => {
+		console.error(chalk.red(err));
+		console.groupEnd();
+		process.exit(1);
+	});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:local": "polymer test --skip-plugin sauce",
     "test:sass": "node-sass --output-style expanded ./test/sass.scss > ./test/sass.output.css",
     "test:sauce": "polymer test --skip-plugin local",
-    "test:travis": "polymer test --config-file wct.conf-travis.json"
+    "test:travis": "polymer test --config-file wct.conf-travis.json",
+    "update-version": "node ./cli/update-version.js"
   },
   "files": [
     "/components",
@@ -49,11 +50,11 @@
     "eslint-plugin-html": "^6",
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
-    "frau-ci": "^1.37.0",
     "mocha": "^6",
     "node-sass": "^4",
     "polymer-cli": "^1",
     "puppeteer": "^1",
+    "simple-git": "^1.120.0",
     "wct-mocha": "^1",
     "whatwg-fetch": "^3"
   },


### PR DESCRIPTION
Swapping out `frauci` for a custom script.

The workflow is similar, but this script requires a commit message containing `[increment major/minor/patch]` -- otherwise it does nothing. 

If it sees that message, it will:
1. Update the version in `package.json` using the `npm version` command
2. Commit that change as BrightspaceGitHubReader, but with `[skip ci]` so that the change doesn't trigger another build
3. Add a tag matching the version number (but with a `v` in it)
4. Push the commit
5. Push the tag
6. Set `TRAVIS_TAG` environment variable to the tag, which will trigger the NPM deployment step