### PR TITLE
Set the version of intl-messageformat back to 2.2.0

### DIFF
--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -1,5 +1,5 @@
 import d2lIntl from 'd2l-intl';
-import IntlMessageFormat from 'intl-messageformat/lib/index.js';
+import IntlMessageFormat from 'intl-messageformat/src/main.js';
 window.IntlMessageFormat = IntlMessageFormat;
 
 export const LocalizeMixin = superclass => class extends superclass {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@webcomponents/shadycss": "^1",
     "@webcomponents/webcomponentsjs": "^2",
     "d2l-intl": "^2",
-    "intl-messageformat": "^5.0.0",
+    "intl-messageformat": "^2.2.0",
     "lit-element": "^2",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"


### PR DESCRIPTION
BSI is currently breaking when trying to pull in the first use of the `meter` component with:
```
error:    Promise rejection: Error: Duplicate export 'parse'
error:    Error: Duplicate export 'parse'
```

Going to try reverting the version of `intl-messageformat` back to 2.2.0 (the same used by `@Polymer/app-localize-behavior`, which is used in the same `activities` component as the `meter`) to unblock for now.