### PR TITLE
adding right padding to demo container for when in RTL

### DIFF
--- a/components/button/button.js
+++ b/components/button/button.js
@@ -1,3 +1,4 @@
+import '../colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ButtonMixin } from './button-mixin.js';
 import { buttonStyles } from './button-styles.js';

--- a/components/demo/demo-snippet-styles.js
+++ b/components/demo/demo-snippet-styles.js
@@ -15,7 +15,7 @@ export const styles = css`
 	:host .d2l-demo-snippet-demo {
 		background-color: white;
 		border-radius: 5px;
-		padding: 18px;
+		padding: 18px 58px 18px 18px;
 	}
 	:host([no-padding]) .d2l-demo-snippet-demo {
 		padding: 0;


### PR DESCRIPTION
When RTL mode is activated, the contents can rub up against the button:

![Screen Shot 2019-07-30 at 3 31 22 PM](https://user-images.githubusercontent.com/5491151/62159260-449b7280-b2df-11e9-8d37-82dfe5d28181.png)
