### PR TITLE
allowing the "d2l-" prefix in the category to be optional

### DIFF
--- a/cli/icon-generator.js
+++ b/cli/icon-generator.js
@@ -73,7 +73,7 @@ function createLoader(categories) {
 		'\tswitch (icon) {\n';
 	categories.forEach((category) => {
 		category.svgs.forEach((name) => {
-			template += `\t\tcase 'd2l-${category.name}:${name}':
+			template += `\t\tcase '${category.name}:${name}':
 			return import('./${category.name}/${name}.js');\n`;
 		});
 	});

--- a/components/icons/README.md
+++ b/components/icons/README.md
@@ -12,10 +12,10 @@ For preset icons, import and use the `<d2l-icon>` web component with the `icon` 
 <script type="module">
   import '@brightspace-ui/core/components/icons/icon.js';
 </script>
-<d2l-icon icon="d2l-tier1:gear"></d2l-icon>
+<d2l-icon icon="tier1:gear"></d2l-icon>
 ```
 
-The `icon` attribute value is of the form `d2l-<category-name>:<icon-name>`. The icon will automatically be the correct color (ferrite) and size based on its category.
+The `icon` attribute value is of the form `<category-name>:<icon-name>`. The icon will automatically be the correct color (ferrite) and size based on its category.
 
 **Note:** Always choose the icon whose native size best matches your desired icon size, ideally exactly.
 
@@ -34,7 +34,7 @@ The `icon` attribute value is of the form `d2l-<category-name>:<icon-name>`. The
 To change an icon's color from ferrite to something else, simply set it from CSS:
 
 ```html
-<d2l-icon icon="d2l-tier3:alert" style="color: red;"></d2l-icon>
+<d2l-icon icon="tier3:alert" style="color: red;"></d2l-icon>
 ```
 
 ### Overriding the Size

--- a/components/icons/demo/icon.html
+++ b/components/icons/demo/icon.html
@@ -20,26 +20,26 @@
 
 			<h3>Tiers</h3>
 			<d2l-demo-snippet>
-				<d2l-icon icon="d2l-tier1:assignments"></d2l-icon>
-				<d2l-icon icon="d2l-tier2:assignments"></d2l-icon>
-				<d2l-icon icon="d2l-tier3:assignments"></d2l-icon>
+				<d2l-icon icon="tier1:assignments"></d2l-icon>
+				<d2l-icon icon="tier2:assignments"></d2l-icon>
+				<d2l-icon icon="tier3:assignments"></d2l-icon>
 			</d2l-demo-snippet>
 
 			<h3>Color Override</h3>
 			<d2l-demo-snippet>
 				<d2l-icon-demo-color-override>
-					<d2l-icon icon="d2l-tier1:assignments"></d2l-icon>
-					<d2l-icon icon="d2l-tier2:assignments"></d2l-icon>
-					<d2l-icon icon="d2l-tier3:assignments"></d2l-icon>
+					<d2l-icon icon="tier1:assignments"></d2l-icon>
+					<d2l-icon icon="tier2:assignments"></d2l-icon>
+					<d2l-icon icon="tier3:assignments"></d2l-icon>
 				</d2l-icon-demo-color-override>
 			</d2l-demo-snippet>
 
 			<h3>Size Override</h3>
 			<d2l-demo-snippet>
 				<d2l-icon-demo-size-override>
-					<d2l-icon icon="d2l-tier1:assignments"></d2l-icon>
-					<d2l-icon icon="d2l-tier2:assignments"></d2l-icon>
-					<d2l-icon icon="d2l-tier3:assignments"></d2l-icon>
+					<d2l-icon icon="tier1:assignments"></d2l-icon>
+					<d2l-icon icon="tier2:assignments"></d2l-icon>
+					<d2l-icon icon="tier3:assignments"></d2l-icon>
 				</d2l-icon-demo-size-override>
 			</d2l-demo-snippet>
 

--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -38,15 +38,15 @@ class Icon extends RtlMixin(LitElement) {
 			:host([hidden]) {
 				display: none;
 			}
-			:host([icon*="d2l-tier1:"]) {
+			:host([icon*="tier1:"]) {
 				height: var(--d2l-icon-height, 18px);
 				width: var(--d2l-icon-width, 18px);
 			}
-			:host([icon*="d2l-tier2:"]) {
+			:host([icon*="tier2:"]) {
 				height: var(--d2l-icon-height, 24px);
 				width: var(--d2l-icon-width, 24px);
 			}
-			:host([icon*="d2l-tier3:"]) {
+			:host([icon*="tier3:"]) {
 				height: var(--d2l-icon-height, 30px);
 				width: var(--d2l-icon-width, 30px);
 			}
@@ -95,7 +95,11 @@ class Icon extends RtlMixin(LitElement) {
 
 	async _getIcon() {
 		if (this.icon) {
-			const svg = await loadSvg(this.icon);
+			let icon = this.icon;
+			if (icon.substring(0, 4) === 'd2l-') {
+				icon = icon.substring(4);
+			}
+			const svg = await loadSvg(icon);
 			return this._fixSvg(svg ? svg.val : undefined);
 		}
 	}

--- a/components/icons/test/icon.visual-diff.html
+++ b/components/icons/test/icon.visual-diff.html
@@ -17,35 +17,38 @@
 	</head>
 	<body class="d2l-typography">
 		<div class="visual-diff">
-			<d2l-icon icon="d2l-tier1:assignments" id="tier1"></d2l-icon>
+			<d2l-icon icon="tier1:assignments" id="tier1"></d2l-icon>
 		</div>
 		<div class="visual-diff">
-			<d2l-icon icon="d2l-tier2:assignments" id="tier2"></d2l-icon>
+			<d2l-icon icon="tier2:assignments" id="tier2"></d2l-icon>
 		</div>
 		<div class="visual-diff">
-			<d2l-icon icon="d2l-tier3:assignments" id="tier3"></d2l-icon>
+			<d2l-icon icon="tier3:assignments" id="tier3"></d2l-icon>
 		</div>
 		<div class="visual-diff">
-			<d2l-icon icon="d2l-tier2:evaluate-all" id="fill-none"></d2l-icon>
+			<d2l-icon icon="d2l-tier3:assignments" id="prefixed"></d2l-icon>
+		</div>
+		<div class="visual-diff">
+			<d2l-icon icon="tier2:evaluate-all" id="fill-none"></d2l-icon>
 		</div>
 		<div class="visual-diff">
 			<d2l-icon-demo-color-override>
-				<d2l-icon icon="d2l-tier3:assignments" id="color-override"></d2l-icon>
+				<d2l-icon icon="tier3:assignments" id="color-override"></d2l-icon>
 			</d2l-icon-demo-color-override>
 		</div>
 		<div class="visual-diff">
 			<d2l-icon-demo-size-override>
-				<d2l-icon icon="d2l-tier3:assignments" id="size-override"></d2l-icon>
+				<d2l-icon icon="tier3:assignments" id="size-override"></d2l-icon>
 			</d2l-icon-demo-size-override>
 		</div>
 		<div class="visual-diff">
-			<d2l-icon icon="d2l-tier1:assignments" dir="rtl" id="rtl-tier1"></d2l-icon>
+			<d2l-icon icon="tier1:assignments" dir="rtl" id="rtl-tier1"></d2l-icon>
 		</div>
 		<div class="visual-diff">
-			<d2l-icon icon="d2l-tier2:assignments" dir="rtl" id="rtl-tier2"></d2l-icon>
+			<d2l-icon icon="tier2:assignments" dir="rtl" id="rtl-tier2"></d2l-icon>
 		</div>
 		<div class="visual-diff">
-			<d2l-icon icon="d2l-tier3:assignments" dir="rtl" id="rtl-tier3"></d2l-icon>
+			<d2l-icon icon="tier3:assignments" dir="rtl" id="rtl-tier3"></d2l-icon>
 		</div>
 	</body>
 </html>

--- a/components/icons/test/icon.visual-diff.js
+++ b/components/icons/test/icon.visual-diff.js
@@ -21,6 +21,7 @@ describe('d2l-icon', function() {
 		'tier1',
 		'tier2',
 		'tier3',
+		'prefixed',
 		'fill-none',
 		'color-override',
 		'size-override',


### PR DESCRIPTION
Now that the `icon` attribute must refer to one of our icons, we're not worried about collisions with Google's iconsets anymore. This let's us treat the `d2l-` prefix in the category as optional. Yay less code!