### PR TITLE
Update to match Colin's research RTL

### DIFF
--- a/components/meter/README.md
+++ b/components/meter/README.md
@@ -17,7 +17,7 @@ import '@brightspace-ui/core/components/meter/meter-linear.js';
 Then add the `d2l-meter-linear`, provide values for the properties, `value` and `max`.
 
 ```html
-<d2l-meter-linear id="no-progress" value="0" max="10" text="Visited: {x} / {y}"></d2l-meter-linear>
+<d2l-meter-linear id="no-progress" value="0" max="10" text="Visited: {x/y}"></d2l-meter-linear>
 <d2l-meter-linear id="has-progress" value="3" max="10" text="Activities" text-inline percent></d2l-meter-linear>
 <d2l-meter-linear id="completed" value="10" max="10" text="{%} Activities"></d2l-meter-linear>
 ```
@@ -29,9 +29,10 @@ Then add the `d2l-meter-linear`, provide values for the properties, `value` and 
 * `percent` (optional): Show the percentage instead of `value/max` value.
 * `text-inline` (optional): Keep the meter to a single line. Text and meter will be on the same line.
 * `text` (optional): Context information about what the meter is about. Such as Activities.
-	- `{x}` in the string will be replaced with `value`
-	- `{y}` in the string will be replaced with `max`
 	- `{%}` in the string will be replaced with percentage value.
+	- `{x/y}` in the string will be replaced with fraction with the proper language support.
+	- **DEPRECATED** `{x}` in the string will be replaced with `value`
+	- **DEPRECATED** `{y}` in the string will be replaced with `max`
 
 ## d2l-meter-radial
 ![Radial meter with no progress](./screenshots/d2l-meter-radial-no-progress.png?raw=true)
@@ -58,6 +59,8 @@ Then add the `d2l-meter-radial`, provide values for the properties, `value` and 
 * `max` (required): Max number of units that is being measured by this meter. For results this should be a positive, non-zero number
 * `percent` (optional): Show the percentage instead of `value/max` value.
 * `text` (optional): Context information about what the meter is about. Displayed under the meter and used for screen readers.
+	- `{%}` in the string will be replaced with percentage value.
+	- `{x/y}` in the string will be replaced with fraction with the proper language support.
 
 ## d2l-meter-circle
 ![Circle meter with no progress](./screenshots/d2l-meter-circle-no-progress.png?raw=true)
@@ -83,3 +86,5 @@ Then add the `d2l-meter-circle`, provide values for the properties, `value` and 
 * `max` (required): Max number of units that is being measured by this meter. For results this should be a positive, non-zero number
 * `percent` (optional): Show the percentage instead of `value/max` value.
 * `text` (optional): Context information about what the meter is about. This is for screen readers.
+	- `{%}` in the string will be replaced with percentage value.
+	- `{x/y}` in the string will be replaced with fraction with the proper language support.

--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -21,7 +21,7 @@
 
 			<d2l-demo-snippet>
 				<d2l-meter-linear value="2" max="15" style="width: 250px" text="Activities" text-inline></d2l-meter-linear>
-				<d2l-meter-linear value="3" max="6" style="width: 200px" text="Visited: {x} / {y}" percent></d2l-meter-linear>
+				<d2l-meter-linear value="3" max="6" style="width: 200px" text="Visited: {x/y}" percent></d2l-meter-linear>
 			</d2l-demo-snippet>
 
 			<h2>Meter Radial</h2>

--- a/components/meter/lang/en.json
+++ b/components/meter/lang/en.json
@@ -4,7 +4,7 @@
     "context": "{term1} and {term2} are seperated ideas seperated by a short pause for screen readers."
   },
   "fraction": {
-    "translation": "{x} / {y}",
+    "translation": "{x}∕{y}",
     "context": "A fraction of tasks that have been done. {x} is the numerator and {y} the denominator."
   },
   "progressIndicator": {

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -44,7 +44,7 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 		const space = lengthOfLine - progressFill;
 		const dashOffset = this.dir === 'rtl' ? 7 * Math.PI + 10 - space : 7 * Math.PI * 2 - 10; // approximation perimeter of circle divide by 3 subtract the rounded edges (5 pixels each)
 
-		const primary = this._primary(this.value, this.max) || '';
+		const primary = this._primary(this.value, this.max, this.dir) || '';
 		const secondary = this._secondary(this.value, this.max, this.text);
 
 		return html`
@@ -58,7 +58,7 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 					visibility="${this.value ? 'visible' : 'hidden'}"></circle>
 
 				<text class="d2l-body-standard d2l-meter-circle-text" x="24" y="28" text-anchor="middle">
-					${primary.split(' ').join('')}
+					${primary}
 				</text>
 			</svg>
 		`;

--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -87,7 +87,7 @@ class MeterLinear extends MeterMixin(RtlMixin(LitElement)) {
 
 	render() {
 		const percentage = this.max > 0 ? this.value / this.max * 100 : 0;
-		const primary = this._primary(this.value, this.max);
+		const primary = this._primary(this.value, this.max, this.dir);
 		const secondary = this._secondary(this.value, this.max, this.text);
 		const textClasses =  {
 			'd2l-meter-linear-text-space-between': !this.textInline && secondary !== this.text,

--- a/components/meter/meter-mixin.js
+++ b/components/meter/meter-mixin.js
@@ -23,11 +23,12 @@ export const MeterMixin = superclass => class extends LocalizeMixin(superclass) 
 		this.value = 0;
 	}
 
-	_primary(value, max) {
+	_primary(value, max, dir) {
 		const percentage = max > 0 ? value / max : 0;
+
 		return this.percent
 			? this.formatNumber(percentage, {style: 'percent', maximumFractionDigits: 0})
-			: this.localize('fraction', 'x', this.value, 'y', this.max);
+			: ( dir !== 'rtl' ? this.localize('fraction', 'x', value, 'y', max) : this.localize('fraction', 'x', max, 'y', value));
 	}
 
 	_secondary(value, max, context) {
@@ -37,6 +38,7 @@ export const MeterMixin = superclass => class extends LocalizeMixin(superclass) 
 
 		const percentage = this.max > 0 ? value / max : 0;
 		context = context.replace('{%}', this.formatNumber(percentage, {style: 'percent', maximumFractionDigits: 0}));
+		context = context.replace('{x/y}', this.localize('fraction', 'x', value, 'y', max));
 		context = context.replace('{x}', value);
 		context = context.replace('{y}', max);
 

--- a/components/meter/meter-mixin.js
+++ b/components/meter/meter-mixin.js
@@ -28,7 +28,7 @@ export const MeterMixin = superclass => class extends LocalizeMixin(superclass) 
 
 		return this.percent
 			? this.formatNumber(percentage, {style: 'percent', maximumFractionDigits: 0})
-			: ( dir !== 'rtl' ? this.localize('fraction', 'x', value, 'y', max) : this.localize('fraction', 'x', max, 'y', value));
+			: (dir !== 'rtl' ? this.localize('fraction', 'x', value, 'y', max) : this.localize('fraction', 'x', max, 'y', value));
 	}
 
 	_secondary(value, max, context) {

--- a/components/meter/meter-radial.js
+++ b/components/meter/meter-radial.js
@@ -49,7 +49,7 @@ class MeterRadial extends MeterMixin(RtlMixin(LitElement)) {
 		const lengthOfLine = 115; // found by approximating half the perimeter of the ellipse with radii 38 and 35
 		const progressFill = this.value / this.max * lengthOfLine;
 
-		const primary = this._primary(this.value, this.max);
+		const primary = this._primary(this.value, this.max, this.dir);
 		const secondary = this._secondary(this.value, this.max, this.text);
 		const secondaryTextElement = this.text ? html`<div class="d2l-body-small d2l-meter-radial-text">${secondary}</div>` : html``;
 		return html `

--- a/components/meter/test/meter-linear.visual-diff.html
+++ b/components/meter/test/meter-linear.visual-diff.html
@@ -14,7 +14,7 @@
 </head>
 <body class="d2l-typography">
 	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear id="no-progress" value="0" max="10" text="Visited: {x} / {y}" percent></d2l-meter-linear>
+		<d2l-meter-linear id="no-progress" value="0" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
 	<div class="visual-diff" style="width: 250px;">
 		<d2l-meter-linear id="has-progress" value="3" max="10" text="Activities" text-inline percent></d2l-meter-linear>
@@ -23,11 +23,11 @@
 		<d2l-meter-linear id="completed" value="10" max="10" text="{%} Activities"></d2l-meter-linear>
 	</div>
 	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear id="max-zero" value="0" max="0" text="Visited: {x} / {y}" percent></d2l-meter-linear>
+		<d2l-meter-linear id="max-zero" value="0" max="0" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
 	<!-- rtl versions-->
 	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear dir="rtl" id="no-progress-rtl" value="0" max="10" text="Visited: {x} / {y}" percent></d2l-meter-linear>
+		<d2l-meter-linear dir="rtl" id="no-progress-rtl" value="0" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
 	<div class="visual-diff" style="width: 250px;">
 		<d2l-meter-linear dir="rtl" id="has-progress-rtl" value="3" max="10" text="Activities" text-inline percent></d2l-meter-linear>


### PR DESCRIPTION
Colin has done a lot of research on RTL and fractions.

He decided that using the fraction character `∕` instead of the slash character `/` gives better spacing.
He also found that fractions shouldn't be flipping in this context.
On some computers  `∕` seems to flip and I would consider that to be a defect but so far this is still a better solution. Matching OS and Browser won't reproduce the issue of flipping fraction character.

Since we will want to use the fraction character I am taking the ability away from the consumer to write the fraction on their own.