### PR TITLE
removing fill from all elements, not just path

### DIFF
--- a/components/icons/fix-svg.js
+++ b/components/icons/fix-svg.js
@@ -1,6 +1,6 @@
 export function fixSvg(svg) {
 
-	const paths = svg.querySelectorAll('path[fill]');
+	const paths = svg.querySelectorAll('[fill]');
 	paths.forEach((path) => {
 		if (path.getAttribute('fill') !== 'none') path.removeAttribute('fill');
 	});

--- a/components/icons/fix-svg.js
+++ b/components/icons/fix-svg.js
@@ -1,8 +1,8 @@
 export function fixSvg(svg) {
 
-	const paths = svg.querySelectorAll('[fill]');
-	paths.forEach((path) => {
-		if (path.getAttribute('fill') !== 'none') path.removeAttribute('fill');
+	const fills = svg.querySelectorAll('[fill]');
+	fills.forEach((fill) => {
+		if (fill.getAttribute('fill') !== 'none') fill.removeAttribute('fill');
 	});
 
 	svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');

--- a/components/icons/test/icon-custom.visual-diff.html
+++ b/components/icons/test/icon-custom.visual-diff.html
@@ -61,6 +61,17 @@
 			</d2l-icon-custom>
 		</div>
 		<div class="visual-diff">
+			<d2l-icon-custom size="tier2" id="fill-circle">
+				<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+					<circle fill="#494c4e" cx="12.5" cy="1.5" r="1.5"/>
+					<circle fill="#494c4e" cx="12.5" cy="6.5" r="1.5"/>
+					<circle fill="#494c4e" cx="12.5" cy="11.5" r="1.5"/>
+					<circle fill="#494c4e" cx="12.5" cy="16.5" r="1.5"/>
+					<circle fill="#494c4e" cx="12.5" cy="21.5" r="1.5"/>
+				</svg>
+			</d2l-icon-custom>
+		</div>
+		<div class="visual-diff">
 			<d2l-icon-demo-color-override>
 				<d2l-icon-custom size="tier3" id="color-override">
 					<svg width="30" height="30" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" mirror-in-rtl="true">

--- a/components/icons/test/icon-custom.visual-diff.js
+++ b/components/icons/test/icon-custom.visual-diff.js
@@ -22,6 +22,7 @@ describe('d2l-icon-custom', function() {
 		'tier2',
 		'tier3',
 		'fill-none',
+		'fill-circle',
 		'color-override',
 		'size-override',
 		'rtl-tier1',

--- a/components/icons/test/icon.visual-diff.html
+++ b/components/icons/test/icon.visual-diff.html
@@ -32,6 +32,9 @@
 			<d2l-icon icon="tier2:evaluate-all" id="fill-none"></d2l-icon>
 		</div>
 		<div class="visual-diff">
+			<d2l-icon icon="tier2:divider-big" id="fill-circle"></d2l-icon>
+		</div>
+		<div class="visual-diff">
 			<d2l-icon-demo-color-override>
 				<d2l-icon icon="tier3:assignments" id="color-override"></d2l-icon>
 			</d2l-icon-demo-color-override>

--- a/components/icons/test/icon.visual-diff.js
+++ b/components/icons/test/icon.visual-diff.js
@@ -23,6 +23,7 @@ describe('d2l-icon', function() {
 		'tier3',
 		'prefixed',
 		'fill-none',
+		'fill-circle',
 		'color-override',
 		'size-override',
 		'rtl-tier1',


### PR DESCRIPTION
Mark found a bug using perceptual diff where the dividers in the navbar were darker than they should be. Turns out this code that removes `fill` from the SVGs was only acting on `path` elements, whereas with the old icon code, it applied to any element -- including `circle` in this case.