### PR TITLE
check if node is element before calling dispatchEvent

### DIFF
--- a/directives/run-async.js
+++ b/directives/run-async.js
@@ -12,7 +12,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import { directive } from 'lit-html/lit-html.js';
-import { isElement } from 'lodash-es';
 
 const hasAbortController = typeof AbortController === 'function';
 const runs = new WeakMap();
@@ -102,7 +101,7 @@ export const runAsync = directive((key, task, templates) => (part) => {
 			await 0;
 			const currentRunState = runs.get(part);
 			if (currentRunState === runState && currentRunState.state === 'pending') {
-				const element = isElement(part.startNode.parentNode) ? part.startNode.parentNode : part.startNode.parentNode.host;
+				const element = part.startNode.parentNode.nodeType === Node.ELEMENT_NODE ? part.startNode.parentNode : part.startNode.parentNode.host;
 				element.dispatchEvent(new CustomEvent('pending-state', {
 					composed: true,
 					bubbles: true,

--- a/directives/run-async.js
+++ b/directives/run-async.js
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import { directive } from 'lit-html/lit-html.js';
+import { isElement } from 'lodash-es';
+
 const hasAbortController = typeof AbortController === 'function';
 const runs = new WeakMap();
 /**
@@ -100,7 +102,8 @@ export const runAsync = directive((key, task, templates) => (part) => {
 			await 0;
 			const currentRunState = runs.get(part);
 			if (currentRunState === runState && currentRunState.state === 'pending') {
-				part.startNode.parentNode.dispatchEvent(new CustomEvent('pending-state', {
+				const element = isElement(part.startNode.parentNode) ? part.startNode.parentNode : part.startNode.parentNode.host;
+				element.dispatchEvent(new CustomEvent('pending-state', {
 					composed: true,
 					bubbles: true,
 					detail: { promise: pendingPromise }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "d2l-intl": "^2",
     "intl-messageformat": "^2.2.0",
     "lit-element": "^2",
+    "lodash-es": "^4.17.15",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"
   }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "d2l-intl": "^2",
     "intl-messageformat": "^2.2.0",
     "lit-element": "^2",
-    "lodash-es": "^4.17.15",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"
   }


### PR DESCRIPTION
We were getting console errors for every instance of `d2l-icon` from this call https://github.com/BrightspaceUI/core/blob/master/components/icons/icon.js#L39
On chrome: `Uncaught (in promise) TypeError: Illegal invocation
    at rc.dispatchEvent (webcomponents-sd.js:2231)
    at run-async.js:129`
On firefox: `TypeError: 'dispatchEvent' called on an object that does not implement interface EventTarget.`
So we check that the `parentNode` is an element before calling `dispatchEvent` on it to avoid this error.