### PR TITLE
set max height of content instead of height [increment patch]

### DIFF
--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -186,7 +186,7 @@ class MoreLess extends LocalizeMixin(LitElement)  {
 		};
 
 		return html`
-			<div class=${classMap(contentClasses)} style=${styleMap({ height: `${this.__contentHeight}` })}>
+			<div class=${classMap(contentClasses)} style=${styleMap({ maxHeight: `${this.__contentHeight}` })}>
 				<slot></slot>
 			</div>
 			<div class="more-less-blur" style=${styleMap({ background: `${this.__blurBackground}`})}></div>

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -186,7 +186,7 @@ class MoreLess extends LocalizeMixin(LitElement)  {
 		};
 
 		return html`
-			<div class=${classMap(contentClasses)} style=${styleMap({ maxHeight: `${this.__contentHeight}` })}>
+			<div class=${classMap(contentClasses)} style=${styleMap({ height: `${this.__contentHeight}` })}>
 				<slot></slot>
 			</div>
 			<div class="more-less-blur" style=${styleMap({ background: `${this.__blurBackground}`})}></div>
@@ -335,7 +335,7 @@ class MoreLess extends LocalizeMixin(LitElement)  {
 	__adjustToContent_makeInactive() {
 		this.inactive = true;
 		this.expanded = false;
-		this.__contentHeight = null;
+		this.__contentHeight = 'unset';
 	}
 
 	__adjustToContent_resize(contentHeight) {


### PR DESCRIPTION
`height` property is defined as `The maximum height of the content when in "less" state.`, however it was being set as the content `height` instead of `max-height`. It was causing our component to have too much of a height when not needed, e.g.:
![image](https://user-images.githubusercontent.com/1471557/62793303-1dcf0000-ba86-11e9-983e-4a9f974ea26e.png)

Was this intentionally set as the height style instead of max-height? If so, maybe we need another property the user can specify for height as well as max-height?