### PR TITLE
Can't use "title" since it ends up as a tooltip

### DIFF
--- a/components/button/demo/button-icon.html
+++ b/components/button/demo/button-icon.html
@@ -62,7 +62,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="d2l-button-icon">
+		<d2l-demo-page page-title="d2l-button-icon">
 
 			<h2>Icon Button</h2>
 

--- a/components/button/demo/button-icon.html
+++ b/components/button/demo/button-icon.html
@@ -62,7 +62,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="d2l-button-icon">
+		<d2l-demo-page name="d2l-button-icon">
 
 			<h2>Icon Button</h2>
 

--- a/components/button/demo/button-subtle.html
+++ b/components/button/demo/button-subtle.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="d2l-button-subtle">
+		<d2l-demo-page page-title="d2l-button-subtle">
 
 			<h2>Subtle Button with Text Only</h2>
 

--- a/components/button/demo/button-subtle.html
+++ b/components/button/demo/button-subtle.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="d2l-button-subtle">
+		<d2l-demo-page name="d2l-button-subtle">
 
 			<h2>Subtle Button with Text Only</h2>
 

--- a/components/button/demo/button.html
+++ b/components/button/demo/button.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="d2l-button">
+		<d2l-demo-page page-title="d2l-button">
 			<h2>Button</h2>
 			<d2l-demo-snippet>
 				<d2l-button>Normal Button</d2l-button>

--- a/components/button/demo/button.html
+++ b/components/button/demo/button.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="d2l-button">
+		<d2l-demo-page name="d2l-button">
 			<h2>Button</h2>
 			<d2l-demo-snippet>
 				<d2l-button>Normal Button</d2l-button>

--- a/components/button/demo/floating-buttons-in-frame.html
+++ b/components/button/demo/floating-buttons-in-frame.html
@@ -34,7 +34,7 @@
 		</style>
 	</head>
 	<body unresolved>
-		<d2l-demo-page title="d2l-floating-buttons">
+		<d2l-demo-page name="d2l-floating-buttons">
 			<h2>Floating Buttons in a frame</h2>
 			<p>(frames are resizable)</p>
 			<div id="demoContainer">

--- a/components/button/demo/floating-buttons-in-frame.html
+++ b/components/button/demo/floating-buttons-in-frame.html
@@ -34,7 +34,7 @@
 		</style>
 	</head>
 	<body unresolved>
-		<d2l-demo-page name="d2l-floating-buttons">
+		<d2l-demo-page page-title="d2l-floating-buttons">
 			<h2>Floating Buttons in a frame</h2>
 			<p>(frames are resizable)</p>
 			<div id="demoContainer">

--- a/components/button/demo/floating-buttons-in-tabs.html
+++ b/components/button/demo/floating-buttons-in-tabs.html
@@ -97,7 +97,7 @@
 		</style>
 	</head>
 	<body unresolved>
-		<d2l-demo-page name="d2l-floating-buttons">
+		<d2l-demo-page page-title="d2l-floating-buttons">
 			<h2>Floating Buttons In a Tab Menu</h2>
 			<ul class="vui-tabmenu" role="tablist" id="TabMenu">
 				<li class="vui-tabmenu-item vui-tabmenu-item-select" role="presentation" style="width: 50%;">

--- a/components/button/demo/floating-buttons-in-tabs.html
+++ b/components/button/demo/floating-buttons-in-tabs.html
@@ -97,7 +97,7 @@
 		</style>
 	</head>
 	<body unresolved>
-		<d2l-demo-page title="d2l-floating-buttons">
+		<d2l-demo-page name="d2l-floating-buttons">
 			<h2>Floating Buttons In a Tab Menu</h2>
 			<ul class="vui-tabmenu" role="tablist" id="TabMenu">
 				<li class="vui-tabmenu-item vui-tabmenu-item-select" role="presentation" style="width: 50%;">

--- a/components/button/demo/floating-buttons-page.html
+++ b/components/button/demo/floating-buttons-page.html
@@ -13,7 +13,7 @@
 		</script>
 	</head>
 	<body unresolved>
-		<d2l-demo-page name="d2l-floating-buttons">
+		<d2l-demo-page page-title="d2l-floating-buttons">
 
 			<h2>Floating Buttons (page)</h2>
 			<d2l-button id="btn-remove-floating">Remove Floating Buttons</d2l-button>

--- a/components/button/demo/floating-buttons-page.html
+++ b/components/button/demo/floating-buttons-page.html
@@ -13,7 +13,7 @@
 		</script>
 	</head>
 	<body unresolved>
-		<d2l-demo-page title="d2l-floating-buttons">
+		<d2l-demo-page name="d2l-floating-buttons">
 
 			<h2>Floating Buttons (page)</h2>
 			<d2l-button id="btn-remove-floating">Remove Floating Buttons</d2l-button>

--- a/components/button/demo/floating-buttons.html
+++ b/components/button/demo/floating-buttons.html
@@ -13,7 +13,7 @@
 		</script>
 	</head>
 	<body unresolved>
-		<d2l-demo-page title="d2l-floating-buttons">
+		<d2l-demo-page name="d2l-floating-buttons">
 
 			<h2>Floating Buttons</h2>
 			<d2l-button id="btn-remove-floating">Remove Floating Buttons</d2l-button>

--- a/components/button/demo/floating-buttons.html
+++ b/components/button/demo/floating-buttons.html
@@ -13,7 +13,7 @@
 		</script>
 	</head>
 	<body unresolved>
-		<d2l-demo-page name="d2l-floating-buttons">
+		<d2l-demo-page page-title="d2l-floating-buttons">
 
 			<h2>Floating Buttons</h2>
 			<d2l-button id="btn-remove-floating">Remove Floating Buttons</d2l-button>

--- a/components/colors/demo/colors.html
+++ b/components/colors/demo/colors.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="d2l-colors">
+		<d2l-demo-page name="d2l-colors">
 
 			<h2>Basic Greys (lightest to darkest)</h2>
 

--- a/components/colors/demo/colors.html
+++ b/components/colors/demo/colors.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="d2l-colors">
+		<d2l-demo-page page-title="d2l-colors">
 
 			<h2>Basic Greys (lightest to darkest)</h2>
 

--- a/components/demo/demo-page.js
+++ b/components/demo/demo-page.js
@@ -20,7 +20,7 @@ class DemoPage extends LitElement {
 
 	static get properties() {
 		return {
-			title: { type: String, reflect: true }
+			name: { type: String, reflect: true }
 		};
 	}
 
@@ -51,13 +51,13 @@ class DemoPage extends LitElement {
 	connectedCallback() {
 		super.connectedCallback();
 		const title = document.createElement('title');
-		title.textContent = this.title;
+		title.textContent = this.name;
 		document.head.insertBefore(title, document.head.firstChild);
 	}
 
 	render() {
 		return html`
-			<h1 class="d2l-heading-2">${this.title}</h1>
+			<h1 class="d2l-heading-2">${this.name}</h1>
 			<div><slot></slot></div>
 		`;
 	}

--- a/components/demo/demo-page.js
+++ b/components/demo/demo-page.js
@@ -20,7 +20,7 @@ class DemoPage extends LitElement {
 
 	static get properties() {
 		return {
-			name: { type: String, reflect: true }
+			pageTitle: { type: String, attribute: 'page-title' }
 		};
 	}
 
@@ -51,13 +51,13 @@ class DemoPage extends LitElement {
 	connectedCallback() {
 		super.connectedCallback();
 		const title = document.createElement('title');
-		title.textContent = this.name;
+		title.textContent = this.pageTitle;
 		document.head.insertBefore(title, document.head.firstChild);
 	}
 
 	render() {
 		return html`
-			<h1 class="d2l-heading-2">${this.name}</h1>
+			<h1 class="d2l-heading-2">${this.pageTitle}</h1>
 			<div><slot></slot></div>
 		`;
 	}

--- a/components/demo/demo/demo-snippet.html
+++ b/components/demo/demo/demo-snippet.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="d2l-demo">
+		<d2l-demo-page name="d2l-demo">
 
 			<h2>Demo Snippet</h2>
 

--- a/components/demo/demo/demo-snippet.html
+++ b/components/demo/demo/demo-snippet.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="d2l-demo">
+		<d2l-demo-page page-title="d2l-demo">
 
 			<h2>Demo Snippet</h2>
 

--- a/components/icons/demo/icon-custom.html
+++ b/components/icons/demo/icon-custom.html
@@ -15,7 +15,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="d2l-icon-custom">
+		<d2l-demo-page page-title="d2l-icon-custom">
 
 			<h3>Tiers</h3>
 			<d2l-demo-snippet>

--- a/components/icons/demo/icon-custom.html
+++ b/components/icons/demo/icon-custom.html
@@ -15,7 +15,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="d2l-icon-custom">
+		<d2l-demo-page name="d2l-icon-custom">
 
 			<h3>Tiers</h3>
 			<d2l-demo-snippet>

--- a/components/icons/demo/icon.html
+++ b/components/icons/demo/icon.html
@@ -16,7 +16,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="d2l-icon">
+		<d2l-demo-page page-title="d2l-icon">
 
 			<h3>Tiers</h3>
 			<d2l-demo-snippet>

--- a/components/icons/demo/icon.html
+++ b/components/icons/demo/icon.html
@@ -16,7 +16,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="d2l-icon">
+		<d2l-demo-page name="d2l-icon">
 
 			<h3>Tiers</h3>
 			<d2l-demo-snippet>

--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -15,7 +15,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="Meter Components">
+		<d2l-demo-page name="Meter Components">
 
 			<h2>Meter Linear</h2>
 

--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -15,7 +15,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="Meter Components">
+		<d2l-demo-page page-title="Meter Components">
 
 			<h2>Meter Linear</h2>
 

--- a/components/more-less/demo/more-less.html
+++ b/components/more-less/demo/more-less.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="d2l-more-less">
+		<d2l-demo-page page-title="d2l-more-less">
 
 			<h2>More-less collapsed</h2>
 

--- a/components/more-less/demo/more-less.html
+++ b/components/more-less/demo/more-less.html
@@ -13,7 +13,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="d2l-more-less">
+		<d2l-demo-page name="d2l-more-less">
 
 			<h2>More-less collapsed</h2>
 

--- a/components/typography/demo/typography.html
+++ b/components/typography/demo/typography.html
@@ -12,7 +12,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page title="d2l-typography">
+		<d2l-demo-page name="d2l-typography">
 
 			<h2>Body</h2>
 

--- a/components/typography/demo/typography.html
+++ b/components/typography/demo/typography.html
@@ -12,7 +12,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page name="d2l-typography">
+		<d2l-demo-page page-title="d2l-typography">
 
 			<h2>Body</h2>
 


### PR DESCRIPTION
Noticed in @m6jones's list demo that the title was ending up as a tooltip on the entire demo. This is technically a breaking change, but I'll just go through the places using this and fix them.