### PR TITLE
not calculating if there's no parent

### DIFF
--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -131,7 +131,7 @@ class FloatingButtons extends RtlMixin(LitElement) {
 
 	_calcContainerPosition() {
 		this._floating = this._shouldFloat();
-		if (!this._floating) {
+		if (!this._floating || !this.offsetParent) {
 			return;
 		}
 


### PR DESCRIPTION
Noticed this error buried in the console when running the tests in Firefox only:

![Screen Shot 2019-08-16 at 2 58 11 PM](https://user-images.githubusercontent.com/5491151/63191643-00c2a000-c037-11e9-97a8-7cbe886d84e8.png)

I'm guessing this calculation is getting done either before, during or after the floating buttons have been removed from the DOM and no longer have an offsetParent. I tried reseting `_floating` to `false` in the disconnected callback but it didn't do anything.