### PR TITLE
only removing fill values that match ferrite

### DIFF
--- a/components/icons/fix-svg.js
+++ b/components/icons/fix-svg.js
@@ -2,7 +2,7 @@ export function fixSvg(svg) {
 
 	const fills = svg.querySelectorAll('[fill]');
 	fills.forEach((fill) => {
-		if (fill.getAttribute('fill') !== 'none') fill.removeAttribute('fill');
+		if (fill.getAttribute('fill').toLowerCase() === '#494c4e') fill.removeAttribute('fill');
 	});
 
 	svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');

--- a/components/icons/test/icon-custom.visual-diff.html
+++ b/components/icons/test/icon-custom.visual-diff.html
@@ -73,6 +73,16 @@
 		</div>
 		<div class="visual-diff">
 			<d2l-icon-demo-color-override>
+				<d2l-icon-custom size="tier2" id="fill-mixed">
+					<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+						<rect fill="#f9fbff" stroke-width="1" stroke="#868c8f" x="0.5" y="0.5" width="23" height="23" rx="5.5"/>
+						<path fill="#494c4e" d="M19.707,7.293a1,1,0,0,0-1.414,0L10,15.586,6.707,12.293a1,1,0,0,0-1.414,1.414l4,4a1,1,0,0,0,1.414,0l9-9A1,1,0,0,0,19.707,7.293Z"/>
+					</svg>
+				</d2l-icon-custom>
+			</d2l-icon-demo-color-override>
+		</div>
+		<div class="visual-diff">
+			<d2l-icon-demo-color-override>
 				<d2l-icon-custom size="tier3" id="color-override">
 					<svg width="30" height="30" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" mirror-in-rtl="true">
 						<path fill="#494c4e" d="M21.5,18H8.5a.5.5,0,0,1,0-1h13a.5.5,0,0,1,0,1Z"/>

--- a/components/icons/test/icon-custom.visual-diff.js
+++ b/components/icons/test/icon-custom.visual-diff.js
@@ -23,6 +23,7 @@ describe('d2l-icon-custom', function() {
 		'tier3',
 		'fill-none',
 		'fill-circle',
+		'fill-mixed',
 		'color-override',
 		'size-override',
 		'rtl-tier1',

--- a/components/icons/test/icon.visual-diff.html
+++ b/components/icons/test/icon.visual-diff.html
@@ -36,6 +36,11 @@
 		</div>
 		<div class="visual-diff">
 			<d2l-icon-demo-color-override>
+				<d2l-icon icon="tier2:check-box" id="fill-mixed"></d2l-icon>
+			</d2l-icon-demo-color-override>
+		</div>
+		<div class="visual-diff">
+			<d2l-icon-demo-color-override>
 				<d2l-icon icon="tier3:assignments" id="color-override"></d2l-icon>
 			</d2l-icon-demo-color-override>
 		</div>

--- a/components/icons/test/icon.visual-diff.js
+++ b/components/icons/test/icon.visual-diff.js
@@ -24,6 +24,7 @@ describe('d2l-icon', function() {
 		'prefixed',
 		'fill-none',
 		'fill-circle',
+		'fill-mixed',
 		'color-override',
 		'size-override',
 		'rtl-tier1',


### PR DESCRIPTION
I think this is our 3rd bug with this... we should have just [copied what the old fill-stripping code did](https://github.com/BrightspaceUI/icons/blob/v6.8.0/cli/iconset-builder.js#L16).

The bug here is that some of our icons (in this case [tier2:check-box](https://github.com/BrightspaceUI/core/blob/master/components/icons/images/tier2/check-box.svg?short_path=8d4168c)) contain fill colours other than ferrite and "none". If we strip them all, then when a new colour gets applied it will be applied to them all. Let's just strip ferrite -- at least things will be consistent.

This caused the following bug, where they were just trying to colour the checkbox blue:
![Screen Shot 2019-08-16 at 3 59 40 PM](https://user-images.githubusercontent.com/5491151/63195462-a2022400-c040-11e9-95b9-a86b15922b40.png)
