### PR TITLE
Add webpackChunkName hint

### DIFF
--- a/cli/icon-generator.js
+++ b/cli/icon-generator.js
@@ -74,7 +74,7 @@ function createLoader(categories) {
 	categories.forEach((category) => {
 		category.svgs.forEach((name) => {
 			template += `\t\tcase '${category.name}:${name}':
-			return import('./${category.name}/${name}.js');\n`;
+			return import(/* webpackChunkName: "icon-${name}" */'./${category.name}/${name}.js');\n`;
 		});
 	});
 


### PR DESCRIPTION
When webpack builds the icons we end up with generic, numbered names due to the dynamic imports:

![image](https://user-images.githubusercontent.com/2243995/63382174-ca9b5e00-c35f-11e9-9363-51562e76454d.png)

If we provide a `webpackChunkName` hint when generating the `presetIconLoader.js` file, we can get some more user-friendly output:

![image](https://user-images.githubusercontent.com/2243995/63382294-059d9180-c360-11e9-8c61-c46b4f39016a.png)