### PR TITLE
Moving requestIdleCallback shim .

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -21,8 +21,8 @@ import {clearDismissible, setDismissible} from '@brightspace-ui/core/helpers/dis
 // Call when component is made visible
 // to be notified of ESC key presses.
 const id = setDismissible(() => {
-	// Callback will be called if user presses ESC.
-	// Component should dismiss itself.
+    // Callback will be called if user presses ESC.
+    // Component should dismiss itself.
 });
 
 // Call when component is hidden or removed
@@ -54,6 +54,22 @@ getOffsetParent(node);
 
 // returns true/false whether the specified ancestorNode is an ancestor of node
 isComposedAncestor(ancestorNode, node);
+```
+
+## requestIdleCallback
+
+A simple shim for [requestIdleCallback](https://www.w3.org/TR/requestidlecallback/#the-requestidlecallback-method) and [cancelIdleCallback](https://www.w3.org/TR/requestidlecallback/#the-cancelidlecallback-method) that transparently falls back to `setTimeout` if it's not natively supported.
+
+### Usage
+
+The Google Developer update on [using requestIdleCallback](https://developers.google.com/web/updates/2015/08/using-requestidlecallback) has some excellent examples of usage. Provide a callback for non-essential work, and optionally a `timeout` after which the callback will be invoked regardless of activity on the main thread. A `deadline` object is passed with a `timeRemaining()` function and a `didTimeout` property, enabling the consumer to queue tasks across callbacks if necessary.
+
+```js
+import '@brightspace-ui/core/helpers/requestIdleCallback.js';
+
+requestIdleCallback((deadline) => {
+    // do some work
+}, { timeout: 1000 });
 ```
 
 ## UniqueId

--- a/helpers/requestIdleCallback.js
+++ b/helpers/requestIdleCallback.js
@@ -1,0 +1,16 @@
+// Shim copied from Google Developer Updates: https://developers.google.com/web/updates/2015/08/using-requestidlecallback
+window.requestIdleCallback = window.requestIdleCallback || function(cb) {
+	const start = Date.now();
+	return setTimeout(() => {
+		cb({
+			didTimeout: false,
+			timeRemaining: function() {
+				return Math.max(0, 50 - (Date.now() - start));
+			}
+		});
+	}, 1);
+};
+
+window.cancelIdleCallback = window.cancelIdleCallback || function(id) {
+	clearTimeout(id);
+};


### PR DESCRIPTION
This is the `requestIdleCallback` shim from `d2l-polymer-behaviors-ui`.  Currently, it appears that the shim is being included via menus, but is actually "used" by a couple of other repos.

* [d2l-menu](https://github.com/BrightspaceUI/menu/blob/660ab50f2c7bb843cd50a6c028c318c10a1d379e/d2l-menu.js#L16) imports the shim and uses it

The following usages query the `window` and fall back directly to `setTimeout` without shimming the API (we should update these to import this shim, and remove the `|| setTimeout` from them):
* [d2l-enrollment-card](https://github.com/BrightspaceHypermediaComponents/enrollments/blob/49ec9a20366059f1a9f0b9d00b9ee5cc4a612fa8/components/d2l-enrollment-card/d2l-enrollment-card.js#L442)
* [d2l-course-image-tile](https://github.com/BrightspaceHypermediaComponents/1.x-hybrid-components/blob/876adbc5a115637633eecb6ef34a1bb49e2f878c/components/d2l-course-image-tile/d2l-course-image-tile.html#L448)
* [d2l-course-image](https://github.com/Brightspace/course-image/blob/a90779d33c4c0e7cbc0c0bca957adb0f9c5b3b26/d2l-course-image.js#L104)
* [d2l-course-tile](https://github.com/Brightspace/d2l-my-courses-ui/blob/6af1f6ae58add9996d4effab7f802509c76e415b/legacy/tile-grid/d2l-course-tile.js#L269)

Once this is merged, we can update the import in `d2l-menu`, and remove the shim from `d2l-polymer-behaviors-ui`.