### PR TITLE
ignoring intl-messageformat greenkeeper updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,10 @@
     "lit-element": "^2",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "intl-messageformat"
+    ]
   }
 }


### PR DESCRIPTION
Tired of getting notifications about this every week. We can't upgrade `intl-messageformat` until either `app-localize-behavior` upgrades or we stop using it. Tracked in #148.