### PR TITLE
fixes #188: if percent rounds to zero, don't display visual lines

### DIFF
--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -49,7 +49,9 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 
 	render() {
 		const lengthOfLine = 21 * Math.PI * 2; // approximation perimeter of circle
-		const progressFill = this.value / this.max * lengthOfLine;
+		const percent = (this.value / this.max);
+		const visibility = (percent < 0.005) ? 'hidden' : 'visible';
+		const progressFill = percent * lengthOfLine;
 		const space = lengthOfLine - progressFill;
 		const dashOffset = this.dir === 'rtl' ? 7 * Math.PI + 10 - space : 7 * Math.PI * 2 - 10; // approximation perimeter of circle divide by 3 subtract the rounded edges (5 pixels each)
 
@@ -64,7 +66,7 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 					cx="24" cy="24" r="21"
 					stroke-dasharray="${progressFill} ${space}"
 					stroke-dashoffset="${dashOffset}"
-					visibility="${this.value ? 'visible' : 'hidden'}"></circle>
+					visibility="${visibility}"></circle>
 
 				<text class="d2l-body-standard d2l-meter-circle-text" x="24" y="28" text-anchor="middle">
 					${primary}

--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -96,7 +96,10 @@ class MeterLinear extends MeterMixin(RtlMixin(LitElement)) {
 	}
 
 	render() {
-		const percentage = this.max > 0 ? this.value / this.max * 100 : 0;
+		let percentage = this.max > 0 ? this.value / this.max * 100 : 0;
+		if (percentage < 0.5) {
+			percentage = 0;
+		}
 		const primary = this._primary(this.value, this.max, this.dir);
 		const secondary = this._secondary(this.value, this.max, this.text);
 		const textClasses =  {

--- a/components/meter/meter-radial.js
+++ b/components/meter/meter-radial.js
@@ -57,8 +57,9 @@ class MeterRadial extends MeterMixin(RtlMixin(LitElement)) {
 
 	render() {
 		const lengthOfLine = 115; // found by approximating half the perimeter of the ellipse with radii 38 and 35
-		const progressFill = this.value / this.max * lengthOfLine;
-
+		const percent = (this.value / this.max);
+		const visibility = (percent < 0.005) ? 'hidden' : 'visible';
+		const progressFill = percent * lengthOfLine;
 		const primary = this._primary(this.value, this.max, this.dir);
 		const secondary = this._secondary(this.value, this.max, this.text);
 		const secondaryTextElement = this.text ? html`<div class="d2l-body-small d2l-meter-radial-text">${secondary}</div>` : html``;
@@ -74,7 +75,7 @@ class MeterRadial extends MeterMixin(RtlMixin(LitElement)) {
 						d="M5 40a37 35 0 0 1 74 0"
 						stroke-dasharray="${progressFill} ${lengthOfLine}"
 						stroke-dashoffset="${this.dir === 'rtl' ? progressFill - lengthOfLine : 0}"
-						visibility="${this.value ? 'visible' : 'hidden'}" />
+						visibility="${visibility}" />
 					<text class="d2l-heading-4 d2l-meter-radial-text" x="38" y="2" text-anchor="middle"  transform="translate(5 39)">
 						${primary}
 					</text>

--- a/components/meter/test/meter-circle.visual-diff.html
+++ b/components/meter/test/meter-circle.visual-diff.html
@@ -23,6 +23,9 @@
 	<div class="visual-diff" style="width: 90px;">
 		<d2l-meter-circle id="completed" value="5" max="5"></d2l-meter-circle>
 	</div>
+	<div class="visual-diff" style="width: 90px;">
+		<d2l-meter-circle id="round-to-zero" value="0.004" max="100"></d2l-meter-circle>
+	</div>
 	<!-- Test scaled versions-->
 	<div class="visual-diff" style="width: 170px;">
 		<d2l-meter-circle id="no-progress-scaled" value="0" max="10"  style="width: 300%;"></d2l-meter-circle>

--- a/components/meter/test/meter-circle.visual-diff.js
+++ b/components/meter/test/meter-circle.visual-diff.js
@@ -21,6 +21,7 @@ describe('d2l-meter-circle', function() {
 		{ title: 'no-progress', fixture: '#no-progress'},
 		{ title: 'has-progress', fixture: '#has-progress'},
 		{ title: 'completed', fixture: '#completed'},
+		{ title: 'round-to-zero', fixture: '#round-to-zero'},
 		{ title: 'no-progress-scaled', fixture: '#no-progress-scaled'},
 		{ title: 'has-progress-scaled', fixture: '#has-progress-scaled'},
 		{ title: 'completed-scaled', fixture: '#completed-scaled'},

--- a/components/meter/test/meter-linear.visual-diff.html
+++ b/components/meter/test/meter-linear.visual-diff.html
@@ -25,6 +25,9 @@
 	<div class="visual-diff" style="width: 250px;">
 		<d2l-meter-linear id="max-zero" value="0" max="0" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
+	<div class="visual-diff" style="width: 250px;">
+		<d2l-meter-linear id="round-to-zero" value="0.004" max="100" text="Visited: {x/y}" percent></d2l-meter-linear>
+	</div>
 	<!-- rtl versions-->
 	<div class="visual-diff" style="width: 250px;">
 		<d2l-meter-linear dir="rtl" id="no-progress-rtl" value="0" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>

--- a/components/meter/test/meter-linear.visual-diff.js
+++ b/components/meter/test/meter-linear.visual-diff.js
@@ -22,6 +22,7 @@ describe('d2l-meter-linear', function() {
 		{ title: 'has-progress', fixture: '#has-progress'},
 		{ title: 'completed', fixture: '#completed'},
 		{ title: 'max-zero', fixture: '#max-zero'},
+		{ title: 'round-to-zero', fixture: '#round-to-zero'},
 		{ title: 'no-progress-rtl', fixture: '#no-progress-rtl'},
 		{ title: 'has-progress-rtl', fixture: '#has-progress-rtl'},
 		{ title: 'completed-rtl', fixture: '#completed-rtl'},

--- a/components/meter/test/meter-radial.visual-diff.html
+++ b/components/meter/test/meter-radial.visual-diff.html
@@ -23,6 +23,9 @@
 	<div class="visual-diff" style="width: 90px;">
 		<d2l-meter-radial id="completed" value="256" max="256" style="display: block;"></d2l-meter-radial>
 	</div>
+	<div class="visual-diff" style="width: 90px;">
+		<d2l-meter-radial id="round-to-zero" value="0.004" max="100" style="display: block;"></d2l-meter-radial>
+	</div>
 	<!-- Test scaled versions-->
 	<div class="visual-diff" style="width: 170px;">
 		<d2l-meter-radial id="no-progress-scaled" value="0" max="10"  style="width: 300%;" text="Completed"></d2l-meter-radial>

--- a/components/meter/test/meter-radial.visual-diff.js
+++ b/components/meter/test/meter-radial.visual-diff.js
@@ -21,6 +21,7 @@ describe('d2l-meter-radial', function() {
 		{ title: 'no-progress', fixture: '#no-progress'},
 		{ title: 'has-progress', fixture: '#has-progress'},
 		{ title: 'completed', fixture: '#completed'},
+		{ title: 'round-to-zero', fixture: '#round-to-zero'},
 		{ title: 'no-progress-scaled', fixture: '#no-progress-scaled'},
 		{ title: 'has-progress-scaled', fixture: '#has-progress-scaled'},
 		{ title: 'completed-scaled', fixture: '#completed-scaled'},


### PR DESCRIPTION
See #188 for details. Essentially, when we render out the percent, the percent formatter rounds things to the nearest percent. So `0.4%` rounds down to `0%`. But we were still showing part of the linear/radial graph, which was confusing.

This changes it up so that if the percent rounds down to zero, we don't render any of the graph.