### PR TITLE
Localize refactor

### DIFF
--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -2,6 +2,7 @@ import '../button/button-subtle.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { getComposedChildren, isComposedAncestor } from '../../helpers/dom.js';
 import { classMap} from 'lit-html/directives/class-map.js';
+import { dispatchRenderEvent } from '../../helpers/dispatchRenderEvent.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeMixin } from '../../mixins/localize-mixin.js';
@@ -183,11 +184,11 @@ class MoreLess extends LocalizeMixin(LitElement)  {
 	}
 
 	render() {
+		dispatchRenderEvent(this);
 		const contentClasses = {
 			'more-less-content': true,
 			'more-less-transition': this.__transitionAdded
 		};
-
 		return html`
 			<div id="${this.__contentId}" class=${classMap(contentClasses)} style=${styleMap({ height: `${this.__contentHeight}` })}>
 				<slot></slot>

--- a/components/more-less/test/more-less.html
+++ b/components/more-less/test/more-less.html
@@ -43,7 +43,7 @@
 			describe('d2l-more-less', () => {
 				let moreless, content;
 
-				function waitForInitialization() {
+				function waitForHeight() {
 					return new Promise((resolve) => {
 						function check() {
 							content = moreless.shadowRoot.querySelector('.more-less-content');
@@ -54,7 +54,15 @@
 								setTimeout(() => resolve(), 400);
 							}
 						}
-						moreless.addEventListener('d2l-element-render', () => check());
+						check();
+					});
+				}
+
+				function waitForRender() {
+					return new Promise((resolve) => {
+						moreless.addEventListener('d2l-element-render', () => {
+							resolve();
+						});
 					});
 				}
 
@@ -62,7 +70,8 @@
 
 					beforeEach(async() => {
 						moreless = fixture('basic');
-						await waitForInitialization();
+						await waitForRender();
+						await waitForHeight();
 					});
 
 					it('should pass all axe tests', async() => {
@@ -75,7 +84,8 @@
 
 					beforeEach(async() => {
 						moreless = fixture('expanded-dynamic');
-						await waitForInitialization();
+						await waitForRender();
+						await waitForHeight();
 					});
 
 					it('should pass all axe tests when expanded', async() => {
@@ -83,19 +93,18 @@
 					});
 
 					it('should expand when more content is dynamically added', async() => {
+
 						const previousContentHeight = content.scrollHeight;
 						expect(moreless.offsetHeight).to.be.above(content.scrollHeight);
 
 						const p = document.getElementById('clone-target');
 						content.appendChild(p.cloneNode(true));
 
-						return new Promise(resolve => {
-							waitForInitialization(() => {
-								expect(content.scrollHeight).to.be.above(previousContentHeight);
-								expect(moreless.offsetHeight).to.be.above(content.scrollHeight);
-								resolve();
-							});
-						});
+						await waitForHeight();
+
+						expect(content.scrollHeight).to.be.above(previousContentHeight);
+						expect(moreless.offsetHeight).to.be.above(content.scrollHeight);
+
 					});
 
 				});

--- a/components/more-less/test/more-less.html
+++ b/components/more-less/test/more-less.html
@@ -43,25 +43,26 @@
 			describe('d2l-more-less', () => {
 				let moreless, content;
 
-				function waitForInitialization(callback) {
-					if (content.style.height === '') {
-						setTimeout(() => { waitForInitialization(callback);}, 10);
-					} else {
-						setTimeout(() => { // Need the second timeout here to give the transition a chance to finish
-							callback();
-						}, 400);
-					}
+				function waitForInitialization() {
+					return new Promise((resolve) => {
+						function check() {
+							content = moreless.shadowRoot.querySelector('.more-less-content');
+							if (content.style.height === '') {
+								setTimeout(() => check(), 10);
+							} else {
+								// Need the second timeout here to give the transition a chance to finish
+								setTimeout(() => resolve(), 400);
+							}
+						}
+						moreless.addEventListener('d2l-element-render', () => check());
+					});
 				}
 
 				describe('basic', () => {
 
 					beforeEach(async() => {
 						moreless = fixture('basic');
-						await moreless.updateComplete;
-						content = moreless.shadowRoot.querySelector('.more-less-content');
-						await new Promise(resolve => {
-							waitForInitialization(resolve);
-						});
+						await waitForInitialization();
 					});
 
 					it('should pass all axe tests', async() => {
@@ -74,11 +75,7 @@
 
 					beforeEach(async() => {
 						moreless = fixture('expanded-dynamic');
-						await moreless.updateComplete;
-						content = moreless.shadowRoot.querySelector('.more-less-content');
-						await new Promise(resolve => {
-							waitForInitialization(resolve);
-						});
+						await waitForInitialization();
 					});
 
 					it('should pass all axe tests when expanded', async() => {

--- a/helpers/dispatchRenderEvent.js
+++ b/helpers/dispatchRenderEvent.js
@@ -1,0 +1,9 @@
+export function dispatchRenderEvent(elem) {
+	const e = new CustomEvent('d2l-element-render', {
+		bubbles: false,
+		composed: false
+	});
+	requestAnimationFrame(
+		() => elem.dispatchEvent(e)
+	);
+}

--- a/helpers/localization.js
+++ b/helpers/localization.js
@@ -1,0 +1,166 @@
+import d2lIntl from 'd2l-intl';
+import IntlMessageFormat from 'intl-messageformat/src/main.js';
+window.IntlMessageFormat = IntlMessageFormat;
+
+let documentLanguage = 'en';
+let documentLanguageFallback = 'en';
+let hasInit = false;
+const listeners = [];
+let htmlElem = null;
+let timezoneObject = {name: '', identifier: ''};
+let overrides = {};
+
+const observer = new MutationObserver((mutations) => {
+
+	let changed = false;
+	for (let i = 0; i < mutations.length; i++) {
+		const mutation = mutations[i];
+		if (mutation.attributeName === 'lang') {
+			documentLanguage = htmlElem.getAttribute('lang');
+			changed = true;
+		} else if (mutation.attributeName === 'data-lang-default') {
+			documentLanguageFallback = htmlElem.getAttribute('data-lang-default');
+			changed = true;
+		} else if (mutation.attributeName === 'data-intl-overrides') {
+			overrides = tryParseHtmlElemAttr('data-intl-overrides', {});
+		} else if (mutation.attributeName === 'data-timezone') {
+			timezoneObject = tryParseHtmlElemAttr('data-timezone', {name: '', identifier: ''});
+		}
+	}
+
+	if (changed) {
+		listeners.forEach((cb) => cb(documentLanguage, documentLanguageFallback));
+	}
+
+});
+
+function init() {
+
+	if (hasInit) return;
+	hasInit = true;
+
+	htmlElem = window.document.getElementsByTagName('html')[0];
+	documentLanguage = htmlElem.getAttribute('lang');
+	documentLanguageFallback = htmlElem.getAttribute('data-lang-default');
+	overrides = tryParseHtmlElemAttr('data-intl-overrides', {});
+	timezoneObject = tryParseHtmlElemAttr('data-timezone', {name: '', identifier: ''});
+
+	observer.observe(htmlElem, { attributes: true });
+
+}
+
+function tryParseHtmlElemAttr(attrName, defaultValue) {
+	if (htmlElem.hasAttribute(attrName)) {
+		try {
+			return JSON.parse(htmlElem.getAttribute(attrName));
+		} catch (e) {
+			// swallow exception
+		}
+	}
+	return defaultValue;
+}
+
+export function addListener(cb) {
+	init();
+	listeners.push(cb);
+	cb(documentLanguage, documentLanguageFallback);
+}
+
+export function removeListener(cb) {
+	const index = listeners.indexOf(cb);
+	if (index < 0) return;
+	listeners.splice(index, 1);
+	if (listeners.length === 0) {
+		observer.disconnect();
+		hasInit = false;
+	}
+}
+
+export function formatDateTime(language, val, opts) {
+	opts = opts || {};
+	opts.locale = overrides;
+	opts.timezone = opts.timezone || timezoneObject.name;
+	const formatter = new d2lIntl.DateTimeFormat(language, opts);
+	return formatter.format(val);
+}
+
+export function formatDate(language, val, opts) {
+	opts = opts || {};
+	opts.locale = overrides;
+	opts.timezone = opts.timezone || timezoneObject.name;
+	const formatter = new d2lIntl.DateTimeFormat(language, opts);
+	return formatter.formatDate(val);
+}
+
+export function formatFileSize(language, val) {
+	const formatter = new d2lIntl.FileSizeFormat(language);
+	return formatter.format(val);
+}
+
+export function formatNumber(language, val, opts) {
+	opts = opts || {};
+	opts.locale = overrides;
+	const formatter = new d2lIntl.NumberFormat(language, opts);
+	return formatter.format(val);
+}
+
+export function formatTime(language, val, opts) {
+	opts = opts || {};
+	opts.locale = overrides;
+	opts.timezone = opts.timezone || timezoneObject.name;
+	const formatter = new d2lIntl.DateTimeFormat(language, opts);
+	return formatter.formatTime(val);
+}
+
+export function parseDate(language, val) {
+	const parser = new d2lIntl.DateTimeParse(
+		language,
+		{ locale: overrides }
+	);
+	return parser.parseDate(val);
+}
+
+export function parseNumber(language, val, opts) {
+	opts = opts || {};
+	opts.locale = overrides;
+	const parser = new d2lIntl.NumberParse(language, opts);
+	return parser.parse(val);
+}
+
+export function parseTime(language, val) {
+	const parser = new d2lIntl.DateTimeParse(language);
+	return parser.parseTime(val);
+}
+
+export function getDocumentLanguage() {
+	init();
+	return documentLanguage;
+}
+
+export function getDocumentLanguageFallback() {
+	init();
+	return documentLanguageFallback;
+}
+
+export function getTimezone() {
+	init();
+	return timezoneObject;
+}
+
+export function localize(key, resources, language, replacements) {
+
+	init();
+
+	if (!key || !resources || !language) {
+		return '';
+	}
+
+	const translatedValue = resources[key];
+	if (!translatedValue) {
+		return '';
+	}
+
+	const translatedMessage = new IntlMessageFormat(translatedValue, language);
+	return translatedMessage.format(replacements);
+
+}

--- a/index.html
+++ b/index.html
@@ -43,5 +43,10 @@
 		<li><a href="helpers/demo/dismissible.html">dismissible</a></li>
 	</ul>
 
+	<h2 class="d2l-heading-3">Mixins</h2>
+	<ul>
+		<li><a href="mixins/demo/localize-mixin.html">localize-mixin</a></li>
+	</ul>
+
 </body>
 </html>

--- a/mixins/demo/localize-mixin.html
+++ b/mixins/demo/localize-mixin.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '../../components/demo/demo-page.js';
+			import './localize-test.js';
+		</script>
+	</head>
+	<body unresolved>
+		<d2l-demo-page page-title="localize-mixin">
+
+			<div style="margin-bottom: 1rem;">
+				<label>Language:
+					<select id="langSwitcher">
+						<option value="ar">Arabic</option>
+						<option value="de">German</option>
+						<option value="en" selected="">English</option>
+						<option value="en-CA">English (Canada)</option>
+						<option value="es">Spanish</option>
+						<option value="fr">French</option>
+						<option value="ja">Japanese</option>
+						<option value="ko">Korean</option>
+						<option value="pt-BR">Portuguese</option>
+						<option value="sv">Swedish</option>
+						<option value="tr">Turkish</option>
+						<option value="zh-CN">Chinese (Simplified)</option>
+						<option value="zh-TW">Chinese (Traditional)</option>
+					</select>
+				</label>
+			</div>
+			<d2l-demo-snippet>
+				<d2l-test-localize name="Bill"></d2l-test-localize>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+		<script>
+			const langSwitcher = document.getElementById('langSwitcher');
+			langSwitcher.addEventListener('change', () => {
+				const value = langSwitcher.options[langSwitcher.selectedIndex].value;
+				document.documentElement.setAttribute('lang', value);
+			});
+		</script>
+	</body>
+</html>

--- a/mixins/demo/localize-test.js
+++ b/mixins/demo/localize-test.js
@@ -1,12 +1,13 @@
-import { LitElement } from 'lit-element/lit-element.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
 import { LocalizeMixin } from '../../mixins/localize-mixin.js';
 
-class LocalizeTestElem extends LocalizeMixin(LitElement) {
+class LocalizeTest extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
-			date: { attribute: false },
-			number: { type: Number }
+			name: {
+				type: String
+			}
 		};
 	}
 
@@ -39,11 +40,17 @@ class LocalizeTestElem extends LocalizeMixin(LitElement) {
 		return null;
 	}
 
-	constructor() {
-		super();
-
-		this.date = new Date();
+	render() {
+		const date = new Date();
+		return html`
+			<p>Text: ${this.localize('hello', 'name', this.name)}</p>
+			<p>Number: ${this.formatNumber(123456.789)}</p>
+			<p>Date: ${this.formatDate(date)}</p>
+			<p>Time: ${this.formatTime(date)}</p>
+			<p>Date &amp; time: ${this.formatDateTime(date)}</p>
+			<p>File size: ${this.formatFileSize(123456789)}</p>
+		`;
 	}
 }
 
-customElements.define('localize-test-elem', LocalizeTestElem);
+customElements.define('d2l-test-localize', LocalizeTest);

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -55,14 +55,6 @@ export const LocalizeMixin = superclass => class extends superclass {
 		return super.shouldUpdate();
 	}
 
-	localize(key) {
-		const args = {};
-		for (let i = 1; i < arguments.length; i += 2) {
-			args[arguments[i]] = arguments[i + 1];
-		}
-		return localize(key, this.__resources, this.__language, args);
-	}
-
 	getTimezone() {
 		return getTimezone();
 	}
@@ -85,6 +77,14 @@ export const LocalizeMixin = superclass => class extends superclass {
 
 	formatTime(val, opts) {
 		return formatTime(this.__language, val, opts);
+	}
+
+	localize(key) {
+		const args = {};
+		for (let i = 1; i < arguments.length; i += 2) {
+			args[arguments[i]] = arguments[i + 1];
+		}
+		return localize(key, this.__resources, this.__language, args);
 	}
 
 	parseDate(val) {

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -1,52 +1,49 @@
-import d2lIntl from 'd2l-intl';
-import IntlMessageFormat from 'intl-messageformat/src/main.js';
-window.IntlMessageFormat = IntlMessageFormat;
+import {
+	addListener, formatDate, formatDateTime, formatFileSize, formatNumber,
+	formatTime, getTimezone, localize, parseDate, parseNumber,
+	parseTime, removeListener
+} from '../helpers/localization.js';
 
 export const LocalizeMixin = superclass => class extends superclass {
 
 	static get properties() {
 		return {
-			__documentLanguage: { type: String },
-			__documentLanguageFallback: { type: String },
 			__language: { type: String },
-			__overrides: { type: Object },
-			__resources: { type: Object },
-			__timezoneObject: { type: Object },
-			__timezone: { type: String }
+			__resources: { type: Object }
 		};
 	}
 
 	constructor() {
 		super();
 
-		this.__documentLanguage = window.document.getElementsByTagName('html')[0].getAttribute('lang');
-		this.__documentLanguageFallback = window.document.getElementsByTagName('html')[0].getAttribute('data-lang-default');
+		let first = true;
+		this.__languageChangeCallback = (documentLanguage, documentLanguageFallback) => {
+			const possibleLanguages = this._generatePossibleLanguages(documentLanguage, documentLanguageFallback);
+			this.constructor.getLocalizeResources(possibleLanguages)
+				.then((res) => {
+					if (!res) {
+						return;
+					}
+					this.__language = res.language;
+					this.__resources = res.resources;
+					if (first) {
+						first = false;
+					} else {
+						this._languageChange();
+					}
+				});
+		};
 
-		this.__overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
-		this.__timezoneObject = this._tryParseHtmlElemAttr('data-timezone', {name: '', identifier: ''});
-		this.__timezone = this._computeTimezone();
-
-		this._startObserver();
 	}
 
-	updated(changedProperties) {
-		changedProperties.forEach((oldValue, propName) => {
-			if (propName === '__documentLanguage' || propName === '__documentLanguageFallback') {
-				const possibleLanguages = this._generatePossibleLanguages(this.__documentLanguage, this.__documentLanguageFallback);
+	connectedCallback() {
+		super.connectedCallback();
+		addListener(this.__languageChangeCallback);
+	}
 
-				this.constructor.getLocalizeResources(possibleLanguages)
-					.then((res) => {
-						if (!res) {
-							return;
-						}
-						this.__language = res.language;
-						this.__resources = res.resources;
-						this._languageChange();
-					});
-			} else if (propName === '__timezoneObject') {
-				this._timezoneChange();
-			}
-		});
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		removeListener(this.__languageChangeCallback);
 	}
 
 	localize(key) {
@@ -54,88 +51,43 @@ export const LocalizeMixin = superclass => class extends superclass {
 		for (let i = 1; i < arguments.length; i += 2) {
 			args[arguments[i]] = arguments[i + 1];
 		}
-
-		return this._computeLocalize(this.__language, this.__resources, key, args);
+		return localize(key, this.__resources, this.__language, args);
 	}
 
 	getTimezone() {
-		return this.__timezoneObject;
+		return getTimezone();
 	}
 
 	formatDateTime(val, opts) {
-		opts = opts || {};
-		opts.locale = this.__overrides;
-		opts.timezone = opts.timezone || this.__timezone;
-		const formatter = new d2lIntl.DateTimeFormat(this.__language, opts);
-		return formatter.format(val);
+		return formatDateTime(this.__language, val, opts);
 	}
 
 	formatDate(val, opts) {
-		opts = opts || {};
-		opts.locale = this.__overrides;
-		opts.timezone = opts.timezone || this.__timezone;
-		const formatter = new d2lIntl.DateTimeFormat(this.__language, opts);
-		return formatter.formatDate(val);
+		return formatDate(this.__language, val, opts);
 	}
 
 	formatFileSize(val) {
-		const formatter = new d2lIntl.FileSizeFormat(this.__language);
-		return formatter.format(val);
+		return formatFileSize(this.__language, val);
 	}
 
 	formatNumber(val, opts) {
-		opts = opts || {};
-		opts.locale = this.__overrides;
-		const formatter = new d2lIntl.NumberFormat(this.__language, opts);
-		return formatter.format(val);
+		return formatNumber(this.__language, val, opts);
 	}
 
 	formatTime(val, opts) {
-		opts = opts || {};
-		opts.locale = this.__overrides;
-		opts.timezone = opts.timezone || this.__timezone;
-		const formatter = new d2lIntl.DateTimeFormat(this.__language, opts);
-		return formatter.formatTime(val);
+		return formatTime(this.__language, val, opts);
 	}
 
 	parseDate(val) {
-		const parser = new d2lIntl.DateTimeParse(
-			this.__language,
-			{ locale: this.__overrides }
-		);
-		return parser.parseDate(val);
+		return parseDate(this.__language, val);
 	}
 
 	parseNumber(val, opts) {
-		opts = opts || {};
-		opts.locale = this.__overrides;
-		const parser = new d2lIntl.NumberParse(this.__language, opts);
-		return parser.parse(val);
+		return parseNumber(this.__language, val, opts);
 	}
 
 	parseTime(val) {
-		const parser = new d2lIntl.DateTimeParse(this.__language);
-		return parser.parseTime(val);
-	}
-
-	_startObserver() {
-		const htmlElem = window.document.getElementsByTagName('html')[0];
-
-		this._observer = new MutationObserver((mutations) => {
-			for (let i = 0; i < mutations.length; i++) {
-				const mutation = mutations[i];
-				if (mutation.attributeName === 'lang') {
-					this.__documentLanguage = htmlElem.getAttribute('lang');
-				} else if (mutation.attributeName === 'data-lang-default') {
-					this.__documentLanguageFallback = htmlElem.getAttribute('data-lang-default');
-				} else if (mutation.attributeName === 'data-intl-overrides') {
-					this.__overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
-				} else if (mutation.attributeName === 'data-timezone') {
-					this.__timezoneObject = this._tryParseHtmlElemAttr('data-timezone', {name: '', identifier: ''});
-				}
-			}
-		});
-		this._observer.observe(htmlElem, { attributes: true });
+		return parseTime(this.__language, val);
 	}
 
 	_generatePossibleLanguages(docLang, docFallbackLang) {
@@ -166,45 +118,10 @@ export const LocalizeMixin = superclass => class extends superclass {
 		return langs;
 	}
 
-	_computeTimezone() {
-		return this.__timezoneObject && this.__timezoneObject.name;
-	}
-
 	_languageChange() {
 		this.dispatchEvent(new CustomEvent(
 			'd2l-localize-behavior-language-changed', { bubbles: true, composed: true }
 		));
 	}
 
-	_timezoneChange() {
-		this.dispatchEvent(new CustomEvent(
-			'd2l-localize-behavior-timezone-changed', { bubbles: true, composed: true }
-		));
-	}
-
-	_computeLocalize(language, resources, key, args) {
-		if (!key || !resources || !language)
-			return;
-
-		const translatedValue = resources[key];
-		if (!translatedValue) {
-			return '';
-		}
-
-		const translatedMessage = new IntlMessageFormat(translatedValue, language);
-
-		return translatedMessage.format(args);
-	}
-
-	_tryParseHtmlElemAttr(attrName, defaultValue) {
-		const htmlElems = window.document.getElementsByTagName('html');
-		if (htmlElems.length === 1 && htmlElems[0].hasAttribute(attrName)) {
-			try {
-				return JSON.parse(htmlElems[0].getAttribute(attrName));
-			} catch (e) {
-				// swallow exception
-			}
-		}
-		return defaultValue;
-	}
 };

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -46,6 +46,15 @@ export const LocalizeMixin = superclass => class extends superclass {
 		removeListener(this.__languageChangeCallback);
 	}
 
+	shouldUpdate() {
+		const ready = this.__language !== undefined
+			&& this.__resources !== undefined;
+		if (!ready) {
+			return false;
+		}
+		return super.shouldUpdate();
+	}
+
 	localize(key) {
 		const args = {};
 		for (let i = 1; i < arguments.length; i += 2) {

--- a/mixins/test/localize-mixin.html
+++ b/mixins/test/localize-mixin.html
@@ -172,15 +172,15 @@
 						await elem.updateComplete;
 					});
 					it('should localize text', () => {
-						const val = elem.localize('hello');
-						expect(val).to.equal('Hello');
+						const val = elem.localize('hello', 'name', 'Bill');
+						expect(val).to.equal('Hello Bill');
 					});
 					it('should re-localize text when locale changes', (done) => {
-						const valInitial = elem.localize('hello');
-						expect(valInitial).to.equal('Hello');
+						const valInitial = elem.localize('hello', 'name', 'Sam');
+						expect(valInitial).to.equal('Hello Sam');
 						const myEventListener = () => {
-							const val = elem.localize('hello');
-							expect(val).to.equal('Bonjour');
+							const val = elem.localize('hello', 'name', 'Mary');
+							expect(val).to.equal('Bonjour Mary');
 							elem.removeEventListener('d2l-localize-behavior-language-changed', myEventListener);
 							done();
 						};
@@ -346,19 +346,15 @@
 						expect(elem.getTimezone().name).to.equal('');
 						expect(elem.getTimezone().identifier).to.equal('');
 					});
-					it('should update timezone if "data-timezone" gets set', (done) => {
+					it('should update timezone if "data-timezone" gets set', async () => {
 						elem = fixture('basic');
-						const myEventListener = () => {
-							expect(elem.getTimezone().name).to.equal('foo');
-							expect(elem.getTimezone().identifier).to.equal('bar');
-							elem.removeEventListener('d2l-localize-behavior-timezone-changed', myEventListener);
-							done();
-						};
-						elem.addEventListener('d2l-localize-behavior-timezone-changed', myEventListener);
 						htmlElem.setAttribute(
 							'data-timezone',
 							JSON.stringify({ name: 'foo', identifier: 'bar' })
 						);
+						await elem.updateComplete;
+						expect(elem.getTimezone().name).to.equal('foo');
+						expect(elem.getTimezone().identifier).to.equal('bar');
 					});
 				});
 			});

--- a/mixins/test/localize-mixin.html
+++ b/mixins/test/localize-mixin.html
@@ -9,17 +9,17 @@
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
-		<script type="module" src="./localize-test-elem.js"></script>
+		<script type="module" src="../demo/localize-test.js"></script>
 	</head>
 	<body>
 		<test-fixture id="basic">
 			<template>
-				<localize-test-elem></localize-test-elem>
+				<d2l-test-localize></d2l-test-localize>
 			</template>
 		</test-fixture>
 		<test-fixture id="lang-set">
 			<template>
-				<localize-test-elem __language="fr"></localize-test-elem>
+				<d2l-test-localize __language="fr"></d2l-test-localize>
 			</template>
 		</test-fixture>
 
@@ -346,7 +346,7 @@
 						expect(elem.getTimezone().name).to.equal('');
 						expect(elem.getTimezone().identifier).to.equal('');
 					});
-					it('should update timezone if "data-timezone" gets set', async () => {
+					it('should update timezone if "data-timezone" gets set', async() => {
 						elem = fixture('basic');
 						htmlElem.setAttribute(
 							'data-timezone',

--- a/mixins/test/localize-test-elem.js
+++ b/mixins/test/localize-test-elem.js
@@ -12,19 +12,19 @@ class LocalizeTestElem extends LocalizeMixin(LitElement) {
 
 	static async getLocalizeResources(langs) {
 		const langResources = {
-			'ar': { 'hello': 'مرحبا' },
-			'de': { 'hello': 'Hallo' },
-			'en': { 'hello': 'Hello' },
-			'en-ca': { 'hello': 'Hello, eh' },
-			'es': { 'hello': 'Hola' },
-			'fr': { 'hello': 'Bonjour' },
-			'ja': { 'hello': 'こんにちは' },
-			'ko': { 'hello': '안녕하세요' },
-			'pt-br': { 'hello': 'Olá' },
-			'sv': { 'hello': 'Hallå' },
-			'tr': { 'hello': 'Merhaba' },
-			'zh-cn': { 'hello': '你好' },
-			'zh-tw': { 'hello': '你好' }
+			'ar': { 'hello': 'مرحبا {name}' },
+			'de': { 'hello': 'Hallo {name}' },
+			'en': { 'hello': 'Hello {name}' },
+			'en-ca': { 'hello': 'Hello, {name} eh' },
+			'es': { 'hello': 'Hola {name}' },
+			'fr': { 'hello': 'Bonjour {name}' },
+			'ja': { 'hello': 'こんにちは {name}' },
+			'ko': { 'hello': '안녕하세요 {name}' },
+			'pt-br': { 'hello': 'Olá {name}' },
+			'sv': { 'hello': 'Hallå {name}' },
+			'tr': { 'hello': 'Merhaba {name}' },
+			'zh-cn': { 'hello': '你好 {name}' },
+			'zh-tw': { 'hello': '你好 {name}' }
 		};
 
 		for (let i = 0; i < langs.length; i++) {


### PR DESCRIPTION
This splits out most of the localization code out of the mixin and into a separate importable module. The motivation is to allow our older Polymer `localize-behavior` to also import this code and reference it directly, instead of having its own copy.

Not only will that centralize all our localization code, but it will allow us to abandon `app-localize-behavior` and upgrade `intl-messageformat` at our leisure.

This also fixes #118, since only a single observer is installed on the page instead of one per element.