### PR TITLE
d2l-list - Reporting and Modify Selections - (4/5)

### DIFF
--- a/components/list/demo/list-demo-control.js
+++ b/components/list/demo/list-demo-control.js
@@ -127,7 +127,6 @@ class ListDemoControl extends LitElement {
 	}
 
 	_onListChange(event) {
-		console.log('here');
 		const list = event.target;
 		const selectAll = this.shadowRoot.querySelector('.select-all');
 		this._numberSelected = event.detail.selectedItems.length;

--- a/components/list/demo/list-demo-control.js
+++ b/components/list/demo/list-demo-control.js
@@ -41,14 +41,19 @@ class ListDemoControl extends LitElement {
 		`];
 	}
 
+	constructor() {
+		super();
+		this._onListChange = this._onListChange.bind(this);
+	}
+
 	connectedCallback() {
 		super.connectedCallback();
 		const list = document.querySelector(`${this.target} d2l-list`);
-		list.addEventListener('change', this._onListChange.bind(this));
+		list.addEventListener('d2l-list-selection-change', this._onListChange);
 	}
 	disconnectedCallback() {
 		const list = document.querySelector(`${this.target} d2l-list`);
-		list.removeEventListener('change', this._onListChange.bind(this));
+		list.removeEventListener('d2l-list-selection-change', this._onListChange);
 		super.disconnectedCallback();
 	}
 
@@ -129,9 +134,12 @@ class ListDemoControl extends LitElement {
 	_onListChange(event) {
 		const list = event.target;
 		const selectAll = this.shadowRoot.querySelector('.select-all');
-		this._numberSelected = event.detail.selectedItems.length;
-		selectAll.indeterminate = list.selectionState() === selectableListStates.indeterminate;
-		selectAll.checked = list.selectionState() === selectableListStates.all;
+		this._numberSelected = event.detail.selected.length;
+		selectAll.indeterminate = list.getSelectionState() === selectableListStates.indeterminate;
+		selectAll.checked = list.getSelectionState() === selectableListStates.all;
+
+		// This line allows you to see how and when the events fire. So check your console log.
+		console.log(event.detail.selected); // eslint-disable-line
 	}
 
 	_onChangeSelectable(event) {
@@ -143,7 +151,7 @@ class ListDemoControl extends LitElement {
 
 	_onChangeSelectAll() {
 		const list = document.querySelector(`${this.target} d2l-list`);
-		list.selectAll();
+		list.toggleSelectAll();
 	}
 }
 

--- a/components/list/demo/list-demo-control.js
+++ b/components/list/demo/list-demo-control.js
@@ -127,9 +127,10 @@ class ListDemoControl extends LitElement {
 	}
 
 	_onListChange(event) {
+		console.log('here');
 		const list = event.target;
 		const selectAll = this.shadowRoot.querySelector('.select-all');
-		this._numberSelected = event.detail.checkedItems.length;
+		this._numberSelected = event.detail.selectedItems.length;
 		selectAll.indeterminate = list.selectionState() === selectableListStates.indeterminate;
 		selectAll.checked = list.selectionState() === selectableListStates.all;
 	}

--- a/components/list/demo/list-demo-control.js
+++ b/components/list/demo/list-demo-control.js
@@ -132,14 +132,7 @@ class ListDemoControl extends LitElement {
 	}
 
 	_onListChange(event) {
-		const list = event.target;
-		const selectAll = this.shadowRoot.querySelector('.select-all');
-		this._numberSelected = event.detail.selected.length;
-		selectAll.indeterminate = list.getSelectionState() === selectableListStates.indeterminate;
-		selectAll.checked = list.getSelectionState() === selectableListStates.all;
-
-		// This line allows you to see how and when the events fire. So check your console log.
-		console.log(event.detail.selected); // eslint-disable-line
+		this._updateSelectAll(event.target);
 	}
 
 	_onChangeSelectable(event) {
@@ -152,6 +145,18 @@ class ListDemoControl extends LitElement {
 	_onChangeSelectAll() {
 		const list = document.querySelector(`${this.target} d2l-list`);
 		list.toggleSelectAll();
+		this._updateSelectAll(list);
+	}
+
+	_updateSelectAll(list) {
+		const selectAll = this.shadowRoot.querySelector('.select-all');
+		const elementsSelected = list.getSelectedKeys();
+		this._numberSelected = elementsSelected.length;
+		selectAll.indeterminate = list.getSelectionState() === selectableListStates.indeterminate;
+		selectAll.checked = list.getSelectionState() === selectableListStates.all;
+
+		// This line allows you to see how and when the events fire. So check your console log.
+		console.log(elementsSelected); // eslint-disable-line
 	}
 }
 

--- a/components/list/demo/list-demo-control.js
+++ b/components/list/demo/list-demo-control.js
@@ -1,15 +1,18 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { bodySmallStyles } from '../../typography/styles.js';
+import { checkboxStyles } from '../../inputs/checkbox-shared-styles.js';
+import { selectableListStates } from '../list.js';
 
 class ListDemoControl extends LitElement {
 	static get properties() {
 		return {
-			target: { type: String }
+			target: { type: String },
+			_numberSelected: { type: Number }
 		};
 	}
 
 	static get styles() {
-		return [ bodySmallStyles, css`
+		return [ checkboxStyles, bodySmallStyles, css`
 		.d2l-list-demo-grid {
 			background: white;
 			border: 1px solid var(--d2l-color-tungsten);
@@ -38,6 +41,17 @@ class ListDemoControl extends LitElement {
 		`];
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		const list = document.querySelector(`${this.target} d2l-list`);
+		list.addEventListener('change', this._onListChange.bind(this));
+	}
+	disconnectedCallback() {
+		const list = document.querySelector(`${this.target} d2l-list`);
+		list.removeEventListener('change', this._onListChange.bind(this));
+		super.disconnectedCallback();
+	}
+
 	render() {
 		return html`
 			<div class="d2l-body-small d2l-list-demo-grid">
@@ -64,6 +78,7 @@ class ListDemoControl extends LitElement {
 				<label>selectable: <input type="checkbox" @change="${this._onChangeSelectable}"></label>
 				<label>hover-effect: <input type="checkbox" @change="${this._onChangeHoverEffect}"></label>
 				<label>Add Action: <input type="checkbox" @change="${this._onChangeAddAction}"></label>
+				<label>Select All: <input type="checkbox" class="select-all" @change="${this._onChangeSelectAll}"> ${this._numberSelected}</label>
 			</div>
 		`;
 	}
@@ -111,11 +126,24 @@ class ListDemoControl extends LitElement {
 		});
 	}
 
+	_onListChange(event) {
+		const list = event.target;
+		const selectAll = this.shadowRoot.querySelector('.select-all');
+		this._numberSelected = event.detail.checkedItems.length;
+		selectAll.indeterminate = list.selectionState() === selectableListStates.indeterminate;
+		selectAll.checked = list.selectionState() === selectableListStates.all;
+	}
+
 	_onChangeSelectable(event) {
 		const listItems = document.querySelectorAll(`${this.target} d2l-list d2l-list-item`);
 		listItems.forEach(item => {
 			item.toggleAttribute('selectable', event.target.checked);
 		});
+	}
+
+	_onChangeSelectAll() {
+		const list = document.querySelector(`${this.target} d2l-list`);
+		list.selectAll();
 	}
 }
 

--- a/components/list/demo/list.html
+++ b/components/list/demo/list.html
@@ -30,19 +30,19 @@
 			<d2l-list-demo-control target="#list-basic"></d2l-list-demo-control>
 			<d2l-demo-snippet id="list-basic">
 				<d2l-list>
-					<d2l-list-item>
+					<d2l-list-item key="1">
 						<d2l-list-item-content>
 							<div>Identify categories of physical activities</div>
 							<div slot="secondary">Specific Expectation A1.2</div>
 						</d2l-list-item-content>
 					</d2l-list-item>
-					<d2l-list-item>
+					<d2l-list-item key="2">
 						<d2l-list-item-content>
 							<div>Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
 							<div slot="secondary">Specific Expectation B2.1</div>
 						</d2l-list-item-content>
 					</d2l-list-item>
-					<d2l-list-item>
+					<d2l-list-item key="3">
 						<d2l-list-item-content>
 							<div>Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
 							<div slot="secondary">Specific Expectation B2.2</div>
@@ -55,7 +55,7 @@
 			<d2l-list-demo-control target="#list-of-users"></d2l-list-demo-control>
 			<d2l-demo-snippet id="list-of-users">
 				<d2l-list>
-					<d2l-list-item>
+					<d2l-list-item key="1">
 						<d2l-list-demo-name-image color="purple" letters="BN" slot="illustration"></d2l-list-demo-name-image>
 						<d2l-list-item-content>
 							<div>Byron Novak</div>
@@ -66,7 +66,7 @@
 							<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
 						</div>
 					</d2l-list-item>
-					<d2l-list-item>
+					<d2l-list-item key="2">
 						<d2l-list-demo-name-image color="red" letters="DW" slot="illustration"></d2l-list-demo-name-image>
 						<d2l-list-item-content>
 							<div>Dimitri Watts</div>
@@ -77,7 +77,7 @@
 							<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
 						</div>
 					</d2l-list-item>
-					<d2l-list-item>
+					<d2l-list-item key="3">
 						<d2l-list-demo-name-image color="teal" letters="PM" slot="illustration"></d2l-list-demo-name-image>
 						<d2l-list-item-content>
 							<div>Petra Macleod</div>
@@ -88,7 +88,7 @@
 							<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
 						</div>
 					</d2l-list-item>
-					<d2l-list-item>
+					<d2l-list-item key="4">
 						<d2l-list-demo-name-image color="grey" letters="YL" slot="illustration"></d2l-list-demo-name-image>
 						<d2l-list-item-content>
 							<div>Yvonne Lord</div>
@@ -106,21 +106,21 @@
 			<d2l-list-demo-control target="#list-of-courses"></d2l-list-demo-control>
 			<d2l-demo-snippet id="list-of-courses">
 				<d2l-list>
-					<d2l-list-item>
+					<d2l-list-item key="1">
 						<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
 						<d2l-list-item-content>
 							<div>Introductory Earth Sciences</div>
 							<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
 						</d2l-list-item-content>
 					</d2l-list-item>
-					<d2l-list-item>
+					<d2l-list-item key="2">
 						<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
 						<d2l-list-item-content>
 							<div>Engineering Materials for Energy Systems</div>
 							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
 						</d2l-list-item-content>
 					</d2l-list-item>
-					<d2l-list-item>
+					<d2l-list-item key="3">
 						<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
 						<d2l-list-item-content>
 							<div>Geomorphology and GIS </div>

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -228,12 +228,12 @@ class ListItem extends RtlMixin(LitElement) {
 			</div>
 		`;
 	}
+
 	updated(changedProperties) {
 		if (changedProperties.has('key')) {
 			const oldValue = changedProperties.get('key');
 			if (typeof oldValue !== 'undefined') {
 				this.setIsSelected(undefined, true);
-				this._fireItemSelected(false, oldValue);
 			}
 		}
 
@@ -264,9 +264,6 @@ class ListItem extends RtlMixin(LitElement) {
 
 	setIsSelected(isSelected, suppressEvent) {
 		this.selected = isSelected;
-		if (typeof this.key === 'undefined') {
-			this.key = getUniqueId();
-		}
 		if (!suppressEvent) {
 			this._fireItemSelected(isSelected);
 		}
@@ -280,7 +277,7 @@ class ListItem extends RtlMixin(LitElement) {
 		key = key ? key : this.key;
 		this.dispatchEvent(new CustomEvent('d2l-list-item-selected', {
 			detail: {
-				key,
+				key: key,
 				selected: value
 			},
 			bubbles: true

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -204,7 +204,7 @@ class ListItem extends RtlMixin(LitElement) {
 		let label, checkbox = html``;
 		if (this.selectable) {
 			label = html`<label class="d2l-list-item-label" for="${this._checkBoxId}" aria-labelledby="${this._contentId}"></label>`;
-			checkbox = html`<input @change="${this._handleChange}" type="checkbox" id="${this._checkBoxId}">`;
+			checkbox = html`<input @change="${this._handleChange}" type="checkbox" id="${this._checkBoxId}" .checked="${this.selected}">`;
 		}
 		const link = html`
 			<a class="d2l-list-item-link" href="${ifDefined(this.href)}" aria-labelledby="${this._contentId}"></a>
@@ -235,11 +235,6 @@ class ListItem extends RtlMixin(LitElement) {
 				this.setIsSelected(undefined, true);
 				this._fireItemSelected(false, oldValue);
 			}
-		}
-
-		if (changedProperties.has('selected')) {
-			const checkBox = this.shadowRoot.querySelector(`#${this._checkBoxId}`);
-			checkBox && (checkBox.checked = this.selected);
 		}
 
 		if (changedProperties.has('breakpoints')) {

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -191,7 +191,6 @@ class ListItem extends RtlMixin(LitElement) {
 		this._breakpoint = 0;
 		this.breakpoints = [842, 636, 580, 0];
 		this.role = 'listitem';
-		this.selected = false;
 		this._contentId = getUniqueId();
 		this._checkBoxId = getUniqueId();
 	}
@@ -206,15 +205,15 @@ class ListItem extends RtlMixin(LitElement) {
 		this.requestUpdate('breakpoints', oldVal);
 	}
 
-	get checked() {
-		return this._checked;
+	get selected() {
+		return this._selected;
 	}
 
-	set checked(value) {
-		const oldVal = this.checked;
-		this._checked = value;
-		this.requestUpdate('checked', oldVal).then(() => {
-			const checkBox = this.shadowRoot.querySelector('.d2l-list-item-checkbox');
+	set selected(value) {
+		const oldVal = this.selected;
+		this._selected = value;
+		this.requestUpdate('selected', oldVal).then(() => {
+			const checkBox = this.shadowRoot.querySelector(`#${this._checkBoxId}`);
 			checkBox && (checkBox.checked = value);
 
 			if (typeof this.ref === 'undefined') {
@@ -265,25 +264,23 @@ class ListItem extends RtlMixin(LitElement) {
 		changedProperties.forEach((oldValue, propName) => {
 			if (propName === 'ref') {
 				if (typeof oldValue === 'undefined') {
-					this._fireItemChecked(this.checked);
+					this._fireItemSelected(this.selected);
 				} else {
-					this.checked = undefined;
-					this._fireItemChecked(false, oldValue);
+					this.selected = undefined;
+					this._fireItemSelected(false, oldValue);
 				}
 				return;
 			}
 
-			if (propName === 'checked') {
-				if (typeof this.checked === 'undefined' || typeof this.ref === 'undefined') {
+			if (propName === 'selected') {
+				if (typeof this.selected === 'undefined' || typeof this.ref === 'undefined') {
 					return;
 				}
-				this._fireItemChecked(this.checked);
+				this._fireItemSelected(this.selected);
 			}
 
 		});
-	}
 
-	updated(changedProperties) {
 		if (changedProperties.has('breakpoints')) {
 			this.resizedCallback(this.offsetWidth);
 		}
@@ -312,12 +309,12 @@ class ListItem extends RtlMixin(LitElement) {
 		this.selected = e.target.checked;
 	}
 
-	_fireItemChecked(value, ref) {
+	_fireItemSelected(value, ref) {
 		ref = ref ? ref : this.ref;
-		this.dispatchEvent(new CustomEvent('d2l-list-item-checked', {
+		this.dispatchEvent(new CustomEvent('d2l-list-item-selected', {
 			detail: {
 				ref: ref,
-				checked: value,
+				selected: value,
 			},
 			bubbles: true
 		}));

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -217,7 +217,7 @@ class ListItem extends RtlMixin(LitElement) {
 			<div class="d2l-list-item-flex d2l-visible-on-ancestor-target" breakpoint="${this._breakpoint}">
 				${label}
 				${this.illustrationOutside ? illustrationSlot : null}
-				${this.hkey ? link : null}
+				${this.href ? link : null}
 				<div class="d2l-list-item-content" id="${this._contentId}">
 					<div class="d2l-list-item-content-flex">
 						${this.illustrationOutside ? null : illustrationSlot}

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -286,7 +286,7 @@ class ListItem extends RtlMixin(LitElement) {
 		this.dispatchEvent(new CustomEvent('d2l-list-item-selected', {
 			detail: {
 				key,
-				selected: value,
+				selected: value
 			},
 			bubbles: true
 		}));

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -66,29 +66,24 @@ class List extends LitElement {
 		`;
 		return [layout, specialCases];
 	}
-
 	constructor() {
 		super();
-		this._selected = {};
 		this.addEventListener('d2l-list-item-selected', this._onlistItemSelected.bind(this));
 	}
 
-	disconnectedCallback() {
-		this._selected = {};
-		super.disconnectedCallback();
-	}
-
-	getSelectedItemKeys() {
-		return Object.keys(this._selected).filter(key => this._selected[key]);
+	getSelectedKeys() {
+		const selectedListItems = [...this.querySelectorAll('d2l-list-item')];
+		return selectedListItems && selectedListItems.filter(listItem => listItem.selected).map(listItem => listItem.key);
 	}
 
 	getSelectionState() {
-		const selectedListItems = this.getSelectedItemKeys();
+		const listItems = [...this.querySelectorAll('d2l-list-item')];
+		const selectedListItems = listItems.filter(listItem => listItem.selected);
 		if (!selectedListItems || selectedListItems.length < 1) {
 			return selectableListStates.none;
 		}
 
-		const notSelectedListItems = this.querySelectorAll('d2l-list-item:not([selected])');
+		const notSelectedListItems = listItems.filter(listItem => !listItem.selected);
 		if (notSelectedListItems.length < 1) {
 			return selectableListStates.all;
 		}
@@ -105,33 +100,24 @@ class List extends LitElement {
 	}
 
 	toggleSelectAll() {
-		const notSelectedListItems = this.querySelectorAll('d2l-list-item:not([selected])');
+		const listItems = [...this.querySelectorAll('d2l-list-item')];
+		const notSelectedListItems = listItems.filter(listItem => !listItem.selected);
 		if (notSelectedListItems.length < 1) {
-			const selectedListItems = this.querySelectorAll('d2l-list-item[selected]');
+			const selectedListItems = listItems.filter(listItem => listItem.selected);
 			selectedListItems.forEach(listItem => {
 				listItem.setIsSelected(false, true);
-				this._selected[listItem.key] = false;
 			});
 		} else {
 			notSelectedListItems.forEach(listItem => {
 				listItem.setIsSelected(true, true);
-				this._selected[listItem.key] = true;
 			});
 		}
-		this._fireSelectionChange();
-	}
-
-	_fireSelectionChange() {
-		this.dispatchEvent(new CustomEvent('d2l-list-selection-change', {
-			detail: {
-				selected: this.getSelectedItemKeys()
-			}
-		}));
 	}
 
 	_onlistItemSelected(event) {
-		this._selected[event.detail.key] = event.detail.selected;
-		this._fireSelectionChange();
+		this.dispatchEvent(new CustomEvent('d2l-list-selection-change', {
+			detail: event.detail
+		}));
 		event.stopPropagation();
 	}
 }

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -69,12 +69,12 @@ class List extends LitElement {
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-		this._checked = {};
-		this.addEventListener('d2l-list-item-checked', this._onlistItemChecked.bind(this));
+		this._selected = {};
+		this.addEventListener('d2l-list-item-selected', this._onlistItemSelected.bind(this));
 	}
 
-	itemsChecked() {
-		return Object.keys(this._checked).filter(ref => this._checked[ref]);
+	itemsSelected() {
+		return Object.keys(this._selected).filter(ref => this._selected[ref]);
 	}
 
 	render() {
@@ -86,13 +86,13 @@ class List extends LitElement {
 	}
 
 	selectionState() {
-		const checkedListItems = this.itemsChecked();
-		if (!checkedListItems || checkedListItems.length < 1) {
+		const selectedListItems = this.itemsSelected();
+		if (!selectedListItems || selectedListItems.length < 1) {
 			return selectableListStates.none;
 		}
 
-		const uncheckedListItems = this.querySelectorAll('d2l-list-item:not([checked])');
-		if (uncheckedListItems.length < 1) {
+		const notSelectedListItems = this.querySelectorAll('d2l-list-item:not([selected])');
+		if (notSelectedListItems.length < 1) {
 			return selectableListStates.all;
 		}
 
@@ -100,29 +100,27 @@ class List extends LitElement {
 	}
 
 	selectAll() {
-		if (!this.selectable) {
-			return;
-		}
-		const uncheckedListItems = this.querySelectorAll('d2l-list-item:not([checked])');
-		if (uncheckedListItems.length < 1) {
-			const checkedListItems = this.querySelectorAll('d2l-list-item[checked]');
-			checkedListItems.forEach(listItem => {
-				listItem.toggleAttribute('checked');
+		const notSelectedListItems = this.querySelectorAll('d2l-list-item:not([selected])');
+		if (notSelectedListItems.length < 1) {
+			const selectedListItems = this.querySelectorAll('d2l-list-item[selected]');
+			selectedListItems.forEach(listItem => {
+				listItem.toggleAttribute('selected');
 			});
 		} else {
-			uncheckedListItems.forEach(listItem => {
-				listItem.toggleAttribute('checked');
+			notSelectedListItems.forEach(listItem => {
+				listItem.toggleAttribute('selected');
 			});
 		}
 	}
 
-	_onlistItemChecked(event) {
+	_onlistItemSelected(event) {
+		console.log('me');
 		event.stopPropagation();
 
-		this._checked[event.detail.ref] = event.detail.checked;
+		this._selected[event.detail.ref] = event.detail.selected;
 		this.dispatchEvent(new CustomEvent('change', {
 			detail: {
-				checkedItems: this.itemsChecked()
+				selectedItems: this.itemsSelected()
 			}
 		}));
 	}

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -114,7 +114,6 @@ class List extends LitElement {
 	}
 
 	_onlistItemSelected(event) {
-		console.log('me');
 		event.stopPropagation();
 
 		this._selected[event.detail.ref] = event.detail.selected;

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -67,10 +67,15 @@ class List extends LitElement {
 		return [layout, specialCases];
 	}
 
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
+	constructor() {
+		super();
 		this._selected = {};
 		this.addEventListener('d2l-list-item-selected', this._onlistItemSelected.bind(this));
+	}
+
+	disconnectedCallback() {
+		this._selected = {};
+		super.disconnectedCallback();
 	}
 
 	getSelectedItemKeys() {

--- a/components/list/test/list.html
+++ b/components/list/test/list.html
@@ -10,62 +10,126 @@
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script type="module" src="../list.js"></script>
+		<script type="module" src="../list-item.js"></script>
+		<script type="module" src="../list-item-content.js"></script>
 	</head>
 	<body>
 
 		<test-fixture id="list">
 			<template>
-				<d2l-list>
-					<d2l-list-item>
-						<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
-						<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>
-					</d2l-list-item>
-					<d2l-list-item>
-						<div class="d2l-list-item-text d2l-body-compact">Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
-						<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.1</div>
-					</d2l-list-item>
-					<d2l-list-item>
-						<div class="d2l-list-item-text d2l-body-compact">Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
-						<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.2</div>
-					</d2l-list-item>
-				</d2l-list>
-				</div>
+					<d2l-list>
+						<d2l-list-item ref="1">
+							<d2l-list-item-content>
+								<div>Identify categories of physical activities</div>
+								<div slot="secondary">Specific Expectation A1.2</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item href="#" id="link" ref="2">
+							<div style="height: 400px; width: 400px; background: red;" slot="illustration"></div>
+							<d2l-list-item-content>
+								<div>Introductory Earth Sciences</div>
+								<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item id="hover" ref="3">
+							<div style="height: 42px; width: 42px; background: red;" slot="illustration"></div>
+							<d2l-list-item-content>
+								<div>Byron Novak</div>
+								<div slot="secondary">bnovak</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item illustration-outside ref="4">
+							<div style="height: 400px; width: 400px; background: red;" slot="illustration"></div>
+							<d2l-list-item-content>
+								<div>Geomorphology and GIS </div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
 			</template>
 		</test-fixture>
 
 		<script type="module">
 			import { runAxe } from '../../../tools/a11y-test-helper.js';
-
+			import { selectableListStates } from '../list.js';
+			let list;
 			describe('d2l-list', () => {
+				describe('Pass Axe tests', () => {
 
-				[
-					{ title: 'List', fixture: 'list'},
-				].forEach((testData) => {
-					let list;
-					describe(testData.title, () => {
+					beforeEach(() => {
+						list = fixture('list');
+					});
 
-						beforeEach(async() => {
-							list = fixture(testData.fixture);
-						});
+					it('should pass all axe tests', async() => {
+						await runAxe(list);
+					});
 
-						it(`should pass all axe tests for ${testData.title}`, async() => {
-							await runAxe(list);
-						});
+					it('should pass all axe when selectable and hover-effect', async() => {
+						list.toggleAttribute('hover-effect', true);
+						list.toggleAttribute('selectable', true);
+						list.querySelectorAll('d2l-list-item').forEach(element => element.checked = true);
+						await runAxe(list);
+					});
 
-						it('should pass all axe tests when focused', async() => {
-							return new Promise((resolve, reject) => {
-								list.addEventListener('focus', async() => {
-									try {
-										await runAxe(list);
-										resolve();
-									} catch (e) {
-										reject(e);
-									}
-								});
-								list.shadowRoot.querySelector('d2l-list-item').focus();
+				});
+
+				// The order in this group of tests matter.
+				describe('Test Selection actions', () => {
+					before(() => {
+						list = fixture('list');
+						list.toggleAttribute('selectable', true);
+					});
+
+					it('Select one element and wait for on change.', async() => {
+						return new Promise((resolve, reject) => {
+							list.addEventListener('change', (e) => {
+								try {
+									expect(e.detail.checkedItems).deep.equal(['1']);
+									resolve();
+								} catch (e) {
+									reject(e);
+								}
 							});
+							list.querySelector('d2l-list-item').checked = true;
+						});
+					});
+
+					it('Selection state indeterminate.', async() => {
+						expect(list.selectionState()).to.equal(selectableListStates.indeterminate);
+					});
+
+					it('Select all.', async() => {
+						await new Promise((resolve, reject) => {
+							list.addEventListener('change', (e) => {
+								try {
+									if (e.detail.checkedItems.length === 4) {
+										resolve();
+									}
+								} catch (e) {
+									reject(e);
+								}
+							});
+							list.selectAll();
 						});
 
+						expect(list.selectionState()).to.equal(selectableListStates.all);
+					});
+
+					it('Select none.', async() => {
+						await new Promise((resolve, reject) => {
+							list.addEventListener('change', (e) => {
+								try {
+									if (e.detail.checkedItems.length === 0) {
+										resolve();
+									}
+								} catch (e) {
+									reject(e);
+								}
+							});
+							list.selectAll();
+						});
+
+						expect(list.selectionState()).to.equal(selectableListStates.none);
 					});
 				});
 

--- a/components/list/test/list.html
+++ b/components/list/test/list.html
@@ -86,11 +86,13 @@
 						list.querySelectorAll('d2l-list-item').forEach(element => element.selectable = false);
 					});
 
-					it('Select one element and wait for on change.', async() => {
+					it('Select one element and wait for on event.', async() => {
 						return new Promise((resolve, reject) => {
 							list.addEventListener('d2l-list-selection-change', (e) => {
 								try {
-									expect(e.detail.selected).deep.equal(['1']);
+									expect(e.detail.key).to.equal('1');
+									expect(e.detail.selected).to.be.true;
+									expect(e.target.getSelectedKeys()).deep.equal(['1']);
 									resolve();
 								} catch (e) {
 									reject(e);
@@ -106,36 +108,14 @@
 					});
 
 					it('Select all.', async() => {
-						await new Promise((resolve, reject) => {
-							list.addEventListener('d2l-list-selection-change', (e) => {
-								try {
-									if (e.detail.selected.length === 4) {
-										resolve();
-									}
-								} catch (e) {
-									reject(e);
-								}
-							});
-							list.toggleSelectAll();
-						});
-
+						list.toggleSelectAll();
+						expect(list.getSelectedKeys()).deep.equal(['1', '2', '3', '4']);
 						expect(list.getSelectionState()).to.equal(selectableListStates.all);
 					});
 
 					it('Select none.', async() => {
-						await new Promise((resolve, reject) => {
-							list.addEventListener('d2l-list-selection-change', (e) => {
-								try {
-									if (e.detail.selected.length === 0) {
-										resolve();
-									}
-								} catch (e) {
-									reject(e);
-								}
-							});
-							list.toggleSelectAll();
-						});
-
+						list.toggleSelectAll();
+						expect(list.getSelectedKeys()).deep.equal([]);
 						expect(list.getSelectionState()).to.equal(selectableListStates.none);
 					});
 				});

--- a/components/list/test/list.html
+++ b/components/list/test/list.html
@@ -18,27 +18,27 @@
 		<test-fixture id="list">
 			<template>
 					<d2l-list>
-						<d2l-list-item ref="1">
+						<d2l-list-item key="1">
 							<d2l-list-item-content>
 								<div>Identify categories of physical activities</div>
 								<div slot="secondary">Specific Expectation A1.2</div>
 							</d2l-list-item-content>
 						</d2l-list-item>
-						<d2l-list-item href="#" id="link" ref="2">
+						<d2l-list-item href="#" id="link" key="2">
 							<div style="height: 400px; width: 400px; background: red;" slot="illustration"></div>
 							<d2l-list-item-content>
 								<div>Introductory Earth Sciences</div>
 								<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
 							</d2l-list-item-content>
 						</d2l-list-item>
-						<d2l-list-item id="hover" ref="3">
+						<d2l-list-item id="hover" key="3">
 							<div style="height: 42px; width: 42px; background: red;" slot="illustration"></div>
 							<d2l-list-item-content>
 								<div>Byron Novak</div>
 								<div slot="secondary">bnovak</div>
 							</d2l-list-item-content>
 						</d2l-list-item>
-						<d2l-list-item illustration-outside ref="4">
+						<d2l-list-item illustration-outside key="4">
 							<div style="height: 400px; width: 400px; background: red;" slot="illustration"></div>
 							<d2l-list-item-content>
 								<div>Geomorphology and GIS </div>
@@ -52,6 +52,7 @@
 		<script type="module">
 			import { runAxe } from '../../../tools/a11y-test-helper.js';
 			import { selectableListStates } from '../list.js';
+
 			let list;
 			describe('d2l-list', () => {
 				describe('Pass Axe tests', () => {
@@ -66,9 +67,10 @@
 
 					it('should pass all axe when selectable and hover-effect', async() => {
 						list.toggleAttribute('hover-effect', true);
-						list.toggleAttribute('selectable', true);
-						list.querySelectorAll('d2l-list-item').forEach(element => element.checked = true);
+						list.querySelectorAll('d2l-list-item').forEach(element => element.selectable = true);
+						list.querySelectorAll('d2l-list-item').forEach(element => element.selected = true);
 						await runAxe(list);
+						list.querySelectorAll('d2l-list-item').forEach(element => element.selectable = false);
 					});
 
 				});
@@ -77,59 +79,63 @@
 				describe('Test Selection actions', () => {
 					before(() => {
 						list = fixture('list');
-						list.toggleAttribute('selectable', true);
+						list.querySelectorAll('d2l-list-item').forEach(element => element.selectable = true);
+					});
+
+					after(() => {
+						list.querySelectorAll('d2l-list-item').forEach(element => element.selectable = false);
 					});
 
 					it('Select one element and wait for on change.', async() => {
 						return new Promise((resolve, reject) => {
-							list.addEventListener('change', (e) => {
+							list.addEventListener('d2l-list-selection-change', (e) => {
 								try {
-									expect(e.detail.checkedItems).deep.equal(['1']);
+									expect(e.detail.selected).deep.equal(['1']);
 									resolve();
 								} catch (e) {
 									reject(e);
 								}
 							});
-							list.querySelector('d2l-list-item').checked = true;
+							list.querySelector('d2l-list-item').setIsSelected(true);
 						});
 					});
 
 					it('Selection state indeterminate.', async() => {
-						expect(list.selectionState()).to.equal(selectableListStates.indeterminate);
+						expect(list.getSelectionState()).to.equal(selectableListStates.indeterminate);
 					});
 
 					it('Select all.', async() => {
 						await new Promise((resolve, reject) => {
-							list.addEventListener('change', (e) => {
+							list.addEventListener('d2l-list-selection-change', (e) => {
 								try {
-									if (e.detail.checkedItems.length === 4) {
+									if (e.detail.selected.length === 4) {
 										resolve();
 									}
 								} catch (e) {
 									reject(e);
 								}
 							});
-							list.selectAll();
+							list.toggleSelectAll();
 						});
 
-						expect(list.selectionState()).to.equal(selectableListStates.all);
+						expect(list.getSelectionState()).to.equal(selectableListStates.all);
 					});
 
 					it('Select none.', async() => {
 						await new Promise((resolve, reject) => {
-							list.addEventListener('change', (e) => {
+							list.addEventListener('d2l-list-selection-change', (e) => {
 								try {
-									if (e.detail.checkedItems.length === 0) {
+									if (e.detail.selected.length === 0) {
 										resolve();
 									}
 								} catch (e) {
 									reject(e);
 								}
 							});
-							list.selectAll();
+							list.toggleSelectAll();
 						});
 
-						expect(list.selectionState()).to.equal(selectableListStates.none);
+						expect(list.getSelectionState()).to.equal(selectableListStates.none);
 					});
 				});
 

--- a/components/list/test/list.html
+++ b/components/list/test/list.html
@@ -101,6 +101,7 @@
 					});
 
 					it('Selection state indeterminate.', async() => {
+						list.querySelector('d2l-list-item').setIsSelected(true);
 						expect(list.getSelectionState()).to.equal(selectableListStates.indeterminate);
 					});
 

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,7 @@
 				'../components/button/test/button-subtle.html',
 				'../components/button/test/button-mixin.html',
 				'../components/button/test/floating-buttons.html',
+				'../components/list/test/list.html',
 				'../components/meter/test/meter-linear.html',
 				'../components/more-less/test/more-less.html',
 				'../helpers/test/dismissible.html',


### PR DESCRIPTION
#  [&larr; PREV](https://github.com/BrightspaceUI/core/pull/211)  : PR NAV : [NEXT &rarr;](https://github.com/BrightspaceUI/core/pull/216)

# About this PR

Selecting items now emits a change event with the list of ref ids of the items selected!

If a list-item doesn't have an ref ids when selected one is automatically generated...

Updated non-visual tests.

## Out of scope:

- Readme update
- Draggable
- Multiple Columns

# Useful Links

## Demo: 

This demo is a demo of the PR series:
http://i-00000089.openstack.d2l:8081/components/@brightspace-ui/core/components/list/demo/list.html

## Readme: 

https://github.com/BrightspaceUI/core/blob/majones/d2lListReadme/components/list/README.md

## Design: 

http://design.d2l/components/lists/