### PR TITLE
d2l-list - Readme Update - (5/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install @brightspace-ui/core
 * [Buttons](components/button/): normal, primary, icon and subtle buttons
 * [Colors](components/colors/): color palette
 * [Icons](components/icons/): iconography SVGs and web components
+* [List](components/list/): list web component.
 * [Meter](components/meter/): linear, radial, circle meter web components.
 * [More/less](components/more-less/): constrain long bits of content
 * [Typography](components/typography/): typography styles and components

--- a/components/list/README.md
+++ b/components/list/README.md
@@ -35,7 +35,7 @@ Output
 ## Signature
 
 ```html
-<d2l-list [divider-mode="[none|all|between]"] [divider-extend] [selectable] [hover-effect]>
+<d2l-list [divider-mode="[none|all|between]"] [divider-extend] [hover-effect]>
     <d2l-list-item>...</d2l-list-item>
     ...
     <d2l-list-item>...</d2l-list-item>
@@ -50,18 +50,17 @@ Output
   - *none*: Show no dividers.
 - **divider-extend**: A boolean attributes that extends the length of the dividers so the space between the list item contents and the left and right edges of the list dividers.
 - **hover-effect**: When the list item is interactive (selectable or link) then this applies a hover effect for the background. In the selectable case it also adds background color and highlights the divider of selected items.
-- **selectable**: Makes all the items in the list selectable.
 
 ## Events
 
-- **change**: Whenever a list item is selected this `change` event will be emitted with a list of items that are current checked.
-It returns `event.detial.checkedItems` which is an array that contains ref id for all selected items.
+- **d2l-list-selection-change**: Whenever a list item is selected this `change` event will be emitted with a list of items that are current selected.
+It returns `event.detial.key` and `event.detial.selected` where `key` is the key of the element that has changed and `selected` is the boolean value that it changed to.
 
 ## Public Methods
 
-- **selectAll()**: Checks all list items if current state is `none` or `indeterminate`. Removes the check from all list items if in the `all` state.
-- **itemsChecked()**: Returns the list of ref ids of list items that are checked.
-- **selectionState()**: Returns a selectableListStates that describes the current state.
+- **toggleSelectAll()**: Checks all list items if current state is `none` or `indeterminate`. Removes the check from all list items if in the `all` state. Note this will suppress the events of items being selected.
+- **getSelectedKeys()**: Returns the list of keys of list items that are selected.
+- **getSelectionState()**: Returns a selectableListStates that describes the current state.
 
 ## Helpers
 
@@ -80,9 +79,9 @@ selectableListStates.all
 
 Values:
 
--**none**: There are no rendered list items that are checked.
--**indeterminate**: There are some but not all list items that are rendered are checked.
--**all**: All rendered list items are checked.
+-**none**: There are no rendered list items that are selected.
+-**indeterminate**: There are some but not all list items that are rendered are selected.
+-**all**: All rendered list items are selected.
 
 # d2l-list-item
 
@@ -91,7 +90,7 @@ Values:
 ## Signature
 
 ```html
-<d2l-list-item [breakpoints=":array" ] [illustration-outside] [href=":url"] [checked]>
+<d2l-list-item [breakpoints=":array" ] [illustration-outside] [href=":url"] [selected] [key=":string"] [selectable]>
     [slot: illustration]
     [slot: default]
     [slot: actions]
@@ -113,9 +112,10 @@ Values:
   - Breakpoint 3
     - Image: max dimensions: `width: 216px` and `height: 120px` and has `20px margin` from the main content;
     - default break: `843px < x`  where `x` is the width of the component.
-- **checked**: This item is checked.
 - **href**: This item will link to the given page.
 - **illustration-outside**: Whether the illustration is outside of the dividers.
+- **selectable**: This item can be selected.
+- **selected**: This item is selected.
 
 ## Slots
 

--- a/components/list/README.md
+++ b/components/list/README.md
@@ -10,6 +10,8 @@ Import
 
 ```js
 import '@brightspace-ui/core/components/list/list.js';
+import '@brightspace-ui/core/components/list/list-item.js';
+import '@brightspace-ui/core/components/list/list-item-content.js';
 ```
 
 Then add the `d2l-list` component to your html and use the `d2l-list-item` to define the `d2l-list`'s children.
@@ -33,7 +35,7 @@ Output
 ## Signature
 
 ```html
-<d2l-list [divider-mode="[none|all|between]"] [divider-extend] [selectable] [hover-effect] [content-center]>
+<d2l-list [divider-mode="[none|all|between]"] [divider-extend] [selectable] [hover-effect]>
     <d2l-list-item>...</d2l-list-item>
     ...
     <d2l-list-item>...</d2l-list-item>
@@ -42,7 +44,6 @@ Output
 
 ## Attributes
 
-- **content-center**: Centers the actions and interactive components in a list item.
 - **divider-mode**: Describes which dividers will be shown for the list.
   - *all* (default): Shows all the dividers including dividers on the top and bottom of the list.
   - *between*: Only show the dividers between list items. The top and bottom dividers are hidden.
@@ -51,6 +52,38 @@ Output
 - **hover-effect**: When the list item is interactive (selectable or link) then this applies a hover effect for the background. In the selectable case it also adds background color and highlights the divider of selected items.
 - **selectable**: Makes all the items in the list selectable.
 
+## Events
+
+- **change**: Whenever a list item is selected this `change` event will be emitted with a list of items that are current checked.
+It returns `event.detial.checkedItems` which is an array that contains ref id for all selected items.
+
+## Public Methods
+
+- **selectAll()**: Checks all list items if current state is `none` or `indeterminate`. Removes the check from all list items if in the `all` state.
+- **itemsChecked()**: Returns the list of ref ids of list items that are checked.
+- **selectionState()**: Returns a selectableListStates that describes the current state.
+
+## Helpers
+
+### selectableListStates
+An enum for the different states of a list selection.
+
+Use:
+
+```js
+import { selectableListStates } from '@brightspace-ui/core/components/list/list.js';
+
+selectableListStates.none
+selectableListStates.indeterminate
+selectableListStates.all
+```
+
+Values:
+
+-**none**: There are no rendered list items that are checked.
+-**indeterminate**: There are some but not all list items that are rendered are checked.
+-**all**: All rendered list items are checked.
+
 # d2l-list-item
 
 `d2l-list-item` defines the items for a `d2l-list`.
@@ -58,30 +91,52 @@ Output
 ## Signature
 
 ```html
-<d2l-list-item [breakpoints="array" ][illustration-outside]>
+<d2l-list-item [breakpoints=":array" ] [illustration-outside] [href=":url"] [checked]>
     [slot: illustration]
     [slot: default]
     [slot: actions]
-</d2l-list>
+</d2l-list-item>
 ```
 
 ## Attributes
- - **breakpoints**: Define breakpoints by pixels on when things should scale. There are four different breakpoints so only the 4 biggest breakpoints will be used. If you use less than 4 breakpoints then you will skip a middle breakpoint and the first and last break points will map to the biggest and smallest visuals. Default: [842, 636, 580, 0].
-   - Breakpoint 0
-     - Image: max dimensions: `width: 90px` and `height: 52px` and has `18px margin` from the main content;
-     - default break: `x < 580px` where `x` is the width of the component.
-   - Breakpoint 1
-     - Image: max dimensions: `width: 120px` and `height: 71px` and has `20px margin` from the main content;
-     - default break: `581px < x < 636px` where `x` is the width of the component.
-   - Breakpoint 2
-     - Image: max dimensions: `width: 180px` and `height: 102px` and has `20px margin` from the main content;
-     - default break: `637px < x < 842px`  where `x` is the width of the component.
-   - Breakpoint 3
-     - Image: max dimensions: `width: 216px` and `height: 120px` and has `20px margin` from the main content;
-     - default break: `843px < x`  where `x` is the width of the component.
- - **illustration-outside**: Whether the illustration is outside of the dividers.
+
+- **breakpoints**: Define breakpoints by pixels on when things should scale. There are four different breakpoints so only the 4 biggest breakpoints will be used. If you use less than 4 breakpoints then you will skip a middle breakpoint and the first and last break points will map to the biggest and smallest visuals. Default: [842, 636, 580, 0].
+  - Breakpoint 0
+    - Image: max dimensions: `width: 90px` and `height: 52px` and has `18px margin` from the main content;
+    - default break: `x < 580px` where `x` is the width of the component.
+  - Breakpoint 1
+    - Image: max dimensions: `width: 120px` and `height: 71px` and has `20px margin` from the main content;
+    - default break: `581px < x < 636px` where `x` is the width of the component.
+  - Breakpoint 2
+    - Image: max dimensions: `width: 180px` and `height: 102px` and has `20px margin` from the main content;
+    - default break: `637px < x < 842px`  where `x` is the width of the component.
+  - Breakpoint 3
+    - Image: max dimensions: `width: 216px` and `height: 120px` and has `20px margin` from the main content;
+    - default break: `843px < x`  where `x` is the width of the component.
+- **checked**: This item is checked.
+- **href**: This item will link to the given page.
+- **illustration-outside**: Whether the illustration is outside of the dividers.
 
 ## Slots
- - **default**: This is for the main content area. You can add styles to the elements in this slot.
- - **illustration**: Responsive slot for images.
-  - **actions**: This is for actions. They will show up on the right side.
+
+- **default**: This is for the main content area. You can add styles to the elements in this slot.
+- **illustration**: Responsive slot for images.
+- **actions**: This is for actions. They will show up on the right side.
+
+# d2l-list-item-content
+
+`d2l-list-item-content` defines the text content for a `d2l-list-item`.
+
+## Signature
+
+```html
+<d2l-list-item-content>
+    [slot: default]
+    [slot: secondary]
+</d2l-list-item-content>
+```
+
+## Slots
+
+- **default**: This slot gives text the style `d2l-body-compact` and if the `d2l-list-item` is a link then turns it blue and adds a hover effect.
+- **secondary**: Adds text under the `default` slot and sets the font to d2l-body-small. If `selectable` and `hover-effect` turned on updates the color of the text on selected elements to meet accessibility requirements.


### PR DESCRIPTION
#  [&larr; PREV ](https://github.com/BrightspaceUI/core/pull/212) : PR NAV

# About this PR

Update the readme file to take into account all the changes in the PR set.

## Out of scope:

- Draggable
- Multiple Columns

# Useful Links

## Demo: 

This demo is a demo of the PR series:
http://i-00000089.openstack.d2l:8081/components/@brightspace-ui/core/components/list/demo/list.html

## Readme: 

https://github.com/BrightspaceUI/core/blob/majones/d2lListReadme/components/list/README.md

## Design: 

http://design.d2l/components/lists/






