### PR TITLE
unpinning intl-messageformat

### DIFF
--- a/helpers/localization.js
+++ b/helpers/localization.js
@@ -1,6 +1,5 @@
 import d2lIntl from 'd2l-intl';
-import IntlMessageFormat from 'intl-messageformat/src/main.js';
-window.IntlMessageFormat = IntlMessageFormat;
+import IntlMessageFormat from 'intl-messageformat';
 
 let documentLanguage = 'en';
 let documentLanguageFallback = 'en';

--- a/package.json
+++ b/package.json
@@ -65,14 +65,9 @@
     "@webcomponents/shadycss": "^1",
     "@webcomponents/webcomponentsjs": "^2",
     "d2l-intl": "^2",
-    "intl-messageformat": "^2.2.0",
+    "intl-messageformat": "^7",
     "lit-element": "^2",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "intl-messageformat"
-    ]
   }
 }


### PR DESCRIPTION
Now that we don't depend on `app-localize-behavior` anymore -- which was using an older version of `intl-messageformat` -- we can finally unpin.