### PR TITLE
reversing intl-messageformat upgrade for now

### DIFF
--- a/helpers/localization.js
+++ b/helpers/localization.js
@@ -1,5 +1,6 @@
 import d2lIntl from 'd2l-intl';
-import IntlMessageFormat from 'intl-messageformat';
+import IntlMessageFormat from 'intl-messageformat/src/main.js';
+window.IntlMessageFormat = IntlMessageFormat;
 
 let documentLanguage = 'en';
 let documentLanguageFallback = 'en';

--- a/package.json
+++ b/package.json
@@ -65,9 +65,14 @@
     "@webcomponents/shadycss": "^1",
     "@webcomponents/webcomponentsjs": "^2",
     "d2l-intl": "^2",
-    "intl-messageformat": "^7",
+    "intl-messageformat": "^2.2.0",
     "lit-element": "^2",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "intl-messageformat"
+    ]
   }
 }


### PR DESCRIPTION
Undoing this change for now. When I [brought it into BSI](https://github.com/Brightspace/brightspace-integration/pull/1616/files), the build started failing on weird `Error: Duplicate export 'parse'` errors.