### PR TITLE
remember all properties that have changed while waiting

### DIFF
--- a/mixins/demo/localize-test.js
+++ b/mixins/demo/localize-test.js
@@ -5,6 +5,9 @@ class LocalizeTest extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
+			async: {
+				type: Boolean
+			},
 			name: {
 				type: String
 			}
@@ -30,14 +33,37 @@ class LocalizeTest extends LocalizeMixin(LitElement) {
 
 		for (let i = 0; i < langs.length; i++) {
 			if (langResources[langs[i]]) {
-				return {
+				this.__langVal = {
 					language: langs[i],
 					resources: langResources[langs[i]]
 				};
+				if (!this.async) {
+					return this.__langVal;
+				}
+				return this.__localizeResourcesPromise;
 			}
 		}
 
 		return null;
+	}
+
+	constructor() {
+		super();
+		this.async = false;
+		this.__localizeResourcesPromise = new Promise((resolve) => {
+			this.__resolve = resolve;
+		});
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		this.dispatchEvent(new CustomEvent('d2l-test-localize-updated', {
+			bubbles: false,
+			composed: false,
+			detail: {
+				props: changedProperties
+			}
+		}));
 	}
 
 	render() {
@@ -57,6 +83,11 @@ class LocalizeTest extends LocalizeMixin(LitElement) {
 			<p>File size: ${this.formatFileSize(123456789)}</p>
 		`;
 	}
+
+	resolveLang() {
+		this.__resolve(this.__langVal);
+	}
+
 }
 
 customElements.define('d2l-test-localize', LocalizeTest);

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -33,6 +33,7 @@ export const LocalizeMixin = superclass => class extends superclass {
 					}
 				});
 		};
+		this.__updatedProperties = new Map();
 
 	}
 
@@ -44,15 +45,25 @@ export const LocalizeMixin = superclass => class extends superclass {
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		removeListener(this.__languageChangeCallback);
+		this.__updatedProperties.clear();
 	}
 
-	shouldUpdate() {
+	shouldUpdate(changedProperties) {
 		const ready = this.__language !== undefined
 			&& this.__resources !== undefined;
 		if (!ready) {
+			changedProperties.forEach((oldValue, propName) => {
+				this.__updatedProperties.set(propName, oldValue);
+			});
 			return false;
 		}
-		return super.shouldUpdate();
+		this.__updatedProperties.forEach((oldValue, propName) => {
+			if (!changedProperties.has(propName)) {
+				changedProperties.set(propName, oldValue);
+			}
+		});
+		this.__updatedProperties.clear();
+		return super.shouldUpdate(changedProperties);
 	}
 
 	getTimezone() {

--- a/mixins/test/localize-mixin.html
+++ b/mixins/test/localize-mixin.html
@@ -22,6 +22,11 @@
 				<d2l-test-localize __language="fr"></d2l-test-localize>
 			</template>
 		</test-fixture>
+		<test-fixture id="async">
+			<template>
+				<d2l-test-localize name="Bill" async></d2l-test-localize>
+			</template>
+		</test-fixture>
 
 		<script type="module">
 			describe('LocalizeMixin', () => {
@@ -383,6 +388,47 @@
 							});
 						});
 					});
+				});
+				describe('shouldUpdate tracking', () => {
+
+					it('should pass all changed properties to updated()', (done) => {
+						const elem = fixture('async');
+						elem.addEventListener('d2l-test-localize-updated', (e) => {
+							const props = e.detail.props;
+							expect(props.size).to.equal(4);
+							expect(props.has('name'));
+							expect(props.has('async'));
+							expect(props.has('__language'));
+							expect(props.has('__resources'));
+							done();
+						});
+						elem.__localizeResourcesPromise.then(() => {
+							elem.resolveLang();
+						});
+					});
+
+					it('should clear changed properties after language resolution', (done) => {
+						const elem = fixture('async');
+						let first = true;
+						elem.addEventListener('d2l-test-localize-updated', (e) => {
+							const props = e.detail.props;
+							if (first) {
+								first = false;
+								expect(props.size).to.equal(4);
+								return;
+							}
+							expect(props.size).to.equal(1);
+							expect(e.detail.props.has('name'));
+							done();
+						});
+						elem.__localizeResourcesPromise.then(() => {
+							elem.resolveLang();
+						});
+						elem.addEventListener('d2l-test-localize-render', () => {
+							elem.setAttribute('name', 'Jim');
+						});
+					});
+
 				});
 			});
 		</script>


### PR DESCRIPTION
@mpharoah-d2l noticed a bug with how we're blocking `shouldUpdate` from happening until the language has resolved: when `shouldUpdate` eventually passes, it triggers a call to `updated(changedProperties)`, except any properties that changed while it was blocked are lost.

This change remembers any properties that changed while it was waiting for the language to resolve, and then adds those back in when things finally become unblocked.