### PR TITLE
Dbatiste/mixin readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ npm install @brightspace-ui/core
 
 ## Mixins
 
-* [Mixins](mixins/): mixins for localization, RTL styles, etc.
+* [ArrowKeysMixin](mixins/arrow-keys-mixin.md): manage focus with arrow keys
+* [LocalizeMixin](mixins/localize-mixin.md): localize text and format & parse numbers, dates, etc.
+* [RtlMixin](mixins/rtl-mixin.md): enable components to define RTL styles
+* [VisibleOnAncestorMixin](mixins/visible-on-ancestor-mixin.md): display element on-hover of an ancestor
 
 ## Usage
 

--- a/mixins/arrow-keys-mixin.md
+++ b/mixins/arrow-keys-mixin.md
@@ -1,13 +1,8 @@
 # ArrowKeysMixin
 
-Used for managing focus with the arrow keys.
+The `ArrowKeysMixin` enables the user to move focus using the arrow keys. The `right/down` arrow keys move focus to the next element or the first element if focus is currently at the end. The `left/up` arrow keys move focus to the previous element, or the last element if focus is currently at beginning. The `home` and `end` key apply focus to the first and last elements respectively.
 
-right/down - focuses next element, or first if currently at the end
-left/up - focuses previous element, or last if currently at beginning
-home - focuses first
-end - focuses last
-
-# Usage
+## Usage
 
 The focusable elements can be provided in one of two ways.
 
@@ -16,16 +11,16 @@ If the elements are known up-front and are in the element's local DOM scope, sim
 ```javascript
 import { ArrowKeysMixin } from '@brightspace-ui/core/mixins/arrowkeys-mixin.js';
 class MyElement extends ArrowKeysMixin(LitElement) {
-   render() {
-      return html`
-         <div>
-            ...
-            <a href="..." class="d2l-arrowkeys-focusable">link 1</a>
-            <a href="..." class="d2l-arrowkeys-focusable">link 2</a>
-            ...
-         </div>
-      `;
-   }
+  render() {
+    return html`
+      <div>
+        ...
+        <a href="..." class="d2l-arrowkeys-focusable">link 1</a>
+        <a href="..." class="d2l-arrowkeys-focusable">link 2</a>
+        ...
+      </div>
+    `;
+  }
 }
 customElements.define('my-element', MyElement);
 ```
@@ -35,25 +30,25 @@ If the elements are not known up front, or the elements cannot be simply queried
 ```javascript
 import { ArrowKeysMixin } from '@brightspace-ui/core/mixins/arrowkeys-mixin.js';
 class MyElement extends ArrowKeysMixin(LitElement) {
-   render() {
-      return html`
-         <div>
-            ...
-            <a href="...">link 1</a>
-            <a href="...">link 2</a>
-            ...
-         </div>
-      `;
-   }
-   async arrowKeysFocusablesProvider() {
-      return [ /* array containing focusable elements */]
-   }
+  render() {
+    return html`
+      <div>
+        ...
+        <a href="...">link 1</a>
+        <a href="...">link 2</a>
+        ...
+      </div>
+    `;
+  }
+  async arrowKeysFocusablesProvider() {
+    return [ /* array containing focusable elements */]
+  }
 }
 customElements.define('my-element', MyElement);
 ```
 
-# Properties:
+**Properties:**
 
-`arrowKeysDirection` (optional): string listing which arrow keys are allowed (default is leftright)
-`arrowKeysNoWrap` (optional): To opt out of wrapping focus from end-to-start and start-to-end
-`arrowKeysBeforeFocus` (optional): Async callback invoked before focus us applied
+- `arrowKeysDirection` (optional, String): Indicates which arrow keys are allowed (default is leftright)
+- `arrowKeysNoWrap` (optional, Boolean): Whether focus should wrap from end-to-start and start-to-end
+- `arrowKeysBeforeFocus` (optional, Function): Async callback invoked before focus us applied

--- a/mixins/rtl-mixin.md
+++ b/mixins/rtl-mixin.md
@@ -1,0 +1,20 @@
+# RtlMixin
+
+The `RtlMixin` creates `dir` attributes on host elements based on the document's `dir`, enabling components to define RTL styles for elements within their shadow-DOMs via `:host([dir="rtl"])`. It is possible to opt-out our this behavior by explicitly setting a `dir` attribute (ex. for testing).
+
+## Usage
+
+Apply the mixin and define RTL styles.
+
+```js
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+class MyComponent extends RtlMixin(LitElement) {
+  static get styles() {
+    return css`
+      :host([dir="rtl"]) .some-elem {
+        /* some RTL styles */
+      }
+    `;
+  }
+}
+```

--- a/mixins/visible-on-ancestor-mixin.md
+++ b/mixins/visible-on-ancestor-mixin.md
@@ -1,35 +1,8 @@
-# Mixins
-
-## LocalizeMixin
-
-Please see the [LocalizeMixin README](localize-mixin.md).
-
-## RtlMixin
-
-The `RtlMixin` creates `dir` attributes on host elements based on the document's `dir`, enabling components to define RTL styles for elements within their shadow-DOMs via `:host([dir="rtl"])`. It is possible to opt-out our this behavior by explicitly setting a `dir` attribute (ex. for testing).
-
-### Usage
-
-Apply the mixin and define RTL styles.
-
-```js
-import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
-class MyComponent extends RtlMixin(LitElement) {
-  static get styles() {
-    return css`
-      :host([dir="rtl"]) .some-elem {
-        /* some RTL styles */
-      }
-    `;
-  }
-}
-```
-
-## VisibleOnAncestorMixin
+# VisibleOnAncestorMixin
 
 The `VisibleOnAncestorMixin` adds a behavior to a component so that it is initially hidden, and becomes visible when user hovers or focuses within an ancestor marked with the `d2l-visible-on-ancestor-target` class. It includes styles that must be included with the component. If the device does not support hovering, the element will be visible regardless of whether the user is hovering or focusing within the target.
 
-### Usage
+## Usage
 
 Apply the mixin and include the required `visibleOnAncestorStyles`.
 


### PR DESCRIPTION
The purpose of this PR is to make the readmes consistent for mixins:

* create separate readmes for `RtlMixin` and `VisibleOnAncestorMixin` (previously grouped in readme while `LocalizeMixin` and `ArrowKeysMixin` were separate)
* list the mixins in the root readme (as we do for components)
* update readme for `ArrowKeysMixin` to be consistent with the rest formatting-wise
* include `ArrowKeysMixin` in the list (previously was not referenced anywhere)

The `helpers` are still a little different, in that they are not individually listed in the root readme, and all of their documentation lives in a single readme. 