### PR TITLE
fixing link type

### DIFF
--- a/components/link/link.js
+++ b/components/link/link.js
@@ -7,7 +7,7 @@ class Link extends LitElement {
 
 	static get properties() {
 		return {
-			ariaLabel: { stype: String, attribute: 'aria-label' },
+			ariaLabel: { type: String, attribute: 'aria-label' },
 			download: { type: Boolean },
 			href: { type: String },
 			main: { type: Boolean, reflect: true },


### PR DESCRIPTION
This was working previously since if you don't specify a type it just assumes `String` and uses the default converters.