### PR TITLE
localize mixin should work even if no language resources exist

### DIFF
--- a/mixins/demo/localize-mixin.html
+++ b/mixins/demo/localize-mixin.html
@@ -26,7 +26,6 @@
 						<option value="ja">Japanese</option>
 						<option value="ko">Korean</option>
 						<option value="pt-BR">Portuguese</option>
-						<option value="sv">Swedish</option>
 						<option value="tr">Turkish</option>
 						<option value="zh-CN">Chinese (Simplified)</option>
 						<option value="zh-TW">Chinese (Traditional)</option>

--- a/mixins/demo/localize-test-no-resources.js
+++ b/mixins/demo/localize-test-no-resources.js
@@ -1,0 +1,18 @@
+import { html, LitElement } from 'lit-element/lit-element.js';
+import { LocalizeMixin } from '../../mixins/localize-mixin.js';
+
+class LocalizeNoResourcesTest extends LocalizeMixin(LitElement) {
+
+	render() {
+		requestAnimationFrame(
+			() => this.dispatchEvent(new CustomEvent('d2l-test-localize-render', {
+				bubbles: false,
+				composed: false
+			}))
+		);
+		return html``;
+	}
+
+}
+
+customElements.define('d2l-test-localize-no-resources', LocalizeNoResourcesTest);

--- a/mixins/demo/localize-test.js
+++ b/mixins/demo/localize-test.js
@@ -25,7 +25,6 @@ class LocalizeTest extends LocalizeMixin(LitElement) {
 			'ja': { 'hello': 'こんにちは {name}' },
 			'ko': { 'hello': '안녕하세요 {name}' },
 			'pt-br': { 'hello': 'Olá {name}' },
-			'sv': { 'hello': 'Hallå {name}' },
 			'tr': { 'hello': 'Merhaba {name}' },
 			'zh-cn': { 'hello': '你好 {name}' },
 			'zh-tw': { 'hello': '你好 {name}' }

--- a/mixins/test/localize-mixin.html
+++ b/mixins/test/localize-mixin.html
@@ -10,6 +10,7 @@
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script type="module" src="../demo/localize-test.js"></script>
+		<script type="module" src="../demo/localize-test-no-resources.js"></script>
 	</head>
 	<body>
 		<test-fixture id="basic">
@@ -25,6 +26,11 @@
 		<test-fixture id="async">
 			<template>
 				<d2l-test-localize name="Bill" async></d2l-test-localize>
+			</template>
+		</test-fixture>
+		<test-fixture id="no-resources">
+			<template>
+				<d2l-test-localize-no-resources></d2l-test-localize-no-resources>
 			</template>
 		</test-fixture>
 
@@ -276,7 +282,7 @@
 						expect(val).to.equal(1234567.89);
 					});
 				});
-				describe('data/time/number overrides', () => {
+				describe('date/time/number overrides', () => {
 
 					const date = new Date(2018, 0, 4, 15, 5);
 					let elem;
@@ -389,15 +395,31 @@
 						});
 					});
 				});
+				describe('no resources', () => {
+
+					it('should use document language even if resources are missing', async() => {
+						htmlElem.setAttribute('lang', 'sv');
+						const elem = await fixtureAndAwaitRender('basic');
+						expect(elem.formatNumber(123456.789)).to.equal('123 456,789');
+					});
+
+					it('should use document language when no resources', async() => {
+						htmlElem.setAttribute('lang', 'es');
+						const elem = await fixtureAndAwaitRender('no-resources');
+						expect(elem.formatNumber(123456.789)).to.equal('123.456,789');
+					});
+
+				});
 				describe('shouldUpdate tracking', () => {
 
 					it('should pass all changed properties to updated()', (done) => {
 						const elem = fixture('async');
 						elem.addEventListener('d2l-test-localize-updated', (e) => {
 							const props = e.detail.props;
-							expect(props.size).to.equal(4);
+							expect(props.size).to.equal(5);
 							expect(props.has('name'));
 							expect(props.has('async'));
+							expect(props.has('__pageLanguage'));
 							expect(props.has('__language'));
 							expect(props.has('__resources'));
 							done();
@@ -414,7 +436,7 @@
 							const props = e.detail.props;
 							if (first) {
 								first = false;
-								expect(props.size).to.equal(4);
+								expect(props.size).to.equal(5);
 								return;
 							}
 							expect(props.size).to.equal(1);


### PR DESCRIPTION
This changes the date/time/number formatting and parsing methods to just always use the document language instead of the one that gets resolved based on what text language resources exist.

It allows us to support the cases where a component simply doesn't have or need language resources and just wants to format a number, or where they have a subset of resources.