### PR TITLE
Dbatiste/dialog updates

### DIFF
--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -2,7 +2,7 @@
 
 ## d2l-dialog
 
-The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary content, and a `footer` slot for workflow buttons.
+The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary content, and a `footer` slot for workflow buttons. Apply the `dialog-action` attribute to workflow buttons to automatically close the dialog with the action value.
 
 ![Dialog](./screenshots/dialog.png?raw=true)
 
@@ -15,16 +15,16 @@ The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary 
 
 <d2l-dialog title-text="Dialog Title">
   <div>Some dialog content</div>
-  <d2l-button slot="footer" primary>Done</d2l-button>
-  <d2l-button slot="footer" id="cancel">Cancel</d2l-button>
+  <d2l-button slot="footer" primary dialog-action="done">Done</d2l-button>
+  <d2l-button slot="footer" dialog-action>Cancel</d2l-button>
 </d2l-dialog>
 
 <script>
   document.querySelector('#open').addEventListener('click', () => {
     document.querySelector('d2l-dialog').opened = true;
   });
-  document.querySelector('#cancel').addEventListener('click', () => {
-    document.querySelector('d2l-dialog').opened = false;
+  document.querySelector('d2l-dialog').addEventListener('d2l-dialog-close', (e) => {
+    console.log('dialog action:', e.detail.action);
   });
 </script>
 ```
@@ -35,9 +35,14 @@ The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary 
 - `opened` (Boolean): Whether or not the dialog is open
 - `width` (Number, default: `600`): The preferred width (unit-less) for the dialog
 
+**Events:**
+
+- `d2l-dialog-open`: dispatched when the dialog is opened
+- `d2l-dialog-close`: dispatched with the action value when the dialog is closed for any reason
+
 ## d2l-dialog-confirm
 
-The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting the user. It provides properties for specifying the required `text` and optional `title-text`, and a `footer` slot for workflow buttons.
+The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting the user. It provides properties for specifying the required `text` and optional `title-text`, and a `footer` slot for workflow buttons. Apply the `dialog-action` attribute to workflow buttons to automatically close the confirm dialog with the action value.
 
 ![Confirmation Dialog](./screenshots/dialog-confirm.png?raw=true)
 
@@ -49,16 +54,16 @@ The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting t
 <d2l-button id="open">Show Confirm</d2l-button>
 
 <d2l-dialog-confirm title-text="Confirm Title" text="Are you sure?">
-  <d2l-button slot="footer" primary>Yes</d2l-button>
-  <d2l-button slot="footer" id="cancel">No</d2l-button>
+  <d2l-button slot="footer" primary dialog-action="yes">Yes</d2l-button>
+  <d2l-button slot="footer" dialog-action>No</d2l-button>
 </d2l-dialog-confirm>
 
 <script>
   document.querySelector('#open').addEventListener('click', () => {
     document.querySelector('d2l-dialog-confirm').opened = true;
   });
-  document.querySelector('#cancel').addEventListener('click', () => {
-    document.querySelector('d2l-dialog-confirm').opened = false;
+  document.querySelector('d2l-dialog-confirm').addEventListener('d2l-dialog-close', (e) => {
+    console.log('confirm action:', e.detail.action);
   });
 </script>
 ```
@@ -68,3 +73,8 @@ The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting t
 - `text` (required, String): The required text content for the confirmation dialog
 - `opened` (Boolean): Whether or not the dialog is open
 - `title-text` (String): The optional title for the confirmation dialog
+
+**Events:**
+
+- `d2l-dialog-open`: dispatched when the dialog is opened
+- `d2l-dialog-close`: dispatched with the action value when the dialog is closed for any reason

--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -18,16 +18,30 @@ The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary 
   <d2l-button slot="footer" primary dialog-action="done">Done</d2l-button>
   <d2l-button slot="footer" dialog-action>Cancel</d2l-button>
 </d2l-dialog>
+```
 
-<script>
-  document.querySelector('#open').addEventListener('click', () => {
-    document.querySelector('d2l-dialog').opened = true;
-  });
-  document.querySelector('d2l-dialog').addEventListener('d2l-dialog-close', (e) => {
+Open the dialog by calling the `open` method to return a promise:
+
+```javascript
+document.querySelector('#open').addEventListener('click', async() => {
+  const action = await document.querySelector('d2l-dialog').open();
+  console.log('dialog action:', action);
+});
+```
+
+Alternatively, set the `opened` property/attribute and listen for the `d2l-dialog-close` event:
+
+```javascript
+document.querySelector('#open').addEventListener('click', () => {
+  const dialog = document.querySelector('d2l-dialog');
+  dialog.opened = true;
+  dialog.addEventListener('d2l-dialog-close', (e) => {
     console.log('dialog action:', e.detail.action);
   });
-</script>
+});
 ```
+
+*Note:* The user may close the dialog in a few different ways: clicking the dialog workflow buttons (marked up with `dialog-action`), by clicking the `[x]` button in the top-right corner, or by pressing the `escape` key. It is possible to listen for click events directly on the workflow buttons, however to be notified in any of these scenarios, it is best to either wait for the `open` method's promise, or listen for the `d2l-dialog-close` event.
 
 **Properties:**
 
@@ -57,15 +71,18 @@ The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting t
   <d2l-button slot="footer" primary dialog-action="yes">Yes</d2l-button>
   <d2l-button slot="footer" dialog-action>No</d2l-button>
 </d2l-dialog-confirm>
+```
 
-<script>
-  document.querySelector('#open').addEventListener('click', () => {
-    document.querySelector('d2l-dialog-confirm').opened = true;
-  });
-  document.querySelector('d2l-dialog-confirm').addEventListener('d2l-dialog-close', (e) => {
+Open the confirm dialog as described for generic dialogs, either by setting the `opened` property/attribute, or by calling the `open` method to get a promise for the result.
+
+```javascript
+document.querySelector('#open').addEventListener('click', () => {
+  const dialog = document.querySelector('d2l-dialog-confirm');
+  dialog.opened = true;
+  dialog.addEventListener('d2l-dialog-close', (e) => {
     console.log('confirm action:', e.detail.action);
   });
-</script>
+});
 ```
 
 **Properties:**

--- a/components/dialog/demo/dialog-nested.html
+++ b/components/dialog/demo/dialog-nested.html
@@ -52,11 +52,11 @@
 				</d2l-dialog>
 
 				<script>
-					document.querySelector('#openParent').addEventListener('click', async () => {
+					document.querySelector('#openParent').addEventListener('click', async() => {
 						const action = await document.querySelector('#parentDialog').open();
 						console.log('parent dialog action:', action);
 					});
-					document.querySelector('#openChild').addEventListener('click', async () => {
+					document.querySelector('#openChild').addEventListener('click', async() => {
 						const action = await document.querySelector('#childDialog').open();
 						console.log('child dialog action:', action);
 					});

--- a/components/dialog/demo/dialog-nested.html
+++ b/components/dialog/demo/dialog-nested.html
@@ -52,14 +52,13 @@
 				</d2l-dialog>
 
 				<script>
-					document.querySelector('#openParent').addEventListener('click', () => {
-						document.querySelector('#parentDialog').opened = true;
+					document.querySelector('#openParent').addEventListener('click', async () => {
+						const action = await document.querySelector('#parentDialog').open();
+						console.log('parent dialog action:', action);
 					});
-					document.querySelector('#openChild').addEventListener('click', () => {
-						document.querySelector('#childDialog').opened = true;
-					});
-					document.querySelector('#parentDialog').addEventListener('d2l-dialog-close', (e) => {
-						console.log('confirm action:', e.detail.action);
+					document.querySelector('#openChild').addEventListener('click', async () => {
+						const action = await document.querySelector('#childDialog').open();
+						console.log('child dialog action:', action);
 					});
 				</script>
 

--- a/components/dialog/demo/dialog-nested.html
+++ b/components/dialog/demo/dialog-nested.html
@@ -42,27 +42,24 @@
 								Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.
 								Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.
 							</div>
-							<d2l-button slot="footer" primary>Child</d2l-button>
-							<d2l-button slot="footer" id="cancelChild">Cancel</d2l-button>
+							<d2l-button slot="footer" primary dialog-action="child ok">Child</d2l-button>
+							<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
 						</d2l-dialog>
 
 					</div>
-					<d2l-button slot="footer" primary>Parent</d2l-button>
-					<d2l-button slot="footer" id="cancelParent">Cancel</d2l-button>
+					<d2l-button slot="footer" primary dialog-action="ok">Parent</d2l-button>
+					<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
 				</d2l-dialog>
 
 				<script>
 					document.querySelector('#openParent').addEventListener('click', () => {
 						document.querySelector('#parentDialog').opened = true;
 					});
-					document.querySelector('#cancelParent').addEventListener('click', () => {
-						document.querySelector('#parentDialog').opened = false;
-					});
 					document.querySelector('#openChild').addEventListener('click', () => {
 						document.querySelector('#childDialog').opened = true;
 					});
-					document.querySelector('#cancelChild').addEventListener('click', () => {
-						document.querySelector('#childDialog').opened = false;
+					document.querySelector('#parentDialog').addEventListener('d2l-dialog-close', (e) => {
+						console.log('confirm action:', e.detail.action);
 					});
 				</script>
 

--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -34,15 +34,15 @@
 						<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
 						<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
 					</div>
-					<d2l-button slot="footer" primary>Click Me!</d2l-button>
-					<d2l-button slot="footer" id="cancel">Cancel</d2l-button>
+					<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
+					<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
 				</d2l-dialog>
 				<script>
 					document.querySelector('#open').addEventListener('click', () => {
 						document.querySelector('#dialog').opened = true;
 					});
-					document.querySelector('#cancel').addEventListener('click', () => {
-						document.querySelector('#dialog').opened = false;
+					document.querySelector('#dialog').addEventListener('d2l-dialog-close', (e) => {
+						console.log('dialog action:', e.detail.action);
 					});
 				</script>
 			</d2l-demo-snippet>
@@ -53,15 +53,15 @@
 
 				<d2l-button id="openConfirm">Show Confirm</d2l-button>
 				<d2l-dialog-confirm id="confirm" title-text="Confirm Title" text="Are you sure you want more cookies?">
-					<d2l-button slot="footer" primary>Yes</d2l-button>
-					<d2l-button slot="footer" id="cancelConfirm">No</d2l-button>
+					<d2l-button slot="footer" primary dialog-action="ok">Yes</d2l-button>
+					<d2l-button slot="footer" dialog-action>No</d2l-button>
 				</d2l-dialog-confirm>
 				<script>
 					document.querySelector('#openConfirm').addEventListener('click', () => {
 						document.querySelector('#confirm').opened = true;
 					});
-					document.querySelector('#cancelConfirm').addEventListener('click', () => {
-						document.querySelector('#confirm').opened = false;
+					document.querySelector('#confirm').addEventListener('d2l-dialog-close', (e) => {
+						console.log('confirm action:', e.detail.action);
 					});
 				</script>
 
@@ -73,15 +73,15 @@
 
 				<d2l-button id="openConfirmNoTitle">Show Confirm</d2l-button>
 				<d2l-dialog-confirm id="confirmNoTitle" text="Are you sure you want more cookies?">
-					<d2l-button slot="footer" primary>Yes</d2l-button>
-					<d2l-button slot="footer" id="cancelConfirmNoTitle">No</d2l-button>
+					<d2l-button slot="footer" primary dialog-action="ok">Yes</d2l-button>
+					<d2l-button slot="footer" dialog-action>No</d2l-button>
 				</d2l-dialog-confirm>
 				<script>
 					document.querySelector('#openConfirmNoTitle').addEventListener('click', () => {
 						document.querySelector('#confirmNoTitle').opened = true;
 					});
-					document.querySelector('#cancelConfirmNoTitle').addEventListener('click', () => {
-						document.querySelector('#confirmNoTitle').opened = false;
+					document.querySelector('#confirmNoTitle').addEventListener('d2l-dialog-close', (e) => {
+						console.log('confirm action:', e.detail.action);
 					});
 				</script>
 

--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -47,6 +47,27 @@
 				</script>
 			</d2l-demo-snippet>
 
+			<h2>Dialog (with promise)</h2>
+
+			<d2l-demo-snippet>
+				<d2l-button id="openPromise">Show Dialog</d2l-button>
+				<d2l-dialog id="dialogPromise" title-text="Dialog Title">
+					<div>
+						<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
+						<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
+						<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
+					</div>
+					<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
+					<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+				</d2l-dialog>
+				<script>
+					document.querySelector('#openPromise').addEventListener('click', async() => {
+						const action = await document.querySelector('#dialogPromise').open();
+						console.log('dialog action:', action);
+					});
+				</script>
+			</d2l-demo-snippet>
+
 			<h2>Confirm Dialog</h2>
 
 			<d2l-demo-snippet>

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -70,6 +70,16 @@ class DialogConfirm extends DialogMixin(LitElement) {
 		);
 	}
 
+	_focusInitial() {
+		const footer = this.shadowRoot.querySelector('.d2l-dialog-footer');
+		const nodes = footer.querySelector('slot').assignedNodes();
+		const initial = nodes.reduce((initial, node) => {
+			if (node.nodeType !== Node.ELEMENT_NODE) return initial;
+			if (!initial && !node.hasAttribute('primary')) return node;
+		}, null);
+		if (initial) initial.focus();
+	}
+
 	_getWidth() {
 		/* override default width measurement and just use max-width */
 	}

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -63,8 +63,11 @@ class DialogConfirm extends DialogMixin(LitElement) {
 			</div>`;
 
 		const labelId = (this.titleText && this.text) ? this._titleId : this._textId;
-		const descriptionId = (this.titleText && this.text) ? this._textId : null;
-		return this._render(labelId, descriptionId, inner);
+		const descId = (this.titleText && this.text) ? this._textId : undefined;
+		return this._render(
+			inner,
+			{ labelId: labelId, descId: descId, role: 'alertdialog' }
+		);
 	}
 
 	_getWidth() {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -61,6 +61,19 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		}
 	}
 
+	open() {
+		if (this.opened) return;
+		this.opened = true;
+		return new Promise((resolve) => {
+			const onClose = function(e) {
+				if (e.target !== this) return; // ignore if bubbling from child dialog
+				this.removeEventListener('d2l-dialog-close', onClose);
+				resolve(e.detail.action);
+			}.bind(this);
+			this.addEventListener('d2l-dialog-close', onClose);
+		});
+	}
+
 	_addHandlers() {
 		window.addEventListener('resize', this._updateSize);
 		document.body.addEventListener('focus', this._handleBodyFocus, true);

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -266,7 +266,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this.shadowRoot.querySelector('.d2l-dialog-content').removeEventListener('scroll', this._updateOverflow);
 	}
 
-	_render(labelId, descriptionId, inner) {
+	_render(inner, info) {
 
 		const styles = {};
 		if (this._left) styles.left = `${this._left}px`;
@@ -288,8 +288,8 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 		return html`${this._useNative ?
 			html`<dialog
-				aria-describedby="${ifDefined(descriptionId)}"
-				aria-labelledby="${labelId}"
+				aria-describedby="${ifDefined(info.descId)}"
+				aria-labelledby="${info.labelId}"
 				class="d2l-dialog-outer"
 				@click="${this._handleClick}"
 				@close="${this._handleClose}"
@@ -297,12 +297,13 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 				@keydown="${this._handleKeyDown}"
 				?overflow-bottom="${this._overflowBottom}"
 				?overflow-top="${this._overflowTop}"
+				role="${info.role}"
 				style=${styleMap(styles)}>
 					${inner}
 				</dialog>` :
 			html`<div
-				aria-describedby="${ifDefined(descriptionId)}"
-				aria-labelledby="${labelId}"
+				aria-describedby="${ifDefined(info.descId)}"
+				aria-labelledby="${info.labelId}"
 				class="d2l-dialog-outer"
 				@click="${this._handleClick}"
 				@d2l-dialog-close="${this._handleDialogClose}"
@@ -312,7 +313,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 				?nested-showing="${this._nestedShowing}"
 				?overflow-bottom="${this._overflowBottom}"
 				?overflow-top="${this._overflowTop}"
-				role="dialog"
+				role="${info.role}"
 				style=${styleMap(styles)}>
 					${inner}
 				</div>

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -114,6 +114,10 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this.shadowRoot.querySelector('.d2l-dialog-trap-start').focus();
 	}
 
+	_focusInitial() {
+		this._focusFirst();
+	}
+
 	_getHeight() {
 		const availableHeight = window.innerHeight - this._margin.top - this._margin.bottom;
 		let preferredHeight = 0;
@@ -257,7 +261,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 		this._updateSize();
 		this._state = 'showing';
-		this._focusFirst();
+		this._focusInitial();
 	}
 
 	_removeHandlers() {

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -90,7 +90,7 @@ class Dialog extends LocalizeStaticMixin(DialogMixin(LitElement)) {
 				<div class="d2l-dialog-header">
 					<div>
 						<h2 id="${this._titleId}" class="d2l-heading-3">${this.titleText}</h2>
-						<d2l-button-icon icon="d2l-tier1:close-small" text="${this.localize('close')}" @click="${() => this._close('abort')}"></d2l-button-icon>
+						<d2l-button-icon icon="d2l-tier1:close-small" text="${this.localize('close')}" @click="${this._abort}"></d2l-button-icon>
 					</div>
 				</div>
 				<div class="d2l-dialog-content">
@@ -102,6 +102,10 @@ class Dialog extends LocalizeStaticMixin(DialogMixin(LitElement)) {
 			</div>
 		`;
 		return this._render(this._titleId, undefined, inner);
+	}
+
+	_abort() {
+		this._close('abort');
 	}
 
 }

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -90,7 +90,7 @@ class Dialog extends LocalizeStaticMixin(DialogMixin(LitElement)) {
 				<div class="d2l-dialog-header">
 					<div>
 						<h2 id="${this._titleId}" class="d2l-heading-3">${this.titleText}</h2>
-						<d2l-button-icon icon="d2l-tier1:close-small" text="${this.localize('close')}" @click="${this._close}"></d2l-button-icon>
+						<d2l-button-icon icon="d2l-tier1:close-small" text="${this.localize('close')}" @click="${() => this._close('abort')}"></d2l-button-icon>
 					</div>
 				</div>
 				<div class="d2l-dialog-content">

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -101,7 +101,10 @@ class Dialog extends LocalizeStaticMixin(DialogMixin(LitElement)) {
 				</div>
 			</div>
 		`;
-		return this._render(this._titleId, undefined, inner);
+		return this._render(
+			inner,
+			{ labelId: this._titleId, role: 'dialog' }
+		);
 	}
 
 	_abort() {


### PR DESCRIPTION
This includes a couple of follow-up changes for dialogs:

* allow workflow buttons to be marked up with `dialog-action` to simplify wire-up
* allow the dialog to be opened with `open` method that returns a promise
* focus on the non-primary button (assumed least destructive action) for `d2l-dialog-confirm`