### PR TITLE
fixing boolean attribute binding

### DIFF
--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -155,7 +155,7 @@ class MoreLess extends LocalizeStaticMixin(LitElement)  {
 				class="more-less-toggle"
 				icon="${this.__computeIcon()}"
 				aria-controls="${this.__contentId}"
-				aria-expanded="${this.expanded}"
+				aria-expanded="${this.__computeAriaExpanded()}"
 				@click="${this.__toggleOnClick}"
 				text="${this.__computeText()}"
 				h-align="${ifDefined(this.hAlign)}">
@@ -215,6 +215,10 @@ class MoreLess extends LocalizeStaticMixin(LitElement)  {
 		}
 		this.__content.addEventListener('focusin', this.__focusIn.bind(this));
 		this.__content.addEventListener('focusout', this.__focusOut.bind(this));
+	}
+
+	__computeAriaExpanded() {
+		return this.expanded ? 'true' : 'false';
 	}
 
 	__computeText() {


### PR DESCRIPTION
Lit-analyzer just started complaining about this (must be a new feature they added), and it's a totally valid complaint. We can't bind a boolean to a string attribute like `aria-expanded`.