### PR TITLE
lock node to version 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js: node
+- "12"
 addons:
   chrome: stable
 jobs:


### PR DESCRIPTION
Node version 13 was released and node-sass does not yet support it, causing build failures (https://travis-ci.com/BrightspaceUI/core/jobs/248716778). Once node-sass releases their v4.13 release this should be fixed.