### PR TITLE
Add announce helper for announcing messages.

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,5 +1,16 @@
 # Helpers
 
+## Announce
+
+A helper for announcing text to screen readers.
+
+```js
+import { announce } from '@brightspace-ui/core/helpers/announce.js';
+
+// announce some text
+announce('...');
+```
+
 ## Dismissible
 
 Dismissible components are those that should be dismissible when the user presses
@@ -8,8 +19,6 @@ on-focus under [WCAG 2.1 Criterio 1.4.13: Content on Hover or Focus](https://www
 
 The dismissible helper uses a first-in-last-out ordering to ensure that each time
 the `ESC` key is pressed, only the most recent component is dismissed.
-
-### Usage
 
 When the component becomes visible to the user, call `setDismissible(cb)`, passing a callback. The callback will be called if the user presses `ESC` and that component should be dismissed.
 
@@ -35,8 +44,6 @@ clearDismissible(id);
 
 DOM helper functions to make your life easier.
 
-### Usage
-
 ```js
 import { ... } from '@brightspace-ui/core/helpers/dom.js';
 
@@ -60,8 +67,6 @@ isComposedAncestor(ancestorNode, node);
 
 A simple shim for [requestIdleCallback](https://www.w3.org/TR/requestidlecallback/#the-requestidlecallback-method) and [cancelIdleCallback](https://www.w3.org/TR/requestidlecallback/#the-cancelidlecallback-method) that transparently falls back to `setTimeout` if it's not natively supported.
 
-### Usage
-
 The Google Developer update on [using requestIdleCallback](https://developers.google.com/web/updates/2015/08/using-requestidlecallback) has some excellent examples of usage. Provide a callback for non-essential work, and optionally a `timeout` after which the callback will be invoked regardless of activity on the main thread. A `deadline` object is passed with a `timeRemaining()` function and a `didTimeout` property, enabling the consumer to queue tasks across callbacks if necessary.
 
 ```js
@@ -75,8 +80,6 @@ requestIdleCallback((deadline) => {
 ## UniqueId
 
 A simple helper that returns a unique id.
-
-### Usage
 
 ```js
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';

--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -1,5 +1,5 @@
+import { html, LitElement } from 'lit-element/lit-element.js';
 import { offscreenStyles } from '../components/offscreen/offscreen-styles.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
 
 class AnnounceContainer extends LitElement {
 

--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -1,41 +1,23 @@
-import { html, LitElement } from 'lit-element/lit-element.js';
-import { offscreenStyles } from '../components/offscreen/offscreen-styles.js';
-
-class AnnounceContainer extends LitElement {
-
-	static get styles() {
-		return [ offscreenStyles ];
-	}
-
-	constructor() {
-		super();
-		this._messages = [];
-	}
-
-	announce(text) {
-		this._messages.push(text);
-		this.requestUpdate();
-	}
-
-	render() {
-		return html`<div aria-live="polite" class="d2l-offscreen">
-			${this._messages.map(message => html`<div>${message}</div>`)}
-		</div>`;
-	}
-
-}
-
-customElements.define('d2l-announce-container', AnnounceContainer);
-
 let container;
+let lastMessage;
 
-export function announce(text) {
-	if (!text) return;
+export function announce(message) {
+	if (!message) return;
 	if (!container) {
-		container = document.createElement('d2l-announce-container');
+		container = document.createElement('div');
+		container.setAttribute('aria-live', 'polite');
+		container.style.display = 'inline-block';
+		container.style.position = 'fixed';
+		container.style.clip = 'rect(0px,0px,0px,0px)';
 		document.body.appendChild(container);
 	}
+	/* VO has strange hueristics for announcement - it will not announce
+	duplicate message unless it is additive, but we prefer content to not grow */
+	if (message !== lastMessage) {
+		container.innerHTML = '';
+	}
 	requestAnimationFrame(() => {
-		container.announce(text);
+		container.appendChild(document.createTextNode(message));
+		lastMessage = message;
 	});
 }

--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -1,0 +1,41 @@
+import { offscreenStyles } from '../components/offscreen/offscreen-styles.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+
+class AnnounceContainer extends LitElement {
+
+	static get styles() {
+		return [ offscreenStyles ];
+	}
+
+	constructor() {
+		super();
+		this._messages = [];
+	}
+
+	announce(text) {
+		this._messages.push(text);
+		this.requestUpdate();
+	}
+
+	render() {
+		return html`<div aria-live="polite" class="d2l-offscreen">
+			${this._messages.map(message => html`<div>${message}</div>`)}
+		</div>`;
+	}
+
+}
+
+customElements.define('d2l-announce-container', AnnounceContainer);
+
+let container;
+
+export function announce(text) {
+	if (!text) return;
+	if (!container) {
+		container = document.createElement('d2l-announce-container');
+		document.body.appendChild(container);
+	}
+	requestAnimationFrame(() => {
+		container.announce(text);
+	});
+}

--- a/helpers/demo/announce-test.js
+++ b/helpers/demo/announce-test.js
@@ -1,7 +1,7 @@
 import '../../components/inputs/input-text.js';
 import '../../components/button/button.js';
-import { announce } from '../announce.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { announce } from '../announce.js';
 
 class AnnounceTest extends LitElement {
 

--- a/helpers/demo/announce-test.js
+++ b/helpers/demo/announce-test.js
@@ -1,0 +1,33 @@
+import '../../components/inputs/input-text.js';
+import '../../components/button/button.js';
+import { announce } from '../announce.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+
+class AnnounceTest extends LitElement {
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+				width: 400px;
+			}
+			d2l-button {
+				margin: 10px 10px 0 0;
+			}
+		`;
+	}
+
+	render() {
+		return html`
+			<d2l-input-text type="text" value="I like cookies." aria-label="message to announce"></d2l-input-text>
+			<d2l-button @click=${this._handleAnnounce} type="button">Announce</d2l-button>`;
+	}
+
+	_handleAnnounce() {
+		const value = this.shadowRoot.querySelector('d2l-input-text').value;
+		announce(value);
+	}
+
+}
+
+customElements.define('d2l-test-announce', AnnounceTest);

--- a/helpers/demo/announce.html
+++ b/helpers/demo/announce.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '../../components/demo/demo-page.js';
+			import './announce-test.js';
+		</script>
+	</head>
+	<body unresolved>
+		<d2l-demo-page page-title="announce">
+
+			<d2l-test-announce></d2l-test-announce>
+
+		</d2l-demo-page>
+	</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
 
 	<h2 class="d2l-heading-3">Helpers</h2>
 	<ul>
+		<li><a href="helpers/demo/announce.html">announce</a></li>
 		<li><a href="helpers/demo/dismissible.html">dismissible</a></li>
 	</ul>
 


### PR DESCRIPTION
This helper defines a singleton `aria-live` container for messages and an `announce` helper that appends to it.  It is similar to the `iron-a11y-announcer` (which has some issues such as appending to the `head`, clobbering successive messages, not respecting the mode on its API).

I think the main reason for having such a container is: 

* `aria-live` elements must be defined as such when they are created and appended to the DOM
* one must not try to append messages until the browser has rendered the live region, otherwise those messages will not be announced 

I have another idea of creating some type of element or directive that consumers could use directly in their component templates, but the async nature of the `aria-live` setup makes things tricky. There may also be some unexpected behavior with nested live regions, which could crop up if we provide such an element or directive.  We'd need to check that scenario.

There are a couple of interesting bits that I will highlight in code. Interested in your thoughts.