### PR TITLE
Dbatiste/list fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install @brightspace-ui/core
 * [Icons](components/icons/): iconography SVGs and web components
 * [Inputs](components/inputs/): text, search, checkbox and radio inputs
 * [Links](components/link/): link component and styles
-* [List](components/list/): list and list-item components and styles
+* [List](components/list/): list and list-item components
 * [Meter](components/meter/): linear, radial, circle meter web components
 * [More/less](components/more-less/): constrain long bits of content
 * [Off-screen](components/offscreen/): component and styles for positioning content off-screen

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm install @brightspace-ui/core
 * [Icons](components/icons/): iconography SVGs and web components
 * [Inputs](components/inputs/): text, search, checkbox and radio inputs
 * [Links](components/link/): link component and styles
+* [List](components/list/): list and list-item components and styles
 * [Meter](components/meter/): linear, radial, circle meter web components
 * [More/less](components/more-less/): constrain long bits of content
 * [Off-screen](components/offscreen/): component and styles for positioning content off-screen

--- a/components/list/README.md
+++ b/components/list/README.md
@@ -1,5 +1,3 @@
-**In Development**
-
 # Lists
 
 ## d2l-list

--- a/components/list/README.md
+++ b/components/list/README.md
@@ -28,12 +28,17 @@ The `d2l-list` is the container to create a styled list of items using `d2l-list
 
 ## d2l-list-item
 
-The `d2l-list-item` provides the appropriate `listitem` semantics for children within a list. It also provides some basic layout and breakpoints for responsiveness.
+The `d2l-list-item` provides the appropriate `listitem` semantics for children within a list. It also provides some basic layout, breakpoints for responsiveness, a link for navigation, and selection.
 
 ![List](./screenshots/list-item.png?raw=true)
 
 ```html
-<d2l-list-item [breakpoints="array"] [illustration-outside]>
+<d2l-list-item breakpoints="array"
+  href="http://www.d2l.com"
+  illustration-outside
+  key="item1"
+  selectable
+  selected>
   <img src="..." slot="illustration">
   <div>...</div>
   <div slot="actions">
@@ -58,7 +63,11 @@ The `d2l-list-item` provides the appropriate `listitem` semantics for children w
   - Breakpoint 3
     - Image: max dimensions: `width: 216px` and `height: 120px` and has `20px margin` from the main content;
     - default break: `843px < x`  where `x` is the width of the component.
+- `href` (String): Address of item link if navigable
 - `illustration-outside` (Boolean): Whether the illustration is rendered outside of the separators
+- `key` (String): Value to identify item if selectable
+- `selectable` (Boolean): Indicates a checkbox should be rendered for selecting the item
+- `selected` (Boolean): Whether the item is selected
 
 ## d2l-list-content
 

--- a/components/list/demo/list.html
+++ b/components/list/demo/list.html
@@ -24,7 +24,7 @@
 	</head>
 	<body unresolved>
 
-		<d2l-demo-page page-title="List Components">
+		<d2l-demo-page page-title="d2l-list">
 
 			<h2>Basic List</h2>
 

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -93,7 +93,8 @@ class ListItem extends RtlMixin(LitElement) {
 				margin-right: 0;
 			}
 
-			::slotted([slot="illustration"]) {
+			.d2l-list-item-container ::slotted([slot="illustration"]),
+			.d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				flex-grow: 0;
 				flex-shrink: 0;
 				margin: 0.15rem 0.9rem 0.15rem 0;
@@ -102,7 +103,8 @@ class ListItem extends RtlMixin(LitElement) {
 				overflow: hidden;
 			}
 
-			:host([dir="rtl"]) ::slotted([slot="illustration"]) {
+			:host([dir="rtl"]) .d2l-list-item-container ::slotted([slot="illustration"]),
+			:host([dir="rtl"]) .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-left: 0.9rem;
 				margin-right: 0;
 			}
@@ -111,7 +113,8 @@ class ListItem extends RtlMixin(LitElement) {
 				padding: 0.55rem 0;
 			}
 
-			:host([illustration-outside]) ::slotted([slot="illustration"]) {
+			:host([illustration-outside]) .d2l-list-item-container ::slotted([slot="illustration"]),
+			:host([illustration-outside]) .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-bottom: 0.7rem;
 				margin-top: 0.7rem;
 			}
@@ -126,7 +129,7 @@ class ListItem extends RtlMixin(LitElement) {
 				margin-top: 0.05rem;
 			}
 
-			::slotted([slot="actions"]) {
+			.d2l-list-item-content-flex ::slotted([slot="actions"]) {
 				align-self: flex-start;
 				display: grid;
 				flex-grow: 0;
@@ -162,35 +165,41 @@ class ListItem extends RtlMixin(LitElement) {
 				outline: none;
 			}
 
-			[breakpoint="1"] ::slotted([slot="illustration"]) {
+			.d2l-list-item-container[breakpoint="1"] ::slotted([slot="illustration"]),
+			.d2l-list-item-container[breakpoint="1"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-right: 1rem;
 				max-height: 3.55rem;
 				max-width: 6rem;
 			}
 
-			:host([dir="rtl"]) [breakpoint="1"] ::slotted([slot="illustration"]) {
+			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="1"] ::slotted([slot="illustration"]),
+			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="1"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-left: 1rem;
 				margin-right: 0;
 			}
 
-			[breakpoint="2"] ::slotted([slot="illustration"]) {
+			.d2l-list-item-container[breakpoint="2"] ::slotted([slot="illustration"]),
+			.d2l-list-item-container[breakpoint="2"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-right: 1rem;
 				max-height: 5.1rem;
 				max-width: 9rem;
 			}
 
-			:host([dir="rtl"]) [breakpoint="2"] ::slotted([slot="illustration"]) {
+			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="2"] ::slotted([slot="illustration"]),
+			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="2"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-left: 1rem;
 				margin-right: 0;
 			}
 
-			[breakpoint="3"] ::slotted([slot="illustration"]) {
+			.d2l-list-item-container[breakpoint="3"] ::slotted([slot="illustration"]),
+			.d2l-list-item-container[breakpoint="3"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-right: 1rem;
 				max-height: 6rem;
 				max-width: 10.8rem;
 			}
 
-			:host([dir="rtl"]) [breakpoint="3"] ::slotted([slot="illustration"]) {
+			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="3"] ::slotted([slot="illustration"]),
+			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="3"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-left: 1rem;
 				margin-right: 0;
 			}
@@ -243,6 +252,7 @@ class ListItem extends RtlMixin(LitElement) {
 			: html`<slot name="illustration"></slot>`;
 
 		const classes = {
+			'd2l-list-item-container': true,
 			'd2l-list-item-flex': label || link || this.illustrationOutside,
 			'd2l-visible-on-ancestor-target': true
 		};

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 			</ul>
 		</li>
 		<li><a href="components/link/demo/link.html">d2l-link</a></li>
+		<li><a href="components/list/demo/list.html">d2l-list</a></li>
 		<li><a href="components/menu/demo/menu-item.html">d2l-menu-item</a></li>
 		<li><a href="components/meter/demo/meter.html">d2l-meter</a></li>
 		<li><a href="components/more-less/demo/more-less.html">d2l-more-less</a></li>


### PR DESCRIPTION
* slotted selector fixes for Edge
* update readme, demo index, and root readme

Note: I have discovered that `::slotted` selectors need to have an immediate parent specified in order for them to work in Edge.