### PR TITLE
Update d2l-demo-snippet to support template-based source code.

### DIFF
--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -46,6 +46,10 @@ class CodeView extends LitElement {
 		super.attributeChangedCallback(name, oldval, newval);
 	}
 
+	firstUpdated() {
+		this._updateCode(this.shadowRoot.querySelector('slot'));
+	}
+
 	get _codeTemplate() {
 		return html`<pre class="language-${this.language}"><code class="language-${this.language}">${unsafeHTML(this._code)}</code></pre>`;
 	}

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -54,7 +54,6 @@ class DemoSnippet extends LitElement {
 		let lines = text.replace(/\t/g, '  ').replace(/<\/script>/g, '\n</script>').replace(/<script>/g, '<script>\n').split('\n');
 		let scriptIndent = 0;
 		lines = lines.map((l) => {
-			//console.log(i, l);
 			if (l.indexOf('<script>') > -1) {
 				scriptIndent = l.match(/^(\s*)/)[0].length;
 				return l;

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -53,7 +53,7 @@ class DemoSnippet extends LitElement {
 		// fix script whitespace (for some reason brower keeps <script> indent but not the rest)
 		let lines = text.replace(/\t/g, '  ').replace(/<\/script>/g, '\n</script>').replace(/<script>/g, '<script>\n').split('\n');
 		let scriptIndent = 0;
-		lines = lines.map((l, i) => {
+		lines = lines.map((l) => {
 			//console.log(i, l);
 			if (l.indexOf('<script>') > -1) {
 				scriptIndent = l.match(/^(\s*)/)[0].length;

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -9,7 +9,8 @@ class DemoSnippet extends LitElement {
 			codeViewHidden: { type: Boolean, reflect: true, attribute: 'code-view-hidden' },
 			noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
 			_code: { type: String },
-			_dirButton: { type: String }
+			_dirButton: { type: String },
+			_importedNodes: { type: Array }
 		};
 	}
 
@@ -21,6 +22,7 @@ class DemoSnippet extends LitElement {
 		super();
 		this._dir = document.documentElement.dir;
 		this._dirButton = this._dir === 'rtl' ? 'ltr' : 'rtl';
+		this._importedNodes = [];
 	}
 
 	render() {
@@ -29,6 +31,7 @@ class DemoSnippet extends LitElement {
 				<div class="d2l-demo-snippet-actions">
 					<button id="d2l-demo-snippet-toggle-dir" @click="${this._handleDirChange}" title="toggle dir">${this._dirButton}</button>
 				</div>
+				${this._importedNodes.map((node) => html`${node}`)}
 				<slot @slotchange="${this._handleSlotChange}"></slot>
 			</div>
 			<d2l-code-view language="html" hide-language>${this._code}</d2l-code-view>
@@ -43,10 +46,15 @@ class DemoSnippet extends LitElement {
 
 		if (!text) return text;
 
+		// remove the leading and trailing template tags
+		text = text.replace(/^[\t]*\n/, '').replace(/\n[\t]*$/, '');
+		text = text.replace(/^[\t]*<template>[\n]*/, '').replace(/[\n]*[\t]*<\/template>$/, '');
+
 		// fix script whitespace (for some reason brower keeps <script> indent but not the rest)
 		let lines = text.replace(/\t/g, '  ').replace(/<\/script>/g, '\n</script>').replace(/<script>/g, '<script>\n').split('\n');
 		let scriptIndent = 0;
-		lines = lines.map((l) => {
+		lines = lines.map((l, i) => {
+			//console.log(i, l);
 			if (l.indexOf('<script>') > -1) {
 				scriptIndent = l.match(/^(\s*)/)[0].length;
 				return l;
@@ -110,12 +118,18 @@ class DemoSnippet extends LitElement {
 			this._code = '';
 			return;
 		}
+		const importedNodes = [];
 		const tempContainer = document.createElement('div');
 		for (let i = 0; i < nodes.length; i++) {
+			if (nodes[i].tagName === 'TEMPLATE') {
+				const clone = document.importNode(nodes[i].content, true);
+				importedNodes.push(clone);
+			}
 			tempContainer.appendChild(nodes[i].cloneNode(true));
 		}
 		const textNode = document.createTextNode(this._formatCode(tempContainer.innerHTML));
 		this._code = textNode.textContent;
+		this._importedNodes = importedNodes;
 	}
 
 }

--- a/components/demo/demo/demo-snippet.html
+++ b/components/demo/demo/demo-snippet.html
@@ -18,7 +18,15 @@
 			<h2>Demo Snippet</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-icon icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
+					<d2l-button-icon icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
+			</d2l-demo-snippet>
+
+			<h2>Demo Snippet (using template)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-button-icon icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Code View</h2>


### PR DESCRIPTION
Some components surface attributes on their host (ex. [ButtonMixin](https://github.com/BrightspaceUI/core/blob/master/components/button/button-mixin.js#L24)), resulting in those attributes being displayed in the formatted code in the demo-snippet.  This is misleading to those using the demo because it leads them to believe that the app must provide those attributes. 

This change adds support for demo code contained by a `template` element. The reasons this was not done from the beginning was: a) to enable demo pages to have more succinct demo snippets; and b) to enable demo pages to wire up event handlers to demo elements at page load-time.  We might eventually want to add an event `d2l-demo-snippet-ready` in the future as a hook, but there is no immediate need for that. 

Below, the reflected default `type="button"` is included in the formatted code if the demo code is not contained by a `template`.  The template makes the demo page's code slightly more verbose, but it's better than devs thinking they need to include those attributes when using the component(s).
```
<d2l-demo-snippet>
    <d2l-button-icon icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
</d2l-demo-snippet>

<d2l-demo-snippet>
    <template>
        <d2l-button-icon icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
    </template>
</d2l-demo-snippet>
```

![image](https://user-images.githubusercontent.com/9042472/68032134-6ec05000-fc93-11e9-9367-758b77fdaecf.png)

