### PR TITLE
Dbatiste/demo snippet updates

### DIFF
--- a/components/button/demo/button-icon.html
+++ b/components/button/demo/button-icon.html
@@ -67,55 +67,69 @@
 			<h2>Icon Button</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-icon id="normal" icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
+				<template>
+					<d2l-button-icon id="normal" icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Icon Button Disabled</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-icon id="disabled" icon="d2l-tier1:gear" text="Icon Button" disabled></d2l-button-icon>
+				<template>
+					<d2l-button-icon id="disabled" icon="d2l-tier1:gear" text="Icon Button" disabled></d2l-button-icon>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Icon Button Translucent</h2>
 
 			<d2l-demo-snippet>
-				<div class="translucent-container">
-					<img alt="" src="https://s.brightspace.com/course-images/images/e4fbb461-4cd9-4512-8304-44f2c2b741f1/tile-low-density-max-size.jpg">
-					<d2l-button-icon id="translucent" icon="d2l-tier1:gear" text="Icon Button" translucent></d2l-button-icon>
-				</div>
+				<template>
+					<div class="translucent-container">
+						<img alt="" src="https://s.brightspace.com/course-images/images/e4fbb461-4cd9-4512-8304-44f2c2b741f1/tile-low-density-max-size.jpg">
+						<d2l-button-icon id="translucent" icon="d2l-tier1:gear" text="Icon Button" translucent></d2l-button-icon>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Icon Button with Horizontal Align</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-icon icon="d2l-tier1:gear" text="Button Edge Aligned (default)"></d2l-button-icon>
-				<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
-				<d2l-button-icon icon="d2l-tier1:gear" text="Button Content Aligned" h-align="text"></d2l-button-icon>
+				<template>
+					<d2l-button-icon icon="d2l-tier1:gear" text="Button Edge Aligned (default)"></d2l-button-icon>
+					<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
+					<d2l-button-icon icon="d2l-tier1:gear" text="Button Content Aligned" h-align="text"></d2l-button-icon>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Icon Button with Visible on Ancestor</h2>
 
 			<d2l-demo-snippet>
-				<div class="ancestor-container d2l-visible-on-ancestor-target">
-					<d2l-button-icon icon="d2l-tier1:home" text="Home"></d2l-button-icon>
-					<d2l-button-icon icon="d2l-tier1:bookmark-hollow" text="Bookmark"></d2l-button-icon>
-					<d2l-button-icon icon="d2l-tier1:gear" text="Gear" visible-on-ancestor></d2l-button-icon>
-				</div>
+				<template>
+					<div class="ancestor-container d2l-visible-on-ancestor-target">
+						<d2l-button-icon icon="d2l-tier1:home" text="Home"></d2l-button-icon>
+						<d2l-button-icon icon="d2l-tier1:bookmark-hollow" text="Bookmark"></d2l-button-icon>
+						<d2l-button-icon icon="d2l-tier1:gear" text="Gear" visible-on-ancestor></d2l-button-icon>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Icon Button with Translucent + Visible on Ancestor</h2>
 
 			<d2l-demo-snippet>
-				<div class="translucent-container d2l-visible-on-ancestor-target">
-					<img alt="" src="https://s.brightspace.com/course-images/images/e4fbb461-4cd9-4512-8304-44f2c2b741f1/tile-low-density-max-size.jpg">
-					<d2l-button-icon icon="d2l-tier1:gear" text="Settings" translucent visible-on-ancestor></d2l-button-icon>
-				</div>
+				<template>
+					<div class="translucent-container d2l-visible-on-ancestor-target">
+						<img alt="" src="https://s.brightspace.com/course-images/images/e4fbb461-4cd9-4512-8304-44f2c2b741f1/tile-low-density-max-size.jpg">
+						<d2l-button-icon icon="d2l-tier1:gear" text="Settings" translucent visible-on-ancestor></d2l-button-icon>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Icon Button with Customized Size and Focus Box-Shadow</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-icon icon="d2l-tier1:search" text="Search" class="custom"></d2l-button-icon>
+				<template>
+					<d2l-button-icon icon="d2l-tier1:search" text="Search" class="custom"></d2l-button-icon>
+				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/components/button/demo/button-subtle.html
+++ b/components/button/demo/button-subtle.html
@@ -18,33 +18,43 @@
 			<h2>Subtle Button with Text Only</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-subtle id="normal" text="Subtle Button"></d2l-button-subtle>
+				<template>
+					<d2l-button-subtle id="normal" text="Subtle Button"></d2l-button-subtle>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Subtle Button Disabled</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-subtle id="disabled" text="Subtle Button" disabled></d2l-button-subtle>
+				<template>
+					<d2l-button-subtle id="disabled" text="Subtle Button" disabled></d2l-button-subtle>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Subtle Button with Text and Icon</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-subtle id="with-icon" icon="d2l-tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
+				<template>
+					<d2l-button-subtle id="with-icon" icon="d2l-tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Subtle Button with Text and Icon on the Right</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-subtle id="icon-right" icon="d2l-tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
+				<template>
+					<d2l-button-subtle id="icon-right" icon="d2l-tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Subtle Button with Horizontal Align</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button-subtle icon="d2l-tier1:gear" text="Button Edge Aligned (default)"></d2l-button-subtle>
-				<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
-				<d2l-button-subtle icon="d2l-tier1:gear" text="Button Content Aligned" h-align="text"></d2l-button-subtle>
+				<template>
+					<d2l-button-subtle icon="d2l-tier1:gear" text="Button Edge Aligned (default)"></d2l-button-subtle>
+					<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
+					<d2l-button-subtle icon="d2l-tier1:gear" text="Button Content Aligned" h-align="text"></d2l-button-subtle>
+				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/components/button/demo/button.html
+++ b/components/button/demo/button.html
@@ -14,22 +14,39 @@
 	<body unresolved>
 
 		<d2l-demo-page page-title="d2l-button">
+
 			<h2>Button</h2>
+
 			<d2l-demo-snippet>
-				<d2l-button>Normal Button</d2l-button>
+				<template>
+					<d2l-button>Normal Button</d2l-button>
+				</template>
 			</d2l-demo-snippet>
+
 			<h2>Button (Primary)</h2>
+
 			<d2l-demo-snippet>
-				<d2l-button primary>Primary Button</d2l-button>
+				<template>
+					<d2l-button primary>Primary Button</d2l-button>
+				</template>
 			</d2l-demo-snippet>
+
 			<h2>Button (Disabled)</h2>
+
 			<d2l-demo-snippet>
-				<d2l-button disabled>Disabled Button</d2l-button>
+				<template>
+					<d2l-button disabled>Disabled Button</d2l-button>
+				</template>
 			</d2l-demo-snippet>
+
 			<h2>Button (Primary and Disabled)</h2>
+
 			<d2l-demo-snippet>
-				<d2l-button disabled primary>Disabled Primary Button</d2l-button>
+				<template>
+					<d2l-button disabled primary>Disabled Primary Button</d2l-button>
+				</template>
 			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 
 	</body>

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -121,7 +121,6 @@ class DemoSnippet extends LitElement {
 			this._code = '';
 			return;
 		}
-		const importedNodes = [];
 		const tempContainer = document.createElement('div');
 		for (let i = 0; i < nodes.length; i++) {
 			if (nodes[i].tagName === 'TEMPLATE') {

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -48,6 +48,8 @@ class DemoSnippet extends LitElement {
 
 		// remove the leading and trailing template tags
 		text = text.replace(/^[\t]*\n/, '').replace(/\n[\t]*$/, '');
+		const templateMatch = text.match(/^[\t]*<template>[\n]*/);
+		const isTemplate = templateMatch && templateMatch.length > 0;
 		text = text.replace(/^[\t]*<template>[\n]*/, '').replace(/[\n]*[\t]*<\/template>$/, '');
 
 		// fix script whitespace (for some reason brower keeps <script> indent but not the rest)
@@ -61,7 +63,7 @@ class DemoSnippet extends LitElement {
 				const nl = this._repeat(' ', scriptIndent) + l ;
 				scriptIndent = 0;
 				return nl;
-			} else if (scriptIndent) {
+			} else if (scriptIndent && !isTemplate) {
 				return this._repeat(' ', scriptIndent + 2) + l;
 			} else {
 				return l;

--- a/components/dialog/demo/dialog-nested.html
+++ b/components/dialog/demo/dialog-nested.html
@@ -29,39 +29,40 @@
 			<h2>Dialog</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button id="openParent">Show Parent</d2l-button>
-				<d2l-dialog id="parentDialog" title-text="Parent Dialog">
-					<div>
+				<template>
+					<d2l-button id="openParent">Show Parent</d2l-button>
+					<d2l-dialog id="parentDialog" title-text="Parent Dialog">
+						<div>
 
-						<div>Quarter bounty jib Letter of Marque clipper ballast warp hulk jack scurvy. Avast code of conduct jury mast spyglass booty sloop piracy overhaul barque Arr. Boom quarter loaded to the gunwalls crow's nest code of conduct spyglass Spanish Main booty run a shot across the bow Gold Road.</div>
-						<d2l-button id="openChild">Show Child</d2l-button>
-						<div>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</div>
+							<div>Quarter bounty jib Letter of Marque clipper ballast warp hulk jack scurvy. Avast code of conduct jury mast spyglass booty sloop piracy overhaul barque Arr. Boom quarter loaded to the gunwalls crow's nest code of conduct spyglass Spanish Main booty run a shot across the bow Gold Road.</div>
+							<d2l-button id="openChild">Show Child</d2l-button>
+							<div>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</div>
 
-						<d2l-dialog id="childDialog" title-text="Child Dialog" width="400">
-							<div>
-								Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.
-								Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.
-							</div>
-							<d2l-button slot="footer" primary dialog-action="child ok">Child</d2l-button>
-							<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
-						</d2l-dialog>
+							<d2l-dialog id="childDialog" title-text="Child Dialog" width="400">
+								<div>
+									Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.
+									Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.
+								</div>
+								<d2l-button slot="footer" primary dialog-action="child ok">Child</d2l-button>
+								<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+							</d2l-dialog>
 
-					</div>
-					<d2l-button slot="footer" primary dialog-action="ok">Parent</d2l-button>
-					<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
-				</d2l-dialog>
+						</div>
+						<d2l-button slot="footer" primary dialog-action="ok">Parent</d2l-button>
+						<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+					</d2l-dialog>
 
-				<script>
-					document.querySelector('#openParent').addEventListener('click', async() => {
-						const action = await document.querySelector('#parentDialog').open();
-						console.log('parent dialog action:', action);
-					});
-					document.querySelector('#openChild').addEventListener('click', async() => {
-						const action = await document.querySelector('#childDialog').open();
-						console.log('child dialog action:', action);
-					});
-				</script>
-
+					<script>
+						document.querySelector('#openParent').addEventListener('click', async() => {
+							const action = await document.querySelector('#parentDialog').open();
+							console.log('parent dialog action:', action);
+						});
+						document.querySelector('#openChild').addEventListener('click', async() => {
+							const action = await document.querySelector('#childDialog').open();
+							console.log('child dialog action:', action);
+						});
+					</script>
+				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -27,85 +27,89 @@
 			<h2>Dialog</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button id="open">Show Dialog</d2l-button>
-				<d2l-dialog id="dialog" title-text="Dialog Title">
-					<div>
-						<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
-						<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
-						<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
-					</div>
-					<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
-					<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
-				</d2l-dialog>
-				<script>
-					document.querySelector('#open').addEventListener('click', () => {
-						document.querySelector('#dialog').opened = true;
-					});
-					document.querySelector('#dialog').addEventListener('d2l-dialog-close', (e) => {
-						console.log('dialog action:', e.detail.action);
-					});
-				</script>
+				<template>
+					<d2l-button id="open">Show Dialog</d2l-button>
+					<d2l-dialog id="dialog" title-text="Dialog Title">
+						<div>
+							<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
+							<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
+							<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
+						</div>
+						<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
+						<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+					</d2l-dialog>
+					<script>
+						document.querySelector('#open').addEventListener('click', () => {
+							document.querySelector('#dialog').opened = true;
+						});
+						document.querySelector('#dialog').addEventListener('d2l-dialog-close', (e) => {
+							console.log('dialog action:', e.detail.action);
+						});
+					</script>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Dialog (with promise)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-button id="openPromise">Show Dialog</d2l-button>
-				<d2l-dialog id="dialogPromise" title-text="Dialog Title">
-					<div>
-						<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
-						<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
-						<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
-					</div>
-					<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
-					<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
-				</d2l-dialog>
-				<script>
-					document.querySelector('#openPromise').addEventListener('click', async() => {
-						const action = await document.querySelector('#dialogPromise').open();
-						console.log('dialog action:', action);
-					});
-				</script>
+				<template>
+					<d2l-button id="openPromise">Show Dialog</d2l-button>
+					<d2l-dialog id="dialogPromise" title-text="Dialog Title">
+						<div>
+							<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
+							<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
+							<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
+						</div>
+						<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
+						<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+					</d2l-dialog>
+					<script>
+						document.querySelector('#openPromise').addEventListener('click', async() => {
+							const action = await document.querySelector('#dialogPromise').open();
+							console.log('dialog action:', action);
+						});
+					</script>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Confirm Dialog</h2>
 
 			<d2l-demo-snippet>
-
-				<d2l-button id="openConfirm">Show Confirm</d2l-button>
-				<d2l-dialog-confirm id="confirm" title-text="Confirm Title" text="Are you sure you want more cookies?">
-					<d2l-button slot="footer" primary dialog-action="ok">Yes</d2l-button>
-					<d2l-button slot="footer" dialog-action>No</d2l-button>
-				</d2l-dialog-confirm>
-				<script>
-					document.querySelector('#openConfirm').addEventListener('click', () => {
-						document.querySelector('#confirm').opened = true;
-					});
-					document.querySelector('#confirm').addEventListener('d2l-dialog-close', (e) => {
-						console.log('confirm action:', e.detail.action);
-					});
-				</script>
-
+				<template>
+					<d2l-button id="openConfirm">Show Confirm</d2l-button>
+					<d2l-dialog-confirm id="confirm" title-text="Confirm Title" text="Are you sure you want more cookies?">
+						<d2l-button slot="footer" primary dialog-action="ok">Yes</d2l-button>
+						<d2l-button slot="footer" dialog-action>No</d2l-button>
+					</d2l-dialog-confirm>
+					<script>
+						document.querySelector('#openConfirm').addEventListener('click', () => {
+							document.querySelector('#confirm').opened = true;
+						});
+						document.querySelector('#confirm').addEventListener('d2l-dialog-close', (e) => {
+							console.log('confirm action:', e.detail.action);
+						});
+					</script>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Confirm Dialog (No Title)</h2>
 
 			<d2l-demo-snippet>
-
-				<d2l-button id="openConfirmNoTitle">Show Confirm</d2l-button>
-				<d2l-dialog-confirm id="confirmNoTitle" text="Are you sure you want more cookies?">
-					<d2l-button slot="footer" primary dialog-action="ok">Yes</d2l-button>
-					<d2l-button slot="footer" dialog-action>No</d2l-button>
-				</d2l-dialog-confirm>
-				<script>
-					document.querySelector('#openConfirmNoTitle').addEventListener('click', () => {
-						document.querySelector('#confirmNoTitle').opened = true;
-					});
-					document.querySelector('#confirmNoTitle').addEventListener('d2l-dialog-close', (e) => {
-						console.log('confirm action:', e.detail.action);
-					});
-				</script>
-
+				<template>
+					<d2l-button id="openConfirmNoTitle">Show Confirm</d2l-button>
+					<d2l-dialog-confirm id="confirmNoTitle" text="Are you sure you want more cookies?">
+						<d2l-button slot="footer" primary dialog-action="ok">Yes</d2l-button>
+						<d2l-button slot="footer" dialog-action>No</d2l-button>
+					</d2l-dialog-confirm>
+					<script>
+						document.querySelector('#openConfirmNoTitle').addEventListener('click', () => {
+							document.querySelector('#confirmNoTitle').opened = true;
+						});
+						document.querySelector('#confirmNoTitle').addEventListener('d2l-dialog-close', (e) => {
+							console.log('confirm action:', e.detail.action);
+						});
+					</script>
+				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/components/icons/demo/icon.html
+++ b/components/icons/demo/icon.html
@@ -20,27 +20,33 @@
 
 			<h3>Tiers</h3>
 			<d2l-demo-snippet>
-				<d2l-icon icon="tier1:assignments"></d2l-icon>
-				<d2l-icon icon="tier2:assignments"></d2l-icon>
-				<d2l-icon icon="tier3:assignments"></d2l-icon>
+				<template>
+					<d2l-icon icon="tier1:assignments"></d2l-icon>
+					<d2l-icon icon="tier2:assignments"></d2l-icon>
+					<d2l-icon icon="tier3:assignments"></d2l-icon>
+				</template>
 			</d2l-demo-snippet>
 
 			<h3>Color Override</h3>
 			<d2l-demo-snippet>
-				<d2l-icon-demo-color-override>
-					<d2l-icon icon="tier1:assignments"></d2l-icon>
-					<d2l-icon icon="tier2:assignments"></d2l-icon>
-					<d2l-icon icon="tier3:assignments"></d2l-icon>
-				</d2l-icon-demo-color-override>
+				<template>
+					<d2l-icon-demo-color-override>
+						<d2l-icon icon="tier1:assignments"></d2l-icon>
+						<d2l-icon icon="tier2:assignments"></d2l-icon>
+						<d2l-icon icon="tier3:assignments"></d2l-icon>
+					</d2l-icon-demo-color-override>
+				</template>
 			</d2l-demo-snippet>
 
 			<h3>Size Override</h3>
 			<d2l-demo-snippet>
-				<d2l-icon-demo-size-override>
-					<d2l-icon icon="tier1:assignments"></d2l-icon>
-					<d2l-icon icon="tier2:assignments"></d2l-icon>
-					<d2l-icon icon="tier3:assignments"></d2l-icon>
-				</d2l-icon-demo-size-override>
+				<template>
+					<d2l-icon-demo-size-override>
+						<d2l-icon icon="tier1:assignments"></d2l-icon>
+						<d2l-icon icon="tier2:assignments"></d2l-icon>
+						<d2l-icon icon="tier3:assignments"></d2l-icon>
+					</d2l-icon-demo-size-override>
+				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/components/inputs/demo/input-checkbox.html
+++ b/components/inputs/demo/input-checkbox.html
@@ -17,40 +17,52 @@
 
 			<h2>Simple checkbox with label</h2>
 			<d2l-demo-snippet>
-				<d2l-input-checkbox checked>Checked item</d2l-input-checkbox>
-				<d2l-input-checkbox>Unchecked item</d2l-input-checkbox>
+				<template>
+					<d2l-input-checkbox checked>Checked item</d2l-input-checkbox>
+					<d2l-input-checkbox>Unchecked item</d2l-input-checkbox>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Checkbox with multi-line label</h2>
 			<d2l-demo-snippet>
-				<d2l-input-checkbox style="width:200px;">
-					Label for checkbox that wraps nicely onto
-					multiple lines and stays aligned
-				</d2l-input-checkbox>
+				<template>
+					<d2l-input-checkbox style="width:200px;">
+						Label for checkbox that wraps nicely onto
+						multiple lines and stays aligned
+					</d2l-input-checkbox>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Checkbox with hidden label</h2>
 			<d2l-demo-snippet>
-				<d2l-input-checkbox aria-label="Label for checkbox"></d2l-input-checkbox>
+				<template>
+					<d2l-input-checkbox aria-label="Label for checkbox"></d2l-input-checkbox>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Disabled checkbox</h2>
 			<d2l-demo-snippet>
-				<d2l-input-checkbox checked disabled>Disabled checkbox</d2l-input-checkbox>
+				<template>
+					<d2l-input-checkbox checked disabled>Disabled checkbox</d2l-input-checkbox>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Checkbox with label and secondary content</h2>
 			<d2l-demo-snippet>
-				<d2l-input-checkbox>Label for checkbox</d2l-input-checkbox>
-				<d2l-input-checkbox-spacer style="color:#999999;">
-					Additional content can go here and will<br>
-					also line up nicely with the checkbox.
-				</d2l-input-checkbox-spacer>
+				<template>
+					<d2l-input-checkbox>Label for checkbox</d2l-input-checkbox>
+					<d2l-input-checkbox-spacer style="color:#999999;">
+						Additional content can go here and will<br>
+						also line up nicely with the checkbox.
+					</d2l-input-checkbox-spacer>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Indeterminate checkbox</h2>
 			<d2l-demo-snippet>
-				<d2l-input-checkbox indeterminate>Indeterminate checkbox</d2l-input-checkbox>
+				<template>
+					<d2l-input-checkbox indeterminate>Indeterminate checkbox</d2l-input-checkbox>
+				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/components/inputs/demo/input-search.html
+++ b/components/inputs/demo/input-search.html
@@ -13,22 +13,30 @@
 	</head>
 	<body unresolved>
 		<d2l-demo-page page-title="d2l-input-search">
+
 			<h2>Search Input</h2>
 			<d2l-demo-snippet>
-				<d2l-input-search label="Search" value="apples" placeholder="Search for some stuff">
-				</d2l-input-search>
+				<template>
+					<d2l-input-search label="Search" value="apples" placeholder="Search for some stuff">
+					</d2l-input-search>
+				</template>
 			</d2l-demo-snippet>
+
 			<h2>Search Input (No Clear)</h2>
 			<d2l-demo-snippet>
-				<d2l-input-search label="Search" value="Clear button will never appear" placeholder="Search for some stuff" no-clear>
-				</d2l-input-search>
+				<template>
+					<d2l-input-search label="Search" value="Clear button will never appear" placeholder="Search for some stuff" no-clear>
+					</d2l-input-search>
+				</template>
 			</d2l-demo-snippet>
+
 			<script>
 				document.body.addEventListener('d2l-input-search-searched', (e) => {
 					// eslint-disable-next-line no-console
 					console.log(e);
 				});
 			</script>
+
 		</d2l-demo-page>
 	</body>
 </html>

--- a/components/inputs/demo/input-text.html
+++ b/components/inputs/demo/input-text.html
@@ -13,26 +13,42 @@
 	</head>
 	<body unresolved>
 		<d2l-demo-page page-title="d2l-input-text">
+
 			<h2>Simple</h2>
 			<d2l-demo-snippet>
-				<d2l-input-text></d2l-input-text>
+				<template>
+					<d2l-input-text></d2l-input-text>
+				</template>
 			</d2l-demo-snippet>
+
 			<h2>Disabled</h2>
 			<d2l-demo-snippet>
-				<d2l-input-text disabled></d2l-input-text>
+				<template>
+					<d2l-input-text disabled></d2l-input-text>
+				</template>
 			</d2l-demo-snippet>
+
 			<h2>Placeholder</h2>
 			<d2l-demo-snippet>
-				<d2l-input-text placeholder="enter some text"></d2l-input-text>
+				<template>
+					<d2l-input-text placeholder="enter some text"></d2l-input-text>
+				</template>
 			</d2l-demo-snippet>
+
 			<h3>Invalid</h3>
 			<d2l-demo-snippet>
-				<d2l-input-text type="email" value="foo@"></d2l-input-text>
+				<template>
+					<d2l-input-text type="email" value="foo@"></d2l-input-text>
+				</template>
 			</d2l-demo-snippet>
+
 			<h3>Aria-Invalid</h3>
 			<d2l-demo-snippet>
-				<d2l-input-text type="text" aria-invalid="true"></d2l-input-text>
+				<template>
+					<d2l-input-text type="text" aria-invalid="true"></d2l-input-text>
+				</template>
 			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 	</body>
 </html>

--- a/components/link/demo/link.html
+++ b/components/link/demo/link.html
@@ -13,18 +13,28 @@
 	</head>
 	<body unresolved>
 		<d2l-demo-page page-title="d2l-link">
+
 			<h2>Standard Link</h2>
 			<d2l-demo-snippet>
-				<d2l-link href="https://www.d2l.com">Standard Link</d2l-link>
+				<template>
+					<d2l-link href="https://www.d2l.com">Standard Link</d2l-link>
+				</template>
 			</d2l-demo-snippet>
+
 			<h2>Main Link</h2>
 			<d2l-demo-snippet>
-				<d2l-link main href="https://www.d2l.com">Main Link</d2l-link>
+				<template>
+					<d2l-link main href="https://www.d2l.com">Main Link</d2l-link>
+				</template>
 			</d2l-demo-snippet>
+
 			<h2>Small Link</h2>
 			<d2l-demo-snippet>
-				<d2l-link small href="https://www.d2l.com">Small Link</d2l-link>
+				<template>
+					<d2l-link small href="https://www.d2l.com">Small Link</d2l-link>
+				</template>
 			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 	</body>
 </html>

--- a/components/list/demo/list.html
+++ b/components/list/demo/list.html
@@ -29,292 +29,312 @@
 			<h2>Basic List</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Identify categories of physical activities</div>
-							<div slot="secondary">Specific Expectation A1.2</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
-							<div slot="secondary">Specific Expectation B2.1</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
-							<div slot="secondary">Specific Expectation B2.2</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Identify categories of physical activities</div>
+								<div slot="secondary">Specific Expectation A1.2</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
+								<div slot="secondary">Specific Expectation B2.1</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
+								<div slot="secondary">Specific Expectation B2.2</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Basic List (separators: between)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list separators="between">
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Identify categories of physical activities</div>
-							<div slot="secondary">Specific Expectation A1.2</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
-							<div slot="secondary">Specific Expectation B2.1</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
-							<div slot="secondary">Specific Expectation B2.2</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list separators="between">
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Identify categories of physical activities</div>
+								<div slot="secondary">Specific Expectation A1.2</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
+								<div slot="secondary">Specific Expectation B2.1</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
+								<div slot="secondary">Specific Expectation B2.2</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Basic List (separators: none)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list separators="none">
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Identify categories of physical activities</div>
-							<div slot="secondary">Specific Expectation A1.2</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
-							<div slot="secondary">Specific Expectation B2.1</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
-							<div slot="secondary">Specific Expectation B2.2</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list separators="none">
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Identify categories of physical activities</div>
+								<div slot="secondary">Specific Expectation A1.2</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
+								<div slot="secondary">Specific Expectation B2.1</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
+								<div slot="secondary">Specific Expectation B2.2</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Basic List (extend separators)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list extend-separators>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Identify categories of physical activities</div>
-							<div slot="secondary">Specific Expectation A1.2</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
-							<div slot="secondary">Specific Expectation B2.1</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-item-content>
-							<div>Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
-							<div slot="secondary">Specific Expectation B2.2</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list extend-separators>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Identify categories of physical activities</div>
+								<div slot="secondary">Specific Expectation A1.2</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
+								<div slot="secondary">Specific Expectation B2.1</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-item-content>
+								<div>Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
+								<div slot="secondary">Specific Expectation B2.2</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>List (with secondary actions)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list>
-					<d2l-list-item>
-						<d2l-list-demo-name-image color="purple" letters="BN" slot="illustration"></d2l-list-demo-name-image>
-						<d2l-list-item-content>
-							<div>Byron Novak</div>
-							<div slot="secondary">bnovak</div>
-						</d2l-list-item-content>
-						<div slot="actions">
-							<d2l-button-icon text="My Button" icon="d2l-tier1:preview"></d2l-button-icon>
-							<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
-						</div>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-demo-name-image color="red" letters="DW" slot="illustration"></d2l-list-demo-name-image>
-						<d2l-list-item-content>
-							<div>Dimitri Watts</div>
-							<div slot="secondary">dwatts</div>
-						</d2l-list-item-content>
-						<div slot="actions">
-							<d2l-button-icon text="My Button" icon="d2l-tier1:preview"></d2l-button-icon>
-							<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
-						</div>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-demo-name-image color="teal" letters="PM" slot="illustration"></d2l-list-demo-name-image>
-						<d2l-list-item-content>
-							<div>Petra Macleod</div>
-							<div slot="secondary">pmacleod</div>
-						</d2l-list-item-content>
-						<div slot="actions">
-							<d2l-button-icon text="My Button" icon="d2l-tier1:preview"></d2l-button-icon>
-							<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
-						</div>
-					</d2l-list-item>
-					<d2l-list-item>
-						<d2l-list-demo-name-image color="grey" letters="YL" slot="illustration"></d2l-list-demo-name-image>
-						<d2l-list-item-content>
-							<div>Yvonne Lord</div>
-							<div slot="secondary">ylord</div>
-						</d2l-list-item-content>
-						<div slot="actions">
-							<d2l-button-icon text="My Button" icon="d2l-tier1:preview"></d2l-button-icon>
-							<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
-						</div>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list>
+						<d2l-list-item>
+							<d2l-list-demo-name-image color="purple" letters="BN" slot="illustration"></d2l-list-demo-name-image>
+							<d2l-list-item-content>
+								<div>Byron Novak</div>
+								<div slot="secondary">bnovak</div>
+							</d2l-list-item-content>
+							<div slot="actions">
+								<d2l-button-icon text="My Button" icon="d2l-tier1:preview"></d2l-button-icon>
+								<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
+							</div>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-demo-name-image color="red" letters="DW" slot="illustration"></d2l-list-demo-name-image>
+							<d2l-list-item-content>
+								<div>Dimitri Watts</div>
+								<div slot="secondary">dwatts</div>
+							</d2l-list-item-content>
+							<div slot="actions">
+								<d2l-button-icon text="My Button" icon="d2l-tier1:preview"></d2l-button-icon>
+								<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
+							</div>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-demo-name-image color="teal" letters="PM" slot="illustration"></d2l-list-demo-name-image>
+							<d2l-list-item-content>
+								<div>Petra Macleod</div>
+								<div slot="secondary">pmacleod</div>
+							</d2l-list-item-content>
+							<div slot="actions">
+								<d2l-button-icon text="My Button" icon="d2l-tier1:preview"></d2l-button-icon>
+								<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
+							</div>
+						</d2l-list-item>
+						<d2l-list-item>
+							<d2l-list-demo-name-image color="grey" letters="YL" slot="illustration"></d2l-list-demo-name-image>
+							<d2l-list-item-content>
+								<div>Yvonne Lord</div>
+								<div slot="secondary">ylord</div>
+							</d2l-list-item-content>
+							<div slot="actions">
+								<d2l-button-icon text="My Button" icon="d2l-tier1:preview"></d2l-button-icon>
+								<d2l-button-icon text="My Button" icon="d2l-tier1:more"></d2l-button-icon>
+							</div>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>List (with illustration)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list>
-					<d2l-list-item>
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Introductory Earth Sciences</div>
-							<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Engineering Materials for Energy Systems</div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item>
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Geomorphology and GIS </div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list>
+						<d2l-list-item>
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Introductory Earth Sciences</div>
+								<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Engineering Materials for Energy Systems</div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item>
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Geomorphology and GIS </div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>List (illustration outside)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list>
-					<d2l-list-item illustration-outside>
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Introductory Earth Sciences</div>
-							<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item illustration-outside>
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Engineering Materials for Energy Systems</div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item illustration-outside>
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Geomorphology and GIS </div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list>
+						<d2l-list-item illustration-outside>
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Introductory Earth Sciences</div>
+								<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item illustration-outside>
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Engineering Materials for Energy Systems</div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item illustration-outside>
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Geomorphology and GIS </div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>List (with href)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list>
-					<d2l-list-item href="http://www.d2l.com">
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Introductory Earth Sciences</div>
-							<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item href="http://www.d2l.com">
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Engineering Materials for Energy Systems</div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item href="http://www.d2l.com">
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Geomorphology and GIS </div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list>
+						<d2l-list-item href="http://www.d2l.com">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Introductory Earth Sciences</div>
+								<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item href="http://www.d2l.com">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Engineering Materials for Energy Systems</div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item href="http://www.d2l.com">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Geomorphology and GIS </div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>List (selectable)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list>
-					<d2l-list-item selectable key="1">
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Introductory Earth Sciences</div>
-							<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item selectable key="2" selected>
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Engineering Materials for Energy Systems</div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item selectable key="3">
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Geomorphology and GIS </div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list>
+						<d2l-list-item selectable key="1">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Introductory Earth Sciences</div>
+								<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item selectable key="2" selected>
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Engineering Materials for Energy Systems</div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item selectable key="3">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Geomorphology and GIS </div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>List (selectable with href)</h2>
 
 			<d2l-demo-snippet>
-				<d2l-list>
-					<d2l-list-item href="http://www.d2l.com" selectable key="1">
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Introductory Earth Sciences</div>
-							<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item href="http://www.d2l.com" selectable key="2" selected>
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Engineering Materials for Energy Systems</div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-					<d2l-list-item href="http://www.d2l.com" selectable key="3">
-						<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
-						<d2l-list-item-content>
-							<div>Geomorphology and GIS </div>
-							<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
-						</d2l-list-item-content>
-					</d2l-list-item>
-				</d2l-list>
+				<template>
+					<d2l-list>
+						<d2l-list-item href="http://www.d2l.com" selectable key="1">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Introductory Earth Sciences</div>
+								<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item href="http://www.d2l.com" selectable key="2" selected>
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Engineering Materials for Energy Systems</div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item href="http://www.d2l.com" selectable key="3">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Geomorphology and GIS </div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -20,44 +20,50 @@
 			<h2>Meter Linear</h2>
 
 			<d2l-demo-snippet>
-				<d2l-meter-linear value="2" max="15" style="width: 250px" text="Activities" text-inline></d2l-meter-linear>
-				<d2l-meter-linear value="3" max="6" style="width: 200px" text="Visited: {x/y}" percent></d2l-meter-linear>
-				<div style="background-color: darkblue;">
-					<d2l-meter-linear value="2" max="15" style="width: 250px" text="Activities" text-inline foreground-light></d2l-meter-linear>
-					<d2l-meter-linear value="3" max="6" style="width: 200px" text="Visited: {x/y}" percent foreground-light></d2l-meter-linear>
-				</div>
+				<template>
+					<d2l-meter-linear value="2" max="15" style="width: 250px" text="Activities" text-inline></d2l-meter-linear>
+					<d2l-meter-linear value="3" max="6" style="width: 200px" text="Visited: {x/y}" percent></d2l-meter-linear>
+					<div style="background-color: darkblue;">
+						<d2l-meter-linear value="2" max="15" style="width: 250px" text="Activities" text-inline foreground-light></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" style="width: 200px" text="Visited: {x/y}" percent foreground-light></d2l-meter-linear>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Meter Radial</h2>
 
 			<d2l-demo-snippet>
-				<d2l-meter-radial value="5" max="13"></d2l-meter-radial>
-				<d2l-meter-radial value="10" max="10"></d2l-meter-radial>
-				<d2l-meter-radial value="0" max="10"></d2l-meter-radial>
-				<d2l-meter-radial value="19" max="26" style="width:25%"></d2l-meter-radial>
-				<d2l-meter-radial value="5" max="10" text="Completed"></d2l-meter-radial>
-				<div style="background-color: darkgreen;">
-					<d2l-meter-radial value="5" max="13" foreground-light></d2l-meter-radial>
-					<d2l-meter-radial value="10" max="10" foreground-light></d2l-meter-radial>
-					<d2l-meter-radial value="0" max="10" foreground-light></d2l-meter-radial>
-					<d2l-meter-radial value="19" max="26" style="width:25%" foreground-light></d2l-meter-radial>
-					<d2l-meter-radial value="5" max="10" text="Completed" foreground-light></d2l-meter-radial>
-				</div>
+				<template>
+					<d2l-meter-radial value="5" max="13"></d2l-meter-radial>
+					<d2l-meter-radial value="10" max="10"></d2l-meter-radial>
+					<d2l-meter-radial value="0" max="10"></d2l-meter-radial>
+					<d2l-meter-radial value="19" max="26" style="width:25%"></d2l-meter-radial>
+					<d2l-meter-radial value="5" max="10" text="Completed"></d2l-meter-radial>
+					<div style="background-color: darkgreen;">
+						<d2l-meter-radial value="5" max="13" foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="10" max="10" foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="0" max="10" foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="19" max="26" style="width:25%" foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="5" max="10" text="Completed" foreground-light></d2l-meter-radial>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>Meter Circle</h2>
 
 			<d2l-demo-snippet>
-				<d2l-meter-circle value="1" max="13"></d2l-meter-circle>
-				<d2l-meter-circle value="10" max="10"></d2l-meter-circle>
-				<d2l-meter-circle value="0" max="10"></d2l-meter-circle>
-				<d2l-meter-circle value="19" max="26" style="width:25%"></d2l-meter-circle>
-				<div style="background-color: darkred;">
-					<d2l-meter-circle value="1" max="13" foreground-light></d2l-meter-circle>
-					<d2l-meter-circle value="10" max="10" foreground-light></d2l-meter-circle>
-					<d2l-meter-circle value="0" max="10" foreground-light></d2l-meter-circle>
-					<d2l-meter-circle value="19" max="26" style="width:25%" foreground-light></d2l-meter-circle>
-				</div>
+				<template>
+					<d2l-meter-circle value="1" max="13"></d2l-meter-circle>
+					<d2l-meter-circle value="10" max="10"></d2l-meter-circle>
+					<d2l-meter-circle value="0" max="10"></d2l-meter-circle>
+					<d2l-meter-circle value="19" max="26" style="width:25%"></d2l-meter-circle>
+					<div style="background-color: darkred;">
+						<d2l-meter-circle value="1" max="13" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="0" max="10" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="19" max="26" style="width:25%" foreground-light></d2l-meter-circle>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/components/more-less/demo/more-less.html
+++ b/components/more-less/demo/more-less.html
@@ -18,35 +18,43 @@
 			<h2>More-less collapsed</h2>
 
 			<d2l-demo-snippet>
-				<d2l-more-less>
-					<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+				<template>
+					<d2l-more-less>
+						<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 
-					<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-				</d2l-more-less>
+						<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+					</d2l-more-less>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>More-less with height</h2>
 
 			<d2l-demo-snippet>
-				<d2l-more-less height="6em">
-					<p id="img-target">Hi everybody! <a href="">Hi!</a></p>
-				</d2l-more-less>
+				<template>
+					<d2l-more-less height="6em">
+						<p id="img-target">Hi everybody! <a href="">Hi!</a></p>
+					</d2l-more-less>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>More-less expanded</h2>
 
 			<d2l-demo-snippet>
-				<d2l-more-less expanded="">
-					<p id="clone-target">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum elementum venenatis arcu sit amet varius. Maecenas posuere magna arcu, quis maximus odio fringilla ac. Integer ligula lorem, faucibus sit amet cursus vel, pellentesque a justo. Aliquam urna metus, molestie at tempor eget, vestibulum a purus. Donec aliquet rutrum mi. Duis ornare congue tempor. Nullam sed massa fermentum, tincidunt leo eu, vestibulum orci. Sed ultrices est in lacus venenatis, posuere suscipit arcu scelerisque. In aliquam ipsum rhoncus, lobortis ligula ut, molestie orci. Proin scelerisque tempor posuere. Phasellus consequat, lorem quis hendrerit tempor, sem lectus sagittis nunc, in tristique dui arcu non arcu. Nunc aliquam nisi et sapien commodo lacinia. <a href="">Quisque</a> iaculis orci vel odio varius porta. Fusce tincidunt dolor enim, vitae sollicitudin purus suscipit eu.</p>
-				</d2l-more-less>
+				<template>
+					<d2l-more-less expanded="">
+						<p id="clone-target">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum elementum venenatis arcu sit amet varius. Maecenas posuere magna arcu, quis maximus odio fringilla ac. Integer ligula lorem, faucibus sit amet cursus vel, pellentesque a justo. Aliquam urna metus, molestie at tempor eget, vestibulum a purus. Donec aliquet rutrum mi. Duis ornare congue tempor. Nullam sed massa fermentum, tincidunt leo eu, vestibulum orci. Sed ultrices est in lacus venenatis, posuere suscipit arcu scelerisque. In aliquam ipsum rhoncus, lobortis ligula ut, molestie orci. Proin scelerisque tempor posuere. Phasellus consequat, lorem quis hendrerit tempor, sem lectus sagittis nunc, in tristique dui arcu non arcu. Nunc aliquam nisi et sapien commodo lacinia. <a href="">Quisque</a> iaculis orci vel odio varius porta. Fusce tincidunt dolor enim, vitae sollicitudin purus suscipit eu.</p>
+					</d2l-more-less>
+				</template>
 			</d2l-demo-snippet>
 
 			<h2>More-less with custom blur color</h2>
 
 			<d2l-demo-snippet>
-				<d2l-more-less blur-color="#f00">
-					<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum elementum venenatis arcu sit amet varius. Maecenas posuere magna arcu, quis maximus odio fringilla ac. Integer ligula lorem, faucibus sit amet cursus vel, pellentesque a justo. Aliquam urna metus, molestie at tempor eget, vestibulum a purus. Donec aliquet rutrum mi. Duis ornare congue tempor. Nullam sed massa fermentum, tincidunt leo eu, vestibulum orci. Sed ultrices est in lacus venenatis, posuere suscipit arcu scelerisque. In aliquam ipsum rhoncus, lobortis ligula ut, molestie orci. Proin scelerisque tempor posuere. Phasellus consequat, lorem quis hendrerit tempor, sem lectus sagittis nunc, in tristique dui arcu non arcu. Nunc aliquam nisi et sapien commodo lacinia. <a href="">Quisque</a> iaculis orci vel odio varius porta. Fusce tincidunt dolor enim, vitae sollicitudin purus suscipit eu.</p>
-				</d2l-more-less>
+				<template>
+					<d2l-more-less blur-color="#f00">
+						<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum elementum venenatis arcu sit amet varius. Maecenas posuere magna arcu, quis maximus odio fringilla ac. Integer ligula lorem, faucibus sit amet cursus vel, pellentesque a justo. Aliquam urna metus, molestie at tempor eget, vestibulum a purus. Donec aliquet rutrum mi. Duis ornare congue tempor. Nullam sed massa fermentum, tincidunt leo eu, vestibulum orci. Sed ultrices est in lacus venenatis, posuere suscipit arcu scelerisque. In aliquam ipsum rhoncus, lobortis ligula ut, molestie orci. Proin scelerisque tempor posuere. Phasellus consequat, lorem quis hendrerit tempor, sem lectus sagittis nunc, in tristique dui arcu non arcu. Nunc aliquam nisi et sapien commodo lacinia. <a href="">Quisque</a> iaculis orci vel odio varius porta. Fusce tincidunt dolor enim, vitae sollicitudin purus suscipit eu.</p>
+					</d2l-more-less>
+				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/components/offscreen/demo/offscreen.html
+++ b/components/offscreen/demo/offscreen.html
@@ -14,16 +14,23 @@
 	</head>
 	<body unresolved>
 		<d2l-demo-page page-title="d2l-offscreen">
+
 			<h2>Web Component</h2>
 			<d2l-demo-snippet>
-				<p>Some off-screen content:</p>
-				<d2l-offscreen>This message will only be visible to assistive technology, such as a screen reader.</d2l-offscreen>
+				<template>
+					<p>Some off-screen content:</p>
+					<d2l-offscreen>This message will only be visible to assistive technology, such as a screen reader.</d2l-offscreen>
+				</template>
 			</d2l-demo-snippet>
+
 			<h2>Web Component Using Styles</h2>
 			<d2l-demo-snippet>
-				<p>Some off-screen content:</p>
-				<d2l-offscreen-demo></d2l-offscreen-demo>
+				<template>
+					<p>Some off-screen content:</p>
+					<d2l-offscreen-demo></d2l-offscreen-demo>
+				</template>
 			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 	</body>
 </html>


### PR DESCRIPTION
This PR is an iteration on my previous PR to support `template` demo snippets.

* render template content into light-DOM so that the consumer's JavaScript can query for elements as they would expect
* wrap core demo snippet content in `template` elements to prevent components from mutating the demo snippet source