### PR TITLE
select inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install @brightspace-ui/core
 * [Colors](components/colors/): color palette
 * [Dialogs](components/dialog/): generic and confirmation dialogs
 * [Icons](components/icons/): iconography SVGs and web components
-* [Inputs](components/inputs/): text, search, checkbox and radio inputs
+* [Inputs](components/inputs/): text, search, select, checkbox and radio inputs
 * [Links](components/link/): link component and styles
 * [List](components/list/): list and list-item components
 * [Meter](components/meter/): linear, radial, circle meter web components

--- a/components/inputs/README.md
+++ b/components/inputs/README.md
@@ -4,6 +4,7 @@ There are various input components available:
 
 - [Text](#text-inputs)
 - [Search](#search-inputs)
+- [Select Lists](#select-lists)
 - [Checkboxes](#checkboxes)
 
 ## Text Inputs
@@ -57,7 +58,7 @@ input.addEventListener('change', (e) => {
 As an alternative to using the `<d2l-input-text>` custom element, you can style a native text input inside your own element. Import `input-styles.js` and apply the `d2l-input` CSS class to the input:
 
 ```javascript
-import { inputStyles } from './input-styles.js';
+import { inputStyles } from '@brightspace-ui/core/inputs/input-styles.js';
 
 class MyElem extends LitElement {
 
@@ -110,6 +111,30 @@ search.addEventListener('d2l-input-search-searched', (e) => {
 ```
 
 When the input is cleared, the same event will be fired with an empty value.
+
+## Select Lists
+
+Native `<select>` elements can be styled by importing `input-select-styles.js` into your LitElement and applying the `d2l-input-select` CSS class.
+
+Note: in order for RTL to function correctly, make sure your component uses the `RtlMixin`.
+
+```javascript
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
+class MyElem extends RtlMixin(LitElement) {
+	static get styles() {
+		return selectStyles;
+	}
+	render() {
+		return html`
+			<select class="d2l-input-select">
+				<option>Option 1</option>
+				<option>Option 2</option>
+			</select>
+		`;
+	}
+}
+```
 
 ## Checkboxes
 
@@ -166,7 +191,7 @@ To align related content below checkboxes, the `d2l-input-checkbox-spacer` eleme
 As an alternative to using the `<d2l-input-checkbox>` custom element, you can style a native checkbox inside your own element. Import `input-checkbox-styles.js` and apply the `d2l-input-checkbox` CSS class to the input:
 
 ```javascript
-import { checkboxStyles } from './input-checkbox-styles.js';
+import { checkboxStyles } from '@brightspace-ui/core/inputs/input-checkbox-styles.js';
 
 class MyElem extends LitElement {
 

--- a/components/inputs/README.md
+++ b/components/inputs/README.md
@@ -122,17 +122,17 @@ Note: in order for RTL to function correctly, make sure your component uses the 
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 class MyElem extends RtlMixin(LitElement) {
-	static get styles() {
-		return selectStyles;
-	}
-	render() {
-		return html`
-			<select class="d2l-input-select">
-				<option>Option 1</option>
-				<option>Option 2</option>
-			</select>
-		`;
-	}
+  static get styles() {
+    return selectStyles;
+  }
+  render() {
+    return html`
+      <select class="d2l-input-select">
+        <option>Option 1</option>
+        <option>Option 2</option>
+      </select>
+      `;
+  }
 }
 ```
 

--- a/components/inputs/demo/input-select-test.js
+++ b/components/inputs/demo/input-select-test.js
@@ -1,0 +1,49 @@
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { RtlMixin } from '../../../mixins/rtl-mixin.js';
+import { selectStyles } from '../input-select-styles.js';
+
+class TestInputSelect extends RtlMixin(LitElement) {
+
+	static get properties() {
+		return {
+			disabled: { type: Boolean },
+			invalid: { type: Boolean },
+			overflow: { type: Boolean }
+		};
+	}
+
+	static get styles() {
+		return [selectStyles,
+			css`
+				:host {
+					display: inline-block;
+				}
+				:host([overflow]) select {
+					max-width: 130px;
+				}
+			`
+		];
+	}
+
+	focus() {
+		const elem = this.shadowRoot.querySelector('select');
+		if (elem) elem.focus();
+	}
+
+	render() {
+		const invalid = this.invalid ? 'true' : 'false';
+		return html`
+			<select
+				aria-label="Choose a dinosaur:"
+				aria-invalid="${invalid}"
+				class="d2l-input-select"
+				?disabled="${this.disabled}">
+				<option>Tyrannosaurus</option>
+				<option>Velociraptor</option>
+				<option>Deinonychus</option>
+			</select>
+		`;
+	}
+
+}
+customElements.define('d2l-test-input-select', TestInputSelect);

--- a/components/inputs/demo/input-select.html
+++ b/components/inputs/demo/input-select.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '../../demo/demo-page.js';
+			import './input-select-test.js';
+		</script>
+	</head>
+	<body unresolved>
+		<d2l-demo-page page-title="Select Lists">
+
+			<h2>Default</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-test-input-select></d2l-test-input-select>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Disabled</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-test-input-select disabled></d2l-test-input-select>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Invalid</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-test-input-select invalid></d2l-test-input-select>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Overflowing</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-test-input-select overflow></d2l-test-input-select>
+				</template>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+	</body>
+</html>

--- a/components/inputs/input-select-styles.js
+++ b/components/inputs/input-select-styles.js
@@ -1,0 +1,84 @@
+import '../colors/colors.js';
+import { css } from 'lit-element/lit-element.js';
+
+export const selectStyles = css`
+	.d2l-input-select {
+		-webkit-appearance:none;
+		-moz-appearance: none;
+		appearance: none;
+		background-position: right center;
+		background-repeat: no-repeat;
+		background-size: contain;
+		border-radius: 0.3rem;
+		border-style: solid;
+		box-sizing: border-box;
+		color: var(--d2l-color-ferrite);
+		display: inline-block;
+		font-family: inherit;
+		font-size: 0.8rem;
+		font-weight: 400;
+		height: auto;
+		letter-spacing: 0.02rem;
+		line-height: 1.2rem;
+		margin: 0;
+		max-height: calc(2rem + 2px);
+		vertical-align: middle;
+	}
+	:host([dir='rtl']) .d2l-input-select {
+		background-position: left center;
+	}
+	.d2l-input-select,
+	.d2l-input-select:hover:disabled {
+		background-color: #ffffff;
+		border-color: var(--d2l-color-galena);
+		border-width: 1px;
+		box-shadow: inset 0 2px 0 0 rgba(181, 189, 194, .2); /* corundum */
+		padding: 0.4rem 0.75rem;
+	}
+	.d2l-input-select,
+	.d2l-input-select:disabled,
+	.d2l-input-select:hover:disabled,
+	.d2l-input-select:focus:disabled {
+		background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23F1F5FB%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23CDD5DC%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23494C4E%22%2F%3E%3C%2Fsvg%3E");
+		padding-right: calc(0.75rem + 42px);
+	}
+	:host([dir='rtl']) .d2l-input-select,
+	:host([dir='rtl']) .d2l-input-select:disabled,
+	:host([dir='rtl']) .d2l-input-select:hover:disabled,
+	:host([dir='rtl']) .d2l-input-select:focus:disabled {
+		background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23F1F5FB%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23CDD5DC%22%20d%3D%22M42%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23494C4E%22%2F%3E%3C%2Fsvg%3E");
+		padding-right: 0.75rem;
+		padding-left: calc(0.75rem + 42px);
+	}
+	.d2l-input-select:hover,
+	.d2l-input-select:focus {
+		background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23E3E9F1%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23CDD5DC%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23494C4E%22%2F%3E%3C%2Fsvg%3E");
+		border-color: var(--d2l-color-celestine);
+		border-width: 2px;
+		outline-width: 0;
+		padding: calc(0.4rem - 1px) calc(0.75rem - 1px);
+		padding-right: calc(0.75rem + 42px - 1px);
+	}
+	:host([dir='rtl']) .d2l-input-select:hover,
+	:host([dir='rtl']) .d2l-input-select:focus {
+		background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23E3E9F1%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23CDD5DC%22%20d%3D%22M42%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23494C4E%22%2F%3E%3C%2Fsvg%3E");
+		padding-left: calc(0.75rem + 42px - 1px);
+		padding-right: calc(0.75rem - 1px);
+	}
+	/* IE11 to prevent selection styling */
+	.d2l-input-select:focus::-ms-value,
+	.d2l-input-select:hover::-ms-value {
+		background-color: transparent;
+		color: var(--d2l-color-ferrite);
+	}
+	/* IE11 to hide the native chevron */
+	.d2l-input-select::-ms-expand {
+		display: none;
+	}
+	.d2l-input-select[aria-invalid='true'] {
+		border-color: var(--d2l-color-cinnabar);
+	}
+	.d2l-input-select:disabled {
+		opacity: 0.5;
+	}
+`;

--- a/components/inputs/test/input-select.visual-diff.html
+++ b/components/inputs/test/input-select.visual-diff.html
@@ -5,150 +5,31 @@
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
+			import '../demo/input-select-test.js';
 		</script>
 		<title>d2l-input-select visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
-		<style>
-			select.vui-input {
-    border-radius: .3rem;
-    border-style: solid;
-    box-sizing: border-box;
-    display: inline-block;
-    height: auto;
-    margin: 0;
-    vertical-align: middle;
-    transition: background-color .5s ease,border-color 1ms ease;
-    color: #494c4e;
-    font-family: inherit;
-    font-size: .8rem;
-    font-weight: 400;
-    letter-spacing: .02rem;
-    line-height: 1.2rem
-}
-select.vui-input::-webkit-input-placeholder {
-    color: #cdd5dc
-}
-select.vui-input::-moz-placeholder {
-    color: #cdd5dc
-}
-select.vui-input:-ms-input-placeholder {
-    color: #cdd5dc
-}
-select.vui-input::-ms-input-placeholder {
-    color: #cdd5dc
-}
-select.vui-input::placeholder {
-    color: #cdd5dc
-}
-select.vui-input,select.vui-input:hover:disabled {
-    background-color: #fff;
-    border-color: #868c8f;
-    border-width: 1px;
-    box-shadow: inset 0 2px 0 0 rgba(181,189,194,.2);
-    padding: .4rem .75rem
-}
-select.vui-input.vui-input-focus,select.vui-input:focus,select.vui-input:hover {
-    border-color: #006fbf;
-    border-width: 2px;
-    outline-width: 0;
-    padding: calc(.4rem - 1px) calc(.75rem - 1px)
-}
-select.vui-input[aria-invalid=true] {
-    border-color: #cd2026
-}
-select.vui-input:disabled {
-    opacity: .5
-}
-select.vui-input::-webkit-search-cancel-button {
-    display: none
-}
-select.vui-input::-ms-clear {
-    display: none;
-    width: 0;
-    height: 0
-}
-select.vui-input option {
-    font-weight: 400
-}
-@media screen and (-webkit-min-device-pixel-ratio: 0),screen and (min--moz-device-pixel-ratio:0),screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-    select.vui-input:not([multiple]) {
-        -webkit-appearance:none;
-        -moz-appearance: none;
-        appearance: none;
-        background-position: right center;
-        background-repeat: no-repeat;
-        background-size: contain;
-        max-height: calc(2rem + 2px)
-    }
-    select.vui-input:not([multiple]).vui-input-focus,select.vui-input:not([multiple]).vui-input-hover,select.vui-input:not([multiple]):focus,select.vui-input:not([multiple]):hover {
-        background-image: url(data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23E3E9F1%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23CDD5DC%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23494C4E%22%2F%3E%3C%2Fsvg%3E);
-        padding-right: calc(.75rem + 42px - 1px)
-    }
-    select.vui-input:not([multiple]).vui-input-focus::-ms-value,select.vui-input:not([multiple]).vui-input-hover::-ms-value,select.vui-input:not([multiple]):focus::-ms-value,select.vui-input:not([multiple]):hover::-ms-value {
-        background-color: transparent;
-        color: #494c4e
-    }
-    select.vui-input:not([multiple]),select.vui-input:not([multiple]):disabled,select.vui-input:not([multiple]):focus:disabled,select.vui-input:not([multiple]):hover:disabled {
-        background-image: url(data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23F1F5FB%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23CDD5DC%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23494C4E%22%2F%3E%3C%2Fsvg%3E);
-        padding-right: calc(.75rem + 42px)
-    }
-    [dir=rtl] select.vui-input:not([multiple]) {
-        background-position: left center
-    }
-    [dir=rtl] select.vui-input:not([multiple]).vui-input-focus,[dir=rtl] select.vui-input:not([multiple]).vui-input-hover,[dir=rtl] select.vui-input:not([multiple]):focus,[dir=rtl] select.vui-input:not([multiple]):hover {
-        background-image: url(data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23E3E9F1%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23CDD5DC%22%20d%3D%22M42%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23494C4E%22%2F%3E%3C%2Fsvg%3E);
-        padding-left: calc(.75rem + 42px - 1px);
-        padding-right: calc(.75rem - 1px)
-    }
-    [dir=rtl] select.vui-input:not([multiple]),[dir=rtl] select.vui-input:not([multiple]):disabled,[dir=rtl] select.vui-input:not([multiple]):focus:disabled,[dir=rtl] select.vui-input:not([multiple]):hover:disabled {
-        background-image: url(data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23F1F5FB%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23CDD5DC%22%20d%3D%22M42%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23494C4E%22%2F%3E%3C%2Fsvg%3E);
-        padding-right: .75rem;
-        padding-left: calc(.75rem + 42px)
-    }
-    select.vui-input::-ms-expand {
-        display: none
-    }
-}
-		</style>
 	</head>
 	<body class="d2l-typography">
 		<div class="visual-diff">
-			<select class="vui-input" id="default">
-				<option>Tyrannosaurus</option>
-				<option>Option 2</option>
-			</select>
+			<d2l-test-input-select id="default"></d2l-test-input-select>
 		</div>
 		<div class="visual-diff">
-			<select class="vui-input" id="overflow" style="max-width: 130px;">
-				<option>Tyrannosaurus</option>
-				<option>Option 2</option>
-			</select>
+			<d2l-test-input-select id="overflow" overflow></d2l-test-input-select>
 		</div>
 		<div class="visual-diff">
-			<select class="vui-input" id="disabled" disabled>
-				<option>Tyrannosaurus</option>
-				<option>Option 2</option>
-			</select>
+			<d2l-test-input-select id="disabled" disabled></d2l-test-input-select>
 		</div>
 		<div class="visual-diff">
-			<select class="vui-input" id="invalid" aria-invalid="true">
-				<option>Tyrannosaurus</option>
-				<option>Option 2</option>
-			</select>
+			<d2l-test-input-select id="invalid" invalid></d2l-test-input-select>
 		</div>
-		<div class="visual-diff" dir="rtl">
-			<select class="vui-input" id="rtl">
-				<option>Tyrannosaurus</option>
-				<option>Option 2</option>
-			</select>
+		<div class="visual-diff">
+			<d2l-test-input-select id="rtl" dir="rtl"></d2l-test-input-select>
 		</div>
-		<div class="visual-diff" dir="rtl">
-			<select class="vui-input" id="rtl-overflow" style="max-width: 130px;">
-				<option>Tyrannosaurus</option>
-				<option>Option 2</option>
-			</select>
+		<div class="visual-diff">
+			<d2l-test-input-select id="rtl-overflow" dir="rtl" overflow></d2l-test-input-select>
 		</div>
 	</body>
-</html> 
+</html>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
 			<ul>
 				<li><a href="components/inputs/demo/input-checkbox.html">d2l-input-checkbox</a></li>
 				<li><a href="components/inputs/demo/input-search.html">d2l-input-search</a></li>
+				<li><a href="components/inputs/demo/input-select.html">d2l-input-select</a></li>
 				<li><a href="components/inputs/demo/input-text.html">d2l-input-text</a></li>
 			</ul>
 		</li>


### PR DESCRIPTION
This brings `<select>` input styling into Lit. There's no custom element here, it only exposes styles that consumers can apply to their own native `<select>`s inside their elements.

These changes do not yet bring it inline with the current design -- I have those changes ready and will add them in a follow-up PR. I just wanted to make these changes first so we could verify that they don't cause a visual diff change.

I've made a few modifications to the original Sass-based CSS:
- I removed `width: 100%` on the `<select>`. In most cases, we just want its width to be as wide as the largest option. In cases where width is constrained, consumers need to put a `width` or `max-width` on it anyway.
- I removed the CSS that was only applying things if `:not([multiple])`. Since consumers need to manually apply these styles to their own `select`s, they should just not do it for ones that support multiple selection.
- I removed the CSS transition -- it wasn't doing anything.
- The media query is gone. This was [originally needed](https://github.com/Brightspace/valence-ui-input/commit/f0d02b2e5634ee8374318edc90db04990c7d1d61#diff-e7d65af6d7a161dd41f69c2306f67de2) years ago to apply special styles for Chrome/Safari and Firefox and to prevent pre-IE10 from not working. Not needed anymore.
- I've removed the `font-weight` styling on `options`. I couldn't find any browser combination where this did anything.
- Placeholder, search-cancel-button, ms-clear styles are gone. These were only there because selects were using the same Sass mixins as other text-based inputs. Selects don't need these overrides.