### PR TITLE
Fix floating buttons when horizontal scrollbar exists

### DIFF
--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -87,7 +87,6 @@ class FloatingButtons extends RtlMixin(LitElement) {
 	constructor() {
 		super();
 		this.minHeight = '500px';
-		this._containerTop = null;
 
 		this._calcContainerPosition = this._calcContainerPosition.bind(this);
 	}
@@ -112,8 +111,6 @@ class FloatingButtons extends RtlMixin(LitElement) {
 
 	firstUpdated() {
 		super.firstUpdated();
-
-		this._containerTop = this.shadowRoot.querySelector('.d2l-floating-detection');
 
 		this._calcContainerPosition();
 		this._startObserver();
@@ -174,13 +171,19 @@ class FloatingButtons extends RtlMixin(LitElement) {
 
 		const viewBottom = window.innerHeight;
 		const containerRectHeight = this.getBoundingClientRect().height;
-		const containerTop = this._containerTop.getBoundingClientRect().top;
+		const containerTop = this.getBoundingClientRect().top;
+
+		let scrollbarHeightEstimate = 0;
+		const hasHorizontalScollbar = document.body.scrollWidth > document.body.clientWidth;
+		if (hasHorizontalScollbar) {
+			scrollbarHeightEstimate = 17; // needed in case of horizontal scrollbar in Windows
+		}
 
 		/* if viewport height is less than minHeight (e.g., mobile device),
-		 * or div.d2l-floating-detection is visible (i.e., buttons no longer need to be floating)
+		 * or user has scrolled to bottom of page
 		 * then do not float the buttons
 		 */
-		if (_viewportIsLessThanMinHeight || ((containerTop + containerRectHeight) <= viewBottom)) {
+		if (_viewportIsLessThanMinHeight || ((containerTop + containerRectHeight + scrollbarHeightEstimate) <= viewBottom)) {
 			return false;
 		} else {
 			return true;
@@ -199,7 +202,6 @@ class FloatingButtons extends RtlMixin(LitElement) {
 		};
 
 		return html`
-			<div class="d2l-floating-detection"></div>
 			<div class="d2l-floating-buttons-container" style=${styleMap(containerStyle)}>
 				<div class="d2l-floating-buttons-inner-container" style=${styleMap(innerContainerStyle)}>
 					<slot></slot>

--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -173,11 +173,11 @@ class FloatingButtons extends RtlMixin(LitElement) {
 		const containerRectHeight = this.getBoundingClientRect().height;
 		const containerTop = this.getBoundingClientRect().top;
 
-		const scrollbarHeightEstimate = 0;
-		// const hasHorizontalScollbar = document.body.scrollWidth > document.body.clientWidth;
-		// if (hasHorizontalScollbar) {
-		// 	scrollbarHeightEstimate = 17; // needed in case of horizontal scrollbar in Windows
-		// }
+		let scrollbarHeightEstimate = 0;
+		const hasHorizontalScollbar = document.body.scrollWidth > document.body.clientWidth;
+		if (hasHorizontalScollbar) {
+			scrollbarHeightEstimate = 17; // needed in case of horizontal scrollbar in Windows
+		}
 
 		/* if viewport height is less than minHeight (e.g., mobile device),
 		 * or user has scrolled to bottom of page

--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -173,11 +173,11 @@ class FloatingButtons extends RtlMixin(LitElement) {
 		const containerRectHeight = this.getBoundingClientRect().height;
 		const containerTop = this.getBoundingClientRect().top;
 
-		let scrollbarHeightEstimate = 0;
-		const hasHorizontalScollbar = document.body.scrollWidth > document.body.clientWidth;
-		if (hasHorizontalScollbar) {
-			scrollbarHeightEstimate = 17; // needed in case of horizontal scrollbar in Windows
-		}
+		const scrollbarHeightEstimate = 0;
+		// const hasHorizontalScollbar = document.body.scrollWidth > document.body.clientWidth;
+		// if (hasHorizontalScollbar) {
+		// 	scrollbarHeightEstimate = 17; // needed in case of horizontal scrollbar in Windows
+		// }
 
 		/* if viewport height is less than minHeight (e.g., mobile device),
 		 * or user has scrolled to bottom of page

--- a/components/button/test/floating-buttons.html
+++ b/components/button/test/floating-buttons.html
@@ -40,107 +40,107 @@
 			</style>
 			<template>
 				<div>
-				<table>
-					<tr>
-						<th><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></th>
-						<th>Lorem ipsum dolor sit amet</th>
-						<th>Lorem ipsum dolor sit amet</th>
-						<th>Lorem ipsum dolor sit amet</th>
-					</tr>
-					<tr>
-						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>Lorem ipsum dolor sit amet</td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>Lorem ipsum dolor sit amet</td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>Lorem ipsum dolor sit amet</td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>Lorem ipsum dolor sit amet</td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>Lorem ipsum dolor sit amet</td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-					<tr>
-						<td>Lorem ipsum dolor sit amet</td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-					</tr>
-				</table>
-				<d2l-floating-buttons>
-					<d2l-button primary>Primary Button</d2l-button>
-					<d2l-button>Secondary Button</d2l-button>
-				</d2l-floating-buttons>
-			</div>
+					<table>
+						<tr>
+							<th><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></th>
+							<th>Lorem ipsum dolor sit amet</th>
+							<th>Lorem ipsum dolor sit amet</th>
+							<th>Lorem ipsum dolor sit amet</th>
+						</tr>
+						<tr>
+							<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td>Lorem ipsum dolor sit amet</td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td>Lorem ipsum dolor sit amet</td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td>Lorem ipsum dolor sit amet</td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td>Lorem ipsum dolor sit amet</td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td>Lorem ipsum dolor sit amet</td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td>Lorem ipsum dolor sit amet</td>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+					</table>
+					<d2l-floating-buttons>
+						<d2l-button primary>Primary Button</d2l-button>
+						<d2l-button>Secondary Button</d2l-button>
+					</d2l-floating-buttons>
+				</div>
 			</template>
 		</test-fixture>
 

--- a/components/button/test/floating-buttons.html
+++ b/components/button/test/floating-buttons.html
@@ -26,6 +26,124 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="table">
+			<style>
+				table {
+					border-collapse: collapse;
+					border-spacing: 0;
+				}
+				td, th {
+					border: 1px solid;
+					min-width: 400px;
+					padding: 10px;
+				}
+			</style>
+			<template>
+				<div>
+				<table>
+					<tr>
+						<th><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></th>
+						<th>Lorem ipsum dolor sit amet</th>
+						<th>Lorem ipsum dolor sit amet</th>
+						<th>Lorem ipsum dolor sit amet</th>
+					</tr>
+					<tr>
+						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td><div>Lorem ipsum dolor sit amet</div><div>Lorem ipsum dolor sit amet</div></td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Lorem ipsum dolor sit amet</td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Lorem ipsum dolor sit amet</td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Lorem ipsum dolor sit amet</td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Lorem ipsum dolor sit amet</td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Lorem ipsum dolor sit amet</td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td>Lorem ipsum dolor sit amet</td>
+						<td></td>
+						<td></td>
+						<td></td>
+						<td></td>
+					</tr>
+				</table>
+				<d2l-floating-buttons>
+					<d2l-button primary>Primary Button</d2l-button>
+					<d2l-button>Secondary Button</d2l-button>
+				</d2l-floating-buttons>
+			</div>
+			</template>
+		</test-fixture>
+
 		<script type="module">
 			import { runAxe } from '../../../tools/a11y-test-helper.js';
 
@@ -44,6 +162,27 @@
 						await runAxe(button);
 					});
 
+				});
+
+				describe('table', () => {
+					let floatingButtons;
+
+					beforeEach(async() => {
+						button = fixture('table');
+						floatingButtons = button.querySelector('d2l-floating-buttons');
+						await floatingButtons.updateComplete;
+					});
+
+					it('always floats', (done) => {
+						window.addEventListener('scroll', () => {
+							expect(floatingButtons._floating).to.equal(true);
+							done();
+						});
+
+						const eventObj = document.createEvent('UIEvents');
+						eventObj.initUIEvent('scroll', true, true, window, 1);
+						document.dispatchEvent(eventObj);
+					});
 				});
 
 			});


### PR DESCRIPTION
When there is a horizontal scrollbar present in Windows, the calculation for whether or not to show the floating buttons no longer works properly. There's some weirdness where `getBoundingClientRect().top;` would calculate something different every other time (though if the `scrollbarHeightEstimate` is added, this no longer happens) so even when the floating buttons were showing as expected the calculated values were actually not what was expected/inconsistent with what was seen on chrome on mac.

This solution feels a bit hacky, so if there are alternative solutions/if there is a better way we have for detecting horizontal scroll I am very open to other options.

I removed the usage of `_containerTop` since its top is the same as the floating-buttons top (it was used at one point, but then some changes were made and it was no longer needed).

I have done cross-browser testing on this on Windows and Mac browsers on the problematic grading page (which has a horizontal scrollbar by default) and on the new quiz page (which does not have horizontal scroll unless width is shrunk) and so far so good.