### PR TITLE
checkbox should use RtlMixin

### DIFF
--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -3,8 +3,9 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { checkboxStyles } from './input-checkbox-styles.js';
 import { classMap} from 'lit-html/directives/class-map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
-class InputCheckbox extends LitElement {
+class InputCheckbox extends RtlMixin(LitElement) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
This should have always been there.

Interestingly it's hard to catch these cases, since `d2l-demo-snippet` will put `dir="rtl"` on all the elements inside its shadow root when you press the button, which triggers the RTL CSS. But if the page itself has `dir="rtl"`, then you notice the problem.