### PR TITLE
getHeight needs more height

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -132,7 +132,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		if (header) preferredHeight += header.scrollHeight;
 
 		const content = this.shadowRoot.querySelector('.d2l-dialog-content > div');
-		if (content) preferredHeight += content.scrollHeight;
+		if (content) preferredHeight += content.scrollHeight + 20;
 
 		const footer = this.shadowRoot.querySelector('.d2l-dialog-footer');
 		if (footer) preferredHeight += footer.scrollHeight;

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -132,7 +132,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		if (header) preferredHeight += header.scrollHeight;
 
 		const content = this.shadowRoot.querySelector('.d2l-dialog-content > div');
-		if (content) preferredHeight += content.scrollHeight + 20;
+		if (content) preferredHeight += content.scrollHeight;
 
 		const footer = this.shadowRoot.querySelector('.d2l-dialog-footer');
 		if (footer) preferredHeight += footer.scrollHeight;

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -94,7 +94,7 @@ class Dialog extends LocalizeStaticMixin(DialogMixin(LitElement)) {
 					</div>
 				</div>
 				<div class="d2l-dialog-content">
-					<div><slot></slot></div>
+					<div style="overflow: auto;"><slot></slot></div>
 				</div>
 				<div class="d2l-dialog-footer">
 					<slot name="footer"></slot>


### PR DESCRIPTION
In the DOM, there is an unaccounted for gap between the a div and it's child, throwing off it's calculation
![image](https://user-images.githubusercontent.com/52468201/69838068-da102a00-121f-11ea-8919-a7f9b67b823b.png)

You might be wondering, what causes this gap? is it padding? margins? line-height?
Nope...font-size!
the green is the unaccounted for space
![image](https://user-images.githubusercontent.com/52468201/69838275-ddf07c00-1220-11ea-85a8-e1b9a348016a.png)

to demonstrate an exaggerated example, look what happens when I make the font-size really large:
![image](https://user-images.githubusercontent.com/52468201/69838320-1728ec00-1221-11ea-9d60-db488b28fad8.png)
The gap in the green gets bigger! Its like magic!