### PR TITLE
Making CSS more specific since shady CSS puts "d2l-input-checkbox" on…

### DIFF
--- a/components/inputs/input-checkbox-styles.js
+++ b/components/inputs/input-checkbox-styles.js
@@ -2,7 +2,7 @@ import '../colors/colors.js';
 import { css } from 'lit-element/lit-element.js';
 
 export const checkboxStyles = css`
-	.d2l-input-checkbox {
+	input[type="checkbox"].d2l-input-checkbox {
 		-webkit-appearance: none;
 		-moz-appearance: none;
 		appearance: none;
@@ -19,26 +19,26 @@ export const checkboxStyles = css`
 		vertical-align: middle;
 		width: 1.2rem;
 	}
-	.d2l-input-checkbox:checked {
+	input[type="checkbox"].d2l-input-checkbox:checked {
 		background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23494C4E%22%20d%3D%22M8.4%2016.6c.6.6%201.5.6%202.1%200l8-8c.6-.6.6-1.5%200-2.1-.6-.6-1.5-.6-2.1%200l-6.9%207-1.9-1.9c-.6-.6-1.5-.6-2.1%200-.6.6-.6%201.5%200%202.1l2.9%202.9z%22/%3E%3C/svg%3E%0A");
 	}
-	.d2l-input-checkbox:indeterminate {
+	input[type="checkbox"].d2l-input-checkbox:indeterminate {
 		background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22%23494C4E%22%20d%3D%22M7.5%2C11h9c0.8%2C0%2C1.5%2C0.7%2C1.5%2C1.5l0%2C0c0%2C0.8-0.7%2C1.5-1.5%2C1.5h-9C6.7%2C14%2C6%2C13.3%2C6%2C12.5l0%2C0%0A%09C6%2C11.7%2C6.7%2C11%2C7.5%2C11z%22/%3E%3C/svg%3E%0A");
 	}
-	.d2l-input-checkbox,
-	.d2l-input-checkbox:hover:disabled {
+	input[type="checkbox"].d2l-input-checkbox,
+	input[type="checkbox"].d2l-input-checkbox:hover:disabled {
 		background-color: var(--d2l-color-regolith);
 		border-color: var(--d2l-color-galena);
 		border-width: 1px;
 	}
-	.d2l-input-checkbox:hover,
-	.d2l-input-checkbox:focus,
-	.d2l-input-checkbox.d2l-input-checkbox-focus {
+	input[type="checkbox"].d2l-input-checkbox:hover,
+	input[type="checkbox"].d2l-input-checkbox:focus,
+	input[type="checkbox"].d2l-input-checkbox.d2l-input-checkbox-focus {
 		border-color: var(--d2l-color-celestine);
 		border-width: 2px;
 		outline-width: 0;
 	}
-	.d2l-input-checkbox:disabled {
+	input[type="checkbox"].d2l-input-checkbox:disabled {
 		opacity: 0.5;
 	}
 `;

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -83,13 +83,13 @@ class ListItem extends RtlMixin(LitElement) {
 				padding-right: 0.9rem;
 			}
 
-			input[type="checkbox"] {
+			input[type="checkbox"].d2l-input-checkbox {
 				flex-grow: 0;
 				flex-shrink: 0;
 				margin: 0.6rem 0.9rem 0.6rem 0;
 			}
 
-			:host([dir="rtl"]) input[type="checkbox"] {
+			:host([dir="rtl"]) input[type="checkbox"].d2l-input-checkbox {
 				margin-left: 0.9rem;
 				margin-right: 0;
 			}
@@ -120,7 +120,7 @@ class ListItem extends RtlMixin(LitElement) {
 				margin-top: 0.7rem;
 			}
 
-			:host([illustration-outside]) input[type="checkbox"] {
+			:host([illustration-outside]) input[type="checkbox"].d2l-input-checkbox {
 				margin-bottom: 1.15rem;
 				margin-top: 1.15rem;
 			}


### PR DESCRIPTION
I'm not sure if these ever worked in Edge... although that's surprising. Basically shady CSS super sucks and put the `d2l-input-checkbox` CSS class on everything (because it's the same name as the custom element), which results in this awesomeness:
![Screen Shot 2019-12-02 at 5 37 24 PM](https://user-images.githubusercontent.com/5491151/70001093-6d9c7000-152a-11ea-9add-0c9845d2c062.png)

Also not sure why Polymer didn't suffer from this. Anyway, making the CSS rules more specific solve this.