### PR TITLE
Make aria-live announcer less flakey.

### DIFF
--- a/helpers/demo/announce-test.js
+++ b/helpers/demo/announce-test.js
@@ -11,21 +11,24 @@ class AnnounceTest extends LitElement {
 				display: block;
 				width: 400px;
 			}
-			d2l-button {
-				margin: 10px 10px 0 0;
+			d2l-input-text {
+				margin-bottom: 10px;
 			}
 		`;
 	}
 
 	render() {
 		return html`
-			<d2l-input-text type="text" value="I like cookies." aria-label="message to announce"></d2l-input-text>
+			<d2l-input-text id="msg1" type="text" value="I like cookies but I also like donuts and many other really yummy things." aria-label="first message to announce"></d2l-input-text>
+			<d2l-input-text id="msg2" type="text" value="I also like cake." aria-label="second message to announce"></d2l-input-text>
 			<d2l-button @click=${this._handleAnnounce} type="button">Announce</d2l-button>`;
 	}
 
 	_handleAnnounce() {
-		const value = this.shadowRoot.querySelector('d2l-input-text').value;
-		announce(value);
+		const value1 = this.shadowRoot.querySelector('#msg1').value;
+		if (value1.length > 0) announce(value1);
+		const value2 = this.shadowRoot.querySelector('#msg2').value;
+		if (value2.length > 0) announce(value2);
 	}
 
 }


### PR DESCRIPTION
This PR improves the behavior of the aria-live announce function. In short, aria-live is terribly frustrating for several reasons:

1. the aria-live region must be rendered before any changes are treated as updated, and a simple requestAnimationFrame is not a sufficient delay
2. the browser internally seems to keep track of the last message, and if it thinks an aria-live region change is the same as something is recently announced, it may ignore it even if it's a different node
3. the browser may or may not coalesce synchronous aria-live announcements... sometimes it will combine them into one announcement, sometimes it will announce them out of order, and sometimes it will only announce one 
4. if new aria-live region changes are made while a previous message is being announced, it may be interrupted regardless of polite vs assertive (ex. updates to the same aria-live region, or multiple aria-live regions with changes at the same time)

The above problems are not consistent across browser + AT combinations. This PR attempts to address 1, 2, 3, and it also purges messages from the DOM. 

