### PR TITLE
Removing binding of "required" to avoid initial invalid styles

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -55,9 +55,11 @@ class InputText extends LitElement {
 	}
 
 	render() {
+		const ariaRequired = this.required ? 'true' : undefined;
 		return html`
 			<input aria-invalid="${ifDefined(this.ariaInvalid)}"
 			 	aria-label="${ifDefined(this.ariaLabel)}"
+				aria-required="${ifDefined(ariaRequired)}"
 				autocomplete="${ifDefined(this.autocomplete)}"
 				?autofocus="${this.autofocus}"
 				@change="${this._handleChange}"
@@ -74,7 +76,6 @@ class InputText extends LitElement {
 				pattern="${ifDefined(this.pattern)}"
 				placeholder="${ifDefined(this.placeholder)}"
 				?readonly="${this.readonly}"
-				?required="${this.required}"
 				size="${ifDefined(this.size)}"
 				step="${ifDefined(this.step)}"
 				tabindex="${ifDefined(this.tabindex)}"

--- a/components/inputs/test/input-text.html
+++ b/components/inputs/test/input-text.html
@@ -100,6 +100,13 @@
 						expect(input.value).to.equal('hello');
 					});
 
+					it('should bind "required" attribute to input "aria-required"', async() => {
+						elem.setAttribute('required', 'required');
+						await elem.updateComplete;
+						expect(input.required).to.be.false;
+						expect(input.getAttribute('aria-required')).to.equal('true');
+					});
+
 					[
 						{name: 'aria-invalid', propName: 'ariaInvalid', value: 'true'},
 						{name: 'aria-label', propName: 'ariaLabel', value: 'hello'},
@@ -114,7 +121,6 @@
 						{name: 'pattern', value: '[A-Za-z]+'},
 						{name: 'placeholder', value: 'enter something'},
 						{name: 'readonly', propName: 'readOnly', value: true},
-						{name: 'required', value: true},
 						{name: 'size', value: 20},
 						{name: 'step', value: '2'},
 						{name: 'type', value: 'email'}


### PR DESCRIPTION
I'm removing this binding of the `required` attribute to the underlying `<input>` element. The reason being that when present, the `required` attribute causes an empty input to be immediately "invalid", which styles it red before the user has even had a chance to interact with it.

![Screen Shot 2019-12-05 at 1 25 45 PM](https://user-images.githubusercontent.com/5491151/70262693-cd7d5b80-1762-11ea-83e5-eb9c1f9c2c41.png)

We don't use this attribute in MVC for this reason.

Eventually when we add in the concept of validation directly to our input components, we may be able to bring back some form of this -- maybe not initially but after a `validate()` call or something. We shall see.

This is only [used in one place](https://github.com/Brightspace/gbl-map-editor/blob/55ea6da886a7f7812f08db59f772dddeaaa3e041/src/components/view-map-activities.js#L109), and I've confirmed with @sgrinwis-d2l that this new behaviour is the one they're looking for.