### PR TITLE
Remove extra whitespace hiding inside d2l-link elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ components/*/test/screenshots/golden/
 mixins/*/test/screenshots/current/
 mixins/*/test/screenshots/golden/
 test/sass.output.css
+.DS_Store

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -41,15 +41,13 @@ class Link extends LitElement {
 	}
 
 	render() {
-		return html`
-			<a class="d2l-link"
+		return html`<a class="d2l-link"
 				aria-label="${ifDefined(this.ariaLabel)}"
 				?download="${this.download}"
 				href="${ifDefined(this.href)}"
 				?main="${this.main}"
 				?small="${this.small}"
-				target="${ifDefined(this.target)}"><slot></slot></a>
-		`;
+				target="${ifDefined(this.target)}"><slot></slot></a>`;
 	}
 
 	focus() {

--- a/components/link/test/link.visual-diff.html
+++ b/components/link/test/link.visual-diff.html
@@ -24,6 +24,12 @@
 			<d2l-link href="https://www.d2l.com" small id="wc-small">Small Link</d2l-link>
 		</div>
 		<div class="visual-diff">
+			<p id="wc-inline">
+				<d2l-link href=#">Hello</d2l-link>, <d2l-link href="#">World</d2l-link>!
+				w<d2l-link href="#">x</d2l-link>y<d2l-link href="#">z</d2l-link>!
+			</p>
+		</div>
+		<div class="visual-diff">
 			<a href="https://www.d2l.com" class="d2l-test-link" id="sass-standard">Standard Link</a>
 		</div>
 		<div class="visual-diff">

--- a/components/link/test/link.visual-diff.js
+++ b/components/link/test/link.visual-diff.js
@@ -21,6 +21,7 @@ describe('d2l-link', function() {
 		'wc-standard',
 		'wc-main',
 		'wc-small',
+		'wc-inline',
 		'sass-standard',
 		'sass-main',
 		'sass-small'


### PR DESCRIPTION
This gap was really noticable when a link was beside punctuation (e.g. commas, periods, etc.)

I noticed this when [switching the blog to use Brightspace UI](https://github.com/Brightspace/cdo-blog/pull/179). Here's the before:

![d2l-link-wc-inline](https://user-images.githubusercontent.com/597907/70379485-3bf52180-18fb-11ea-8dad-6ee9a81679c4.png)

and after:

![d2l-link-wc-inline](https://user-images.githubusercontent.com/597907/70379482-34ce1380-18fb-11ea-87d4-bf241e49c668.png)

I didn't look closely at how visual-diff works; it looked like something else was maybe supposed to push the goldens to GitHub so I just left it alone. If this fails CI or there is more to do I can check it out on Monday!