### PR TITLE
typography needs to reference colors

### DIFF
--- a/components/typography/typography.js
+++ b/components/typography/typography.js
@@ -1,4 +1,5 @@
 import '@webcomponents/shadycss/entrypoints/custom-style-interface.js';
+import '../colors/colors.js';
 
 const importUrl = 'https://s.brightspace.com/lib/fonts/0.5.0/assets/';
 


### PR DESCRIPTION
Noticed this is a visual diff page where it was only including typography and labels were black instead of ferrite.