### PR TITLE
removing box-shadow transition on buttons

### DIFF
--- a/components/button/button-styles.js
+++ b/components/button/button-styles.js
@@ -14,7 +14,6 @@ export const buttonStyles = css`
 		min-height: calc(2rem + 2px);
 		outline: none;
 		text-align: center;
-		transition: box-shadow 0.2s;
 		-webkit-user-select: none;
 		-moz-user-select: none;
 		-ms-user-select: none;

--- a/components/button/test/button-icon.visual-diff.js
+++ b/components/button/test/button-icon.visual-diff.js
@@ -40,7 +40,7 @@ describe('d2l-button-icon', function() {
 						if (entry.category === 'translucent-enabled') {
 							await focus(page, '#translucent-enabled > d2l-button-icon');
 						} else {
-							await focus(page, `#${entry.category}`);
+							await page.$eval(`#${entry.category}`, (elem) => elem.focus());
 						}
 					}
 

--- a/components/button/test/button-subtle.visual-diff.js
+++ b/components/button/test/button-subtle.visual-diff.js
@@ -10,7 +10,6 @@ describe('d2l-button-subtle', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await visualDiff.disableAnimations(page);
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
 		await page.goto(`${visualDiff.getBaseUrl()}/components/button/test/button-subtle.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 		await page.bringToFront();
@@ -29,7 +28,7 @@ describe('d2l-button-subtle', function() {
 					if (name === 'hover') {
 						await page.hover(`#${entry.category}`);
 					} else if (name === 'focus') {
-						await focus(page, `#${entry.category}`);
+						await page.$eval(`#${entry.category}`, (elem) => elem.focus());
 					}
 
 					const rectId = (name.indexOf('disabled') !== -1 || name.indexOf('icon') !== -1) ? name : entry.category;
@@ -39,15 +38,5 @@ describe('d2l-button-subtle', function() {
 			});
 		});
 	});
-
-	const focus = async(page, selector) => {
-		return page.evaluate((selector) => {
-			return new Promise((resolve) => {
-				const elem = document.querySelector(selector);
-				elem.shadowRoot.querySelector('button').addEventListener('transitionend', resolve);
-				elem.focus();
-			});
-		}, selector);
-	};
 
 });

--- a/components/button/test/button.visual-diff.js
+++ b/components/button/test/button.visual-diff.js
@@ -10,7 +10,6 @@ describe('d2l-button', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await visualDiff.disableAnimations(page);
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
 		await page.goto(`${visualDiff.getBaseUrl()}/components/button/test/button.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 		await page.bringToFront();
@@ -28,7 +27,7 @@ describe('d2l-button', function() {
 					if (name === 'hover') {
 						await page.hover(`#${entry.category}`);
 					} else if (name === 'focus') {
-						await focus(page, `#${entry.category}`);
+						await page.$eval(`#${entry.category}`, (elem) => elem.focus());
 					}
 
 					const rectId = (name.indexOf('disabled') !== -1) ? name : entry.category;
@@ -38,15 +37,5 @@ describe('d2l-button', function() {
 			});
 		});
 	});
-
-	const focus = (page, selector) => {
-		return page.evaluate((selector) => {
-			return new Promise((resolve) => {
-				const elem = document.querySelector(selector);
-				elem.shadowRoot.querySelector('button').addEventListener('transitionend', resolve);
-				elem.focus();
-			});
-		}, selector);
-	};
 
 });

--- a/components/inputs/test/input-search.visual-diff.js
+++ b/components/inputs/test/input-search.visual-diff.js
@@ -10,9 +10,6 @@ describe('d2l-input-search', () => {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		const client = await page.target().createCDPSession();
-		await client.send('Animation.enable');
-		await client.send('Animation.setPlaybackRate', { playbackRate: 100 });
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
 		await page.goto(`${visualDiff.getBaseUrl()}/components/inputs/test/input-search.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 		await page.bringToFront();


### PR DESCRIPTION
None of the other inputs have transitions on the focus styles anymore, and this is causing a lot of grief in our visual diff tests.