### PR TITLE
adding a method to simulate clicks on the checkbox

### DIFF
--- a/components/inputs/README.md
+++ b/components/inputs/README.md
@@ -270,6 +270,10 @@ The `<d2l-input-checkbox>` element can be used to get a checkbox and optional vi
 - `not-tabbable` (optional, Boolean): sets `tabindex="-1"` on the checkbox
 - `value` (optional, String): value of the input
 
+**Methods:**
+
+- `simulateClick()`: useful for testing, it simulates the user clicking on the checkbox, which toggles the state of the checkbox and fires the `change` event
+
 **Events:**
 
 When the checkbox's state changes, it dispatches the `change` event:

--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -107,6 +107,15 @@ class InputCheckbox extends RtlMixin(LitElement) {
 		if (elem) elem.focus();
 	}
 
+	simulateClick() {
+		this.checked = !this.checked;
+		this.indeterminate = false;
+		this.dispatchEvent(new CustomEvent(
+			'change',
+			{bubbles: true, composed: false}
+		));
+	}
+
 	_handleChange(e) {
 		this.checked = e.target.checked;
 		this.indeterminate = false;
@@ -124,12 +133,7 @@ class InputCheckbox extends RtlMixin(LitElement) {
 	_handleClick() {
 		const browserType = window.navigator.userAgent;
 		if (this.indeterminate && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
-			this.checked = !this.checked;
-			this.indeterminate = false;
-			this.dispatchEvent(new CustomEvent(
-				'change',
-				{bubbles: true, composed: false}
-			));
+			this.simulateClick();
 		}
 	}
 

--- a/components/inputs/test/input-checkbox.html
+++ b/components/inputs/test/input-checkbox.html
@@ -163,6 +163,24 @@
 
 				});
 
+				describe('simulateClick', () => {
+
+					beforeEach(async() => await getFixture('basic'));
+
+					it('should set "checked" property', () => {
+						elem.simulateClick();
+						expect(elem.checked).to.be.true;
+					});
+
+					it('should trigger an event', () => {
+						let pass = false;
+						elem.addEventListener('change', () => pass = true);
+						elem.simulateClick();
+						expect(pass).to.be.true;
+					});
+
+				});
+
 				describe('indeterminate', () => {
 
 					it('should set aria-checked to "mixed" when indeterminate and checked', async() => {


### PR DESCRIPTION
This is so that folks can simulate a user interaction with the checkbox in their tests without needing to reach into the shadow root and click on the underlying `input` element.