### PR TITLE
Bind to the checked property of the checkbox, rather than attribute, …

### DIFF
--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -91,7 +91,7 @@ class InputCheckbox extends RtlMixin(LitElement) {
 					@change="${this._handleChange}"
 					class="d2l-input-checkbox"
 					@click="${this._handleClick}"
-					?checked="${this.checked}"
+					.checked="${this.checked}"
 					?disabled="${this.disabled}"
 					.indeterminate="${this.indeterminate}"
 					name="${ifDefined(this.name)}"

--- a/components/inputs/test/input-checkbox.html
+++ b/components/inputs/test/input-checkbox.html
@@ -277,11 +277,11 @@
 						await elem.updateComplete;
 						expect(elem.checked).to.be.true;
 						expect(input.checked).to.be.true;
-						elem.checked = false;
+						elem.checked = false; // eslint-disable-line require-atomic-updates
 						await elem.updateComplete;
 						expect(elem.checked).to.be.false;
 						expect(input.checked).to.be.false;
-						elem.checked = true;
+						elem.checked = true; // eslint-disable-line require-atomic-updates
 						await elem.updateComplete;
 						expect(elem.checked).to.be.true;
 						expect(input.checked).to.be.true;

--- a/components/inputs/test/input-checkbox.html
+++ b/components/inputs/test/input-checkbox.html
@@ -113,9 +113,15 @@
 						expect(input.indeterminate).to.be.true;
 					});
 
+					it('should bind "checked" attribute to input property', async() => {
+						expect(input.checked).to.be.false;
+						elem.setAttribute('checked', 'true');
+						await elem.updateComplete;
+						expect(input.checked).to.be.true;
+					});
+
 					[
 						{name: 'aria-label', propName: 'ariaLabel', value: 'hello'},
-						{name: 'checked', value: true},
 						{name: 'disabled', value: true},
 						{name: 'name', value: 'jim'}
 					].forEach((attr) => {
@@ -256,6 +262,33 @@
 							done();
 						});
 						elem.focus();
+					});
+
+				});
+
+				describe('input checked property handled correctly', () => {
+
+					beforeEach(async() => await getFixture('basic'));
+
+					it('should keep input and element in sync with both physical clicks and programatic changes to the checked property', async() => {
+						expect(elem.checked).to.be.false;
+						expect(input.checked).to.be.false;
+						input.click();
+						await elem.updateComplete;
+						expect(elem.checked).to.be.true;
+						expect(input.checked).to.be.true;
+						elem.checked = false;
+						await elem.updateComplete;
+						expect(elem.checked).to.be.false;
+						expect(input.checked).to.be.false;
+						elem.checked = true;
+						await elem.updateComplete;
+						expect(elem.checked).to.be.true;
+						expect(input.checked).to.be.true;
+						input.click();
+						await elem.updateComplete;
+						expect(elem.checked).to.be.false;
+						expect(input.checked).to.be.false;
 					});
 
 				});


### PR DESCRIPTION
…as described here:

https://github.com/Polymer/lit-element/issues/601
This fixes an issue whereby the checkbox could not have its checked property changed programatically, after it had been physically clicked.