### PR TITLE
binding to input property to fix user interaction bug

### DIFF
--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -91,7 +91,7 @@ class InputCheckbox extends RtlMixin(LitElement) {
 					@change="${this._handleChange}"
 					class="d2l-input-checkbox"
 					@click="${this._handleClick}"
-					?checked="${this.checked}"
+					.checked="${this.checked}"
 					?disabled="${this.disabled}"
 					.indeterminate="${this.indeterminate}"
 					name="${ifDefined(this.name)}"

--- a/components/inputs/test/input-checkbox.html
+++ b/components/inputs/test/input-checkbox.html
@@ -113,9 +113,30 @@
 						expect(input.indeterminate).to.be.true;
 					});
 
+					it('should bind "checked" attribute to input property', async() => {
+						elem.setAttribute('checked', 'checked');
+						await elem.updateComplete;
+						expect(input.checked).to.be.true;
+					});
+
+					it('should bind "checked" property to input property', async() => {
+						elem.checked = true;
+						await elem.updateComplete;
+						expect(input.checked).to.be.true;
+					});
+
+					it('should continue to bind "checked" property after interaction', async() => {
+						input.click();
+						expect(input.checked).to.be.true;
+						expect(elem.checked).to.be.true;
+						await elem.updateComplete;
+						elem.checked = false; // eslint-disable-line require-atomic-updates
+						await elem.updateComplete;
+						expect(input.checked).to.be.false;
+					});
+
 					[
 						{name: 'aria-label', propName: 'ariaLabel', value: 'hello'},
-						{name: 'checked', value: true},
 						{name: 'disabled', value: true},
 						{name: 'name', value: 'jim'}
 					].forEach((attr) => {


### PR DESCRIPTION
Re-created #310 (FYI @tylergee) as a branch so that visual diff tests could run.

This issue [is described here](Polymer/lit-element#601). Essentially what's happening is that by binding to the underlying input's attribute instead of its property, as long as all interaction happens with `<d2l-input-checkbox>`, all is well. But when the user interacts directly with the checkbox (as is bound to happen!), then subsequent manipulation of `<d2l-input-checkbox>` does nothing. Once interacted with, native checkbox inputs don't seem to care about whether or not they have a `checked` attribute -- they respect their property instead.