### PR TITLE
Rename export const for input-label-styles.js

### DIFF
--- a/components/inputs/README.md
+++ b/components/inputs/README.md
@@ -22,13 +22,13 @@ Groups of inputs (like checkboxes or radios) should be wrapped in a `<fieldset>`
 Import the label styles and `RtlMixin` and include them in your component:
 
 ```javascript
-import {labelStyles} from '@brightspace-ui/core/components/inputs/input-label-styles.js';
+import {inputLabelStyles} from '@brightspace-ui/core/components/inputs/input-label-styles.js';
 import {RtlMixin} from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
 class MyElem extends RtlMixin(LitElement) {
 
   static get styles() {
-    return labelStyles;
+    return inputLabelStyles;
   }
 
 }

--- a/components/inputs/input-fieldset.js
+++ b/components/inputs/input-fieldset.js
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { labelStyles } from './input-label-styles.js';
+import { inputLabelStyles } from './input-label-styles.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 class InputFieldset extends RtlMixin(LitElement) {
@@ -12,7 +12,7 @@ class InputFieldset extends RtlMixin(LitElement) {
 	}
 
 	static get styles() {
-		return [ labelStyles,
+		return [ inputLabelStyles,
 			css`
 				:host {
 					display: block;

--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -1,6 +1,6 @@
 import { css } from 'lit-element/lit-element.js';
 
-export const labelStyles = css`
+export const inputLabelStyles = css`
 	.d2l-input-label {
 		cursor: default;
 		display: block;

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -1,7 +1,7 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputStyles } from './input-styles.js';
-import { labelStyles } from './input-label-styles.js';
+import { inputLabelStyles } from './input-label-styles.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 class InputText extends RtlMixin(LitElement) {
@@ -32,7 +32,7 @@ class InputText extends RtlMixin(LitElement) {
 	}
 
 	static get styles() {
-		return [ inputStyles, labelStyles,
+		return [ inputStyles, inputLabelStyles,
 			css`
 				:host {
 					display: inline-block;

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -1,7 +1,7 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
-import { inputStyles } from './input-styles.js';
 import { inputLabelStyles } from './input-label-styles.js';
+import { inputStyles } from './input-styles.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 class InputText extends RtlMixin(LitElement) {

--- a/components/inputs/test/input-label.visual-diff.html
+++ b/components/inputs/test/input-label.visual-diff.html
@@ -75,7 +75,7 @@
 			import { getUniqueId } from '../../../helpers/uniqueId.js';
 			import { ifDefined } from 'lit-html/directives/if-defined.js';
 			import { inputStyles } from '../input-styles.js';
-			import { labelStyles } from '../input-label-styles.js';
+			import { inputLabelStyles } from '../input-label-styles.js';
 			import { radioStyles } from '../input-radio-styles.js';
 			import { RtlMixin } from '../../../mixins/rtl-mixin.js';
 
@@ -88,7 +88,7 @@
 				}
 
 				static get styles() {
-					return [inputStyles, labelStyles, css`:host { display: block; }`];
+					return [inputStyles, inputLabelStyles, css`:host { display: block; }`];
 				}
 
 				render() {
@@ -117,7 +117,7 @@
 				}
 
 				static get styles() {
-					return [inputStyles, labelStyles, css`:host { display: block; }`];
+					return [inputStyles, inputLabelStyles, css`:host { display: block; }`];
 				}
 
 				render() {
@@ -170,7 +170,7 @@
 				}
 
 				static get styles() {
-					return [labelStyles];
+					return [inputLabelStyles];
 				}
 
 				render() {

--- a/components/inputs/test/input-label.visual-diff.html
+++ b/components/inputs/test/input-label.visual-diff.html
@@ -74,8 +74,8 @@
 			import { classMap} from 'lit-html/directives/class-map.js';
 			import { getUniqueId } from '../../../helpers/uniqueId.js';
 			import { ifDefined } from 'lit-html/directives/if-defined.js';
-			import { inputStyles } from '../input-styles.js';
 			import { inputLabelStyles } from '../input-label-styles.js';
+			import { inputStyles } from '../input-styles.js';
 			import { radioStyles } from '../input-radio-styles.js';
 			import { RtlMixin } from '../../../mixins/rtl-mixin.js';
 


### PR DESCRIPTION
* It had the same name as the style.js in typography.
* Also renamed the uses of it