### PR TITLE
Accounting for when footer children aren't in a slot.

### DIFF
--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -72,7 +72,16 @@ class DialogConfirm extends DialogMixin(LitElement) {
 
 	_focusInitial() {
 		const footer = this.shadowRoot.querySelector('.d2l-dialog-footer slot');
-		const nodes = footer.assignedNodes();
+		let nodes;
+		if (footer) {
+			nodes = footer.assignedNodes();
+		} else {
+			//For Edge.
+			nodes = [...(this.childNodes.length ? this.childNodes : [])];
+			nodes = nodes.filter(
+				node => node.slot === 'footer'
+			);
+		}
 		for (let i = 0; i < nodes.length; i++) {
 			const node = nodes[i];
 			if (node.nodeType !== Node.ELEMENT_NODE) continue;

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -58,7 +58,7 @@ class DialogConfirm extends DialogMixin(LitElement) {
 					<div>${this.text}</div>
 				</div>
 				<div class="d2l-dialog-footer">
-					<slot name="footer"></slot>
+					<slot name="footer" class="d2l-dialog-footer-slot"></slot>
 				</div>
 			</div>`;
 
@@ -71,17 +71,8 @@ class DialogConfirm extends DialogMixin(LitElement) {
 	}
 
 	_focusInitial() {
-		const footer = this.shadowRoot.querySelector('.d2l-dialog-footer slot');
-		let nodes;
-		if (footer) {
-			nodes = footer.assignedNodes();
-		} else {
-			//For Edge.
-			nodes = [...(this.childNodes.length ? this.childNodes : [])];
-			nodes = nodes.filter(
-				node => node.slot === 'footer'
-			);
-		}
+		const footer = this.shadowRoot.querySelector('.d2l-dialog-footer-slot');
+		const nodes = footer.assignedNodes();
 		for (let i = 0; i < nodes.length; i++) {
 			const node = nodes[i];
 			if (node.nodeType !== Node.ELEMENT_NODE) continue;


### PR DESCRIPTION
The children of the footer slot aren't being grabbed in Edge because the `.d2l-dialog-footer slot` selector doesn't match anything (they're direct children of the dialog, rather than in a slot), resulting in a null reference.