### PR TITLE
upgrading to intl-messageformat 7

### DIFF
--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -1,6 +1,5 @@
 import {getDocumentLocaleSettings} from '@brightspace-ui/intl/lib/common.js';
-import IntlMessageFormat from 'intl-messageformat/src/main.js';
-window.IntlMessageFormat = IntlMessageFormat;
+import IntlMessageFormat from 'intl-messageformat';
 
 export const LocalizeMixin = superclass => class extends superclass {
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@brightspace-ui/intl": "^3",
     "@webcomponents/shadycss": "^1",
     "@webcomponents/webcomponentsjs": "^2",
-    "intl-messageformat": "^2.2.0",
+    "intl-messageformat": "^7",
     "lit-element": "^2",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"


### PR DESCRIPTION
Using the latest and ES6 module friendly version of `intl-messageformat`. Will need to work alongside [this new version](https://github.com/BrightspaceUI/localize-behavior/pull/30) of `localize-behavior`.