### PR TITLE
Polyfill Intl.PluralRules

### DIFF
--- a/mixins/demo/localize-test.js
+++ b/mixins/demo/localize-test.js
@@ -18,7 +18,10 @@ class LocalizeTest extends LocalizeMixin(LitElement) {
 		const langResources = {
 			'ar': { 'hello': 'مرحبا {name}' },
 			'de': { 'hello': 'Hallo {name}' },
-			'en': { 'hello': 'Hello {name}' },
+			'en': {
+				'hello': 'Hello {name}',
+				'plural': 'You have {itemCount, plural, =0 {no items} one {1 item} other {{itemCount} items}}.'
+			},
 			'en-ca': { 'hello': 'Hello, {name} eh' },
 			'es': { 'hello': 'Hola {name}' },
 			'fr': { 'hello': 'Bonjour {name}' },

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -1,3 +1,4 @@
+import '@formatjs/intl-pluralrules/dist-es6/polyfill-locales.js';
 import {getDocumentLocaleSettings} from '@brightspace-ui/intl/lib/common.js';
 import IntlMessageFormat from 'intl-messageformat';
 

--- a/mixins/test/localize-mixin.html
+++ b/mixins/test/localize-mixin.html
@@ -86,6 +86,10 @@
 						elem.addEventListener('d2l-localize-behavior-language-changed', myEventListener);
 						documentLocaleSettings.language = 'fr';
 					});
+					it('should localize term using plurals', () => {
+						const val = elem.localize('plural', {itemCount: 1});
+						expect(val).to.equal('You have 1 item.');
+					});
 				});
 				describe('shouldUpdate tracking', () => {
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@brightspace-ui/intl": "^3",
+    "@formatjs/intl-pluralrules": "^1",
     "@webcomponents/shadycss": "^1",
     "@webcomponents/webcomponentsjs": "^2",
     "intl-messageformat": "^7",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -16,7 +16,7 @@
 				{
 					"browserName": "safari",
 					"platform": "OS X 10.13",
-					"version": "11.1"
+					"version": ""
 				},
 				{
 					"browserName": "firefox",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -16,7 +16,7 @@
 				{
 					"browserName": "safari",
 					"platform": "OS X 10.13",
-					"version": ""
+					"version": "11.1"
 				},
 				{
 					"browserName": "firefox",


### PR DESCRIPTION
With the new `intl-messageformat`, we need to include a polyfill for the `Intl.PluralRules` stuff, which doesn't exist in Edge or older versions of Safari.