### PR TITLE
remove override

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,5 @@
     "lit-element": "^2",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "intl-messageformat"
-    ]
   }
 }


### PR DESCRIPTION
Now that we're on the latest `intl-messageformat`, we don't need Greenkeeper to ignore this anymore.