### PR TITLE
using the latest node version again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-node_js:
-- '12'
+node_js: node
 jobs:
   include:
   - stage: code-tests


### PR DESCRIPTION
Seems like this was locked [because node-sass didn't support version 13](https://github.com/BrightspaceUI/core/pull/257). If the build passes, it's fixed.