### PR TITLE
Fix Inconsistencies with the Polymer Dropdown

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -161,6 +161,10 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 	updated(changedProperties) {
 		changedProperties.forEach((_, propName) => {
 			if (propName === 'verticalOffset') {
+				let newVerticalOffset = parseInt(this.verticalOffset);
+				if (isNaN(newVerticalOffset)) {
+					newVerticalOffset = 20;
+				}
 				// for IE11
 				if (window.ShadyCSS) window.ShadyCSS.styleSubtree(this, { '--d2l-dropdown-verticaloffset': `${this.verticalOffset}px` });
 				else this.style.setProperty('--d2l-dropdown-verticaloffset', `${this.verticalOffset}px`);

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -128,9 +128,11 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 
 	set opened(val) {
 		const oldVal = this.__opened;
-		this.__opened = val;
-		this.requestUpdate('opened', oldVal);
-		this.__openedChanged(val);
+		if (oldVal !== val) {
+			this.__opened = val;
+			this.requestUpdate('opened', oldVal);
+			this.__openedChanged(val);
+		}
 	}
 
 	firstUpdated(changedProperties) {
@@ -166,8 +168,8 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 					newVerticalOffset = 20;
 				}
 				// for IE11
-				if (window.ShadyCSS) window.ShadyCSS.styleSubtree(this, { '--d2l-dropdown-verticaloffset': `${this.verticalOffset}px` });
-				else this.style.setProperty('--d2l-dropdown-verticaloffset', `${this.verticalOffset}px`);
+				if (window.ShadyCSS) window.ShadyCSS.styleSubtree(this, { '--d2l-dropdown-verticaloffset': `${newVerticalOffset}px` });
+				else this.style.setProperty('--d2l-dropdown-verticaloffset', `${newVerticalOffset}px`);
 			}
 		});
 	}

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -64,14 +64,6 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 				reflect: true,
 				attribute: 'opened-above'
 			},
-			/**
-			 * Whether to render the content immediately. By default, the content rendering
-			 * is deferred.
-			 */
-			renderContent: {
-				type: Boolean,
-				attribute: 'render-content'
-			},
 			verticalOffset: {
 				type: String,
 				attribute: 'vertical-offset'
@@ -184,17 +176,12 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 	}
 
 	/**
-	 * Synchronously stamps and attaches the content into the DOM. By default, rendering of the
-	 * content into the DOM is deferred as a performance optimization, so if access to the content
-	 * DOM is required (for example by calling `document.querySelector`) before opening the dropdown,
-	 * `forceRender` may be used.
+	 * forceRender is no longer necessary, this is left as a stub so that
+	 * places calling it will not break. It will be removed once the Polymer
+	 * dropdown is swapped over to use this and all instances of
+	 * forceRender are removed.
 	 */
-	async forceRender() {
-		if (!this.renderContent) {
-			this.renderContent = true;
-		}
-		await this.updateComplete;
-	}
+	forceRender() {}
 
 	toggleOpen(applyFocus) {
 		if (this.opened) {
@@ -259,7 +246,7 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 				<div class="d2l-dropdown-content-width" style=${styleMap(widthStyle)}>
 					<div class=${classMap(topClasses)}></div>
 					<div class="d2l-dropdown-content-container" style=${styleMap(containerStyle)} @scroll=${this.__toggleScrollStyles}>
-						${this.renderContent ? html`<slot></slot>` : null}
+						<slot></slot>
 					</div>
 					<div class=${classMap(bottomClasses)}></div>
 				</div>
@@ -388,9 +375,6 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 		};
 
 		if (newValue) {
-			if (!this.renderContent) {
-				this.renderContent = true;
-			}
 
 			await doOpen();
 

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -242,7 +242,6 @@ describe('d2l-dropdown', () => {
 		});
 
 		it('should focus on container when opened and no focusable light descendant exists', async() => {
-			await content.forceRender();
 			content.querySelector('#focusable_inside').setAttribute('tabindex', '-1');
 			content.setAttribute('opened', true);
 

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -56,6 +56,24 @@ describe('d2l-dropdown', () => {
 			expect(content.opened).to.be.false;
 		});
 
+		it('doesnt fire open event when already opened', async() => {
+			content.opened = true;
+			await oneEvent(content, 'd2l-dropdown-open');
+			let hasDuplicateEvent = false;
+			oneEvent(content, 'd2l-dropdown-open').then(() => hasDuplicateEvent = true);
+			content.opened = true;
+			await aTimeout(100);
+			expect(hasDuplicateEvent).to.be.false;
+		});
+
+		it('doesnt fire close event when already closed', async() => {
+			let hasDuplicateEvent = false;
+			oneEvent(content, 'd2l-dropdown-close').then(() => hasDuplicateEvent = true);
+			content.opened = false;
+			await aTimeout(100);
+			expect(hasDuplicateEvent).to.be.false;
+		});
+
 	});
 
 	describe('toggleOpen', () => {
@@ -260,6 +278,36 @@ describe('d2l-dropdown', () => {
 			await opener.updateComplete;
 			expect(opener.getAttribute('aria-expanded')).to.equal('false');
 		});
+	});
+
+	describe('vertical-offset', () => {
+
+		it('vertical offset should update if set without px', async() => {
+			content.setAttribute('vertical-offset', 100);
+			await nextFrame();
+			expect(content.style.getPropertyValue('--d2l-dropdown-verticaloffset')).to.equal('100px');
+		});
+
+		it('vertical offset should update if set with px', async() => {
+			content.setAttribute('vertical-offset', '50px');
+			await nextFrame();
+			expect(content.style.getPropertyValue('--d2l-dropdown-verticaloffset')).to.equal('50px');
+		});
+
+		it('vertical offset should default to 20 if removed', async() => {
+			content.setAttribute('vertical-offset', 100);
+			await nextFrame();
+			content.removeAttribute('vertical-offset');
+			await nextFrame();
+			expect(content.style.getPropertyValue('--d2l-dropdown-verticaloffset')).to.equal('20px');
+		});
+
+		it('vertical offset should default to 20 if set to an invalid number', async() => {
+			content.setAttribute('vertical-offset', 'thisisnotasize');
+			await nextFrame();
+			expect(content.style.getPropertyValue('--d2l-dropdown-verticaloffset')).to.equal('20px');
+		});
+
 	});
 
 });


### PR DESCRIPTION
# Changes
1. Fix `vertical-offset` to function with or without the `px` suffix and to default back to `20px` if removed or set to an invalid value.
1. Fix `__openedChanged` so that it is only called when the `opened` value actually changes.
1. Remove `forceRender` and `render-content` because the performance optimization is no longer worth the additional complexity it adds.