### PR TITLE
Dropdown Button Disable

### DIFF
--- a/components/dropdown/dropdown-button-subtle.js
+++ b/components/dropdown/dropdown-button-subtle.js
@@ -19,7 +19,7 @@ class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 
 	render() {
 		return html`
-			<d2l-button-subtle text=${this.text} icon="tier1:chevron-down" icon-right></d2l-button-subtle>
+			<d2l-button-subtle text=${this.text} icon="tier1:chevron-down" icon-right ?disabled=${this.disabled}></d2l-button-subtle>
 			<slot></slot>
 		`;
 	}

--- a/components/dropdown/dropdown-button.js
+++ b/components/dropdown/dropdown-button.js
@@ -44,7 +44,7 @@ class DropdownButton extends DropdownOpenerMixin(RtlMixin(LitElement)) {
 
 	render() {
 		return html`
-			<d2l-button ?primary=${this.primary}>
+			<d2l-button ?primary=${this.primary} ?disabled=${this.disabled}>
 				${this.text}<d2l-icon icon="tier1:chevron-down"></d2l-icon>
 			</d2l-button>
 			<slot></slot>


### PR DESCRIPTION
Pass the `disabled` attribute through to the inner `dropdown-button` and `dropdown-button-subtle` so that they get correctly styled when disabled.