### PR TITLE
Dropdown scales based on header&footer content

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -445,7 +445,10 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 
 			const targetRect = target.getBoundingClientRect();
 			contentRect = contentRect ? contentRect : content.getBoundingClientRect();
-			const headerFooterHeight =  header.getBoundingClientRect().height + footer.getBoundingClientRect().height;
+			const headerRect = header.getBoundingClientRect();
+			const footerRect = footer.getBoundingClientRect();
+			const headerFooterHeight = headerRect.height + footerRect.height;
+			const widestRectWidth = Math.max(headerRect.width, contentRect.width, footerRect.width);
 
 			const spaceAround = this._constrainSpaceAround({
 				above: targetRect.top - 50,
@@ -456,14 +459,14 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 
 			const spaceRequired = {
 				height: contentRect.height + headerFooterHeight + 10,
-				width: contentRect.width
+				width: widestRectWidth
 			};
 
 			if (!ignoreVertical) {
 				this.openedAbove = this._getOpenedAbove(spaceAround, spaceRequired);
 			}
 
-			const centerDelta = contentRect.width - targetRect.width;
+			const centerDelta = widestRectWidth - targetRect.width;
 			const position = this._getPosition(spaceAround, centerDelta);
 			if (position) {
 				this._position = position;
@@ -481,7 +484,7 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 			this.dispatchEvent(new CustomEvent('d2l-dropdown-position', { bubbles: true, composed: true }));
 		};
 
-		this._width = this._getWidth(content.scrollWidth);
+		this._width = this._getWidth(Math.max(header.scrollWidth, content.scrollWidth, footer.scrollWidth));
 		await this.updateComplete;
 
 		await adjustPosition();

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -242,7 +242,7 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 			minWidth: this.minWidth ? `${this.minWidth}px` : undefined,
 			/* set width of content in addition to width container so IE will render scroll inside border */
 			width: this._width ? `${this._width + 18}px` : '',
-		}
+		};
 
 		const contentStyle = {
 			...contentWidthStyle,

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -238,10 +238,14 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 			width: this._width ? `${this._width + 20}px` : ''
 		};
 
-		const containerStyle = {
+		const contentWidthStyle = {
 			minWidth: this.minWidth ? `${this.minWidth}px` : undefined,
 			/* set width of content in addition to width container so IE will render scroll inside border */
 			width: this._width ? `${this._width + 18}px` : '',
+		}
+
+		const contentStyle = {
+			...contentWidthStyle,
 			maxHeight: this._maxHeight ? `${this._maxHeight}px` : 'none',
 			overflowY: this._contentOverflow ? 'auto' : 'hidden'
 		};
@@ -260,13 +264,13 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 		return html`
 			<div class="d2l-dropdown-content-position" style=${styleMap(positionStyle)}>
 				<div class="d2l-dropdown-content-width" style=${styleMap(widthStyle)}>
-					<div class=${classMap(topClasses)}>
+					<div class=${classMap(topClasses)} style=${styleMap(contentWidthStyle)}>
 						<slot name="header" @slotchange="${this.__handleHeaderSlotChange}"></slot>
 					</div>
-					<div class="d2l-dropdown-content-container" style=${styleMap(containerStyle)} @scroll=${this.__toggleScrollStyles}>
+					<div class="d2l-dropdown-content-container" style=${styleMap(contentStyle)} @scroll=${this.__toggleScrollStyles}>
 						<slot></slot>
 					</div>
-					<div class=${classMap(bottomClasses)}>
+					<div class=${classMap(bottomClasses)} style=${styleMap(contentWidthStyle)}>
 						<slot name="footer" @slotchange="${this.__handleFooterSlotChange}"></slot>
 					</div>
 				</div>
@@ -445,10 +449,7 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 
 			const targetRect = target.getBoundingClientRect();
 			contentRect = contentRect ? contentRect : content.getBoundingClientRect();
-			const headerRect = header.getBoundingClientRect();
-			const footerRect = footer.getBoundingClientRect();
-			const headerFooterHeight = headerRect.height + footerRect.height;
-			const widestRectWidth = Math.max(headerRect.width, contentRect.width, footerRect.width);
+			const headerFooterHeight = header.getBoundingClientRect().height + footer.getBoundingClientRect().height;
 
 			const spaceAround = this._constrainSpaceAround({
 				above: targetRect.top - 50,
@@ -459,14 +460,14 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 
 			const spaceRequired = {
 				height: contentRect.height + headerFooterHeight + 10,
-				width: widestRectWidth
+				width: contentRect.width
 			};
 
 			if (!ignoreVertical) {
 				this.openedAbove = this._getOpenedAbove(spaceAround, spaceRequired);
 			}
 
-			const centerDelta = widestRectWidth - targetRect.width;
+			const centerDelta = contentRect.width - targetRect.width;
 			const position = this._getPosition(spaceAround, centerDelta);
 			if (position) {
 				this._position = position;

--- a/components/dropdown/dropdown-content-styles.js
+++ b/components/dropdown/dropdown-content-styles.js
@@ -79,6 +79,9 @@ export const dropdownContentStyles = css`
 		max-width: 370px;
 		position: absolute;
 		width: 100vw;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
 	}
 
 	:host([opened-above]) .d2l-dropdown-content-width {
@@ -87,15 +90,15 @@ export const dropdownContentStyles = css`
 
 	.d2l-dropdown-content-container {
 		box-sizing: border-box;
-		display: inline-block;
 		max-width: 100%;
 		outline: none;
 		padding: 1rem;
-		vertical-align: top; /* prevents baseline bloat - fix for github issue #173 */
 	}
 
 	.d2l-dropdown-content-top,
 	.d2l-dropdown-content-bottom {
+		box-sizing: border-box;
+		max-width: 100%;
 		min-height: 5px;
 		position: relative;
 		z-index: 2;


### PR DESCRIPTION
Dropdown width is determined by header, content or footer - whichever is widest.
Previously it only considered content.