### PR TITLE
Add optional predicate to getFirstFocusableDescendant focus helper

### DIFF
--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -99,13 +99,11 @@ export function getPreviousFocusable(node, includeHidden) {
 	return focusable;
 }
 
-export function getNextFocusable(node, includeHidden, predicate) {
+export function getNextFocusable(node, includeHidden) {
 
 	if (!node) return null;
 
 	if (includeHidden === undefined) includeHidden = false;
-
-	if (predicate === undefined) predicate = () => true;
 
 	const _getNextAncestorSibling = (node) => {
 		let parentNode = getComposedParent(node);
@@ -121,24 +119,24 @@ export function getNextFocusable(node, includeHidden, predicate) {
 	};
 
 	const _getNextFocusable = (node, ignore, ignoreChildren) => {
-		if (!ignore && isFocusable(node, includeHidden)) return node;
+		if (!ignore) return node;
 
 		if (!ignoreChildren) {
-			const focusable = getFirstFocusableDescendant(node, includeHidden, predicate);
-			if (focusable && predicate(focusable)) return focusable;
+			const focusable = getFirstFocusableDescendant(node, includeHidden);
+			if (focusable) return focusable;
 		}
 
 		const nextSibling = node.nextElementSibling;
 		if (nextSibling) {
 			const siblingFocusable = _getNextFocusable(nextSibling, false, false);
-			if (siblingFocusable && predicate(siblingFocusable)) return siblingFocusable;
+			if (siblingFocusable) return siblingFocusable;
 			return null;
 		}
 
 		const nextParentSibling = _getNextAncestorSibling(node);
 		if (nextParentSibling) {
 			const parentSibingFocusable = _getNextFocusable(nextParentSibling, false, false);
-			if (parentSibingFocusable && predicate(parentSibingFocusable)) return parentSibingFocusable;
+			if (parentSibingFocusable) return parentSibingFocusable;
 		}
 
 		return null;

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -26,14 +26,16 @@ export function getComposedActiveElement() {
 	return node;
 }
 
-export function getFirstFocusableDescendant(node, includeHidden) {
+export function getFirstFocusableDescendant(node, includeHidden, predicate) {
+	if (predicate === undefined) predicate = () => true;
+
 	const composedChildren = getComposedChildren(node);
 
 	for (let i = 0; i < composedChildren.length; i++) {
-		if (isFocusable(composedChildren[i], includeHidden)) return composedChildren[i];
+		if (isFocusable(composedChildren[i], includeHidden) && predicate(composedChildren[i])) return composedChildren[i];
 
-		const focusable = getFirstFocusableDescendant(composedChildren[i], includeHidden);
-		if (focusable) return focusable;
+		const focusable = getFirstFocusableDescendant(composedChildren[i], includeHidden, predicate);
+		if (focusable && predicate(focusable)) return focusable;
 	}
 
 	return null;
@@ -97,11 +99,13 @@ export function getPreviousFocusable(node, includeHidden) {
 	return focusable;
 }
 
-export function getNextFocusable(node, includeHidden) {
+export function getNextFocusable(node, includeHidden, predicate) {
 
 	if (!node) return null;
 
 	if (includeHidden === undefined) includeHidden = false;
+
+	if (predicate === undefined) predicate = () => true;
 
 	const _getNextAncestorSibling = (node) => {
 		let parentNode = getComposedParent(node);
@@ -120,21 +124,21 @@ export function getNextFocusable(node, includeHidden) {
 		if (!ignore && isFocusable(node, includeHidden)) return node;
 
 		if (!ignoreChildren) {
-			const focusable = getFirstFocusableDescendant(node, includeHidden);
-			if (focusable) return focusable;
+			const focusable = getFirstFocusableDescendant(node, includeHidden, predicate);
+			if (focusable && predicate(focusable)) return focusable;
 		}
 
 		const nextSibling = node.nextElementSibling;
 		if (nextSibling) {
 			const siblingFocusable = _getNextFocusable(nextSibling, false, false);
-			if (siblingFocusable) return siblingFocusable;
+			if (siblingFocusable && predicate(siblingFocusable)) return siblingFocusable;
 			return null;
 		}
 
 		const nextParentSibling = _getNextAncestorSibling(node);
 		if (nextParentSibling) {
 			const parentSibingFocusable = _getNextFocusable(nextParentSibling, false, false);
-			if (parentSibingFocusable) return parentSibingFocusable;
+			if (parentSibingFocusable && predicate(parentSibingFocusable)) return parentSibingFocusable;
 		}
 
 		return null;

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -119,7 +119,7 @@ export function getNextFocusable(node, includeHidden) {
 	};
 
 	const _getNextFocusable = (node, ignore, ignoreChildren) => {
-		if (!ignore) return node;
+		if (!ignore && isFocusable(node, includeHidden)) return node;
 
 		if (!ignoreChildren) {
 			const focusable = getFirstFocusableDescendant(node, includeHidden);

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -35,7 +35,7 @@ export function getFirstFocusableDescendant(node, includeHidden, predicate) {
 		if (isFocusable(composedChildren[i], includeHidden) && predicate(composedChildren[i])) return composedChildren[i];
 
 		const focusable = getFirstFocusableDescendant(composedChildren[i], includeHidden, predicate);
-		if (focusable && predicate(focusable)) return focusable;
+		if (focusable) return focusable;
 	}
 
 	return null;

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -94,7 +94,7 @@ describe('focus', () => {
 
 	});
 
-	describe('getFirstFocusableDescendant', () => {
+	describe('getFirstFocusableDescendant without predicate', () => {
 
 		it('returns focusable child', async() => {
 			const elem = await fixture(simpleFixture);
@@ -124,6 +124,42 @@ describe('focus', () => {
 			const elem = await fixture(wcFixture);
 			expect(getFirstFocusableDescendant(elem.getContent()))
 				.to.equal(elem.querySelector('#light1'));
+		});
+
+	});
+
+	describe('getFirstFocusableDescendant with predicate', () => {
+		const lightPredicate = node => node.id === 'light2';
+		const shadowPredicate = node => node.id === 'shadow2';
+
+		it('returns focusable child', async() => {
+			const elem = await fixture(simpleFixture);
+			expect(getFirstFocusableDescendant(elem, false, lightPredicate))
+				.to.equal(elem.querySelector('#light2'));
+		});
+
+		it('returns focusable descendant', async() => {
+			const elem = await fixture(nestedFixture);
+			expect(getFirstFocusableDescendant(elem, false, lightPredicate))
+				.to.equal(elem.querySelector('#light2'));
+		});
+
+		it('returns null if no children', async() => {
+			const elem = await fixture(html`<div></div>`);
+			expect(getFirstFocusableDescendant(elem, false, lightPredicate))
+				.to.be.null;
+		});
+
+		it('returns focusable child in shadow-dom', async() => {
+			const elem = await fixture(wcFixture);
+			expect(getFirstFocusableDescendant(elem, false, shadowPredicate))
+				.to.equal(elem.getShadow2());
+		});
+
+		it('returns focusable distributed child', async() => {
+			const elem = await fixture(wcFixture);
+			expect(getFirstFocusableDescendant(elem.getContent(), false, lightPredicate))
+				.to.equal(elem.querySelector('#light2'));
 		});
 
 	});


### PR DESCRIPTION
When an error occurs in the FACE editors, we want to focus on the first input field that is in error.
Doing this via mixins/events/etc might be tricky, fragile, and high-maintenance, due to the many different sub-editors on the page and the state management to support the new save-cancel workflow.

The alternative is to do a dom search, which is what this PR strives to help support.
Since our use case doesn't care about the _next_ focusable element but instead the next focusable element that is also in error, this PR adds an optional predicate which allows us to filter the nodes returned by `getFirstFocusableDescendant`. Now it will return the first node that is focusable _and_ fulfills the predicate.

If this is generally approved of, I can add some tests.
(And I had originally also added the predicate to `getNextFocusable`, but ended up not needing that function so I removed it.)