### PR TITLE
Fix bug with clicking a menu-item-link with voiceover on

### DIFF
--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -90,7 +90,6 @@ The link menu item, `d2l-menu-item-link`, is used for navigating.
 * `text` (required, String): text displayed by the menu item
 * `href` (required, String): the url the menu item link navigates to
 * `disabled` (Boolean): disables the menu item
-* `prevent-default` (Boolean): Disables normal link behavior.  This can help if you want both a JS handler and the browser's 'open in new tab' functionality (e.g. popup window links).
 
 ### d2l-menu-item-checkbox
 

--- a/components/menu/menu-item-link.js
+++ b/components/menu/menu-item-link.js
@@ -8,7 +8,6 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 	static get properties() {
 		return {
 			href: { type: String },
-			preventDefault: { type: Boolean, reflect: true, attribute: 'prevent-default' },
 			target: { type: String }
 		};
 	}
@@ -60,18 +59,11 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 		return null;
 	}
 
-	_onClick(e) {
-		this.shadowRoot.querySelector('a').dispatchEvent(new CustomEvent('click', { bubbles: false }));
-		if (this.preventDefault) {
-			e.preventDefault();
-		}
+	_onClick() {
+		this.shadowRoot.querySelector('a').dispatchEvent(new CustomEvent('click'));
 	}
 
 	_onKeyDown(e) {
-		if (this.preventDefault) {
-			e.preventDefault();
-			return;
-		}
 		if (e.keyCode === this.__keyCodes.ENTER || e.keyCode === this.__keyCodes.SPACE) {
 			const target = this._getTarget();
 			if (target === '_parent') {

--- a/components/menu/menu-item-link.js
+++ b/components/menu/menu-item-link.js
@@ -39,7 +39,7 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 	firstUpdated() {
 		super.firstUpdated();
 		this.addEventListener('keydown', this._onKeyDown);
-		this.shadowRoot.querySelector('a').addEventListener('click', this._onClick);
+		this.addEventListener('click', this._onClick);
 	}
 
 	render() {
@@ -61,6 +61,7 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 	}
 
 	_onClick(e) {
+		this.shadowRoot.querySelector('a').dispatchEvent(new CustomEvent('click', { bubbles: false }));
 		if (this.preventDefault) {
 			e.preventDefault();
 		}

--- a/components/menu/menu-item-link.js
+++ b/components/menu/menu-item-link.js
@@ -37,13 +37,14 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 
 	firstUpdated() {
 		super.firstUpdated();
-		this.addEventListener('keydown', this._onKeyDown);
 		this.addEventListener('click', this._onClick);
+		this.addEventListener('keydown', this._onKeyDown);
 	}
 
 	render() {
+		const rel = this.target ? 'noreferrer noopener' : undefined;
 		return html`
-			<a href="${ifDefined(this.href)}" target="${ifDefined(this.target)}" tabindex="-1">${this.text}</a>
+			<a href="${ifDefined(this.href)}" rel="${ifDefined(rel)}" target="${ifDefined(this.target)}" tabindex="-1">${this.text}</a>
 		`;
 	}
 


### PR DESCRIPTION
This affects any voice over users using iOS 13.

The anchor just isn't receiving any click event when voice over is on. I haven't been able to track down exactly what changed to cause this. I think this fix is fairly safe but let me know if there's something I'm missing or if there is potentially a better option. The `bubbles: false` is to prevent the `d2l-menu-item-select` event from being dispatched a second time.