### PR TITLE
Fix issue where the d2l-visible-on-ancestor-target may not have loaded

### DIFF
--- a/mixins/test/visible-on-ancestor-mixin.test.js
+++ b/mixins/test/visible-on-ancestor-mixin.test.js
@@ -1,0 +1,38 @@
+
+import '../../components/button/button-icon.js';
+import { defineCE, expect, fixture, html, nextFrame } from '@open-wc/testing';
+import { LitElement } from 'lit-element/lit-element.js';
+
+const targetTag = defineCE(
+	class extends LitElement {
+
+		render() {
+			return html`
+				<div class="d2l-visible-on-ancestor-target">
+					<slot></slot>
+				</div>
+			`;
+		}
+	}
+);
+
+describe('VisibleOnAncestorMixin', () => {
+
+	let elem;
+
+	beforeEach(async() => {
+		elem = await fixture(`
+			<${targetTag}>
+				<d2l-button-icon id="visible-on-ancestor" icon="d2l-tier1:gear" text="Gear" visible-on-ancestor></d2l-button-icon>
+			</${targetTag}>
+		`);
+	});
+
+	it('should find target in ancestors shadow DOM', async() => {
+		await nextFrame();
+		const target = elem.shadowRoot.querySelector('.d2l-visible-on-ancestor-target');
+		const visibleOnAncestor = elem.querySelector('#visible-on-ancestor');
+		expect(visibleOnAncestor.__voaTarget).to.equal(target);
+	});
+
+});

--- a/mixins/visible-on-ancestor-mixin.js
+++ b/mixins/visible-on-ancestor-mixin.js
@@ -48,8 +48,9 @@ export const VisibleOnAncestorMixin = superclass => class extends superclass {
 	connectedCallback() {
 		super.connectedCallback();
 		this.__voaAttached = true;
-		if (this.visibleOnAncestor) this.__voaInit();
-		else this.__voaState = null;
+		if (this.visibleOnAncestor) {
+			requestAnimationFrame(() => this.__voaInit());
+		} else this.__voaState = null;
 	}
 
 	disconnectedCallback() {


### PR DESCRIPTION
When the `connectedCallback` is run, there is no guarantee that the ancestors' shadow
DOMs have loaded. If the `d2l-visible-on-ancestor-target` is within an ancestor's
shadow DOM then the look up in `__voaInit` will fail and the `visible-on-ancestor-mixin`
will not find a target.

To account for the async loading of ancestors' shadow DOMs, this delays until the
next animation frame.