### PR TITLE
Dbatiste/swipe gesture

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -51,10 +51,10 @@ class DemoSnippet extends LitElement {
 		text = text.replace(/^[\t]*<template>[\n]*/, '').replace(/[\n]*[\t]*<\/template>$/, '');
 
 		// fix script whitespace (for some reason brower keeps <script> indent but not the rest)
-		let lines = text.replace(/\t/g, '  ').replace(/<\/script>/g, '\n</script>').replace(/<script>/g, '<script>\n').split('\n');
+		let lines = text.replace(/\t/g, '  ').replace(/<\/script>/g, '\n</script>').replace(/<script>/g, '<script>\n').replace(/<script type="module">/g, '<script type="module">\n').split('\n');
 		let scriptIndent = 0;
 		lines = lines.map((l) => {
-			if (l.indexOf('<script>') > -1) {
+			if (l.indexOf('<script') > -1) {
 				scriptIndent = l.match(/^(\s*)/)[0].length;
 				return l;
 			} else if (l.indexOf('</script>') > -1) {

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -63,6 +63,28 @@ getOffsetParent(node);
 isComposedAncestor(ancestorNode, node);
 ```
 
+## Gesture - Swipe
+
+A simple helper for swipe touch gestures, providing distance, direction, and duration.
+
+```js
+import { registerGestureSwipe } from '@brightspace-ui/core/helpers/gestures.js';
+
+// sets up event listeners for swipe gesture
+registerGestureSwipe(element);
+
+// listen for custom swipe event
+element.addEventListener('d2l-gesture-swipe', (e) => {
+    console.log(
+        e.detail.distance,             // .x/.y
+        e.detail.direction.angle,      // deg, clock-wise from y-axis
+        e.detail.direction.horizontal, // left/right
+        e.detail.direction.vertical,   // up/down
+        e.detail.duration              // ms
+    );
+});
+```
+
 ## queueMicrotask
 
 A polyfill for [queueMicrotask](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask). For more information on microtasks, read [this article from Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide).
@@ -86,28 +108,6 @@ import '@brightspace-ui/core/helpers/requestIdleCallback.js';
 requestIdleCallback((deadline) => {
     // do some work
 }, { timeout: 1000 });
-```
-
-## Swipe
-
-A simple helper for swipe touch gestures, providing distance, direction, and duration.
-
-```js
-import { registerSwipe } from '@brightspace-ui/core/helpers/gestures.js';
-
-// sets up event listeners for swipe gesture
-registerSwipe(element);
-
-// listen for custom swipe event
-element.addEventListener('d2l-swipe', (e) => {
-    console.log(
-        e.detail.distance,             // .x/.y
-        e.detail.direction.angle,      // deg
-        e.detail.direction.horizontal, // left/right
-        e.detail.direction.vertical,   // up/down
-        e.detail.duration              // ms
-    );
-});
 ```
 
 ## UniqueId

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -63,6 +63,17 @@ getOffsetParent(node);
 isComposedAncestor(ancestorNode, node);
 ```
 
+## queueMicrotask
+
+A polyfill for [queueMicrotask](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask). For more information on microtasks, read [this article from Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide).
+
+```js
+import '@brightspace-ui/core/helpers/queueMicrotask.js';
+queueMicrotask(() => {
+    // do some work
+});
+```
+
 ## requestIdleCallback
 
 A simple shim for [requestIdleCallback](https://www.w3.org/TR/requestidlecallback/#the-requestidlecallback-method) and [cancelIdleCallback](https://www.w3.org/TR/requestidlecallback/#the-cancelidlecallback-method) that transparently falls back to `setTimeout` if it's not natively supported.
@@ -77,14 +88,25 @@ requestIdleCallback((deadline) => {
 }, { timeout: 1000 });
 ```
 
-## queueMicrotask
+## Swipe
 
-A polyfill for [queueMicrotask](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask). For more information on microtasks, read [this article from Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide).
+A simple helper for swipe touch gestures, providing distance, direction, and duration.
 
 ```js
-import '@brightspace-ui/core/helpers/queueMicrotask.js';
-queueMicrotask(() => {
-	// do some work
+import { registerSwipe } from '@brightspace-ui/core/helpers/gestures.js';
+
+// sets up event listeners for swipe gesture
+registerSwipe(element);
+
+// listen for custom swipe event
+element.addEventListener('d2l-swipe', (e) => {
+    console.log(
+        e.detail.distance,             // .x/.y
+        e.detail.direction.angle,      // deg
+        e.detail.direction.horizontal, // left/right
+        e.detail.direction.vertical,   // up/down
+        e.detail.duration              // ms
+    );
 });
 ```
 

--- a/helpers/demo/gestures.html
+++ b/helpers/demo/gestures.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '../../components/demo/demo-page.js';
+		</script>
+		<style>
+			#container {
+				height: 300px;
+				padding-top: 100px;
+				padding: 100px 1rem 1rem 1rem;
+				text-align: center;
+			}
+			#container > :first-child {
+				color: var(--d2l-color-galena);
+				margin-bottom: 1rem;
+			}
+		</style>
+	</head>
+	<body unresolved>
+		<d2l-demo-page page-title="gestures">
+
+			<h2>Swipe</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<div id="container">
+						<div>swipe while using emulator or touch enabled device</div>
+						<div id="distance"></div>
+						<div id="direction"></div>
+						<div id="duration"></div>
+					</div>
+					<script type="module">
+						import { registerSwipe } from '../gestures.js';
+
+						const container = document.querySelector('#container');
+						registerSwipe(container);
+
+						container.addEventListener('d2l-swipe', (e) => {
+							document.querySelector('#distance').textContent =
+								JSON.stringify(e.detail.distance);
+							document.querySelector('#direction').textContent =
+								JSON.stringify(e.detail.direction);
+							document.querySelector('#duration').textContent =
+								JSON.stringify(e.detail.duration);
+							console.log('d2l-swipe', e.detail);
+						});
+					</script>
+				</template>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+
+	</body>
+</html>

--- a/helpers/demo/gestures.html
+++ b/helpers/demo/gestures.html
@@ -36,19 +36,19 @@
 						<div id="duration"></div>
 					</div>
 					<script type="module">
-						import { registerSwipe } from '../gestures.js';
+						import { registerGestureSwipe } from '../gestures.js';
 
 						const container = document.querySelector('#container');
-						registerSwipe(container);
+						registerGestureSwipe(container);
 
-						container.addEventListener('d2l-swipe', (e) => {
+						container.addEventListener('d2l-gesture-swipe', (e) => {
 							document.querySelector('#distance').textContent =
 								JSON.stringify(e.detail.distance);
 							document.querySelector('#direction').textContent =
 								JSON.stringify(e.detail.direction);
 							document.querySelector('#duration').textContent =
 								JSON.stringify(e.detail.duration);
-							console.log('d2l-swipe', e.detail);
+							console.log('d2l-gesture-swipe', e.detail);
 						});
 					</script>
 				</template>

--- a/helpers/gestures.js
+++ b/helpers/gestures.js
@@ -1,7 +1,7 @@
 const maxTime = 2000;
 const minDistance = 30;
 
-export function registerSwipe(node) {
+export function registerGestureSwipe(node) {
 	node.addEventListener('touchstart', handleTouchStart);
 }
 
@@ -80,7 +80,7 @@ function handleTouchStart(e) {
 			}
 		}
 
-		node.dispatchEvent(new CustomEvent('d2l-swipe', {
+		node.dispatchEvent(new CustomEvent('d2l-gesture-swipe', {
 			detail: {
 				distance: {
 					x: distanceX,

--- a/helpers/gestures.js
+++ b/helpers/gestures.js
@@ -44,14 +44,21 @@ function handleTouchStart(e) {
 		const distanceX = tracking.end.x - tracking.start.x;
 		const distanceY = tracking.end.y - tracking.start.y;
 
+		// angle of right-angle tri from y (radians)
 		let theta = Math.atan(Math.abs(distanceX) / Math.abs(distanceY));
+
+		// angle of arc from y (deg)
 		if (distanceY > 0 && distanceX > 0) {
+			// swipe down and right
 			theta = (Math.PI - theta) * 57.3;
 		} else if (distanceY > 0 && distanceX < 0) {
+			// swipe down and left
 			theta = (Math.PI + theta) * 57.3;
 		} else if (distanceY < 0 && distanceX > 0) {
+			// swipe up and right
 			theta = theta * 57.3;
 		} else if (distanceY < 0 && distanceX < 0) {
+			// swipe up and left
 			theta = ((2 * Math.PI) - theta) * 57.3;
 		}
 

--- a/helpers/gestures.js
+++ b/helpers/gestures.js
@@ -11,7 +11,7 @@ function handleTouchStart(e) {
 
 	let tracking = {
 		start: {
-			time: new Date().getTime(),
+			time: performance.now(),
 			x: e.touches[0].clientX,
 			y: e.touches[0].clientY
 		}
@@ -35,7 +35,7 @@ function handleTouchStart(e) {
 			return;
 		}
 
-		const elapsedTime = new Date().getTime() - tracking.start.time;
+		const elapsedTime = performance.now() - tracking.start.time;
 		if (elapsedTime > maxTime) {
 			reset();
 			return;

--- a/helpers/gestures.js
+++ b/helpers/gestures.js
@@ -1,0 +1,109 @@
+const maxTime = 2000;
+const minDistance = 30;
+
+export function registerSwipe(node) {
+	node.addEventListener('touchstart', handleTouchStart);
+}
+
+function handleTouchStart(e) {
+
+	const node = this; /* eslint-disable-line no-invalid-this */
+
+	let tracking = {
+		start: {
+			time: new Date().getTime(),
+			x: e.touches[0].clientX,
+			y: e.touches[0].clientY
+		}
+	};
+
+	const reset = () => {
+		tracking = null;
+		node.removeEventListener('touchend', handleTouchEnd);
+		node.removeEventListener('touchermove', handleTouchMove);
+		node.removeEventListener('touchcancel', handleTouchCancel);
+	};
+
+	const handleTouchCancel = () => {
+		reset();
+		return;
+	};
+
+	const handleTouchEnd = () => {
+
+		if (!tracking || !tracking.end) {
+			return;
+		}
+
+		const elapsedTime = new Date().getTime() - tracking.start.time;
+		if (elapsedTime > maxTime) {
+			reset();
+			return;
+		}
+
+		const distanceX = tracking.end.x - tracking.start.x;
+		const distanceY = tracking.end.y - tracking.start.y;
+
+		let theta = Math.atan(Math.abs(distanceX) / Math.abs(distanceY));
+		if (distanceY > 0 && distanceX > 0) {
+			theta = (Math.PI - theta) * 57.3;
+		} else if (distanceY > 0 && distanceX < 0) {
+			theta = (Math.PI + theta) * 57.3;
+		} else if (distanceY < 0 && distanceX > 0) {
+			theta = theta * 57.3;
+		} else if (distanceY < 0 && distanceX < 0) {
+			theta = ((2 * Math.PI) - theta) * 57.3;
+		}
+
+		let horizontal = 'none';
+		if (Math.abs(distanceX) >= minDistance) {
+			if (theta > 205 && theta < 335) {
+				horizontal = 'left';
+			} else if (theta > 25 && theta < 155) {
+				horizontal = 'right';
+			}
+		}
+
+		let vertical = 'none';
+		if (Math.abs(distanceY) >= minDistance) {
+			if (theta > 295 || theta < 65) {
+				vertical = 'up';
+			} else if (theta > 115 && theta < 245) {
+				vertical = 'down';
+			}
+		}
+
+		node.dispatchEvent(new CustomEvent('d2l-swipe', {
+			detail: {
+				distance: {
+					x: distanceX,
+					y: distanceY
+				},
+				direction: {
+					angle: theta,
+					horizontal: horizontal,
+					vertical: vertical
+				},
+				duration: elapsedTime
+			}
+		}));
+
+		reset();
+	};
+
+	const handleTouchMove = (e) => {
+		if (!tracking) {
+			return;
+		}
+		e.preventDefault();
+		tracking.end = {
+			x: e.touches[0].clientX,
+			y: e.touches[0].clientY
+		};
+	};
+
+	node.addEventListener('touchend', handleTouchEnd);
+	node.addEventListener('touchmove', handleTouchMove);
+	node.addEventListener('touchcancel', handleTouchCancel);
+
+}

--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@
 	<ul>
 		<li><a href="helpers/demo/announce.html">announce</a></li>
 		<li><a href="helpers/demo/dismissible.html">dismissible</a></li>
+		<li><a href="helpers/demo/gestures.html">gestures</a></li>
 	</ul>
 
 	<h2 class="d2l-heading-3">Mixins</h2>


### PR DESCRIPTION
This PR is the first step in moving the swipe gesture code from [d2l-polymer-behaviors-ui](https://github.com/Brightspace/d2l-polymer-behaviors-ui/blob/master/d2l-gestures-swipe.js).  It is used by image-based nav tray. It provides basic info - distance, direction, and duration of swipe.  Next step will be to remove that implementation, and update BSI to assign `window.D2L.Gestures.Swipe = {register: registerSwipe};`.
