### PR TITLE
Tooltip (1/2): Add tooltip show/hide logic

### DIFF
--- a/components/tooltip/demo/tooltip.html
+++ b/components/tooltip/demo/tooltip.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<meta charset="UTF-8">
+	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script type="module">
+		import '../../button/button.js';
+		import '../../colors/colors.js';
+		import '../../demo/demo-page.js';
+		import '../../inputs/input-text.js';
+		import '../tooltip.js';
+	</script>
+	<style>
+		#tooltip-error {
+			width: auto;
+		}
+
+		.boundary {
+			background-color: var(--d2l-color-citrine);
+			box-sizing: border-box;
+			display: inline-block;
+			padding-bottom: 75px;
+			padding-left: 200px;
+			padding-right: 25px;
+			padding-top: 40px;
+		}
+	</style>
+</head>
+
+<body unresolved>
+
+	<d2l-demo-page page-title="d2l-tooltip">
+
+		<h2>Tooltip (info)</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-button id="tooltip-info">Hover for Info</d2l-button>
+				<d2l-tooltip for="tooltip-info">
+					Your info message will display here
+				</d2l-tooltip>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Tooltip (error)</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-input-text placeholder="Hover for Error" id="tooltip-error"></d2l-input-text>
+				<d2l-tooltip for="tooltip-error" state="error">
+					Your error message will display here
+				</d2l-tooltip>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Tooltip (delay)</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-button id="tooltip-delay">Hover and Wait</d2l-button>
+				<d2l-tooltip for="tooltip-delay" delay="1000">
+					Your delayed message will display here
+				</d2l-tooltip>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Tooltip (force-show)</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-button id="tooltip-force-show">Always visible</d2l-button>
+				<d2l-tooltip for="tooltip-force-show" force-show>
+					Always visible message
+				</d2l-tooltip>
+			</template>
+		</d2l-demo-snippet>
+
+	</d2l-demo-page>
+
+</body>
+
+</html>

--- a/components/tooltip/test/.eslintrc.json
+++ b/components/tooltip/test/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "brightspace/open-wc-testing-config"
+}

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -25,10 +25,16 @@ describe('d2l-tooltip', () => {
 			await expect(tooltip).to.be.accessible;
 		});
 
-		it('should pass all aXe tests (show)', async() => {
-			tooltip.setAttribute('showing', 'showing');
-			await tooltip.updateComplete;
-			await expect(tooltip).to.be.accessible;
+		[
+			'info',
+			'error'
+		].forEach(state => {
+			it(`should pass all aXe tests for state ${state} (show)`, async() => {
+				tooltip.setAttribute('state', state);
+				tooltip.setAttribute('showing', 'showing');
+				await tooltip.updateComplete;
+				await expect(tooltip).to.be.accessible;
+			});
 		});
 	});
 
@@ -139,13 +145,16 @@ describe('d2l-tooltip', () => {
 		].forEach((testCase) => {
 			it(`should hide when ESC key is pressed while ${testCase.case}`, async() => {
 				const target = tooltipFixture.querySelector('#explicit-target');
-				if (testCase.hover) {
-					target.dispatchEvent(new Event('mouseenter'));
-				}
-				if (testCase.focus) {
-					await triggerFocusFor(target);
-				}
+				setTimeout(() => {
+					if (testCase.focus) {
+						triggerFocusFor(target);
+					}
+					if (testCase.hover) {
+						target.dispatchEvent(new Event('mouseenter'));
+					}
+				}, 0);
 				await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+				await aTimeout();
 
 				const eventObj = document.createEvent('Events');
 				eventObj.initEvent('keyup', true, true);

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -1,0 +1,248 @@
+import '../tooltip.js';
+import { aTimeout, expect, fixture, html, oneEvent, triggerBlurFor, triggerFocusFor } from '@open-wc/testing';
+
+const basicFixture = html`
+	<div>
+		<div id="implicit-target" tabindex="-1">
+			<button id="explicit-target">Hover me for tips</button>
+			<d2l-tooltip for="explicit-target">If I got a problem then a problem's got a problem.</d2l-tooltip>
+		</div>
+	</div>
+`;
+
+describe('d2l-tooltip', () => {
+
+	let tooltipFixture, tooltip;
+
+	beforeEach(async() => {
+		tooltipFixture = await fixture(basicFixture);
+		tooltip = tooltipFixture.querySelector('d2l-tooltip');
+	});
+
+	describe('accessibility', () => {
+
+		it('should pass all aXe tests (hide)', async() => {
+			await expect(tooltip).to.be.accessible;
+		});
+
+		it('should pass all aXe tests (show)', async() => {
+			tooltip.setAttribute('showing', 'showing');
+			await tooltip.updateComplete;
+			await expect(tooltip).to.be.accessible;
+		});
+	});
+
+	describe('events', () => {
+
+		it('doesnt fire show event when already showing', async() => {
+			tooltip.showing = true;
+			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+			oneEvent(tooltipFixture, 'd2l-tooltip-show').then(() => {
+				expect.fail('d2l-tooltip-hide hide should not have been fired');
+			});
+			tooltip.showing = true;
+			await aTimeout(100);
+		});
+
+		it('doesnt fire hide event when already hidden', async() => {
+			oneEvent(tooltipFixture, 'd2l-tooltip-hide').then(() => {
+				expect.fail('d2l-tooltip-hide hide should not have been fired');
+			});
+			tooltip.showing = false;
+			await aTimeout(100);
+		});
+	});
+
+	describe('explict target', () => {
+
+		it('should find target using for attribute', async() => {
+			const expectedTarget = tooltipFixture.querySelector('#explicit-target');
+			expect(tooltip._target).to.equal(expectedTarget);
+		});
+	});
+
+	describe('implicit target', () => {
+
+		beforeEach(async() => {
+			tooltip.removeAttribute('for');
+			await tooltip.updateComplete;
+		});
+
+		it('should find parent target', async() => {
+			const expectedTarget = tooltipFixture.querySelector('#implicit-target');
+			expect(tooltip._target).to.equal(expectedTarget);
+		});
+	});
+
+	describe('show-hide', () => {
+
+		it('should show when target is focused', async() => {
+			await triggerFocusFor(tooltipFixture.querySelector('#explicit-target'));
+			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+			expect(tooltip.showing).to.be.true;
+		});
+
+		it('should show event when target is hovered', async() => {
+			tooltipFixture.querySelector('#explicit-target').dispatchEvent(new Event('mouseenter'));
+			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+			expect(tooltip.showing).to.be.true;
+		});
+
+		it('should hide from blur when target is focused', async() => {
+			const target = tooltipFixture.querySelector('#explicit-target');
+			await triggerFocusFor(target);
+			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+
+			setTimeout(() => triggerBlurFor(target));
+			await oneEvent(tooltipFixture, 'd2l-tooltip-hide');
+			expect(tooltip.showing).to.be.false;
+		});
+
+		it('should hide from mouseleave when target is hovered', async() => {
+			const target = tooltipFixture.querySelector('#explicit-target');
+			target.dispatchEvent(new Event('mouseenter'));
+			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+
+			setTimeout(() => target.dispatchEvent(new Event('mouseleave')));
+			await oneEvent(tooltipFixture, 'd2l-tooltip-hide');
+			expect(tooltip.showing).to.be.false;
+		});
+
+		it('should not hide from mouseleave when target is focused', async() => {
+
+			const target = tooltipFixture.querySelector('#explicit-target');
+			target.dispatchEvent(new Event('mouseenter'));
+			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+			await triggerFocusFor(target);
+
+			target.dispatchEvent(new Event('mouseleave'));
+			await aTimeout(100);
+			expect(tooltip.showing).to.be.true;
+		});
+
+		it('should not hide from blur when target is hovered', async() => {
+
+			const target = tooltipFixture.querySelector('#explicit-target');
+			target.dispatchEvent(new Event('mouseenter'));
+			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+			await triggerFocusFor(target);
+
+			await triggerBlurFor(target);
+			await aTimeout(100);
+			expect(tooltip.showing).to.be.true;
+		});
+
+		[
+			{ case: 'hovered and focused', hover: true, focus: true},
+			{ case: 'hovered', hover: true, focus: false },
+			{ case: 'focused', hover: false, focus: true }
+		].forEach((testCase) => {
+			it(`should hide when ESC key is pressed while ${testCase.case}`, async() => {
+				const target = tooltipFixture.querySelector('#explicit-target');
+				if (testCase.hover) {
+					target.dispatchEvent(new Event('mouseenter'));
+				}
+				if (testCase.focus) {
+					await triggerFocusFor(target);
+				}
+				await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+
+				const eventObj = document.createEvent('Events');
+				eventObj.initEvent('keyup', true, true);
+				eventObj.keyCode = 27;
+
+				setTimeout(() => document.dispatchEvent(eventObj));
+				await oneEvent(tooltipFixture, 'd2l-tooltip-hide');
+				expect(tooltip.showing).to.be.false;
+			});
+		});
+	});
+
+	describe('delay', () => {
+
+		beforeEach(async() => {
+			tooltip.setAttribute('delay', 100);
+			await tooltip.updateComplete;
+		});
+
+		it('should not show if hover is lost before tooltip delay finishes', async() => {
+
+			oneEvent(tooltipFixture, 'd2l-tooltip-show').then(() => {
+				expect.fail('tooltip should not have been shown');
+			});
+			const target = tooltipFixture.querySelector('#explicit-target');
+			target.dispatchEvent(new Event('mouseenter'));
+			await aTimeout(tooltip.delay / 2);
+			target.dispatchEvent(new Event('mouseleave'));
+			await aTimeout(tooltip.delay);
+			expect(tooltip.showing).to.be.false;
+		});
+
+		it('should not show if hover is gained and lost multiple times before tooltip delay finishes', async() => {
+
+			oneEvent(tooltipFixture, 'd2l-tooltip-show').then(() => {
+				expect.fail('tooltip should not have been shown');
+			});
+			const target = tooltipFixture.querySelector('#explicit-target');
+			for (let i = 0; i < 5; i++) {
+				target.dispatchEvent(new Event('mouseenter'));
+				await aTimeout(tooltip.delay / 2);
+				target.dispatchEvent(new Event('mouseleave'));
+				await aTimeout(tooltip.delay / 2);
+			}
+			await aTimeout(tooltip.delay);
+			expect(tooltip.showing).to.be.false;
+		});
+
+		it('should show if hover is maintained for the tooltip delay', async() => {
+			const target = tooltipFixture.querySelector('#explicit-target');
+			target.dispatchEvent(new Event('mouseenter'));
+			await aTimeout(tooltip.delay * 0.9);
+			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+			expect(tooltip.showing).to.be.true;
+		});
+	});
+
+	describe('force-show', () => {
+
+		beforeEach(async() => {
+			tooltip.setAttribute('force-show', 'force-show');
+			await tooltip.updateComplete;
+		});
+
+		it('should display the tooltip by default', () => {
+			expect(tooltip.showing).to.be.true;
+		});
+
+		it('should not hide when ESC key is pressed ', async() => {
+
+			const eventObj = document.createEvent('Events');
+			eventObj.initEvent('keyup', true, true);
+			eventObj.keyCode = 27;
+			document.dispatchEvent(eventObj);
+			await aTimeout(100);
+
+			expect(tooltip.showing).to.be.true;
+		});
+	});
+
+	describe('disable-focus-lock', () => {
+
+		beforeEach(async() => {
+			tooltip.setAttribute('disable-focus-lock', 'disable-focus-lock');
+			await tooltip.updateComplete;
+		});
+
+		it('should hide on mouseleave even when focused', async() => {
+
+			const target = tooltipFixture.querySelector('#explicit-target');
+			target.dispatchEvent(new Event('mouseenter'));
+			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
+			await triggerFocusFor(target);
+
+			setTimeout(() => target.dispatchEvent(new Event('mouseleave')));
+			await oneEvent(tooltipFixture, 'd2l-tooltip-hide');
+			expect(tooltip.showing).to.be.false;
+		});
+	});
+});

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -1,0 +1,238 @@
+import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { bodyCompactStyles } from '../typography/styles.js';
+import { getUniqueId } from '../../helpers/uniqueId.js';
+import { RtlMixin } from '../../mixins/rtl-mixin.js';
+
+class Tooltip extends RtlMixin(LitElement) {
+
+	static get properties() {
+		return {
+			delay: { type: Number },
+			disableFocusLock: { type: Boolean, attribute: 'disable-focus-lock' },
+			for: { type: String },
+			forceShow: { type: Boolean, attribute: 'force-show' },
+			showing: { type: Boolean, reflect: true, attribute: 'showing' },
+			state: { type: String, reflect: true }, /* Valid values are: 'info' and 'error' */
+		};
+	}
+
+	static get styles() {
+		return [bodyCompactStyles, css`
+			:host {
+				--d2l-tooltip-background-color: var(--d2l-color-ferrite); /* Deprecated, use state attribute instead */
+				background-color: var(--d2l-tooltip-background-color);
+				box-sizing: border-box;
+				color: white;
+				display: none;
+				position: absolute;
+				text-align: left;
+				white-space: normal;
+				z-index: 1000; /* position on top of floating buttons */
+			}
+
+			:host([state="error"]) {
+				--d2l-tooltip-background-color: var(--d2l-color-cinnabar);
+			}
+
+			:host([dir="rtl"]) {
+				text-align: right;
+			}
+
+			:host([showing]) {
+				display: inline-block;
+			}
+		`];
+	}
+
+	constructor() {
+		super();
+
+		this._onMouseEnter = this._onMouseEnter.bind(this);
+		this._onMouseLeave = this._onMouseLeave.bind(this);
+		this._onFocus = this._onFocus.bind(this);
+		this._onBlur = this._onBlur.bind(this);
+
+		this.delay = 0;
+		this.disableFocusLock = false;
+		this.forceShow = false;
+		this.showing = false;
+		this.state = 'info';
+
+		this._isFocusing = false;
+		this._isHovering = false;
+		this._dismissibleId = null;
+	}
+
+	get for() {
+		return this._for;
+	}
+	set for(val) {
+		const oldVal = this._for;
+		if (oldVal !== val) {
+			this._for = val;
+			this.requestUpdate('for', oldVal);
+			this._updateTarget();
+		}
+	}
+
+	get forceShow() {
+		return this._forceShow;
+	}
+	set forceShow(val) {
+		const oldVal = this._forceShow;
+		if (oldVal !== val) {
+			this._forceShow = val;
+			this.requestUpdate('force-show', oldVal);
+			this._updateShowing();
+		}
+	}
+
+	get showing() {
+		return this._showing;
+	}
+	set showing(val) {
+		const oldVal = this._showing;
+		if (oldVal !== val) {
+			this._showing = val;
+			this.requestUpdate('showing', oldVal);
+			this._showingChanged(val);
+		}
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+
+		requestAnimationFrame(() => {
+			this._updateTarget();
+		});
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		clearDismissible(this._dismissibleId);
+		this._dismissibleId = null;
+	}
+
+	render() {
+
+		return html`
+			<slot>
+			</slot>`
+		;
+	}
+
+	hide() {
+		this._isHovering = false;
+		this._isFocusing = false;
+		this._updateShowing();
+	}
+
+	show() {
+		this.showing = true;
+	}
+
+	_updateTarget() {
+		this._removeListeners();
+		const target = this._findTarget();
+		if (target) {
+			this.id = this.id || getUniqueId();
+			target.setAttribute('aria-describedby', this.id);
+		}
+		this._target = target;
+		this._addListeners();
+
+		if (this.showing) {
+			// TODO: Perform layout
+		}
+	}
+
+	_findTarget() {
+		const parentNode = this.parentNode;
+		const ownerRoot = this.getRootNode();
+
+		let target;
+		if (this.for) {
+			const targetSelector = `#${this.for}`;
+			target = ownerRoot.querySelector(targetSelector);
+			target = target || (ownerRoot && ownerRoot.host && ownerRoot.host.querySelector(targetSelector));
+		} else {
+			target = parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE ? ownerRoot.host : parentNode;
+		}
+		return target;
+	}
+
+	_addListeners() {
+		if (!this._target) {
+			return;
+		}
+		this._target.addEventListener('mouseenter', this._onMouseEnter);
+		this._target.addEventListener('mouseleave', this._onMouseLeave);
+		this._target.addEventListener('focus', this._onFocus);
+		this._target.addEventListener('blur', this._onBlur);
+	}
+
+	_removeListeners() {
+		if (!this._target) {
+			return;
+		}
+		this._target.removeEventListener('mouseenter', this._onMouseEnter);
+		this._target.removeEventListener('mouseleave', this._onMouseLeave);
+		this._target.removeEventListener('focus', this._onFocus);
+		this._target.removeEventListener('blur', this._onBlur);
+	}
+
+	_onMouseEnter() {
+		this._hoverTimeout = setTimeout(() => {
+			this._isHovering = true;
+			this._updateShowing();
+		}, this.delay);
+	}
+
+	_onMouseLeave() {
+		clearTimeout(this._hoverTimeout);
+		this._isHovering = false;
+		this._updateShowing();
+	}
+
+	_onFocus() {
+		if (this.disableFocusLock) {
+			this.showing = true;
+		} else {
+			this._isFocusing = true;
+			this._updateShowing();
+		}
+	}
+
+	_onBlur() {
+		this._isFocusing = false;
+		this._updateShowing();
+	}
+
+	_updateShowing() {
+		this.showing = this._isFocusing || this._isHovering || this.forceShow;
+	}
+
+	async _showingChanged(newValue) {
+		clearTimeout(this._hoverTimeout);
+		if (newValue) {
+			await this.updateComplete;
+
+			// TODO: Perform layout
+
+			this._dismissibleId = setDismissible(() => this.hide());
+			this.dispatchEvent(new CustomEvent(
+				'd2l-tooltip-show', { bubbles: true, composed: true }
+			));
+		} else {
+			if (this._dismissibleId) {
+				clearDismissible(this._dismissibleId);
+				this._dismissibleId = null;
+			}
+			this.dispatchEvent(new CustomEvent(
+				'd2l-tooltip-hide', { bubbles: true, composed: true }
+			));
+		}
+	}
+}
+customElements.define('d2l-tooltip', Tooltip);

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -12,7 +12,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			disableFocusLock: { type: Boolean, attribute: 'disable-focus-lock' },
 			for: { type: String },
 			forceShow: { type: Boolean, attribute: 'force-show' },
-			showing: { type: Boolean, reflect: true, attribute: 'showing' },
+			showing: { type: Boolean, reflect: true },
 			state: { type: String, reflect: true }, /* Valid values are: 'info' and 'error' */
 		};
 	}


### PR DESCRIPTION
# Changes
- This pull request adds the logic to show the tooltip on `mouseenter`, `focus`, and if `force-show` is set.
- The tooltip is closed when it isn't hovered, focused, or `force-show` is set.

## Next PR
- Layout and positioning