### PR TITLE
Time Input Dropdown Fixes

### DIFF
--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -7,7 +7,6 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { formatTime, parseTime } from '@brightspace-ui/intl/lib/dateTime.js';
 import { bodySmallStyles } from '../typography/styles.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
 import { inputStyles } from './input-styles.js';
 import { offscreenStyles } from '../offscreen/offscreen-styles.js';
@@ -133,7 +132,7 @@ class InputTime extends LitElement {
 						aria-expanded="false">
 						<input
 							aria-controls="${this._dropdownId}"
-							aria-labelledby="${ifDefined(this._getAriaLabel())}"
+							aria-labelledby="${this._dropdownId}-label"
 							@change="${this._handleChange}"
 							class="d2l-input"
 							?disabled="${this.disabled}"

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -10,6 +10,7 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
 import { inputStyles } from './input-styles.js';
+import { offscreenStyles } from '../offscreen/offscreen-styles.js';
 
 const VALUE_RE = /^([0-9]{1,2}):([0-9]{1,2})(:([0-9]{1,2}))?$/;
 const TODAY = new Date();
@@ -78,7 +79,7 @@ class InputTime extends LitElement {
 	}
 
 	static get styles() {
-		return [ inputStyles, inputLabelStyles, bodySmallStyles,
+		return [ inputStyles, inputLabelStyles, bodySmallStyles, offscreenStyles, 
 			css`
 				:host {
 					display: inline-block;
@@ -122,47 +123,43 @@ class InputTime extends LitElement {
 	render() {
 		getIntervals();
 		const input = html`
-			<d2l-dropdown>
-				<div
-					role="combobox"
-					aria-owns="${this._dropdownId}"
-					class="d2l-dropdown-opener"
-					aria-expanded="false">
-					<input
-						aria-controls="${this._dropdownId}"
-						aria-label="${ifDefined(this._getAriaLabel())}"
-						@change="${this._handleChange}"
-						class="d2l-input"
-						?disabled="${this.disabled}"
-						@keypress="${this._handleKeypress}"
-						.value="${this._formattedValue}">
-				</div>
-				<d2l-dropdown-menu id="dropdown" no-padding-footer min-width="195">
-					<d2l-menu
-						id="${this._dropdownId}"
-						role="listbox"
-						class="d2l-input-time-menu"
-						aria-label="${ifDefined(this.label)}"
-						@d2l-menu-item-change="${this._handleDropdownChange}">
-						${INTERVALS.map(i => html`
-							<d2l-menu-item-radio
-								text="${formatTime(i)}"
-								value="${formatValue(i)}"
-								?selected=${this._value === formatValue(i)}>
-							</d2l-menu-item-radio>
-						`)}
-					</d2l-menu>
-					<div class="d2l-input-time-timezone d2l-body-small" slot="footer">${this._timezone}</div>
-				</d2l-dropdown-menu>
-			</d2l-dropdown>
+			<label>
+				<span class="${this.label && !this.labelHidden ? 'd2l-input-label' : 'd2l-offscreen'}" id="${this._dropdownId}-label">${this.label}</span>
+				<d2l-dropdown ?disabled="${this.disabled}">
+					<div
+						role="combobox"
+						aria-owns="${this._dropdownId}"
+						class="d2l-dropdown-opener"
+						aria-expanded="false">
+						<input
+							aria-controls="${this._dropdownId}"
+							aria-labelledby="${ifDefined(this._getAriaLabel())}"
+							@change="${this._handleChange}"
+							class="d2l-input"
+							?disabled="${this.disabled}"
+							@keypress="${this._handleKeypress}"
+							.value="${this._formattedValue}">
+					</div>
+					<d2l-dropdown-menu id="dropdown" no-padding-footer min-width="195">
+						<d2l-menu
+							id="${this._dropdownId}"
+							role="listbox"
+							class="d2l-input-time-menu"
+							aria-labelledby="${this._dropdownId}-label"
+							@d2l-menu-item-change="${this._handleDropdownChange}">
+							${INTERVALS.map(i => html`
+								<d2l-menu-item-radio
+									text="${formatTime(i)}"
+									value="${formatValue(i)}"
+									?selected=${this._value === formatValue(i)}>
+								</d2l-menu-item-radio>
+							`)}
+						</d2l-menu>
+						<div class="d2l-input-time-timezone d2l-body-small" slot="footer">${this._timezone}</div>
+					</d2l-dropdown-menu>
+				</d2l-dropdown>
+			</label>
 		`;
-		if (this.label && !this.labelHidden) {
-			return html`
-				<label>
-					<span class="d2l-input-label">${this.label}</span>
-					${input}
-				</label>`;
-		}
 		return input;
 	}
 

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -79,7 +79,7 @@ class InputTime extends LitElement {
 	}
 
 	static get styles() {
-		return [ inputStyles, inputLabelStyles, bodySmallStyles, offscreenStyles, 
+		return [ inputStyles, inputLabelStyles, bodySmallStyles, offscreenStyles,
 			css`
 				:host {
 					display: inline-block;

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -162,6 +162,12 @@ class InputTime extends LitElement {
 		return input;
 	}
 
+	firstUpdated() {
+		if (this.label === null) {
+			console.warn('d2l-input-time component requires label text');
+		}
+	}
+
 	focus() {
 		const elem = this.shadowRoot.querySelector('.d2l-input');
 		if (elem) elem.focus();

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -54,7 +54,7 @@ describe('d2l-input-time', () => {
 			expect(elem.shadowRoot.querySelector('.d2l-input-label').innerText).to.equal('label text');
 		});
 
-		it('should created offscreen label when label-hidden', async() => {
+		it('should create offscreen label when label-hidden', async() => {
 			const elem = await fixture(labelHiddenFixture);
 			expect(elem.shadowRoot.querySelector('.d2l-offscreen').innerText).to.equal('label text');
 		});

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -49,19 +49,14 @@ describe('d2l-input-time', () => {
 
 	describe('labelling', () => {
 
-		function getLabel(elem) {
-			return elem.shadowRoot.querySelector('.d2l-input-label');
-		}
-
 		it('should display visible label', async() => {
 			const elem = await fixture(basicFixture);
-			expect(getLabel(elem).innerText).to.equal('label text');
+			expect(elem.shadowRoot.querySelector('.d2l-input-label').innerText).to.equal('label text');
 		});
 
-		it('should put hidden label on "aria-label"', async() => {
+		it.only('should created offscreen label when label-hidden', async() => {
 			const elem = await fixture(labelHiddenFixture);
-			expect(getLabel(elem)).to.be.null;
-			expect(getInput(elem).getAttribute('aria-label')).to.equal('label text');
+			expect(elem.shadowRoot.querySelector('.d2l-offscreen').innerText).to.equal('label text');
 		});
 	});
 

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -54,7 +54,7 @@ describe('d2l-input-time', () => {
 			expect(elem.shadowRoot.querySelector('.d2l-input-label').innerText).to.equal('label text');
 		});
 
-		it.only('should created offscreen label when label-hidden', async() => {
+		it('should created offscreen label when label-hidden', async() => {
 			const elem = await fixture(labelHiddenFixture);
 			expect(elem.shadowRoot.querySelector('.d2l-offscreen').innerText).to.equal('label text');
 		});


### PR DESCRIPTION
- Dropdown no longer appears when `input-time` component is disabled
- Fixed label issue for time dropdown. Combobox requires `aria-labelledby` instead of `aria-label`. Label now always exists, but is offscreen when hidden.
  - Tweaked tests related to labels based on implementation changes