### PR TITLE
Tweak stamped snippet placement.

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -127,7 +127,10 @@ class DemoSnippet extends LitElement {
 				const demoContainer = document.createElement('div');
 				demoContainer.setAttribute('slot', '_demo');
 				demoContainer.appendChild(document.importNode(nodes[i].content, true));
-				this.appendChild(demoContainer);
+				/* must insert before template, else getPreviousFocusable (in consumer code)
+				will walk composed dom from template, thereby returning last focusable in
+				element due to order of slots */
+				this.insertBefore(demoContainer, nodes[i]);
 			}
 
 			tempContainer.appendChild(nodes[i].cloneNode(true));


### PR DESCRIPTION
This change tweaks the placement of the stamped demo snippet so that `getPreviousFocusable` (in consumer code) will not walk the composed DOM from the `template` element which would result in incorrectly returning the last focusable inside the stamped demo element.

Alternatively, the order of the slots could have been reversed to fix this.  I chose the JS change since it offered ability to more clearly comment the reason without adding comments to the HTML template.