### PR TITLE
input-date: legacy edge: enter was not opening dropdown

### DIFF
--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -162,7 +162,7 @@ class InputDate extends LocalizeStaticMixin(LitElement) {
 
 	render() {
 		return html`
-			<d2l-dropdown ?disabled="${this.disabled}">
+			<d2l-dropdown ?disabled="${this.disabled}" no-auto-open>
 				<d2l-input-text
 					@change="${this._handleChange}"
 					class="d2l-dropdown-opener"
@@ -170,6 +170,7 @@ class InputDate extends LocalizeStaticMixin(LitElement) {
 					@keydown="${this._handleKeydown}"
 					label="${ifDefined(this.label)}"
 					?label-hidden="${this.labelHidden}"
+					@mouseup="${this._handleMouseup}"
 					placeholder="${(this._dateTimeDescriptor.formats.dateFormats.short).toUpperCase()}"
 					title="${this.localize('openInstructions')}"
 					.value="${this._formattedValue}">
@@ -260,6 +261,10 @@ class InputDate extends LocalizeStaticMixin(LitElement) {
 
 	_handleDropdownOpen() {
 		this._dropdownOpened = true;
+	}
+
+	_handleMouseup() {
+		this._dropdown.toggleOpen(false);
 	}
 
 	_handleSetToToday() {


### PR DESCRIPTION
When pressing enter in legacy edge, open was run but then dropdown-opener's `toggleOpen` was also run (which I'm not really sure why that isn't happening on non-edge - dropdown-opener's `__onKeyPress` just isn't being called when `this._dropdown.open();` is in the input-date code but if I comment it out then `__onKeyPress` happens so I'm probably missing something in the dropdown logic). Overall `input-date` handling its own opening functionality seems a bit safer.