### PR TITLE
Dialog: Reload page between tests

### DIFF
--- a/components/dialog/test/dialog-confirm.visual-diff.js
+++ b/components/dialog/test/dialog-confirm.visual-diff.js
@@ -27,11 +27,7 @@ describe('d2l-dialog-confirm', () => {
 			});
 
 			beforeEach(async() => {
-				await helper.reset(page, '#confirm');
-				await helper.reset(page, '#confirmLongTitle');
-				await helper.reset(page, '#confirmNoTitle');
-				await helper.reset(page, '#confirmLongText');
-				await helper.reset(page, '#confirmRtl');
+				await page.reload();
 			});
 
 			[

--- a/components/dialog/test/dialog-ifrau.visual-diff.js
+++ b/components/dialog/test/dialog-ifrau.visual-diff.js
@@ -28,7 +28,7 @@ describe('d2l-dialog-ifrau', () => {
 			});
 
 			beforeEach(async() => {
-				await helper.reset(page, '#ifrau-dialog');
+				await page.reload();
 			});
 
 			[

--- a/components/dialog/test/dialog.visual-diff.js
+++ b/components/dialog/test/dialog.visual-diff.js
@@ -27,10 +27,7 @@ describe('d2l-dialog', () => {
 			});
 
 			beforeEach(async() => {
-				await helper.reset(page, '#dialog');
-				await helper.reset(page, '#dialogLong');
-				await helper.reset(page, '#dialogRtl');
-				await helper.reset(page, '#dialogResize');
+				await page.reload();
 			});
 
 			[


### PR DESCRIPTION
This isn't a great fix, but I thought I would get one in so that the builds aren't all broken and then open an issue and work further on this, since it doesn't seem to be a quick fix (at least from what I have found so far).

Findings so far:
- I don't know why this is now broken. dialog hasn't been touched in a bit.
- In subsequent tests, `reset` in the dialog-helper doesn't seem to reset enough?
- In the broken tests `state` is being set to `showing` but it isn't triggering a render until too late and after the `transitionend` event in open, so the screenshot is being taken before the backdrop is rendered