### PR TITLE
Dbatiste/dialog render fix

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -268,9 +268,12 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		// native dialog backdrop does not prevent body scrolling
 		this._bodyScrollKey = preventBodyScroll();
 
-		this._updateSize();
-		this._state = 'showing';
-		this._focusInitial();
+		requestAnimationFrame(() => {
+			this._updateSize();
+			this._state = 'showing';
+			this._focusInitial();
+		});
+
 	}
 
 	_removeHandlers() {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -249,13 +249,13 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 		const dialog = this.shadowRoot.querySelector('.d2l-dialog-outer');
 
-		const transitionEnd = () => {
-			dialog.removeEventListener('transitionend', transitionEnd);
-			this.dispatchEvent(new CustomEvent(
-				'd2l-dialog-open', { bubbles: true, composed: true }
-			));
-		};
-		dialog.addEventListener('transitionend', transitionEnd);
+		const animPromise = new Promise((resolve) => {
+			const transitionEnd = () => {
+				dialog.removeEventListener('transitionend', transitionEnd);
+				resolve();
+			};
+			dialog.addEventListener('transitionend', transitionEnd);
+		});
 
 		if (this._useNative) {
 			dialog.showModal();
@@ -268,10 +268,14 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		// native dialog backdrop does not prevent body scrolling
 		this._bodyScrollKey = preventBodyScroll();
 
-		requestAnimationFrame(() => {
-			this._updateSize();
+		requestAnimationFrame(async() => {
+			await this._updateSize();
 			this._state = 'showing';
 			this._focusInitial();
+			await animPromise;
+			this.dispatchEvent(new CustomEvent(
+				'd2l-dialog-open', { bubbles: true, composed: true }
+			));
 		});
 
 	}
@@ -358,6 +362,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._height = this._getHeight();
 		await this.updateComplete;
 		this._updateOverflow();
+		await this.updateComplete;
 	}
 
 };

--- a/components/dialog/test/dialog-helper.js
+++ b/components/dialog/test/dialog-helper.js
@@ -10,7 +10,7 @@ module.exports = {
 
 	async close(page, selector) {
 		const closeEvent = this.getCloseEvent(page, selector);
-		await page.$eval(selector, (dialog) => dialog.removeAttribute('opened'));
+		await page.$eval(selector, (dialog) => dialog.opened = false);
 		return closeEvent;
 	},
 
@@ -36,7 +36,7 @@ module.exports = {
 
 	async open(page, selector) {
 		const openEvent = this.getOpenEvent(page, selector);
-		await page.$eval(selector, (dialog) => dialog.setAttribute('opened', 'opened'));
+		await page.$eval(selector, (dialog) => dialog.opened = true);
 		return openEvent;
 	},
 
@@ -46,7 +46,7 @@ module.exports = {
 				dialog.shadowRoot.querySelector('.d2l-dialog-content').scrollTo(0, 0);
 				if (dialog._state) {
 					dialog.addEventListener('d2l-dialog-close', () => resolve(), { once: true });
-					dialog.removeAttribute('opened');
+					dialog.opened = false;
 				} else {
 					resolve();
 				}

--- a/components/dialog/test/dialog-helper.js
+++ b/components/dialog/test/dialog-helper.js
@@ -10,7 +10,7 @@ module.exports = {
 
 	async close(page, selector) {
 		const closeEvent = this.getCloseEvent(page, selector);
-		await page.$eval(selector, (dialog) => dialog.opened = false);
+		await page.$eval(selector, (dialog) => dialog.removeAttribute('opened'));
 		return closeEvent;
 	},
 
@@ -36,7 +36,7 @@ module.exports = {
 
 	async open(page, selector) {
 		const openEvent = this.getOpenEvent(page, selector);
-		await page.$eval(selector, (dialog) => dialog.opened = true);
+		await page.$eval(selector, (dialog) => dialog.setAttribute('opened', 'opened'));
 		return openEvent;
 	},
 
@@ -46,7 +46,7 @@ module.exports = {
 				dialog.shadowRoot.querySelector('.d2l-dialog-content').scrollTo(0, 0);
 				if (dialog._state) {
 					dialog.addEventListener('d2l-dialog-close', () => resolve(), { once: true });
-					dialog.opened = false;
+					dialog.removeAttribute('opened');
 				} else {
 					resolve();
 				}

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -39,7 +39,7 @@ class FocusTrap extends LitElement {
 	}
 
 	focus() {
-		this.querySelector('.d2l-focus-trap-start').focus();
+		this.shadowRoot.querySelector('.d2l-focus-trap-start').focus();
 	}
 
 	render() {


### PR DESCRIPTION
Interestingly, when the dialog is opened via the attribute, changes to internal properties will trigger a rerender (as desired), however when the dialog is opened via property assignment, subsequent internal properties changes do not.  Bumping these updated to the next frame results in render calls as needed to update the width, followed by height measurement, etc.  This also fixes the issue where the `showing` state was not causing a rerender, which was in turn causing the backdrop not to be rendered as expected.