### PR TITLE
Calendar: initial focus date should be today

### DIFF
--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -312,11 +312,7 @@ class Calendar extends LocalizeStaticMixin(LitElement) {
 
 		this._today = getDateFromDateObj(getToday());
 		const date = this.selectedValue ? getDateFromISODate(this.selectedValue) : this._today;
-		this._focusDate = new Date(
-			date.getFullYear(),
-			date.getMonth(),
-			this.selectedValue ? date.getDate() : 1
-		);
+		this._focusDate = new Date(date);
 		this._shownMonth = date.getMonth();
 		this._shownYear = date.getFullYear();
 

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -110,11 +110,11 @@ describe('d2l-calendar', () => {
 		});
 
 		it('has initial correct _focusDate when on month with no selected-value', async() => {
-			const newToday = new Date('2018-02-12');
+			const newToday = new Date('2018-02-12T12:00Z');
 			const clock = sinon.useFakeTimers(newToday.getTime());
 
 			const calendar = await fixture(html`<d2l-calendar></d2l-calendar>`);
-			const expectedFocusDate = new Date(2018, 1, 1);
+			const expectedFocusDate = new Date(2018, 1, 12);
 			expect(calendar._focusDate).to.deep.equal(expectedFocusDate);
 
 			clock.restore();
@@ -162,6 +162,27 @@ describe('d2l-calendar', () => {
 			const expectedFocusDate = new Date(2015, 7, 1);
 			expect(calendar._focusDate).to.deep.equal(expectedFocusDate);
 			expect(calendar._shownMonth).to.equal(7);
+		});
+
+		it('has correct _focusDate when user changes month to previous month then back to month with today', async() => {
+			const newToday = new Date('2018-05-10');
+			const clock = sinon.useFakeTimers({now: newToday.getTime(), toFake: ['Date']});
+
+			const calendar = await fixture(html`<d2l-calendar></d2l-calendar>`);
+			const el = calendar.shadowRoot.querySelector('d2l-button-icon[text="Show April"]');
+			setTimeout(() => el.click());
+			await oneEvent(el, 'click');
+			await aTimeout(1);
+
+			const el2 = calendar.shadowRoot.querySelector('d2l-button-icon[text="Show May"]');
+			setTimeout(() => el2.click());
+			await oneEvent(el2, 'click');
+			await aTimeout(1);
+
+			const expectedFocusDate = new Date(2018, 4, 1);
+			expect(calendar._focusDate).to.deep.equal(expectedFocusDate);
+
+			clock.restore();
 		});
 
 		it('has correct _focusDate when user changes month to previous month that contains the selected date from a different month', async() => {

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -165,10 +165,13 @@ describe('d2l-calendar', () => {
 		});
 
 		it('has correct _focusDate when user changes month to previous month then back to month with today', async() => {
-			const newToday = new Date('2018-05-10');
+			const newToday = new Date('2018-05-10T12:00Z');
 			const clock = sinon.useFakeTimers({now: newToday.getTime(), toFake: ['Date']});
 
 			const calendar = await fixture(html`<d2l-calendar></d2l-calendar>`);
+			const expectedFocusDate1 = new Date(2018, 4, 10);
+			expect(calendar._focusDate).to.deep.equal(expectedFocusDate1);
+
 			const el = calendar.shadowRoot.querySelector('d2l-button-icon[text="Show April"]');
 			setTimeout(() => el.click());
 			await oneEvent(el, 'click');
@@ -179,8 +182,8 @@ describe('d2l-calendar', () => {
 			await oneEvent(el2, 'click');
 			await aTimeout(1);
 
-			const expectedFocusDate = new Date(2018, 4, 1);
-			expect(calendar._focusDate).to.deep.equal(expectedFocusDate);
+			const expectedFocusDate2 = new Date(2018, 4, 1);
+			expect(calendar._focusDate).to.deep.equal(expectedFocusDate2);
 
 			clock.restore();
 		});


### PR DESCRIPTION
When the calendar initially loads and there is no `selected-value`, focus date should be today. If the user navigates to another month then returns to the month containing today, focus date should be the first of the month.