### PR TITLE
Dbatiste/tabs no panels fix

### DIFF
--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -541,6 +541,7 @@ class Tabs extends LocalizeStaticMixin(ArrowKeysMixin(RtlMixin(LitElement))) {
 		const panels = this._getPanels(e.target);
 
 		if (this._initialized) this._updateTabListVisibility(panels);
+		else if (panels.length === 0) return;
 
 		let selectedTabInfo = null;
 


### PR DESCRIPTION
During some integration testing with My Courses I discovered that the tabs component may throw an error if the panel slot change even is triggered without any panels in it... this happens initially for My Courses.  This PR improves fixes that issue and improves the reliability of adding/removing tabs.

