### PR TITLE
input-date-time: remove required demo

### DIFF
--- a/components/inputs/demo/input-date-time.html
+++ b/components/inputs/demo/input-date-time.html
@@ -28,13 +28,6 @@
 				</template>
 			</d2l-demo-snippet>
 
-			<h2>Required</h2>
-			<d2l-demo-snippet>
-				<template>
-					<d2l-input-date-time label="Name (required)" required></d2l-input-date-time>
-				</template>
-			</d2l-demo-snippet>
-
 			<h2>Disabled</h2>
 			<d2l-demo-snippet>
 				<template>


### PR DESCRIPTION
`required` is not yet supported by `input-date-time` so removing this demo in order to have it not be misleading at this point.