### PR TITLE
Visual Diff Typography Preload

### DIFF
--- a/components/dropdown/test/dropdown-content.visual-diff.html
+++ b/components/dropdown/test/dropdown-content.visual-diff.html
@@ -4,7 +4,7 @@
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
-		import '../../typography/typography.js';
+		import '../../../test/typography-preload.js';
 		import '../../button/button.js';
 		import '../dropdown.js';
 		import '../dropdown-content.js';

--- a/components/tooltip/test/tooltip.visual-diff.html
+++ b/components/tooltip/test/tooltip.visual-diff.html
@@ -4,7 +4,7 @@
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
-		import '../../typography/typography.js';
+		import '../../../test/typography-preload.js';
 		import '../../button/button.js';
 		import '../tooltip.js';
 	</script>

--- a/components/typography/typography.js
+++ b/components/typography/typography.js
@@ -1,7 +1,11 @@
 import '@webcomponents/shadycss/entrypoints/custom-style-interface.js';
 import '../colors/colors.js';
 
-const importUrl = 'https://s.brightspace.com/lib/fonts/0.5.0/assets/';
+export const importUrl = 'https://s.brightspace.com/lib/fonts/0.5.0/assets/';
+export const fonts = {
+	regular: 'Lato-400',
+	bold: 'Lato-700'
+};
 
 if (!document.head.querySelector('#d2l-typography-font-face')) {
 	const style = document.createElement('style');
@@ -11,13 +15,13 @@ if (!document.head.querySelector('#d2l-typography-font-face')) {
 			font-family: 'Lato';
 			font-style: normal;
 			font-weight: 400;
-			src: local('Lato Regular'), local('Lato-Regular'), url(${new URL('Lato-400.woff2', importUrl)}) format('woff2'), url(${new URL('Lato-400.woff', importUrl)}) format('woff'), url(${new URL('Lato-400.ttf', importUrl)}) format('truetype');
+			src: local('Lato Regular'), local('Lato-Regular'), url(${new URL(`${fonts.regular}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.regular}.woff`, importUrl)}) format('woff'), url(${new URL(`${fonts.regular}.ttf`, importUrl)}) format('truetype');
 		}
 		@font-face {
 			font-family: 'Lato';
 			font-style: normal;
 			font-weight: 700;
-			src: local('Lato Bold'), local('Lato-Bold'), url(${new URL('Lato-700.woff2', importUrl)}) format('woff2'), url(${new URL('Lato-700.woff', importUrl)}) format('woff'), url(${new URL('Lato-700.ttf', importUrl)}) format('truetype');
+			src: local('Lato Bold'), local('Lato-Bold'), url(${new URL(`${fonts.bold}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.bold}.woff`, importUrl)}) format('woff'), url(${new URL(`${fonts.bold}.ttf`, importUrl)}) format('truetype');
 		}
 
 		.d2l-typography {

--- a/test/typography-preload.js
+++ b/test/typography-preload.js
@@ -1,0 +1,15 @@
+import { fonts, importUrl } from '../components/typography/typography.js';
+
+if (!document.head.querySelector('.d2l-typography-font-face-preload')) {
+	for (const type of Object.keys(fonts)) {
+
+		const preload = document.createElement('link');
+		preload.rel = 'preload';
+		preload.className = 'd2l-typography-font-face-preload';
+		preload.href = `${new URL(`${fonts[type]}.woff2`, importUrl)}`;
+		preload.as = 'font';
+		preload.crossOrigin = 'anonymous';
+		document.head.appendChild(preload);
+	}
+}
+


### PR DESCRIPTION
# Changes
- Add typography preload to prevent visual diff tests failing due to the font not loading at initial page load. This change is required because browsers do not load fonts until they are displayed on the page. For visual diff tests without any text initially on the page, font loading gets missed by the `networkidle0` wait.