### PR TITLE
list-item: composed d2l-list-item-selected event

### DIFF
--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -323,7 +323,8 @@ class ListItem extends RtlMixin(LitElement) {
 	_dispatchSelected(value) {
 		this.dispatchEvent(new CustomEvent('d2l-list-item-selected', {
 			detail: { key: this.key, selected: value },
-			bubbles: true
+			bubbles: true,
+			composed: true
 		}));
 	}
 


### PR DESCRIPTION
Same situation as https://github.com/BrightspaceUI/core/pull/463

`<d2l-list-item>` is being rendered inside a wrapping "list-item" component.