### PR TITLE
calendar: use string for aria-selected

### DIFF
--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -372,7 +372,7 @@ class Calendar extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 				return html`
 					<td
 						aria-label="${formatDate(day, {format: 'medium'})}"
-						aria-selected="${selected}"
+						aria-selected="${selected ? 'true' : 'false'}"
 						class="d2l-calendar-date"
 						@click="${this._onDateSelected}"
 						data-date=${date}


### PR DESCRIPTION
This doesn't fix the chrome/NVDA bug but should be fixed.