### PR TITLE
Fix for radio dropdown sometimes not scrolling

### DIFF
--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -36,6 +36,14 @@ class DropdownMenu extends DropdownContentMixin(LitElement) {
 	_onMenuResize(e) {
 		this.__position(!this._initializingHeight, e.detail);
 		this._initializingHeight = false;
+
+		const menu = this.__getMenuElement();
+		if (menu.getMenuType() === 'menu-radio') {
+			const selected = menu.querySelector('[selected]');
+			if (selected !== null) {
+				setTimeout(() => selected.scrollIntoView({ block: 'nearest'}), 0);
+			}
+		}
 	}
 
 	_onClose(e) {
@@ -62,15 +70,6 @@ class DropdownMenu extends DropdownContentMixin(LitElement) {
 
 		if (this.__applyFocus) {
 			menu.focus();
-		}
-
-		if (menu.getMenuType() === 'menu-radio') {
-			const selected = menu.querySelector('[selected]');
-			if (selected !== null) {
-				setTimeout(() => selected.scrollIntoView({
-					block: 'nearest'
-				}), 0);
-			}
 		}
 	}
 


### PR DESCRIPTION
Fix for [DE38481](https://rally1.rallydev.com/#/detail/defect/379578838464?fdp=true): Time Input > Selected date scroll into view intermittent with Firefox and broken in Legacy Edge

- Firefox / LEdge now consistently scroll to visible item when opened