### PR TITLE
Temporarily remove explicit announce for tooltips

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -21,13 +21,6 @@ const contentBorderRadius = 6;
 const contentBorderSize = 1;
 const contentHorizontalPadding = 15;
 
-const interactiveElements = {
-	'input': true,
-	'select': true,
-	'textarea': true,
-	'button': true
-};
-
 const computeTooltipShift = (centerDelta, spaceLeft, spaceRight) => {
 
 	const contentXAdjustment = centerDelta / 2;
@@ -582,12 +575,8 @@ class Tooltip extends RtlMixin(LitElement) {
 		return this._openDir === 'bottom' || this._openDir === 'top';
 	}
 
-	_isInteractive(ele) {
-		if (ele.nodeType !== Node.ELEMENT_NODE) {
-			return false;
-		}
-		const nodeName = ele.nodeName.toLowerCase();
-		return !!interactiveElements[nodeName];
+	_isInteractive() {
+		return true;
 	}
 
 	_onTargetBlur() {


### PR DESCRIPTION
# Changes
- Temporarily remove explicit announce for tooltips on non-interactive targets to avoid regressions where explicit announce is already being done due to poor accesibility support in the old tooltip.
- Removing because I found a couple regressions where stuff is being announced twice. Just want to revert this before branching then add it back tomorrow so I have all next release to fix any duplicate announces that get introduced.