### PR TITLE
Fix Broken Tooltip Constructor

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -269,7 +269,6 @@ class Tooltip extends RtlMixin(LitElement) {
 		this.disableFocusLock = false;
 		this.forceShow = false;
 		this.offset = pointerRotatedOverhang + pointerGap;
-		this.showing = false;
 		this.state = 'info';
 
 		this._dismissibleId = null;
@@ -292,6 +291,7 @@ class Tooltip extends RtlMixin(LitElement) {
 
 	connectedCallback() {
 		super.connectedCallback();
+		this.showing = false;
 		window.addEventListener('resize', this._onTargetResize);
 
 		requestAnimationFrame(() => {


### PR DESCRIPTION
# Defect
- Fix defect where `document.creatElement('d2l-tooltip')` triggers an error due to attributes being set in the constructor.
- Error: `Uncaught DOMException: Failed to construct 'CustomElement': The result must not have attributes`

# Fix
- Move `showing` to the `connectedCallback` so `setAttribute` isn't called in the constructor.
- I tried to create a test case that calls `createElement('d2l-tooltip')` but it doesn't seem to cause the exception to be thrown.