### PR TITLE
Add Constructor Tests

### DIFF
--- a/components/backdrop/test/backdrop.test.js
+++ b/components/backdrop/test/backdrop.test.js
@@ -1,0 +1,14 @@
+import '../backdrop.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-backdrop', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-backdrop');
+		});
+
+	});
+
+});

--- a/components/button/test/button-icon.test.js
+++ b/components/button/test/button-icon.test.js
@@ -1,5 +1,6 @@
 import '../button-icon.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-button-icon icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>`;
 
@@ -22,6 +23,14 @@ describe('d2l-button-icon', () => {
 			setTimeout(() => el.shadowRoot.querySelector('button').focus());
 			await oneEvent(el, 'focus');
 			await expect(el).to.be.accessible();
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-button-icon');
 		});
 
 	});

--- a/components/button/test/button-subtle.test.js
+++ b/components/button/test/button-subtle.test.js
@@ -1,5 +1,6 @@
 import '../button-subtle.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-button-subtle text="Subtle Button"></d2l-button-subtle>`;
 const iconFixture = html`<d2l-button-subtle text="Subtle Button with Icon" icon="d2l-tier1:gear"></d2l-button-subtle>`;
@@ -40,6 +41,14 @@ describe('d2l-button', () => {
 			setTimeout(() => el.shadowRoot.querySelector('button').focus());
 			await oneEvent(el, 'focus');
 			await expect(el).to.be.accessible();
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-button-subtle');
 		});
 
 	});

--- a/components/button/test/button.test.js
+++ b/components/button/test/button.test.js
@@ -1,5 +1,6 @@
 import '../button.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-button>Normal Button</d2l-button>`;
 const primaryFixture = html`<d2l-button primary>Primary Button</d2l-button>`;
@@ -40,6 +41,14 @@ describe('d2l-button', () => {
 			setTimeout(() => el.shadowRoot.querySelector('button').focus());
 			await oneEvent(el, 'focus');
 			await expect(el).to.be.accessible();
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-button');
 		});
 
 	});

--- a/components/button/test/floating-buttons.test.js
+++ b/components/button/test/floating-buttons.test.js
@@ -1,0 +1,14 @@
+import '../floating-buttons.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-floating-buttons', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-floating-buttons');
+		});
+
+	});
+
+});

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -8,6 +8,7 @@ import { checkIfDatesEqual,
 	getPrevMonth
 } from '../calendar.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';
 
 const normalFixture = html`<d2l-calendar selected-value="2015-09-02"></d2l-calendar>`;
@@ -20,6 +21,12 @@ describe('d2l-calendar', () => {
 		it('passes all axe tests', async() => {
 			const calendar = await fixture(normalFixture);
 			await expect(calendar).to.be.accessible();
+		});
+	});
+
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-calendar');
 		});
 	});
 

--- a/components/dialog/test/dialog-confirm.test.js
+++ b/components/dialog/test/dialog-confirm.test.js
@@ -1,0 +1,14 @@
+import '../dialog-confirm.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-dialog-confirm', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-dialog-confirm');
+		});
+
+	});
+
+});

--- a/components/dialog/test/dialog.test.js
+++ b/components/dialog/test/dialog.test.js
@@ -1,0 +1,14 @@
+import '../dialog.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-dialog', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-dialog');
+		});
+
+	});
+
+});

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -1,6 +1,7 @@
 import '../dropdown.js';
 import '../dropdown-content.js';
 import { aTimeout, expect, fixture, html, nextFrame, oneEvent, triggerFocusFor } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`
 	<div>
@@ -25,6 +26,14 @@ describe('d2l-dropdown', () => {
 	beforeEach(async() => {
 		dropdown = await fixture(normalFixture);
 		content = dropdown.querySelector('d2l-dropdown-content');
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-dropdown-content');
+		});
+
 	});
 
 	describe('opener', () => {

--- a/components/dropdown/test/dropdown-menu.test.js
+++ b/components/dropdown/test/dropdown-menu.test.js
@@ -4,6 +4,7 @@ import '../../menu/menu.js';
 import '../../menu/menu-item.js';
 import '../../menu/menu-item-radio';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const itemFixture = html`
 	<div>
@@ -53,6 +54,14 @@ describe('d2l-dropdown-menu', () => {
 				expect(content.opened).to.be.false;
 			});
 		});
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-dropdown-menu');
+		});
+
 	});
 
 });

--- a/components/dropdown/test/dropdown-openers.test.js
+++ b/components/dropdown/test/dropdown-openers.test.js
@@ -1,0 +1,29 @@
+import '../dropdown-button-subtle.js';
+import '../dropdown-button.js';
+import '../dropdown-context-menu.js';
+import '../dropdown-more.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-dropdown-openers', () => {
+
+	describe('constructor', () => {
+
+		it('should construct dropdown-button-subtle', () => {
+			runConstructor('d2l-dropdown-button-subtle');
+		});
+
+		it('should construct dropdown-button', () => {
+			runConstructor('d2l-dropdown-button');
+		});
+
+		it('should construct dropdown-context-menu', () => {
+			runConstructor('d2l-dropdown-context-menu');
+		});
+
+		it('should construct dropdown-more', () => {
+			runConstructor('d2l-dropdown-more');
+		});
+
+	});
+
+});

--- a/components/dropdown/test/dropdown-tabs.test.js
+++ b/components/dropdown/test/dropdown-tabs.test.js
@@ -1,0 +1,14 @@
+import '../dropdown-tabs.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-dropdown-tabs', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-dropdown-tabs');
+		});
+
+	});
+
+});

--- a/components/focus-trap/test/focus-trap.test.js
+++ b/components/focus-trap/test/focus-trap.test.js
@@ -1,5 +1,6 @@
 import '../focus-trap.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`
 	<div>
@@ -21,6 +22,14 @@ describe('d2l-focus-trap', () => {
 	beforeEach(async() => {
 		elem = await fixture(normalFixture);
 		focusTrap = elem.querySelector('d2l-focus-trap');
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-focus-trap');
+		});
+
 	});
 
 	describe('not trapping', () => {

--- a/components/hierarchical-view/test/hierarchical-view.test.js
+++ b/components/hierarchical-view/test/hierarchical-view.test.js
@@ -1,5 +1,6 @@
 import '../hierarchical-view.js';
 import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { spy } from 'sinon';
 
 const viewsFixture = html`
@@ -118,6 +119,14 @@ describe('d2l-hierarchical-view', () => {
 		setTimeout(() => view2_content.dispatchEvent(eventObj));
 		await oneEvent(view1, 'd2l-hierarchical-view-hide-complete');
 		expect(view1.isActive()).to.be.true;
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-hierarchical-view');
+		});
+
 	});
 
 	describe('focus management', () => {

--- a/components/icons/test/icon-custom.test.js
+++ b/components/icons/test/icon-custom.test.js
@@ -1,0 +1,14 @@
+import '../icon-custom.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-icon-custom', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-icon-custom');
+		});
+
+	});
+
+});

--- a/components/icons/test/icon.test.js
+++ b/components/icons/test/icon.test.js
@@ -1,0 +1,14 @@
+import '../icon.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-icon', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-icon');
+		});
+
+	});
+
+});

--- a/components/inputs/test/input-checkbox.test.js
+++ b/components/inputs/test/input-checkbox.test.js
@@ -1,5 +1,6 @@
 import '../input-checkbox.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const uncheckedFixture = html`<d2l-input-checkbox aria-label="basic"></d2l-input-checkbox>`;
 const indeterminateCheckedFixture = html`<d2l-input-checkbox indeterminate checked></d2l-input-checkbox>`;
@@ -33,6 +34,14 @@ describe('d2l-input-checkbox', () => {
 			setTimeout(() => getInput(elem).focus());
 			await oneEvent(elem, 'focus');
 			await expect(elem).to.be.accessible();
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-input-checkbox');
 		});
 
 	});

--- a/components/inputs/test/input-date-time.test.js
+++ b/components/inputs/test/input-date-time.test.js
@@ -1,6 +1,7 @@
 import { expect, fixture, oneEvent } from '@open-wc/testing';
 import { formatDateTimeInISO } from '../input-date-time.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = '<d2l-input-date-time label="label text"></d2l-input-date-time>';
 
@@ -38,6 +39,14 @@ describe('d2l-input-date-time', () => {
 			await oneEvent(elem, 'focus');
 			await expect(elem).to.be.accessible({ignoredRules: ['color-contrast']}); // color-contrast takes a while and should be covered by axe tests in the individual components
 		}).timeout(4000);
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-input-date-time');
+		});
+
 	});
 
 	describe('utility function', () => {

--- a/components/inputs/test/input-date.test.js
+++ b/components/inputs/test/input-date.test.js
@@ -1,6 +1,7 @@
 import { aTimeout, expect, fixture, oneEvent } from '@open-wc/testing';
 import { formatISODateInUserCalDescriptor } from '../input-date.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';
 
 const basicFixture = '<d2l-input-date label="label text"></d2l-input-date>';
@@ -45,6 +46,14 @@ describe('d2l-input-date', () => {
 			await oneEvent(elem, 'focus');
 			await expect(elem).to.be.accessible();
 		});
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-input-date');
+		});
+
 	});
 
 	describe('focus trap', () => {

--- a/components/inputs/test/input-fieldset.test.js
+++ b/components/inputs/test/input-fieldset.test.js
@@ -1,0 +1,14 @@
+import '../input-fieldset.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-input-fieldset', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-input-fieldset');
+		});
+
+	});
+
+});

--- a/components/inputs/test/input-radio-spacer.test.js
+++ b/components/inputs/test/input-radio-spacer.test.js
@@ -1,0 +1,14 @@
+import '../input-radio-spacer.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-input-radio-spacer', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-input-radio-spacer');
+		});
+
+	});
+
+});

--- a/components/inputs/test/input-search.test.js
+++ b/components/inputs/test/input-search.test.js
@@ -1,5 +1,6 @@
 import '../input-search.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-search label="search"></d2l-input-search>`;
 const valueSetFixture = html`<d2l-input-search value="foo"></d2l-input-search>`;
@@ -62,6 +63,14 @@ describe('d2l-input-search', () => {
 			const elem = await fixture(normalFixture);
 			elem.focus();
 			await expect(elem).to.be.accessible();
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-input-search');
 		});
 
 	});

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -1,6 +1,7 @@
 import '../input-text.js';
 import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-text label="label"></d2l-input-text>`;
 
@@ -65,6 +66,14 @@ describe('d2l-input-text', () => {
 		it('should pass all aXe tests (hidden label)', async() => {
 			const elem = await fixture(html`<d2l-input-text label="label" label-hidden></d2l-input-text>`);
 			await expect(elem).to.be.accessible;
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-input-text');
 		});
 
 	});

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -1,5 +1,6 @@
 import '../input-time.js';
 import { aTimeout, expect, fixture, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = '<d2l-input-time label="label text"></d2l-input-time>';
 const fixtureWithValue = '<d2l-input-time value="11:22:33"></d2l-input-time>';
@@ -50,6 +51,14 @@ describe('d2l-input-time', () => {
 			await oneEvent(elem, 'focus');
 			await expect(elem).to.be.accessible();
 		}).timeout(5000);
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-input-time');
+		});
+
 	});
 
 	describe('labelling', () => {

--- a/components/link/test/link.test.js
+++ b/components/link/test/link.test.js
@@ -1,6 +1,7 @@
 import '../link.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-link href="https://www.d2l.com">Link Test</d2l-link>`;
 
@@ -73,6 +74,14 @@ describe('d2l-link', () => {
 				await elem.updateComplete;
 				expect(elem.hasAttribute(attrName)).to.be.true;
 			});
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-link');
 		});
 
 	});

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -1,5 +1,8 @@
 import '../list.js';
+import '../list-item.js';
+import '../list-item-content.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`
 	<d2l-list>
@@ -25,6 +28,22 @@ describe('d2l-list', () => {
 		it('should pass all aXe tests', async() => {
 			const elem = await fixture(normalFixture);
 			await expect(elem).to.be.accessible;
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct list', () => {
+			runConstructor('d2l-list');
+		});
+
+		it('should construct list-item', () => {
+			runConstructor('d2l-list-item');
+		});
+
+		it('should construct list-item-content', () => {
+			runConstructor('d2l-list-item-content');
 		});
 
 	});

--- a/components/loading-spinner/test/.eslintrc.json
+++ b/components/loading-spinner/test/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "brightspace/open-wc-testing-config"
+}

--- a/components/loading-spinner/test/loading-spinner.test.js
+++ b/components/loading-spinner/test/loading-spinner.test.js
@@ -1,0 +1,14 @@
+import '../loading-spinner.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-loading-spinner', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-loading-spinner');
+		});
+
+	});
+
+});

--- a/components/menu/test/menu-item-checkbox.test.js
+++ b/components/menu/test/menu-item-checkbox.test.js
@@ -1,5 +1,6 @@
 import '../menu-item-checkbox.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 function dispatchItemSelectEvent(elem) {
 	const e = new CustomEvent(
@@ -16,6 +17,14 @@ describe('d2l-menu-item-checkbox', () => {
 		it('has role="menuitemcheckbox"', async() => {
 			const elem = await fixture(html`<d2l-menu-item-checkbox></d2l-menu-item-checkbox>`);
 			expect(elem.getAttribute('role')).to.equal('menuitemcheckbox');
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-menu-item-checkbox');
 		});
 
 	});

--- a/components/menu/test/menu-item-link.test.js
+++ b/components/menu/test/menu-item-link.test.js
@@ -1,0 +1,14 @@
+import '../menu-item-link.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-menu-item-link', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-menu-item-link');
+		});
+
+	});
+
+});

--- a/components/menu/test/menu-item-radio.test.js
+++ b/components/menu/test/menu-item-radio.test.js
@@ -1,5 +1,6 @@
 import '../menu-item-radio.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 function dispatchItemSelectEvent(elem) {
 	const e = new CustomEvent(
@@ -16,6 +17,14 @@ describe('d2l-menu-item-radio', () => {
 		it('has role="menuitemradio"', async() => {
 			const elem = await fixture(html`<d2l-menu-item-radio></d2l-menu-item-radio>`);
 			expect(elem.getAttribute('role')).to.equal('menuitemradio');
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-menu-item-radio');
 		});
 
 	});

--- a/components/menu/test/menu-item-return.test.js
+++ b/components/menu/test/menu-item-return.test.js
@@ -1,0 +1,14 @@
+import '../menu-item-return.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-menu-item-return', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-menu-item-return');
+		});
+
+	});
+
+});

--- a/components/menu/test/menu-item-separator.test.js
+++ b/components/menu/test/menu-item-separator.test.js
@@ -1,5 +1,6 @@
 import '../menu-item-separator.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-menu-item-separator', () => {
 
@@ -8,6 +9,14 @@ describe('d2l-menu-item-separator', () => {
 		it('has role="separator"', async() => {
 			const elem = await fixture(html`<d2l-menu-item-separator></d2l-menu-item-separator>`);
 			expect(elem.getAttribute('role')).to.equal('separator');
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-menu-item-separator');
 		});
 
 	});

--- a/components/menu/test/menu.test.js
+++ b/components/menu/test/menu.test.js
@@ -2,6 +2,7 @@ import '../menu.js';
 import '../menu-item.js';
 import './custom-slots.js';
 import { expect, fixture, html, nextFrame, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 function dispatchKeyEvent(elem, key) {
 	const eventObj = document.createEvent('Events');
@@ -34,6 +35,18 @@ describe('d2l-menu', () => {
 
 		it('has "aria-label" equal to label text', () => {
 			expect(elem.getAttribute('aria-label')).to.equal('menu label');
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct menu', () => {
+			runConstructor('d2l-menu');
+		});
+
+		it('should construct menu-item', () => {
+			runConstructor('d2l-menu-item');
 		});
 
 	});

--- a/components/meter/test/meter-circle.test.js
+++ b/components/meter/test/meter-circle.test.js
@@ -1,5 +1,6 @@
 import '../meter-circle.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-meter-circle', () => {
 
@@ -18,6 +19,14 @@ describe('d2l-meter-circle', () => {
 		it('should pass all aXe tests (completed)', async() => {
 			const elem = await fixture(html`<d2l-meter-circle value="10" max="10"></d2l-meter-circle>`);
 			await expect(elem).to.be.accessible();
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-meter-circle');
 		});
 
 	});

--- a/components/meter/test/meter-linear.test.js
+++ b/components/meter/test/meter-linear.test.js
@@ -1,5 +1,6 @@
 import '../meter-linear.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-meter-linear', () => {
 
@@ -18,6 +19,14 @@ describe('d2l-meter-linear', () => {
 		it('should pass all aXe tests (completed)', async() => {
 			const elem = await fixture(html`<d2l-meter-linear value="10" max="10"></d2l-meter-linear>`);
 			await expect(elem).to.be.accessible();
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-meter-linear');
 		});
 
 	});

--- a/components/meter/test/meter-radial.test.js
+++ b/components/meter/test/meter-radial.test.js
@@ -1,5 +1,6 @@
 import '../meter-radial.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-meter-radial', () => {
 
@@ -22,4 +23,11 @@ describe('d2l-meter-radial', () => {
 
 	});
 
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-meter-radial');
+		});
+
+	});
 });

--- a/components/more-less/test/more-less.test.js
+++ b/components/more-less/test/more-less.test.js
@@ -1,5 +1,6 @@
 import '../more-less.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 function waitForHeight(elem) {
 	return new Promise((resolve) => {
@@ -37,6 +38,14 @@ describe('d2l-more-less', () => {
 			await waitForRender(elem);
 			await waitForHeight(elem);
 			await expect(elem).to.be.accessible();
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-more-less');
 		});
 
 	});

--- a/components/offscreen/test/offscreen.test.js
+++ b/components/offscreen/test/offscreen.test.js
@@ -1,0 +1,14 @@
+import '../offscreen.js';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+describe('d2l-offscreen', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-offscreen');
+		});
+
+	});
+
+});

--- a/components/status-indicator/test/status-indicator.test.js
+++ b/components/status-indicator/test/status-indicator.test.js
@@ -1,5 +1,6 @@
 import '../status-indicator.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-status-indicator', () => {
 
@@ -40,6 +41,14 @@ describe('d2l-status-indicator', () => {
 			elem.bold = true;
 			await elem.updateComplete;
 			expect(elem.hasAttribute('bold')).to.be.true;
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-status-indicator');
 		});
 
 	});

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -1,6 +1,7 @@
 import '../tabs.js';
 import '../tab-panel.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`
 	<div>
@@ -19,6 +20,18 @@ describe('d2l-tabs', () => {
 		it('passes all aXe tests', async() => {
 			const el = await fixture(normalFixture);
 			await expect(el).to.be.accessible();
+		});
+
+	});
+
+	describe('constructor', () => {
+
+		it('should construct tabs', () => {
+			runConstructor('d2l-tabs');
+		});
+
+		it('should construct tab-panel', () => {
+			runConstructor('d2l-tab-panel');
 		});
 
 	});

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -1,5 +1,6 @@
 import '../tooltip.js';
 import { aTimeout, expect, fixture, html, oneEvent, triggerBlurFor, triggerFocusFor } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`
 	<div>
@@ -36,6 +37,14 @@ describe('d2l-tooltip', () => {
 				await expect(tooltip).to.be.accessible;
 			});
 		});
+	});
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-tooltip');
+		});
+
 	});
 
 	describe('events', () => {

--- a/tools/constructor-test-helper.js
+++ b/tools/constructor-test-helper.js
@@ -1,0 +1,7 @@
+import { expect } from '@open-wc/testing';
+
+export function runConstructor(nodeName) {
+	const ctor = customElements.get(nodeName);
+	expect(ctor).to.not.be.undefined;
+	document.createElement(nodeName);
+}


### PR DESCRIPTION
# Changes
- Add constructor tests to all components to ensure that they can successfully be created. This test case was added because `createElement` will fail if custom elements set attributes within their constructor. These tests protect against that.