### PR TITLE
Tooltip Accessibility Documentation

### DIFF
--- a/components/tooltip/README.md
+++ b/components/tooltip/README.md
@@ -35,7 +35,7 @@ If the tooltip's target is an interactive element then it will automatically be 
 
 **Static / Custom Target Elements:**
 
-If the tooltip's target is a static or custom element then the target must be both focusable and given an interactive aria role. Note, a role should only be added to an element if the role semantically aligns with what the element represents. [A list of interactive roles can be found here.](./tooltip.js#L38)
+If the tooltip's target is a static or custom element then the target must be both focusable and given an interactive ARIA role. Note, a role should only be added to an element if the role semantically aligns with what the element represents. [A list of interactive roles can be found here.](./tooltip.js#L38)
 
 Adding roles to custom elements that contain internal interactive elements should be avoided to prevent the element type being announced twice. In situations like these, the tooltip should be moved inside the custom element so that it can be attached directly as shown below:
 ```html
@@ -49,7 +49,7 @@ Adding roles to custom elements that contain internal interactive elements shoul
 ```
 If you need a tooltip in a core component that does not currently support it please create a Github issue.
 
-If you are unable to add a semantically aligned aria role or attach the tooltip to an interactive element then accessibility may be inconsistent across different screen readers. In these scenarios, putting critical information inside the tooltip should be avoided because some users may not be able to access it.
+If you are unable to add a semantically aligned ARIA role or attach the tooltip to an interactive element then accessibility may be inconsistent across different screen readers. In these scenarios, putting critical information inside the tooltip should be avoided because some users may not be able to access it.
 
 ### Advanced Usages
 

--- a/components/tooltip/README.md
+++ b/components/tooltip/README.md
@@ -27,6 +27,30 @@ The `d2l-tooltip` component is used to display additional information when users
 * `d2l-tooltip-show`: dispatched when the tooltip is opened
 * `d2l-tooltip-hide`: dispatched when the tooltip is closed
 
+### Accessibility
+
+**Interactive Target Elements:**
+
+If the tooltip's target is an interactive element then it will automatically be accessibile. [A list of interactive elements can be found here.](./tooltip.js#L24)
+
+**Static / Custom Target Elements:**
+
+If the tooltip's target is a static or custom element then the target must be both focusable and given an interactive aria role. Note, a role should only be added to an element if the role semantically aligns with what the element represents. [A list of interactive roles can be found here.](./tooltip.js#L38)
+
+Adding roles to custom elements that contain internal interactive elements should be avoided to prevent the element type being announced twice. In situations like these, the tooltip should be moved inside the custom element so that it can be attached directly as shown below:
+```html
+<my-custom-button>
+	#shadow-root (open)
+		<!---->
+		<button id="my-button">Click Me</button>
+		<d2l-tooltip for="my-button">Your tooltip message.</d2l-tooltip>
+		<!---->
+</my-custom-button>
+```
+If you need a tooltip in a core component that does not currently support it please create a Github issue.
+
+If you are unable to add a semantically aligned aria role or attach the tooltip to an interactive element then accessibility may be inconsistent across different screen readers. In these scenarios, putting critical information inside the tooltip should be avoided because some users may not be able to access it.
+
 ### Advanced Usages
 
 **Boundaries:**

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -709,7 +709,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			target.setAttribute('aria-describedby', this.id);
 			if (!this._isInteractive(target)) {
 				console.warn(
-					'd2l-tooltip may be used in a non-accessible manner; it should be attached to interactive elements like \'a\', \'button\',' +
+					'd2l-tooltip may be being used in a non-accessible manner; it should be attached to interactive elements like \'a\', \'button\',' +
 					'\'input\'', '\'select\', \'textarea\' or static / custom elements if a role has been set and the element is focusable.'
 				);
 			}


### PR DESCRIPTION
# Changes
- Add `console.warn` when tooltip is used in a way that may not be accessible.
- Add a README section on using tooltip in an accessible manner