### PR TITLE
Button Icon Tooltip Integration

### DIFF
--- a/components/button/README.md
+++ b/components/button/README.md
@@ -79,7 +79,7 @@ The `d2l-button-icon` element can be used just like the native `button`, for ins
 **Properties:**
 
 - `icon` (required, String): [Preset icon key](../icons#preset-icons) (e.g. `tier1:gear`)
-- `text` (required, String): Accessible text for the button
+- `text` (required, String): Accessible text for the button displayed on hover and focus
 - `disabled` (Boolean): disables the button
 - `h-align` (String): `text` aligns the leading edge of text
 - `translucent` (Boolean): Indicates to display translucent (ex. on rich backgrounds)

--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -1,8 +1,10 @@
 import '../icons/icon.js';
+import '../tooltip/tooltip.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { VisibleOnAncestorMixin, visibleOnAncestorStyles } from '../../mixins/visible-on-ancestor-mixin.js';
 import { ButtonMixin } from './button-mixin.js';
 import { buttonStyles } from './button-styles.js';
+import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
@@ -13,7 +15,8 @@ class ButtonIcon extends ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement)
 			hAlign: { type: String, reflect: true, attribute: 'h-align' },
 			icon: { type: String, reflect: true },
 			text: { type: String, reflect: true },
-			translucent: { type: Boolean, reflect: true }
+			translucent: { type: Boolean, reflect: true },
+			_buttonId: { type: String }
 		};
 	}
 
@@ -110,12 +113,21 @@ class ButtonIcon extends ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement)
 		];
 	}
 
+	constructor() {
+		super();
+		this._buttonId = getUniqueId();
+	}
+
 	render() {
+		const tooltipType = this.text && this.ariaLabel ? 'descriptor' : 'label';
+		const tooltipText = this.text || this.ariaLabel;
+		const label = this.text ? this.ariaLabel : undefined;
 		return html`
 			<button
+				id=${this._buttonId}
 				aria-expanded="${ifDefined(this.ariaExpanded)}"
 				aria-haspopup="${ifDefined(this.ariaHaspopup)}"
-				aria-label="${this.ariaLabel ? this.ariaLabel : ifDefined(this.text)}"
+				aria-label="${ifDefined(label)}"
 				?autofocus="${this.autofocus}"
 				class="d2l-label-text"
 				?disabled="${this.disabled}"
@@ -126,9 +138,9 @@ class ButtonIcon extends ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement)
 				?formnovalidate="${this.formnovalidate}"
 				formtarget="${ifDefined(this.formtarget)}"
 				name="${ifDefined(this.name)}"
-				title="${ifDefined(this.text)}"
 				type="${this._getType()}">
 				<d2l-icon icon="${ifDefined(this.icon)}" class="d2l-button-icon"></d2l-icon>
+				${tooltipText ? html`<d2l-tooltip for=${this._buttonId} for-type=${tooltipType} disable-focus-lock>${tooltipText}</d2l-tooltip>` : null}
 		</button>
 		`;
 	}

--- a/components/button/test/button-icon.test.js
+++ b/components/button/test/button-icon.test.js
@@ -3,6 +3,8 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-button-icon icon="d2l-tier1:gear" text="Icon Button"></d2l-button-icon>`;
+const labelFixture = html`<d2l-button-icon icon="d2l-tier1:gear" aria-label="Icon Button"></d2l-button-icon>`;
+const labelAndTextFixture = html`<d2l-button-icon icon="d2l-tier1:gear" aria-label="Icon Button" text="This is the rest"></d2l-button-icon>`;
 
 describe('d2l-button-icon', () => {
 
@@ -23,6 +25,27 @@ describe('d2l-button-icon', () => {
 			setTimeout(() => el.shadowRoot.querySelector('button').focus());
 			await oneEvent(el, 'focus');
 			await expect(el).to.be.accessible();
+		});
+
+		it('should be labelled-by its tooltip when text is present', async() => {
+			const el = await fixture(normalFixture);
+			const innerButton = el.shadowRoot.querySelector('button');
+			expect(innerButton.hasAttribute('aria-label')).to.be.false;
+			expect(innerButton.hasAttribute('aria-labelledby')).to.be.true;
+		});
+
+		it('should be labelled-by its tooltip when aria-label is present', async() => {
+			const el = await fixture(labelFixture);
+			const innerButton = el.shadowRoot.querySelector('button');
+			expect(innerButton.hasAttribute('aria-label')).to.be.false;
+			expect(innerButton.hasAttribute('aria-labelledby')).to.be.true;
+		});
+
+		it('should be described-by its tooltip and have a label when text and an aria-label are present', async() => {
+			const el = await fixture(labelAndTextFixture);
+			const innerButton = el.shadowRoot.querySelector('button');
+			expect(innerButton.getAttribute('aria-label')).to.equal(el.getAttribute('aria-label'));
+			expect(innerButton.hasAttribute('aria-describedby')).to.be.true;
 		});
 
 	});

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -281,6 +281,12 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		// native dialog backdrop does not prevent body scrolling
 		this._bodyScrollKey = preventBodyScroll();
 
+		// native dialogs have their own _focusInitial logic causing the close button to be focused
+		// and the tooltip to be factored into height calculations so clear focus until our own
+		// _focusInitial logic runs
+		if (document.activeElement) {
+			document.activeElement.blur();
+		}
 		requestAnimationFrame(async() => {
 			await this._updateSize();
 			this._state = 'showing';

--- a/components/tooltip/README.md
+++ b/components/tooltip/README.md
@@ -80,6 +80,7 @@ In the following example to constrain the tooltip to the dashed boundary we can 
 * `boundary` (Object) - optionally provide boundaries to constrain where the tooltip will appear. Valid properties are `"top"`, `"bottom"`, `"left"` and `"right"`. The boundary is relative to the tooltip's [offset parent](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent).
 * `disable-focus-lock` (Boolean, default: `false`) - disables focus lock so that the tooltip will automatically close when no longer hovered even if it still has focus
 * `force-show` (Boolean, default: `false`): force the tooltip to stay open as long as it remains `true`
+* `for-type` (String, default: `descriptor`) accessibility type for the tooltip to specify whether it is the primary label for the target or a secondary descriptor. Valid values are: `label` and `descriptor`.
 * `position` (String): optionally force the tooltip to open in a certain direction. Valid values are: `top`, `bottom`, `left` and `right`. If no position is provided, the tooltip will open in the first position that has enough space for it in the order: bottom, top, right, left.
 
 ## Future Enhancements

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -4,7 +4,7 @@ import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`
 	<div>
-		<div id="implicit-target" tabindex="-1">
+		<div id="implicit-target" tabindex="-1" role="button">
 			<button id="explicit-target">Hover me for tips</button>
 			<d2l-tooltip for="explicit-target" for-type="descriptor">If I got a problem then a problem's got a problem.</d2l-tooltip>
 		</div>

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -6,8 +6,15 @@ const basicFixture = html`
 	<div>
 		<div id="implicit-target" tabindex="-1">
 			<button id="explicit-target">Hover me for tips</button>
-			<d2l-tooltip for="explicit-target">If I got a problem then a problem's got a problem.</d2l-tooltip>
+			<d2l-tooltip for="explicit-target" for-type="descriptor">If I got a problem then a problem's got a problem.</d2l-tooltip>
 		</div>
+	</div>
+`;
+
+const labelFixture = html`
+	<div>
+		<button id="label-target">Hover me for tips</button>
+		<d2l-tooltip for="label-target" for-type="label">If I got a problem then a problem's got a problem.</d2l-tooltip>
 	</div>
 `;
 
@@ -37,6 +44,18 @@ describe('d2l-tooltip', () => {
 				await expect(tooltip).to.be.accessible;
 			});
 		});
+
+		it('should add aria-labelledby to its target if for-type is \'label\'', async() => {
+			const tooltipLabelFixture = await fixture(labelFixture);
+			const target = tooltipLabelFixture.querySelector('#label-target');
+			expect(target.hasAttribute('aria-labelledby')).to.be.true;
+		});
+
+		it('should add aria-describedby to its target if for-type is \'descriptor\'', async() => {
+			const target = tooltipFixture.querySelector('#explicit-target');
+			expect(target.hasAttribute('aria-describedby')).to.be.true;
+		});
+
 	});
 
 	describe('constructor', () => {

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -679,10 +679,10 @@ class Tooltip extends RtlMixin(LitElement) {
 	async _showingChanged(newValue) {
 		clearTimeout(this._hoverTimeout);
 		if (newValue) {
-			await this.updateComplete;
-			await this.updatePosition();
 			this._dismissibleId = setDismissible(() => this.hide());
 			this.setAttribute('aria-hidden', 'false');
+			await this.updateComplete;
+			await this.updatePosition();
 			this.dispatchEvent(new CustomEvent(
 				'd2l-tooltip-show', { bubbles: true, composed: true }
 			));

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -612,19 +612,19 @@ class Tooltip extends RtlMixin(LitElement) {
 	}
 
 	_isInteractive(ele) {
-		if (!isFocusable(ele)) {
+		if (!isFocusable(ele, true, false, true)) {
 			return false;
 		}
 		if (ele.nodeType !== Node.ELEMENT_NODE) {
 			return false;
 		}
 		const nodeName = ele.nodeName.toLowerCase();
-		const isInteractive = !!interactiveElements[nodeName];
+		const isInteractive = interactiveElements[nodeName];
 		if (isInteractive) {
 			return true;
 		}
 		const role = (ele.getAttribute('role') || '');
-		return (nodeName === 'a' && ele.hasAttribute('href')) || !!interactiveRoles[role];
+		return (nodeName === 'a' && ele.hasAttribute('href')) || interactiveRoles[role];
 	}
 
 	_onTargetBlur() {

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -84,6 +84,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			disableFocusLock: { type: Boolean, attribute: 'disable-focus-lock' },
 			for: { type: String },
 			forceShow: { type: Boolean, attribute: 'force-show' },
+			forType: { type: String, attribute: 'for-type' },
 			offset: { type: Number }, /* tooltipOffset */
 			position: { type: String }, /* Valid values are: 'top', 'bottom', 'left' and 'right' */
 			showing: { type: Boolean, reflect: true },
@@ -302,6 +303,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		this.delay = 0;
 		this.disableFocusLock = false;
 		this.forceShow = false;
+		this.forType = 'descriptor';
 		this.offset = pointerRotatedOverhang + pointerGap;
 		this.state = 'info';
 
@@ -706,7 +708,11 @@ class Tooltip extends RtlMixin(LitElement) {
 		if (target) {
 			this.id = this.id || getUniqueId();
 			this.setAttribute('role', 'tooltip');
-			target.setAttribute('aria-describedby', this.id);
+			if (this.forType === 'label') {
+				target.setAttribute('aria-labelledby', this.id);
+			} else {
+				target.setAttribute('aria-describedby', this.id);
+			}
 			if (!this._isInteractive(target)) {
 				console.warn(
 					'd2l-tooltip may be being used in a non-accessible manner; it should be attached to interactive elements like \'a\', \'button\',' +

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -163,9 +163,9 @@ export function getPreviousFocusableAncestor(node, includeHidden, includeTabbabl
 	return null;
 }
 
-export function isFocusable(node, includeHidden, includeTabbablesOnly) {
+export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDisabled) {
 
-	if (!node || node.nodeType !== 1 || node.disabled) return false;
+	if (!node || node.nodeType !== 1 || (!includeDisabled && node.disabled)) return false;
 
 	if (includeTabbablesOnly === undefined) includeTabbablesOnly = true;
 


### PR DESCRIPTION
# Changes
- Update `d2l-button-icon` to show a tooltip with the `text` instead of setting the `title` attribute on the `button`