### PR TITLE
Fix primary-secondary template width when width-type="normal"

### DIFF
--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -20,6 +20,7 @@ class TemplatePrimarySecondary extends LitElement {
 			}
 			:host([width-type="normal"]) .d2l-template-primary-secondary-content-container,
 			:host([width-type="normal"]) .d2l-template-primary-secondary-footer-container {
+				width: 100%;
 				max-width: 1230px;
 				margin: 0 auto;
 			}

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -20,9 +20,9 @@ class TemplatePrimarySecondary extends LitElement {
 			}
 			:host([width-type="normal"]) .d2l-template-primary-secondary-content-container,
 			:host([width-type="normal"]) .d2l-template-primary-secondary-footer-container {
-				width: 100%;
-				max-width: 1230px;
 				margin: 0 auto;
+				max-width: 1230px;
+				width: 100%;
 			}
 			.container {
 				display: grid;


### PR DESCRIPTION
When `width-type="normal"` is set, the combination of `max-width` and auto `margin` was allowing the template width to shrink below the desired 1230px if none of the slotted elements were wide enough. The template should always be 1230px wide if there is the space for it.

An alternative to setting `width: 100%` as I've done here would be to change the `minmax` min value to 410px (aka 1230/3), thus setting the lower bound of the grid width to 1230px in total. Not sure if there's a preference. (https://github.com/BrightspaceUI/core/blob/master/templates/primary-secondary/primary-secondary.js#L41)