### PR TITLE
[a11y bug] input-text: use this.label as aria-label unless aria-label

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -186,7 +186,7 @@ class InputText extends RtlMixin(LitElement) {
 	}
 
 	_getAriaLabel() {
-		if (this.label && this.labelHidden) {
+		if (this.label && (this.labelHidden || !this.hasAttribute('aria-label'))) {
 			return this.label;
 		}
 		if (this.hasAttribute('aria-label')) {


### PR DESCRIPTION
Bug: 
[NVDA/Firefox] When there is a label wrapped around an input, for example:
```
<label>
    <span>Name:</span>
    <input placeholder="my placeholder"></input>
</label>
```
the placeholder is read as part of the label and then again as part of the input (or if there is an entered value, then it will read that during the second read). 

Fix Notes:
Setting the label as the `aria-label` seems to fix this and does not result in duplication. It also improves the the experience in voiceover/safari, as previously the label was read as "Nameand one more item" (no space between "Name" and "and" on purpose), whereas with this change it's just "Name" (and other necessary information).

Overall this fixes the problem and seems to improve experience, but I'm just worried that there is something bad about this approach that I'm missing.