### PR TITLE
input-text: use for/id for labeling

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
 import { inputStyles } from './input-styles.js';
@@ -90,6 +91,7 @@ class InputText extends RtlMixin(LitElement) {
 
 		this._focused = false;
 		this._hovered = false;
+		this._inputId = getUniqueId();
 		this._firstSlotWidth = 0;
 		this._lastSlotWidth = 0;
 	}
@@ -143,6 +145,7 @@ class InputText extends RtlMixin(LitElement) {
 					@change="${this._handleChange}"
 					class="${classMap(inputClasses)}"
 					?disabled="${this.disabled}"
+					id="${this._inputId}"
 					@input="${this._handleInput}"
 					@invalid="${this._handleInvalid}"
 					@keypress="${this._handleKeypress}"
@@ -167,10 +170,10 @@ class InputText extends RtlMixin(LitElement) {
 		`;
 		if (this.label && !this.labelHidden) {
 			return html`
-				<label>
+				<label for="${this._inputId}">
 					<span class="d2l-input-label">${this.label}</span>
-					${input}
-				</label>`;
+				</label>
+				${input}`;
 		}
 		return input;
 	}

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -170,9 +170,7 @@ class InputText extends RtlMixin(LitElement) {
 		`;
 		if (this.label && !this.labelHidden) {
 			return html`
-				<label for="${this._inputId}">
-					<span class="d2l-input-label">${this.label}</span>
-				</label>
+				<label class="d2l-input-label" for="${this._inputId}">${this.label}</label>
 				${input}`;
 		}
 		return input;


### PR DESCRIPTION
This fixes of the problem of over-reading the placeholder on input.
Hover/click behavior seems to be working the same as before when hovering/clicking on the label text (checked chrome, legacy edge, firefox, safari).

The only other place I saw where we use the `label` wrapped around the `input` is `input-time` and I am hesitant to change that one due to it being a bit more complex, and it not using placeholders so it would not have the bug anyways.
