### PR TITLE
Tooltip for-type

### DIFF
--- a/components/tooltip/README.md
+++ b/components/tooltip/README.md
@@ -81,6 +81,7 @@ In the following example to constrain the tooltip to the dashed boundary we can 
 * `close-on-click` (Boolean, default: `false`) - causes the tooltip to close when its target is clicked
 * `disable-focus-lock` (Boolean, default: `false`) - disables focus lock so that the tooltip will automatically close when no longer hovered even if it still has focus
 * `force-show` (Boolean, default: `false`): force the tooltip to stay open as long as it remains `true`
+* `for-type` (String, default: `descriptor`) accessibility type for the tooltip to specify whether it is the primary label for the target or a secondary descriptor. Valid values are: `label` and `descriptor`.
 * `position` (String): optionally force the tooltip to open in a certain direction. Valid values are: `top`, `bottom`, `left` and `right`. If no position is provided, the tooltip will open in the first position that has enough space for it in the order: bottom, top, right, left.
 
 ## Future Enhancements

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -4,7 +4,7 @@ import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`
 	<div>
-		<div id="implicit-target" tabindex="-1">
+		<div id="implicit-target" tabindex="-1" role="button">
 			<button id="explicit-target">Hover me for tips</button>
 			<d2l-tooltip for="explicit-target" for-type="descriptor">If I got a problem then a problem's got a problem.</d2l-tooltip>
 		</div>

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -6,8 +6,15 @@ const basicFixture = html`
 	<div>
 		<div id="implicit-target" tabindex="-1">
 			<button id="explicit-target">Hover me for tips</button>
-			<d2l-tooltip for="explicit-target">If I got a problem then a problem's got a problem.</d2l-tooltip>
+			<d2l-tooltip for="explicit-target" for-type="descriptor">If I got a problem then a problem's got a problem.</d2l-tooltip>
 		</div>
+	</div>
+`;
+
+const labelFixture = html`
+	<div>
+		<button id="label-target">Hover me for tips</button>
+		<d2l-tooltip for="label-target" for-type="label">If I got a problem then a problem's got a problem.</d2l-tooltip>
 	</div>
 `;
 
@@ -37,6 +44,18 @@ describe('d2l-tooltip', () => {
 				await expect(tooltip).to.be.accessible;
 			});
 		});
+
+		it('should add aria-labelledby to its target if for-type is \'label\'', async() => {
+			const tooltipLabelFixture = await fixture(labelFixture);
+			const target = tooltipLabelFixture.querySelector('#label-target');
+			expect(target.hasAttribute('aria-labelledby')).to.be.true;
+		});
+
+		it('should add aria-describedby to its target if for-type is \'descriptor\'', async() => {
+			const target = tooltipFixture.querySelector('#explicit-target');
+			expect(target.hasAttribute('aria-describedby')).to.be.true;
+		});
+
 	});
 
 	describe('constructor', () => {

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -85,6 +85,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			disableFocusLock: { type: Boolean, attribute: 'disable-focus-lock' },
 			for: { type: String },
 			forceShow: { type: Boolean, attribute: 'force-show' },
+			forType: { type: String, attribute: 'for-type' },
 			offset: { type: Number }, /* tooltipOffset */
 			position: { type: String }, /* Valid values are: 'top', 'bottom', 'left' and 'right' */
 			showing: { type: Boolean, reflect: true },
@@ -307,6 +308,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		this.delay = 0;
 		this.disableFocusLock = false;
 		this.forceShow = false;
+		this.forType = 'descriptor';
 		this.offset = pointerRotatedOverhang + pointerGap;
 		this.state = 'info';
 
@@ -736,7 +738,11 @@ class Tooltip extends RtlMixin(LitElement) {
 		if (target) {
 			this.id = this.id || getUniqueId();
 			this.setAttribute('role', 'tooltip');
-			target.setAttribute('aria-describedby', this.id);
+			if (this.forType === 'label') {
+				target.setAttribute('aria-labelledby', this.id);
+			} else {
+				target.setAttribute('aria-describedby', this.id);
+			}
 			if (!this._isInteractive(target)) {
 				console.warn(
 					'd2l-tooltip may be being used in a non-accessible manner; it should be attached to interactive elements like \'a\', \'button\',' +

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -621,19 +621,19 @@ class Tooltip extends RtlMixin(LitElement) {
 	}
 
 	_isInteractive(ele) {
-		if (!isFocusable(ele)) {
+		if (!isFocusable(ele, true, false, true)) {
 			return false;
 		}
 		if (ele.nodeType !== Node.ELEMENT_NODE) {
 			return false;
 		}
 		const nodeName = ele.nodeName.toLowerCase();
-		const isInteractive = !!interactiveElements[nodeName];
+		const isInteractive = interactiveElements[nodeName];
 		if (isInteractive) {
 			return true;
 		}
 		const role = (ele.getAttribute('role') || '');
-		return (nodeName === 'a' && ele.hasAttribute('href')) || !!interactiveRoles[role];
+		return (nodeName === 'a' && ele.hasAttribute('href')) || interactiveRoles[role];
 	}
 
 	_onTargetBlur() {

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -709,10 +709,10 @@ class Tooltip extends RtlMixin(LitElement) {
 		clearTimeout(this._hoverTimeout);
 		clearTimeout(this._longPressTimeout);
 		if (newValue) {
-			await this.updateComplete;
-			await this.updatePosition();
 			this._dismissibleId = setDismissible(() => this.hide());
 			this.setAttribute('aria-hidden', 'false');
+			await this.updateComplete;
+			await this.updatePosition();
 			this.dispatchEvent(new CustomEvent(
 				'd2l-tooltip-show', { bubbles: true, composed: true }
 			));

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -163,9 +163,9 @@ export function getPreviousFocusableAncestor(node, includeHidden, includeTabbabl
 	return null;
 }
 
-export function isFocusable(node, includeHidden, includeTabbablesOnly) {
+export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDisabled) {
 
-	if (!node || node.nodeType !== 1 || node.disabled) return false;
+	if (!node || node.nodeType !== 1 || (!includeDisabled && node.disabled)) return false;
 
 	if (includeTabbablesOnly === undefined) includeTabbablesOnly = true;
 


### PR DESCRIPTION
# Changes
- This PR includes the changes in [Button Icon Tooltip Integration #500](https://github.com/BrightspaceUI/core/pull/500) excluding the actual integration commit.
1. Add `for-type` to allow it to either be a primary label or secondary descriptor.
1. Update tooltip accessibility warning to exclude hidden or disabled targets.
1. Fix tooltip race condition when it is shown then hidden extremely quickly causing cleanup to occur before show has finished.