### PR TITLE
Sakulick/date time open same direction

### DIFF
--- a/components/inputs/demo/input-date-time.html
+++ b/components/inputs/demo/input-date-time.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-timezone='{"name": "est", "identifier": "America/Toronto"}'>
+<html lang="en" data-timezone='{"name":"Canada - Toronto", "identifier":"America/Toronto"}'>
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -103,6 +103,7 @@ class InputDateTime extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 					?hidden="${timeHidden}"
 					label="${this.localize('time')}"
 					label-hidden
+					max-height="430"
 					.value="${this._parsedDateTime}">
 				</d2l-input-time>
 			</d2l-input-fieldset>

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -181,7 +181,6 @@ class InputDate extends LocalizeStaticMixin(LitElement) {
 						slot="left"></d2l-icon>
 				</d2l-input-text>
 				<d2l-dropdown-content
-					boundary="{&quot;above&quot;:0}"
 					@d2l-dropdown-close="${this._handleDropdownClose}"
 					@d2l-dropdown-open="${this._handleDropdownOpen}"
 					max-width="335"

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -116,7 +116,6 @@ class InputTime extends LitElement {
 		this.disabled = false;
 		this.enforceTimeIntervals = false;
 		this.labelHidden = false;
-		this.maxHeight = "";
 		this.timeInterval = 'thirty';
 		this._dropdownId = getUniqueId();
 		this._formattedValue = formatTime(DEFAULT_VALUE);

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -8,6 +8,7 @@ import { formatTime, parseTime } from '@brightspace-ui/intl/lib/dateTime.js';
 import { getToday, parseISOTime } from '../../helpers/dateTime.js';
 import { bodySmallStyles } from '../typography/styles.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
 import { inputStyles } from './input-styles.js';
 import { offscreenStyles } from '../offscreen/offscreen-styles.js';
@@ -73,9 +74,10 @@ class InputTime extends LitElement {
 		return {
 			disabled: { type: Boolean },
 			enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
-			timeInterval: { type: String, attribute: 'time-interval' },
 			label: { type: String },
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
+			maxHeight: { type: Number, attribute: 'max-height' },
+			timeInterval: { type: String, attribute: 'time-interval' },
 			value: { type: String },
 			_formattedValue: { type: String }
 		};
@@ -113,8 +115,9 @@ class InputTime extends LitElement {
 		super();
 		this.disabled = false;
 		this.enforceTimeIntervals = false;
-		this.timeInterval = 'thirty';
 		this.labelHidden = false;
+		this.maxHeight = "";
+		this.timeInterval = 'thirty';
 		this._dropdownId = getUniqueId();
 		this._formattedValue = formatTime(DEFAULT_VALUE);
 		this._timezone = formatTime(new Date(), {format: 'ZZZ'});
@@ -157,7 +160,7 @@ class InputTime extends LitElement {
 							@keypress="${this._handleKeypress}"
 							.value="${this._formattedValue}">
 					</div>
-					<d2l-dropdown-menu id="dropdown" no-padding-footer min-width="195">
+					<d2l-dropdown-menu id="dropdown" no-padding-footer max-height="${ifDefined(this.maxHeight)}" min-width="195">
 						<d2l-menu
 							id="${this._dropdownId}"
 							role="listbox"


### PR DESCRIPTION
Set a max height for the time-dropdown in date-time dropdown equivalent to the maximum height of the date-dropdown. _Mostlty_ resolves [US115781](https://rally1.rallydev.com/#/detail/userstory/386124276604?fdp=true): [Date-Time] Time Input > Set a max height as a workaround for awkward dropdown behaviour

There is one edge-case: If the distance to the bottom of the viewport is in between the height of the date picker when it displays 5 rows and its height when it displays 6 rows, the inputs may still open in different directions.

- input-time now supports max-height
- input-date is now able to open above its input field if there isn't enough room below