### PR TITLE
Improve event handling for nested tabs

### DIFF
--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -56,27 +56,6 @@
 				</template>
 			</d2l-demo-snippet>
 
-			<h2>Tabs (nested)</h2>
-
-			<d2l-demo-snippet>
-				<template>
-					<d2l-tabs>
-						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-						<d2l-tab-panel text="Earth Sciences">
-							Nested tabs for Earth Sciences...
-							<d2l-tabs>
-								<d2l-tab-panel text="Mineralogy">Tab content for Mineralogy</d2l-tab-panel>
-								<d2l-tab-panel text="Hydrology">Tab content for Hydrology</d2l-tab-panel>
-								<d2l-tab-panel text="Geochemistry">Tab content for Geochemistry</d2l-tab-panel>
-								<d2l-tab-panel text="Groundwater Modeling">Tab content for Groundwater Modeling</d2l-tab-panel>
-								<d2l-tab-panel text="Stratigraphy">Tab content for Stratigraphy</d2l-tab-panel>
-							</d2l-tabs>
-						</d2l-tab-panel>
-						<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
-					</d2l-tabs>
-				</template>
-			</d2l-demo-snippet>
-
 			<h3>Tabs (with slot)</h3>
 
 			<d2l-demo-snippet>
@@ -135,6 +114,27 @@
 						<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
 						<d2l-tab-panel text="Math">Tab content for Math</d2l-tab-panel>
 						<d2l-tab-panel text="Community">Tab content for Community</d2l-tab-panel>
+					</d2l-tabs>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Tabs (nested)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-tabs>
+						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel text="Earth Sciences">
+							Nested tabs for Earth Sciences...
+							<d2l-tabs>
+								<d2l-tab-panel text="Mineralogy">Tab content for Mineralogy</d2l-tab-panel>
+								<d2l-tab-panel text="Hydrology">Tab content for Hydrology</d2l-tab-panel>
+								<d2l-tab-panel text="Geochemistry">Tab content for Geochemistry</d2l-tab-panel>
+								<d2l-tab-panel text="Groundwater Modeling">Tab content for Groundwater Modeling</d2l-tab-panel>
+								<d2l-tab-panel text="Stratigraphy">Tab content for Stratigraphy</d2l-tab-panel>
+							</d2l-tabs>
+						</d2l-tab-panel>
+						<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
 					</d2l-tabs>
 				</template>
 			</d2l-demo-snippet>

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -118,27 +118,6 @@
 				</template>
 			</d2l-demo-snippet>
 
-			<h2>Tabs (nested)</h2>
-
-			<d2l-demo-snippet>
-				<template>
-					<d2l-tabs>
-						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-						<d2l-tab-panel text="Earth Sciences">
-							Nested tabs for Earth Sciences...
-							<d2l-tabs>
-								<d2l-tab-panel text="Mineralogy">Tab content for Mineralogy</d2l-tab-panel>
-								<d2l-tab-panel text="Hydrology">Tab content for Hydrology</d2l-tab-panel>
-								<d2l-tab-panel text="Geochemistry">Tab content for Geochemistry</d2l-tab-panel>
-								<d2l-tab-panel text="Groundwater Modeling">Tab content for Groundwater Modeling</d2l-tab-panel>
-								<d2l-tab-panel text="Stratigraphy">Tab content for Stratigraphy</d2l-tab-panel>
-							</d2l-tabs>
-						</d2l-tab-panel>
-						<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
-					</d2l-tabs>
-				</template>
-			</d2l-demo-snippet>
-
 		</d2l-demo-page>
 
 		<script>

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -56,6 +56,27 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Tabs (nested)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-tabs>
+						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel text="Earth Sciences">
+							Nested tabs for Earth Sciences...
+							<d2l-tabs>
+								<d2l-tab-panel text="Mineralogy">Tab content for Mineralogy</d2l-tab-panel>
+								<d2l-tab-panel text="Hydrology">Tab content for Hydrology</d2l-tab-panel>
+								<d2l-tab-panel text="Geochemistry">Tab content for Geochemistry</d2l-tab-panel>
+								<d2l-tab-panel text="Groundwater Modeling">Tab content for Groundwater Modeling</d2l-tab-panel>
+								<d2l-tab-panel text="Stratigraphy">Tab content for Stratigraphy</d2l-tab-panel>
+							</d2l-tabs>
+						</d2l-tab-panel>
+						<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
+					</d2l-tabs>
+				</template>
+			</d2l-demo-snippet>
+
 			<h3>Tabs (with slot)</h3>
 
 			<d2l-demo-snippet>

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -612,12 +612,18 @@ class Tabs extends LocalizeStaticMixin(ArrowKeysMixin(RtlMixin(LitElement))) {
 	}
 
 	_handlePanelSelected(e) {
-		this._getTabInfo(e.target.id).selected = true;
+		const tabInfo = this._getTabInfo(e.target.id);
+		// event could be from nested tabs
+		if (!tabInfo) return;
+		tabInfo.selected = true;
 		this.requestUpdate();
 	}
 
 	async _handlePanelTextChange(e) {
-		this._getTabInfo(e.target.id).text = e.target.text;
+		const tabInfo = this._getTabInfo(e.target.id);
+		// event could be from nested tabs
+		if (!tabInfo) return;
+		tabInfo.text = e.target.text;
 		this.requestUpdate();
 		await this.updateComplete;
 		this._updateMeasures();


### PR DESCRIPTION
The original code would have worked - this change just avoid possible JS error when `d2l-tab-panel-selected` or `d2l-tab-panel-text-changed` is dispatched from a nested set of tabs.