### PR TITLE
PoC: Implement a custom `d2l-form` component and a FormElementMixin

### DIFF
--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -2,10 +2,11 @@ import '../colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { checkboxStyles } from './input-checkbox-styles.js';
 import { classMap} from 'lit-html/directives/class-map.js';
+import { FormElementMixin } from '../validation/form-element-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
-class InputCheckbox extends RtlMixin(LitElement) {
+class InputCheckbox extends RtlMixin(FormElementMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -103,6 +104,16 @@ class InputCheckbox extends RtlMixin(LitElement) {
 					.value="${this.value}"><span class="${classMap(textClasses)}"><slot></slot></span>
 			</label>
 		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((_, prop) => {
+			if (prop === 'checked') {
+				this.setFormValue(this.value);
+			}
+		});
 	}
 
 	focus() {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { FormElementMixin } from '../validation/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
@@ -7,7 +8,7 @@ import { inputStyles } from './input-styles.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
-class InputText extends RtlMixin(LitElement) {
+class InputText extends RtlMixin(FormElementMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -111,6 +112,7 @@ class InputText extends RtlMixin(LitElement) {
 
 		changedProperties.forEach((oldVal, prop) => {
 			if (prop === 'value') {
+				this.setFormValue(this.value);
 				this._prevValue = (oldVal === undefined) ? '' : oldVal;
 			}
 		});

--- a/components/validation/demo/validation.html
+++ b/components/validation/demo/validation.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<meta charset="UTF-8">
+	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script type="module">
+			import '../../inputs/input-checkbox.js';
+			import '../../inputs/input-text.js';
+			import '../../typography/typography.js';
+			import '../../button/button.js';
+			import '../../colors/colors.js';
+			import '../form.js';
+	</script>
+	<style>
+		body {
+			padding: 30px;
+		}
+	</style>
+</head>
+
+<body>
+
+	<d2l-form action="/" onsubmit="return validate()">
+		<label for="fname">First name:</label><br>
+		<div>
+		<d2l-input-text type="text" required id="fname" name="fname" value="John"></d2l-input-text><br>
+		</div>
+		<label for="lname">Last name:</label><br>
+		<input type="text" id="lname" name="lname" value="Doe"><br><br>
+		<d2l-input-checkbox checked name="chcke">Checked item</d2l-input-checkbox>
+		<d2l-input-checkbox name="chbox2">Unchecked item</d2l-input-checkbox>
+		<button type="submit">Submit</button>
+	</d2l-form>
+</body>
+
+</html>

--- a/components/validation/form-element-mixin.js
+++ b/components/validation/form-element-mixin.js
@@ -1,0 +1,29 @@
+export const FormElementMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			_value: { type: Object }
+		};
+	}
+
+	static formAssociated = true;
+
+	formAssociatedCallback(form) {
+		this.__form = form;
+		if (this._value) {
+			this.__form.setFormValue(this, this._value);
+		}
+	}
+
+	setFormValue(val) {
+		this._value = val;
+		if (this.__form) {
+			this.__form.setFormValue(this, val);
+		}
+	}
+
+	get name() {
+		return this.getAttribute('name');
+	}
+
+};

--- a/components/validation/form.js
+++ b/components/validation/form.js
@@ -1,0 +1,108 @@
+import '../colors/colors.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+
+const formElements = {
+	'button': true,
+	'fieldset': true,
+	'input': true,
+	'object': true,
+	'output': true,
+	'select': true,
+	'textarea': true
+};
+
+class Form extends LitElement {
+
+	static get properties() {
+		return {
+			action: { type: String, reflect: true }
+		};
+	}
+
+	static get styles() {
+		return css``;
+	}
+
+	constructor() {
+		super();
+		this._associatedFormElements = [];
+		this._associateCustomElements = [];
+		this._onMutation = this._onMutation.bind(this);
+		this._mutationObserver = new MutationObserver(this._onMutation);
+		this._formData = new FormData();
+		requestAnimationFrame(() => {
+			this._form = this.shadowRoot.querySelector('form');
+			this._associateElements(this);
+			this._mutationObserver.observe(this, { childList: true, subtree: true, attributes: true });
+		});
+	}
+
+	render() {
+		return html`<slot></slot>`;
+	}
+
+	_onMutation(mutationsList) {
+		for (const mutation of mutationsList) {
+			console.log(mutation.type);
+			if (mutation.type === 'childList') {
+				for (const node of mutation.addedNodes) {
+					this._associateElementIfNecessary(node);
+				}
+			} else {
+				console.log(mutation.type);
+			}
+		}
+	}
+
+	_associateElements(e) {
+		for (const ele of e.children) {
+			this._associateElementIfNecessary(ele);
+			this._associateElements(ele);
+		}
+	}
+
+	_associateElementIfNecessary(ele) {
+		if (ele.nodeType !== Node.ELEMENT_NODE) {
+			return;
+		}
+		const nodeName = ele.nodeName.toLowerCase();
+		if (formElements[nodeName]) {
+			this._associateFormElement(ele);
+		} else if (ele.constructor.formAssociated) {
+			this._associateCustomElement(ele);
+		}
+	}
+
+	_associateFormElement(ele) {
+		ele.addEventListener('input', (e) => {
+			this.setFormValue(ele, e.target.value);
+		});
+		this.setFormValue(ele, ele.getAttribute('value'));
+		this._associatedFormElements.push(ele);
+
+		if (ele.type === 'submit') {
+			ele.addEventListener('click', () => this.submit());
+		}
+	}
+
+	_associateCustomElement(ele) {
+		this._associateCustomElements.push(ele);
+		ele.formAssociatedCallback(this);
+
+		if (ele.type === 'submit') {
+			ele.addEventListener('click', () => this.submit());
+		}
+	}
+
+	setFormValue(ele, val) {
+		console.log(`${ele.name  }: ${  val}`);
+		this._formData.set(ele.name, val);
+	}
+
+	submit() {
+		const request = new XMLHttpRequest();
+		request.open('POST', this.action);
+		request.send(this._formData);
+	}
+}
+customElements.define('d2l-form', Form);

--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
 		<li><a href="components/status-indicator/demo/status-indicator.html">d2l-status-indicator</a></li>
 		<li><a href="components/tabs/demo/tabs.html">d2l-tabs</a></li>
 		<li><a href="components/tooltip/demo/tooltip.html">d2l-tooltip</a></li>
+		<li><a href="components/validation/demo/validation.html">validation poc</a></li>
 	</ul>
 
 	<h2 class="d2l-heading-3">Helpers</h2>


### PR DESCRIPTION
## Proof of Concept
This is a proof of concept of creating a custom form element that supports both custom elements and native form elements. In this case I used the `FormData` API and manually sent it but the approach could also be done by adding a form with hidden inputs.

Because we need to detect native form elements, we need to search up for elements that participate in forms since native form elements can't send events asking to be registered with the form.

This proof of concept was roughly based on the [Form Associated Custom Elements API](https://web.dev/more-capable-form-controls/#form-associated-custom-elements)

### Pros

1. Extreme flexibility to support both standard forms and Hypermedia
2. Allows for async validation
3. Can be implemented to mirror the Form Associated Custom Element API

### Cons

1. Complex to implement
2. Less performant due to tracking DOM changes
3. No support for native forms