### PR TITLE
PoC: Add hidden inputs to the light DOM using a FormElementMixin and use a native form

### DIFF
--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -2,10 +2,11 @@ import '../colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { checkboxStyles } from './input-checkbox-styles.js';
 import { classMap} from 'lit-html/directives/class-map.js';
+import { FormElementMixin } from '../validation/form-element-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
-class InputCheckbox extends RtlMixin(LitElement) {
+class InputCheckbox extends RtlMixin(FormElementMixin(LitElement)) {
 
 	static get properties() {
 		return {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { FormElementMixin } from '../validation/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
@@ -7,7 +8,7 @@ import { inputStyles } from './input-styles.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
-class InputText extends RtlMixin(LitElement) {
+class InputText extends RtlMixin(FormElementMixin(LitElement)) {
 
 	static get properties() {
 		return {

--- a/components/validation/demo/mock-app.js
+++ b/components/validation/demo/mock-app.js
@@ -1,0 +1,35 @@
+import '../../inputs/input-checkbox.js';
+import '../../inputs/input-text.js';
+import '../../typography/typography.js';
+import '../../button/button.js';
+import '../../colors/colors.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
+
+class MockApp extends LitElement {
+
+	static get properties() {
+		return {
+			action: { type: String, reflect: true }
+		};
+	}
+	render() {
+		return html`
+			<form action="/action" @submit=${this.validate}>
+				<label for="fname">First name:</label><br>
+				<d2l-input-text type="text" required id="fname" name="fname" value="John"></d2l-input-text><br>
+				<label for="lname">Last name:</label><br>
+				<input type="text" id="lname" name="lname" value="Doe"><br><br>
+				<d2l-input-checkbox checked name="chcke">Checked item</d2l-input-checkbox>
+				<d2l-input-checkbox name="chbox2">Unchecked item</d2l-input-checkbox>
+				<button type="submit">Submit</button>
+			</form>
+		`;
+	}
+
+	validate(e) {
+		/*if (!performSynchronousValidation()) {
+			e.preventDefault();
+		}*/
+	}
+}
+customElements.define('d2l-mock-app', MockApp);

--- a/components/validation/demo/validation.html
+++ b/components/validation/demo/validation.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<meta charset="UTF-8">
+	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script type="module">
+			import '../../inputs/input-checkbox.js';
+			import '../../inputs/input-text.js';
+			import '../../typography/typography.js';
+			import '../../button/button.js';
+			import '../../colors/colors.js';
+	</script>
+	<style>
+		body {
+			padding: 30px;
+		}
+	</style>
+</head>
+
+<body>
+
+	<form action="/action" onsubmit="return validate()">
+		<label for="fname">First name:</label><br>
+		<d2l-input-text type="text" required id="fname" name="fname" value="John"></d2l-input-text><br>
+		<label for="lname">Last name:</label><br>
+		<input type="text" id="lname" name="lname" value="Doe"><br><br>
+		<d2l-input-checkbox checked name="chcke">Checked item</d2l-input-checkbox>
+		<d2l-input-checkbox name="chbox2">Unchecked item</d2l-input-checkbox>
+		<button type="submit">Submit</button>
+	</form>
+	<script>
+		function validate() {
+			console.log('perform synchronous validation');
+			return true;
+		}
+	</script>
+</body>
+
+</html>

--- a/components/validation/demo/validation.html
+++ b/components/validation/demo/validation.html
@@ -8,11 +8,7 @@
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
 	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
-			import '../../inputs/input-checkbox.js';
-			import '../../inputs/input-text.js';
-			import '../../typography/typography.js';
-			import '../../button/button.js';
-			import '../../colors/colors.js';
+			import './mock-app.js';
 	</script>
 	<style>
 		body {
@@ -22,22 +18,7 @@
 </head>
 
 <body>
-
-	<form action="/action" onsubmit="return validate()">
-		<label for="fname">First name:</label><br>
-		<d2l-input-text type="text" required id="fname" name="fname" value="John"></d2l-input-text><br>
-		<label for="lname">Last name:</label><br>
-		<input type="text" id="lname" name="lname" value="Doe"><br><br>
-		<d2l-input-checkbox checked name="chcke">Checked item</d2l-input-checkbox>
-		<d2l-input-checkbox name="chbox2">Unchecked item</d2l-input-checkbox>
-		<button type="submit">Submit</button>
-	</form>
-	<script>
-		function validate() {
-			console.log('perform synchronous validation');
-			return true;
-		}
-	</script>
+	<d2l-mock-app></d2l-mock-app>
 </body>
 
 </html>

--- a/components/validation/form-element-mixin.js
+++ b/components/validation/form-element-mixin.js
@@ -1,0 +1,35 @@
+export const FormElementMixin = superclass => class extends superclass {
+
+	constructor() {
+		super();
+		this.__hiddenInput = document.createElement('input');
+		this.__hiddenInput.type = 'hidden';
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		requestAnimationFrame(() => {
+			const parentNode = this.parentNode;
+			const parent = parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE ? this.getRootNode().host : parentNode;
+			parent.appendChild(this.__hiddenInput);
+		});
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.__hiddenInput.parentNode.removeChild(this.__hiddenInput);
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((_, prop) => {
+			if (prop === 'value') {
+				this.__hiddenInput.value = this.value;
+			} else if (prop === 'name') {
+				this.__hiddenInput.name = this.name;
+			}
+		});
+	}
+
+};

--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
 		<li><a href="components/status-indicator/demo/status-indicator.html">d2l-status-indicator</a></li>
 		<li><a href="components/tabs/demo/tabs.html">d2l-tabs</a></li>
 		<li><a href="components/tooltip/demo/tooltip.html">d2l-tooltip</a></li>
+		<li><a href="components/validation/demo/validation.html">validation poc</a></li>
 	</ul>
 
 	<h2 class="d2l-heading-3">Helpers</h2>


### PR DESCRIPTION
## Proof of Concept
This works really well for including custom elements in forms but falls short on validation support.

### Pros

1. Easy to implement
2. Works with native forms

### Cons

1. No support for `async` validation. `onsubmit` can prevent submission but only synchronously since input validity is either valid or error, there is no pending state. https://developer.mozilla.org/en-US/docs/Web/API/Constraint_validation
2. We need to wire up our own validation in the form submit event because `setCustomValidity` is only supported on native form elements and ignored on hidden inputs.