### PR TITLE
not using nullish coalescing operator 

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -465,7 +465,7 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 			});
 
 			const spaceRequired = {
-				height: Math.min(this.maxHeight ?? Number.MAX_VALUE, contentRect.height + headerFooterHeight) + 10,
+				height: Math.min(this.maxHeight ? this.maxHeight : Number.MAX_VALUE, contentRect.height + headerFooterHeight) + 10,
 				width: contentRect.width
 			};
 


### PR DESCRIPTION
For some unexplained reason, `??` causes Polymer build to explode. This is causing strange build errors in BSI where it can't find this file. Probably if `polymer build` encounters a syntax error or something it just dies and whatever called it assumes the file can't be found.