### PR TITLE
Visual-diff updates 

### DIFF
--- a/components/dialog/test/dialog.visual-diff.js
+++ b/components/dialog/test/dialog.visual-diff.js
@@ -44,34 +44,40 @@ describe('d2l-dialog', () => {
 					});
 
 					it('opened', async function() {
-						await helper.open(page, '#dialog');
+						await page.$eval('#dialog', (dialog) => dialog.opened = true);
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
 					it('scroll bottom shadow', async function() {
-						await helper.open(page, '#dialogLong');
+						await page.$eval('#dialogLong', (dialog) => dialog.opened = true);
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
 					it('scroll top shadow', async function() {
-						await helper.open(page, '#dialogLong');
-						await page.$eval('#dialogLong #bottom', (bottom) => {
-							bottom.scrollIntoView();
+						await page.$eval('#dialogLong', (dialog) => {
+							dialog.opened = true;
+							return new Promise((resolve) => {
+								requestAnimationFrame(() => {
+									dialog.querySelector('#bottom').scrollIntoView();
+									resolve();
+								});
+							});
 						});
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
 					it('rtl', async function() {
-						await helper.open(page, '#dialogRtl');
+						await page.$eval('#dialogRtl', (dialog) => dialog.opened = true);
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
 					it('resize', async function() {
-						await helper.open(page, '#dialogResize');
-						await page.$eval('#dialogResize', (dialog) => {
+						await page.$eval('#dialogResize', async(dialog) => {
+							dialog.opened = true;
 							dialog.querySelector('div').style.height = '60px';
 							dialog.width = 500;
 							dialog.resize();
+							return new Promise((resolve) => requestAnimationFrame(resolve));
 						});
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});

--- a/components/menu/test/menu-rtl.visual-diff.js
+++ b/components/menu/test/menu-rtl.visual-diff.js
@@ -39,12 +39,7 @@ describe('d2l-menu rtl', () => {
 
 		it('opens submenu on click', async function() {
 			// this scenario also tests height change when going from 1 menu item to 2 within nested menu
-			await page.$eval('#nested-item', item => {
-				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
-					item.click();
-				});
-			});
+			await page.$eval('#nested-item', item => item.click());
 			const rect = await visualDiff.getRect(page, '#nested');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
@@ -56,12 +51,7 @@ describe('d2l-menu rtl', () => {
 
 		it('opens long menu item submenu on click', async function() {
 			// this scenario also tests height change going from 3 menu items to 2 within nested menu
-			await page.$eval('#nested-item-long', item => {
-				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
-					item.click();
-				});
-			});
+			await page.$eval('#nested-item-long', item => item.click());
 			const rect = await visualDiff.getRect(page, '#nested-long');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
@@ -74,8 +64,8 @@ describe('d2l-menu rtl', () => {
 		it('opens custom submenu on click', async function() {
 			await page.$eval('#custom-view-item', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
 					item.click();
+					requestAnimationFrame(resolve);
 				});
 			});
 			const rect = await visualDiff.getRect(page, '#custom-view');

--- a/components/menu/test/menu.visual-diff.js
+++ b/components/menu/test/menu.visual-diff.js
@@ -37,6 +37,7 @@ describe('d2l-menu', () => {
 	});
 
 	describe('normal', () => {
+
 		afterEach(async() => {
 			await page.reload();
 		});
@@ -115,22 +116,14 @@ describe('d2l-menu', () => {
 
 		it('opens submenu on click', async function() {
 			// this scenario also tests height change when going from 1 menu item to 2 within nested menu
-			await page.$eval('#nested-item', item => {
-				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
-					item.click();
-				});
-			});
+			await page.$eval('#nested-item', item => item.click());
 			const rect = await visualDiff.getRect(page, '#nested');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 
 		it('leaves submenu when return clicked', async function() {
 			await page.$eval('#nested-menu', item => {
-				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-hide-complete', resolve, { once: true });
-					item.shadowRoot.querySelector('d2l-menu-item-return').click();
-				});
+				item.shadowRoot.querySelector('d2l-menu-item-return').click();
 			});
 			const rect = await visualDiff.getRect(page, '#nested');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -139,11 +132,11 @@ describe('d2l-menu', () => {
 		it('opens submenu on enter', async function() {
 			await page.$eval('#nested-item', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
 					const eventObj = document.createEvent('Events');
 					eventObj.initEvent('keydown', true, true);
 					eventObj.keyCode = 13;
 					item.dispatchEvent(eventObj);
+					requestAnimationFrame(resolve);
 				});
 			});
 			const rect = await visualDiff.getRect(page, '#nested');
@@ -153,11 +146,11 @@ describe('d2l-menu', () => {
 		it('leaves submenu on escape', async function() {
 			await page.$eval('#nested-menu', (item) => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-hide-complete', resolve, { once: true });
 					const eventObj = document.createEvent('Events');
 					eventObj.initEvent('keyup', true, true);
 					eventObj.keyCode = 27;
 					item.querySelector('#b2').dispatchEvent(eventObj);
+					requestAnimationFrame(resolve);
 				});
 			});
 			const rect = await visualDiff.getRect(page, '#nested');
@@ -171,12 +164,7 @@ describe('d2l-menu', () => {
 
 		it('opens long menu item submenu on click', async function() {
 			// this scenario also tests height change going from 3 menu items to 2 within nested menu
-			await page.$eval('#nested-item-long', item => {
-				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
-					item.click();
-				});
-			});
+			await page.$eval('#nested-item-long', item => item.click());
 			const rect = await visualDiff.getRect(page, '#nested-long');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
@@ -189,8 +177,8 @@ describe('d2l-menu', () => {
 		it('opens custom submenu on click', async function() {
 			await page.$eval('#custom-view-item', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
 					item.click();
+					requestAnimationFrame(resolve);
 				});
 			});
 			const rect = await visualDiff.getRect(page, '#custom-view');


### PR DESCRIPTION
The reduced motion stuff avoids having to listen for transition/animation events.  These listeners were removed from test code in previous PRs.

Ideally, other developers can interact with the core components in their app components and get correct, consistent screenshots without waiting, especially arbitrarily.  This PR attempts to explore that, and considers updating tests in core to do exactly that.

Interested in thoughts/opinions.  No rush.  Even if we keep visual-diff tests the same, this at least helps to understand what app developers should/must do if they are interacting with complex core components in their diff tests. Similar changes could be made to dropdown, tooltip, and other tests.