### PR TITLE
Bump package.json version to skip cert version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-ui/core",
-  "version": "1.43.6",
+  "version": "1.43.7",
   "description": "A collection of accessible, free, open-source web components for building Brightspace applications",
   "repository": "https://github.com/BrightspaceUI/core.git",
   "publishConfig": {


### PR DESCRIPTION
`1.43.7` is the cert patch version, so merging this with `[increment patch]` should result in master release `1.43.8`.