### PR TITLE
 Spike: Triggering Validation and Collecting Errors

### DIFF
--- a/components/inputs/input-checkbox-styles.js
+++ b/components/inputs/input-checkbox-styles.js
@@ -41,4 +41,7 @@ export const checkboxStyles = css`
 	input[type="checkbox"].d2l-input-checkbox:disabled {
 		opacity: 0.5;
 	}
+	:host(.d2l-dirty) input[type="checkbox"][aria-invalid="true"].d2l-input-checkbox {
+		border-color: var(--d2l-color-cinnabar);
+	}
 `;

--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -51,7 +51,7 @@ export const inputStyles = css`
 		outline-width: 0;
 		padding: var(--d2l-input-padding-focus, calc(0.4rem - 1px) calc(0.75rem - 1px));
 	}
-	[aria-invalid="true"].d2l-input,
+	:host(.d2l-dirty) [aria-invalid="true"].d2l-input,
 	.d2l-input:invalid {
 		border-color: var(--d2l-color-cinnabar);
 	}

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { FormElementMixin } from '../validation/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
@@ -7,7 +8,7 @@ import { inputStyles } from './input-styles.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
-class InputText extends RtlMixin(LitElement) {
+class InputText extends RtlMixin(FormElementMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -111,9 +112,19 @@ class InputText extends RtlMixin(LitElement) {
 
 		changedProperties.forEach((oldVal, prop) => {
 			if (prop === 'value') {
+				this.checkValidity();
 				this._prevValue = (oldVal === undefined) ? '' : oldVal;
 			}
 		});
+	}
+
+	async checkValidity() {
+		if (this.required && !this.value) {
+			this.setValidity({ valueMissing: true }, 'Oh no this value is required');
+		} else {
+			this.setValidity({ valid: true });
+		}
+		return this.validity.valid;
 	}
 
 	render() {
@@ -137,7 +148,7 @@ class InputText extends RtlMixin(LitElement) {
 		const input = html`
 			<div class="d2l-input-text-container">
 				<input aria-haspopup="${ifDefined(this.ariaHaspopup)}"
-					aria-invalid="${ifDefined(this.ariaInvalid)}"
+					aria-invalid="${this.invalid ? 'true' : 'false'}"
 					aria-label="${ifDefined(this._getAriaLabel())}"
 					aria-required="${ifDefined(ariaRequired)}"
 					autocomplete="${ifDefined(this.autocomplete)}"

--- a/components/validation/demo/mock-app.js
+++ b/components/validation/demo/mock-app.js
@@ -1,0 +1,57 @@
+import '../../inputs/input-checkbox.js';
+import '../../inputs/input-text.js';
+import '../validation-container.js';
+import '../../typography/typography.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { selectStyles } from '../../inputs/input-select-styles.js';
+
+class MockApp extends LitElement {
+
+	static get properties() {
+		return {
+			action: { type: String, reflect: true }
+		};
+	}
+
+	static get styles() {
+		return [selectStyles, css`
+			:host {
+				display: block;
+				margin: 100px 200px 100px 200px;
+			}
+			.d2l-dirty:invalid {
+				border-color: var(--d2l-color-cinnabar);
+			}
+		`];
+	}
+	render() {
+		return html`
+			<d2l-validation-container form='my-form'>
+				<form id='my-form' action="/action" @submit=${this.validate}>
+					<d2l-input-text label="First name" type="text" required id="fname" name="fname"></d2l-input-text><br>
+					<label for="mname">Optional middle name:</label><br>
+					<input type="text" id="mname" name="mname"><br><br>
+					<label for="lname">Last name:</label><br>
+					<input required type="text" id="lname" name="lname"><br><br>
+					<select class="d2l-input-select" required name="pets" id="pet-select">
+						<option value="">--Please choose an option--</option>
+						<option value="dog">Dog</option>
+						<option value="cat">Cat</option>
+						<option value="hamster">Hamster</option>
+						<option value="parrot">Parrot</option>
+						<option value="spider">Spider</option>
+						<option value="goldfish">Goldfish</option>
+					</select>
+					<d2l-input-checkbox checked name="chcke">Optional check item</d2l-input-checkbox>
+					<d2l-input-checkbox required name="chbox2">Unchecked item</d2l-input-checkbox>
+					<button type="submit">Submit</button>
+				</form>
+			</d2l-validation-container>
+		`;
+	}
+
+	getFormElement() {
+		return this.shadowRoot.querySelector('form');
+	}
+}
+customElements.define('d2l-mock-app', MockApp);

--- a/components/validation/demo/validation.html
+++ b/components/validation/demo/validation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<meta charset="UTF-8">
+	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script type="module">
+		import './mock-app.js';
+	</script>
+</head>
+
+<body>
+	<d2l-mock-app></d2l-mock-app>
+</body>
+
+</html>

--- a/components/validation/form-element-mixin.js
+++ b/components/validation/form-element-mixin.js
@@ -1,0 +1,126 @@
+
+export class FormElementValidityState {
+
+	constructor(flags) {
+		this.flags = {
+			...{
+				valueMissing: false,
+				typeMismatch: false,
+				patternMismatch: false,
+				tooLong: false,
+				tooShort: false,
+				rangeUnderflow: false,
+				rangeOverflow: false,
+				stepMismatch: false,
+				badInput: false,
+				customError: false,
+				valid: false
+			},
+			...flags
+		};
+	}
+
+	get valid() {
+		return this.flags.valid;
+	}
+
+	get valueMissing() {
+		return this.flags.valueMissing;
+	}
+
+	get patternMismatch() {
+		return this.flags.patternMismatch;
+	}
+
+	get tooLong() {
+		return this.flags.tooLong;
+	}
+
+	get tooShort() {
+		return this.flags.tooShort;
+	}
+
+	get stepMismatch() {
+		return this.flags.stepMismatch;
+	}
+
+	get badInput() {
+		return this.flags.badInput;
+	}
+
+	get customError() {
+		return this.flags.customError;
+	}
+}
+
+export const FormElementMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			invalid: { type: Boolean, reflect: true },
+			_validationMessage: { type: String },
+			_validity: { type: Object }
+		};
+	}
+
+	constructor() {
+		super();
+		this.__hiddenInput = document.createElement('input');
+		this.__hiddenInput.type = 'hidden';
+		this._validity = new FormElementValidityState({ valid: true });
+		this._validationMessage = '';
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		requestAnimationFrame(() => {
+			const parentNode = this.parentNode;
+			const parent = parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE ? this.getRootNode().host : parentNode;
+			parent.appendChild(this.__hiddenInput);
+		});
+		this.dispatchEvent(new CustomEvent(
+			'd2l-form-element-connected', { bubbles: true, composed: true }
+		));
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.__hiddenInput.parentNode.removeChild(this.__hiddenInput);
+		this.dispatchEvent(new CustomEvent(
+			'd2l-form-element-disconnected', { bubbles: true, composed: true }
+		));
+	}
+
+	async checkValidity() {
+		return this._validity && this._validity.valid;
+	}
+
+	setValidity(flags, message) {
+		if (message !== undefined) {
+			this._validationMessage = message;
+		}
+		this._validity = new FormElementValidityState(flags);
+		this.invalid = !this._validity.valid;
+	}
+
+	get validity() {
+		return this._validity;
+	}
+
+	get validationMessage() {
+		// TODO: Generate message based on validity state or use custom
+		return this._validationMessage;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((_, prop) => {
+			if (prop === 'value') {
+				this.__hiddenInput.value = this.value;
+			} else if (prop === 'name') {
+				this.__hiddenInput.name = this.name;
+			}
+		});
+	}
+};

--- a/components/validation/validation-container-mixin.js
+++ b/components/validation/validation-container-mixin.js
@@ -1,0 +1,115 @@
+export const ValidationContainerMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			_customElements: { type: Array },
+			_dirty: { type: Boolean },
+			_errors: { type: Array }
+		};
+	}
+
+	constructor() {
+		super();
+		this._onFormSubmit = this._onFormSubmit.bind(this);
+		this._onChangeEvent = this._onChangeEvent.bind(this);
+		this._onUnload = this._onUnload.bind(this);
+		this._customElements = [];
+
+		this.addEventListener('d2l-form-element-connected', this._onFormElementConnected);
+		this.addEventListener('d2l-form-element-disconnected', this._onFormElementDisconnected);
+		this.addEventListener('change', this._onChangeEvent);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('beforeunload', this._onUnload);
+
+		requestAnimationFrame(() => {
+			const form = this.getFormElement();
+			if (form) {
+				form.addEventListener('submit', this._onFormSubmit);
+				form.setAttribute('novalidate', '');
+			}
+		});
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.remove('beforeunload', this._onUnload);
+	}
+
+	async _onFormSubmit(e) {
+		e.preventDefault();
+
+		const errors = [];
+		const validations = [];
+		const customElements = [...this._customElements];
+		for (const ele of customElements) {
+			validations.push(ele.checkValidity());
+			ele.classList.add('d2l-dirty');
+		}
+		const validationsPromise = Promise.all(validations);
+		const form = this.getFormElement();
+		if (form) {
+			for (const ele of form.elements) {
+				if (!ele.validity.valid) {
+					errors.push({ ele, message: ele.validationMessage});
+				}
+				ele.classList.add('d2l-dirty');
+			}
+		}
+		const validationResults = await validationsPromise;
+		for (let i = 0; i < validationResults.length; i += 1) {
+			const valid = validationResults[i];
+			if (!valid) {
+				const ele = customElements[i];
+				errors.push({ ele, message: ele.validationMessage});
+			}
+		}
+		if (errors.length !== 0) {
+			// TODO: Order errors on DOM order or getBoundingClientRect top
+			this._errors = errors;
+			return;
+		}
+		if (form) {
+			this._dirty = false;
+			form.submit();
+		}
+	}
+
+	_onChangeEvent(e) {
+		const ele = e.composedPath()[0];
+		const form = this.getFormElement();
+		const nativeElements = (form && [...form.elements]) || [];
+		if (nativeElements.indexOf(ele) === -1 && this._customElements.indexOf(ele) === -1) {
+			return;
+		}
+		if (ele.validity.valid && this._errors) {
+			this._errors = this._errors.filter(error => error.ele !== ele);
+		}
+		ele.classList.add('d2l-dirty');
+		this._dirty = true;
+	}
+
+	_onFormElementConnected(e) {
+		const formElement = e.composedPath()[0];
+		this._customElements.push(formElement);
+	}
+
+	_onFormElementDisconnected(e) {
+		const formElement = e.composedPath()[0];
+		const index = this._customElements.indexOf(formElement);
+		if (index > -1) {
+			this._customElements.splice(index, 1);
+		}
+	}
+
+	_onUnload(e) {
+		if (this._dirty) {
+			e.returnValue = 'You have unsaved changes!';
+		}
+	}
+
+	// Override by users of the mixin
+	getFormElement() {}
+};

--- a/components/validation/validation-container.js
+++ b/components/validation/validation-container.js
@@ -1,0 +1,54 @@
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { ValidationContainerMixin } from './validation-container-mixin';
+
+class ValidationContainer extends ValidationContainerMixin(LitElement) {
+
+	static get properties() {
+		return { form: { type: String }};
+	}
+
+	static get styles() {
+		return css``;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+	}
+
+	render() {
+		return html`
+			${this._errors ? html`<ol>${this._errors.map(e => html`<li>${e.message}</li>`)}<ol>` : null }
+			<slot>
+			</slot>
+		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((_, prop) => {
+			if (prop === 'form') {
+				this._form = this._findForm();
+			}
+		});
+	}
+
+	_findForm() {
+		let form;
+		if (this.form) {
+			const ownerRoot = this.getRootNode();
+			const targetSelector = `#${this.form}`;
+			form = ownerRoot.querySelector(targetSelector);
+		}
+		return form;
+	}
+
+	getFormElement() {
+		return this._form;
+	}
+}
+customElements.define('d2l-validation-container', ValidationContainer);


### PR DESCRIPTION
# Spike
## Components / Mixins
### `FormElementMixin`
- This mixin is used to allow custom elements to associate themselves with the `ValidationContainerMixin`. It does the following:
    - Adds a `hidden` `input` to the parent DOM to allow it to be included in form submission
    - Allows users of it to set validity state and validation message to toggle between valid and error states.
    - Sends `d2l-form-element-connected` and `d2l-form-element-disconnected` events to allow the `ValidationContainerMixin` to track validity states for the custom element.

### `ValidationContainerMixin`
- This mixin is used to maintain the list of native and custom elements participating in validation. It does the following:
    - Marks inputs as dirty when they fire `change` events
    - Hijacks form submission to perform `async` validation of all elements and aggregate the error messages.
    - Warns about unsaved changes on page unload if there are any inputs marked as dirty.

### `d2l-validation-container`
- This component extends the `ValidationContainerMixin` and handles rendering the aggregated errors and associating with a `form` in the light DOM / parent shadow DOM. It does the following:
    - Finds an associated `form` element in the light DOM / parent shadow DOM to find native elements participating in validation.
    - Renders the aggregated errors.

## Form Validation
![form-validation](https://user-images.githubusercontent.com/11379933/80741506-bd865f80-8ae7-11ea-8734-57bceb36add5.gif)

## Unsaved Form
![form-unsaved](https://user-images.githubusercontent.com/11379933/80741501-bbbc9c00-8ae7-11ea-89aa-1f9d1b6f9342.gif)
