### PR TITLE
Fix tabs find and findIndex for IE11.

### DIFF
--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -378,12 +378,7 @@ class Tabs extends LocalizeStaticMixin(ArrowKeysMixin(RtlMixin(LitElement))) {
 			const handleTransitionEnd = (e) => {
 				if (e.propertyName !== 'max-width') return;
 				tab.removeEventListener('transitionend', handleTransitionEnd);
-				if (this._tabInfos.findIndex) {
-					this._tabInfos.splice(this._tabInfos.findIndex(info => info.id === tabInfo.id), 1);
-				} else {
-					// IE11
-					this._tabInfos.splice(this._getTabInfoIndex(this._tabInfos, tabInfo.id), 1);
-				}
+				this._tabInfos.splice(this._tabInfos.findIndex(info => info.id === tabInfo.id), 1);
 				this.requestUpdate();
 				resolve();
 			};
@@ -519,20 +514,12 @@ class Tabs extends LocalizeStaticMixin(ArrowKeysMixin(RtlMixin(LitElement))) {
 			.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.role === 'tabpanel');
 	}
 
-	// IE11 only
-	_getTabInfoIndex(infos, id) {
-		for (let i = 0; i < infos.length; i++) {
-			if (infos[i].id === id) return i;
-		}
-		return -1;
-	}
-
 	_getTabInfo(id) {
 		if (this._tabInfos.find) {
 			return this._tabInfos.find((t) => t.id === id);
 		} else {
 			// IE11
-			const index = this._getTabInfoIndex(this._tabInfos, id);
+			const index = this._tabInfos.findIndex((t) => t.id === id);
 			return index !== -1 ? this._tabInfos[index] : null;
 		}
 	}
@@ -568,15 +555,8 @@ class Tabs extends LocalizeStaticMixin(ArrowKeysMixin(RtlMixin(LitElement))) {
 			let state = '';
 			if (this._initialized && !reduceMotion && panels.length !== this._tabInfos.length) {
 				// if it's a new tab, update state to animate addition
-				if (this._tabInfos.findIndex) {
-					if (this._tabInfos.findIndex(info => info.id === panel.id) === -1) {
-						state = 'adding';
-					}
-				} else {
-					// IE11
-					if (this._getTabInfoIndex(this._tabInfos, panel.id) === -1) {
-						state = 'adding';
-					}
+				if (this._tabInfos.findIndex(info => info.id === panel.id) === -1) {
+					state = 'adding';
 				}
 			}
 			const tabInfo = {
@@ -592,19 +572,10 @@ class Tabs extends LocalizeStaticMixin(ArrowKeysMixin(RtlMixin(LitElement))) {
 		if (this._initialized && !reduceMotion && this._tabInfos.length !== newTabInfos.length) {
 			this._tabInfos.forEach((info, index) => {
 				// if a tab was removed, include old info to animate it away
-				if (newTabInfos.findIndex) {
-					if (newTabInfos.findIndex(newInfo => newInfo.id === info.id) === -1) {
-						info.state = 'removing';
-						newTabInfos.splice(index, 0, info);
-					}
-				} else {
-					// IE11
-					if (this._getTabInfoIndex(newTabInfos, info.id) === -1) {
-						info.state = 'removing';
-						newTabInfos.splice(index, 0, info);
-					}
+				if (newTabInfos.findIndex(newInfo => newInfo.id === info.id) === -1) {
+					info.state = 'removing';
+					newTabInfos.splice(index, 0, info);
 				}
-
 			});
 		}
 		this._tabInfos = newTabInfos;

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -18,6 +18,34 @@ const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 const scrollButtonWidth = 56;
 
+// remove once IE11 is no longer supported
+if (!Array.prototype.findIndex) {
+	Object.defineProperty(Array.prototype, 'findIndex', {
+		value: function(predicate) {
+
+			if (this === null) throw new TypeError('"this" is null or not defined');
+
+			const o = Object(this);
+			const len = o.length >>> 0;
+
+			if (typeof predicate !== 'function') throw new TypeError('predicate must be a function');
+
+			const thisArg = arguments[1];
+			let k = 0;
+
+			while (k < len) {
+				var kValue = o[k];
+				if (predicate.call(thisArg, kValue, k, o)) return k;
+				k++;
+			}
+
+			return -1;
+		},
+		configurable: true,
+		writable: true
+	});
+}
+
 class Tabs extends LocalizeStaticMixin(ArrowKeysMixin(RtlMixin(LitElement))) {
 
 	static get properties() {

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -34,7 +34,7 @@ if (!Array.prototype.findIndex) {
 			let k = 0;
 
 			while (k < len) {
-				var kValue = o[k];
+				const kValue = o[k];
 				if (predicate.call(thisArg, kValue, k, o)) return k;
 				k++;
 			}


### PR DESCRIPTION
Given this code will not be around for very long (famous last words), I opted to not include a full blown array polyfill, and I kept this code as close to the original as possible so that removing it is just a matter of deleting the conditional statements/else block, even though it results in a tiny bit of repeat.