### PR TITLE
input-text: fix width calculation when not initially displayed

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -258,9 +258,10 @@ class InputText extends RtlMixin(LitElement) {
 		if (!slotContent) return;
 		const id = e.target.parentNode.id;
 
-		this.requestUpdate(); // needed for legacy Edge
-		this.updateComplete.then(() => {
-			const slotWidth = parseFloat(getComputedStyle(slotContent).width) + parseFloat(getComputedStyle(slotContent).marginLeft) + parseFloat(getComputedStyle(slotContent).marginRight);
+		// requestUpdate needed for legacy Edge
+		this.requestUpdate().then(() => {
+			const style = getComputedStyle(slotContent);
+			const slotWidth = parseFloat(style.width) + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
 			if (id === 'first-slot') this._firstSlotWidth = slotWidth;
 			else this._lastSlotWidth = slotWidth;
 		});

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -253,11 +253,16 @@ class InputText extends RtlMixin(LitElement) {
 		this._hovered = false;
 	}
 
-	_onSlotChange() {
+	_onSlotChange(e) {
+		const slotContent = e.target.assignedNodes()[0];
+		if (!slotContent) return;
+		const id = e.target.parentNode.id;
+
 		this.requestUpdate(); // needed for legacy Edge
 		this.updateComplete.then(() => {
-			this._firstSlotWidth = this.shadowRoot.querySelector('#first-slot').offsetWidth;
-			this._lastSlotWidth = this.shadowRoot.querySelector('#last-slot').offsetWidth;
+			const slotWidth = parseFloat(getComputedStyle(slotContent).width) + parseFloat(getComputedStyle(slotContent).marginLeft) + parseFloat(getComputedStyle(slotContent).marginRight);
+			if (id === 'first-slot') this._firstSlotWidth = slotWidth;
+			else this._lastSlotWidth = slotWidth;
 		});
 	}
 


### PR DESCRIPTION
This surfaced as a bug where the placeholder text was overlapping with the icon in input-date.
The problem was that input-date was within a div that was initially not displayed, and `offsetWidth` does not seem to work to calculate the slot content width if not displayed. This solution gets the slot content (`d2l-icon`) and calculates overall width using width and margins.