### PR TITLE
Added down-arrow behaviour and improved focus for input-time

### DIFF
--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -168,12 +168,16 @@ class InputTime extends LitElement {
 						aria-controls="${this._dropdownId}"
 						aria-labelledby="${this._dropdownId}-label"
 						@change="${this._handleChange}"
+						@keydown="${this._handleKeydown}"
 						class="d2l-input"
 						?disabled="${this.disabled}"
-						@keypress="${this._handleKeypress}"
 						.value="${this._formattedValue}">
 				</div>
-				<d2l-dropdown-menu id="dropdown" no-padding-footer max-height="${ifDefined(this.maxHeight)}" min-width="195">
+				<d2l-dropdown-menu
+					@d2l-dropdown-close="${this.focus}"
+					no-padding-footer
+					max-height="${ifDefined(this.maxHeight)}"
+					min-width="195">
 					<d2l-menu
 						aria-describedby="${this._dropdownId}-timezone"
 						id="${this._dropdownId}"
@@ -259,6 +263,17 @@ class InputTime extends LitElement {
 			'change',
 			{bubbles: true, composed: false}
 		));
+	}
+
+	async _handleKeydown(e) {
+		console.log(e.keyCode);
+		const dropdown = this.shadowRoot.querySelector('d2l-dropdown-menu');
+		// open and focus dropdown on down arrow or enter
+		if (e.keyCode === 40 || e.keyCode === 13) {
+			dropdown.open(true);
+			this.shadowRoot.querySelector('d2l-menu').focus();
+			if (e.keyCode === 40) e.preventDefault();
+		}
 	}
 }
 customElements.define('d2l-input-time', InputTime);

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -266,7 +266,6 @@ class InputTime extends LitElement {
 	}
 
 	async _handleKeydown(e) {
-		console.log(e.keyCode);
 		const dropdown = this.shadowRoot.querySelector('d2l-dropdown-menu');
 		// open and focus dropdown on down arrow or enter
 		if (e.keyCode === 40 || e.keyCode === 13) {

--- a/components/inputs/test/input-time.visual-diff.js
+++ b/components/inputs/test/input-time.visual-diff.js
@@ -43,6 +43,7 @@ describe('d2l-input-time', () => {
 			await helper.open(page, `#${name}`);
 			const rect = await helper.getRect(page, `#${name}`);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			await helper.reset(page, `#${name}`); //Make sure the dropdown is closed before the next test
 		});
 	});
 


### PR DESCRIPTION
Updated `input-time` focus and keyboard behaviour to match `input-date`
- When input is focused pressing `down arrow` will open and focus the dropdown
- When dropdown is closed, focus moves back to the input instead of the next element on the page