### PR TITLE
Time Input: Down Arrow Focus Dropdown With Non-Matching Value

### DIFF
--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -271,7 +271,7 @@ class InputTime extends LitElement {
 		if (e.keyCode === 40 || e.keyCode === 13) {
 			dropdown.open(true);
 			this.shadowRoot.querySelector('d2l-menu').focus();
-			if (e.keyCode === 40) e.preventDefault();
+			e.preventDefault();
 		}
 	}
 }

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -152,7 +152,11 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 
 	_focusSelected() {
 		const selected = this.querySelector('[selected]');
-		if (selected) selected.focus();
+		if (selected) {
+			selected.focus();
+		} else {
+			this._focusFirst();
+		}
 	}
 
 	_focusPrevious(item) {


### PR DESCRIPTION
Fix for [DE39048](https://rally1.rallydev.com/#/detail/defect/390426252452?fdp=true): Time Input > Down Arrow with value not in list should shift focus to item in list.

Opening dropdown with down arrow now moves focus to the menu correctly when value in input doesn't exist in dropdown (ex: 5:07 isn't in 30-minute increment list). Focus then starts at 12:00AM.

Also a fix for `Enter` press inconsistency / not opening dropdown after first press in Chrome/LEdge