### PR TITLE
input-text: fix rtl in input-date

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -255,13 +255,15 @@ class InputText extends RtlMixin(LitElement) {
 
 	_onSlotChange(e) {
 		const slotContent = e.target.assignedNodes()[0];
-		if (!slotContent) return;
 		const id = e.target.parentNode.id;
 
 		// requestUpdate needed for legacy Edge
 		this.requestUpdate().then(() => {
-			const style = getComputedStyle(slotContent);
-			const slotWidth = parseFloat(style.width) + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+			let slotWidth = 0;
+			if (slotContent) {
+				const style = getComputedStyle(slotContent);
+				slotWidth = parseFloat(style.width) + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+			}
 			if (id === 'first-slot') this._firstSlotWidth = slotWidth;
 			else this._lastSlotWidth = slotWidth;
 		});


### PR DESCRIPTION
Bug: `input-date` with `rtl` had padding of 40 on both sides.

Solution notes: If there is no slot content, then the `_firstSlotWidth` or `_lastSlotWidth` should be reset to 0 (since dir was initially behaving as ltr then in a later render changing to rtl logic but these widths weren't changing to 0).