### PR TITLE
Focus the checkbox when label is clicked

### DIFF
--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -56,6 +56,8 @@ export const ListItemCheckboxMixin = superclass => class extends superclass {
 		event.preventDefault();
 		if (this.disabled) return;
 		this.setSelected(!this.selected);
+		const checkbox = this.shadowRoot.querySelector(`#${this._checkboxId}`);
+		if (checkbox) checkbox.focus();
 	}
 
 	_handleCheckboxChange(event) {


### PR DESCRIPTION
Fixes a bug that prevented the checkbox from being focused when the action is clicked.

Caught in this story: [US115380](https://rally1.rallydev.com/#/detail/userstory/382436537132?fdp=true)