### PR TITLE
[20.20.6] - DE39211 - Delay tab panel selected event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ jobs:
         - secure: hETcU1ZRPPz7ipofSeUj8fLkdM9JJda/Qg/oXU83FqZ/y/LZya6jMJjBfcHgEGsCLmVOPLw4lj2+pcyA6ZprJuujdS56elnbWPYUa4iwCbPN7ayfFQQjQx3jo3LYd7jFlCilgMT+Q+s+SnVfmV1Wa91N5WOpINpi7NzIarBRhWVeoiCQJmaabAX2pIn4G5VnBIE562SJULq+05Ucavl9zWrSFHDsMqMtcVcHG7TI6BExENJf76iutEk/YqWdaSvk5LY4xLrO29tThZBVJ7lX5wQGa3MkmlJkHZqxoONBWbGsKfrwh5I7QHExkj8PYYfvpYHQd+VugFrSkDTW3wHsoe/cmrzVe8aEbpHfUSPpO5HOkTdOqy92NVjyh4MOE7hJexmQsYRD+zjFzL4AS876hOdjrf/FS5ume843MvZseSZiCpK7uHTQWwVmitib/dNJdy8YyWoAyceWHpz46QOArrECVYOFhMKYuPrNy3gYY05kCLHCEW24pVN1ToRW2Gp6Z3Z3YblfWShjFHl3eU8riOPeCU9RaBV1k1UuP0C5POyFDPS12K8glPNIJ6dbp6GyI6KKW3iYuX/O3G4w/evO/AMy9nQPL4tUOPU5gQsPvr4Z77+bluP9VqEd3o1VBC6IBwLEcc8tzO+5EAeRbj9THU7zDmoIQH0oRHpIo+elg/8=
     - stage: deploy
       script: npm run build
-      after_success: frauci-update-version -d=skip && export TRAVIS_TAG=$(frauci-get-version)
       env:
         - REPO_NAME=core
         - OWNER_NAME=BrightspaceUI

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -33,11 +33,23 @@ export const TabPanelMixin = superclass => class extends superclass {
 		this.role = 'tabpanel';
 	}
 
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((oldVal, prop) => {
+			if (prop === 'selected') {
+				if (this.selected) {
+					requestAnimationFrame(() => {
+						this._dispatchSelected();
+					});
+				}
+			}
+		});
+	}
+
 	async attributeChangedCallback(name, oldval, newval) {
 		super.attributeChangedCallback(name, oldval, newval);
-		if (name === 'selected') {
-			if (this.selected) this._dispatchSelected();
-		} else if (name === 'text') {
+		if (name === 'text') {
 			this.setAttribute('aria-label', this.text);
 			this.dispatchEvent(new CustomEvent(
 				'd2l-tab-panel-text-changed', { bubbles: true, composed: true, detail: { text: this.text } }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-ui/core",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "description": "A collection of accessible, free, open-source web components for building Brightspace applications",
   "repository": "https://github.com/BrightspaceUI/core.git",
   "publishConfig": {


### PR DESCRIPTION
Withe the migration of tabs to Lit, my-courses is missing the first `d2l-tab-panel-selected` event which can get dispatched before the panels are connected or event listeners are setup.  It looks like the old behavior had this delay: https://github.com/BrightspaceUI/tabs/blob/master/d2l-tab-panel-behavior.js#L75