### PR TITLE
fixes #557: making key shortcuts to menu items case-insensitive

### DIFF
--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -256,7 +256,7 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 		e.stopPropagation();
 
 		const startsWith = function(item, value) {
-			if (item.text && item.text.length > 0 && item.text.substr(0, 1) === value) {
+			if (item.text && item.text.length > 0 && item.text.toLowerCase().substr(0, 1) === value) {
 				return true;
 			}
 			return false;
@@ -275,7 +275,7 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 		}.bind(this);
 
 		/* "charCode" is used instead of "key" due to Safari not supporting */
-		const searchChar = String.fromCharCode(e.charCode);
+		const searchChar = String.fromCharCode(e.charCode).toLowerCase();
 
 		let itemIndex = getNextOrFirstIndex(targetItemIndex);
 		while (itemIndex !== targetItemIndex) {

--- a/components/menu/test/menu.test.js
+++ b/components/menu/test/menu.test.js
@@ -57,7 +57,7 @@ describe('d2l-menu', () => {
 					<d2l-menu-item id="a1" text="a"></d2l-menu-item>
 					<d2l-menu-item id="b1" text="b" disabled></d2l-menu-item>
 					<d2l-menu-item id="a2" text="a"></d2l-menu-item>
-					<d2l-menu-item id="c1" text="c"></d2l-menu-item>
+					<d2l-menu-item id="c1" text="C"></d2l-menu-item>
 					<d2l-menu-item id="d1" text="d"></d2l-menu-item>
 				</d2l-menu>
 			`);
@@ -113,6 +113,14 @@ describe('d2l-menu', () => {
 			const eventObj = document.createEvent('Events');
 			eventObj.initEvent('keypress', true, true);
 			eventObj.charCode = 99;
+			elem.querySelector('#a1').dispatchEvent(eventObj);
+			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
+		});
+
+		it('sets focus to next item that starts with uppercase character pressed', () => {
+			const eventObj = document.createEvent('Events');
+			eventObj.initEvent('keypress', true, true);
+			eventObj.charCode = 67;
 			elem.querySelector('#a1').dispatchEvent(eventObj);
 			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
 		});


### PR DESCRIPTION
If we want to make these checks case insensitive, here's a way to do it.