### PR TITLE
Lit analyzer list fixes

### DIFF
--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -1,6 +1,6 @@
 import { css, html } from 'lit-element/lit-element.js';
-import { classMap} from 'lit-html/directives/class-map.js';
 import { checkboxStyles } from '../inputs/input-checkbox-styles.js';
+import { classMap} from 'lit-html/directives/class-map.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { nothing } from 'lit-html';
 

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -1,4 +1,5 @@
 import { css, html } from 'lit-element/lit-element.js';
+import { classMap} from 'lit-html/directives/class-map.js';
 import { checkboxStyles } from '../inputs/input-checkbox-styles.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { nothing } from 'lit-html';
@@ -21,7 +22,7 @@ export const ListItemCheckboxMixin = superclass => class extends superclass {
 				display: block;
 				cursor: pointer;
 			}
-			.d2l-checkbox-action[disabled] {
+			.d2l-checkbox-action.d2l-checkbox-action-disabled {
 				cursor: default;
 			}
 		` ];
@@ -77,10 +78,13 @@ export const ListItemCheckboxMixin = superclass => class extends superclass {
 	}
 
 	_renderCheckboxAction(inner) {
+		const labelClasses = {
+			'd2l-checkbox-action': true,
+			'd2l-checkbox-action-disabled': this.disabled
+		};
 		return this.selectable ? html`
 			<label @click="${this._handleCheckboxActionClick}"
-				class="d2l-checkbox-action"
-				?disabled="${this.disabled}"
+				class="${classMap(labelClasses)}"
 				for="${this._checkboxId}">
 				${inner}
 			</label>

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -60,15 +60,15 @@ class ListItem extends RtlMixin(LitElement) {
 				width: 100%;
 			}
 
-			:host(:first-child) .d2l-list-item-content[separators="between"] {
+			:host(:first-child) .d2l-list-item-content[data-separators="between"] {
 				border-top: 1px solid transparent;
 			}
 
-			:host(:last-child) .d2l-list-item-content[separators="between"] {
+			:host(:last-child) .d2l-list-item-content[data-separators="between"] {
 				border-bottom: 1px solid transparent;
 			}
 
-			.d2l-list-item-content[separators="none"] {
+			.d2l-list-item-content[data-separators="none"] {
 				border-top: 1px solid transparent;
 				border-bottom: 1px solid transparent;
 			}
@@ -79,7 +79,7 @@ class ListItem extends RtlMixin(LitElement) {
 				padding: 0.55rem 0;
 			}
 
-			.d2l-list-item-content[extend-separators] .d2l-list-item-content-flex {
+			.d2l-list-item-content.d2l-list-item-content-extend-separators .d2l-list-item-content-flex {
 				padding-left: 0.9rem;
 				padding-right: 0.9rem;
 			}
@@ -256,15 +256,18 @@ class ListItem extends RtlMixin(LitElement) {
 			'd2l-list-item-flex': label || link,
 			'd2l-visible-on-ancestor-target': true
 		};
+		const contentClasses = {
+			'd2l-list-item-content': true,
+			'd2l-list-item-content-extend-separators': this._extendSeparators
+		};
 
 		return html`
 			<div class="${classMap(classes)}" data-breakpoint="${this._breakpoint}">
 				${label}
 				${link}
 				<div id="${this._contentId}"
-					class="d2l-list-item-content"
-					?extend-separators="${this._extendSeparators}"
-					separators="${ifDefined(this._separators)}">
+					class="${classMap(contentClasses)}"
+					data-separators="${ifDefined(this._separators)}">
 					<div class="d2l-list-item-content-flex">
 						${beforeContent}
 						<div class="d2l-list-item-main"><slot></slot></div>

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -153,41 +153,41 @@ class ListItem extends RtlMixin(LitElement) {
 				outline: none;
 			}
 
-			.d2l-list-item-container[breakpoint="1"] ::slotted([slot="illustration"]),
-			.d2l-list-item-container[breakpoint="1"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
+			.d2l-list-item-container[data-breakpoint="1"] ::slotted([slot="illustration"]),
+			.d2l-list-item-container[data-breakpoint="1"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-right: 1rem;
 				max-height: 3.55rem;
 				max-width: 6rem;
 			}
 
-			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="1"] ::slotted([slot="illustration"]),
-			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="1"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
+			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="1"] ::slotted([slot="illustration"]),
+			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="1"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-left: 1rem;
 				margin-right: 0;
 			}
 
-			.d2l-list-item-container[breakpoint="2"] ::slotted([slot="illustration"]),
-			.d2l-list-item-container[breakpoint="2"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
+			.d2l-list-item-container[data-breakpoint="2"] ::slotted([slot="illustration"]),
+			.d2l-list-item-container[data-breakpoint="2"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-right: 1rem;
 				max-height: 5.1rem;
 				max-width: 9rem;
 			}
 
-			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="2"] ::slotted([slot="illustration"]),
-			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="2"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
+			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="2"] ::slotted([slot="illustration"]),
+			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="2"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-left: 1rem;
 				margin-right: 0;
 			}
 
-			.d2l-list-item-container[breakpoint="3"] ::slotted([slot="illustration"]),
-			.d2l-list-item-container[breakpoint="3"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
+			.d2l-list-item-container[data-breakpoint="3"] ::slotted([slot="illustration"]),
+			.d2l-list-item-container[data-breakpoint="3"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-right: 1rem;
 				max-height: 6rem;
 				max-width: 10.8rem;
 			}
 
-			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="3"] ::slotted([slot="illustration"]),
-			:host([dir="rtl"]) .d2l-list-item-container[breakpoint="3"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
+			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="3"] ::slotted([slot="illustration"]),
+			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="3"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
 				margin-left: 1rem;
 				margin-right: 0;
 			}
@@ -258,7 +258,7 @@ class ListItem extends RtlMixin(LitElement) {
 		};
 
 		return html`
-			<div class="${classMap(classes)}" breakpoint="${this._breakpoint}">
+			<div class="${classMap(classes)}" data-breakpoint="${this._breakpoint}">
 				${label}
 				${link}
 				<div id="${this._contentId}"


### PR DESCRIPTION
When in strict mode (which we want to enable), `lit-analyzer` doesn't like putting attributes on elements that aren't actually real. So this switches list over to use either a CSS class or a `data-*` attribute in the places where it was using custom attributes.