### PR TITLE
Fix class member sort order linting errors.

### DIFF
--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -82,19 +82,6 @@ class AlertToast extends LitElement {
 		this._state = states.CLOSED;
 	}
 
-	get _state() {
-		return this.__state;
-	}
-
-	set _state(val) {
-		const oldVal = this.__state;
-		if (oldVal !== val) {
-			this.__state = val;
-			this.requestUpdate('_state', oldVal);
-			this._stateChanged(val, oldVal);
-		}
-	}
-
 	get open() {
 		return this._open;
 	}
@@ -116,6 +103,19 @@ class AlertToast extends LitElement {
 				</d2l-alert>
 			</div>
 		`;
+	}
+
+	get _state() {
+		return this.__state;
+	}
+
+	set _state(val) {
+		const oldVal = this.__state;
+		if (oldVal !== val) {
+			this.__state = val;
+			this.requestUpdate('_state', oldVal);
+			this._stateChanged(val, oldVal);
+		}
 	}
 
 	_onCloseClicked(e) {

--- a/components/alert/alert.js
+++ b/components/alert/alert.js
@@ -124,6 +124,18 @@ class Alert extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 		this.type = 'default';
 	}
 
+	render() {
+		return html`
+			<div class="d2l-alert-highlight"></div>
+			<div class="d2l-alert-text">
+				<slot></slot>
+				${this.subtext ? html`<p class="d2l-body-compact d2l-alert-subtext">${this.subtext}</p>` : null}
+			</div>
+			${this.buttonText && this.buttonText.length > 0 ? html`<d2l-button-subtle class="d2l-alert-action" text=${this.buttonText} @click=${this._onButtonClick}></d2l-button-subtle>` : null}
+			${this.hasCloseButton ? html`<d2l-button-icon class="d2l-alert-action" icon="d2l-tier1:close-default" text="${this.localize('close')}" @click=${this.close}></d2l-button-icon>` : null}
+		`;
+	}
+
 	close() {
 		const event = new CustomEvent('d2l-alert-closed', { bubbles: true, composed: true, cancelable: true });
 		if (this.dispatchEvent(event)) {
@@ -137,17 +149,6 @@ class Alert extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 		));
 	}
 
-	render() {
-		return html`
-			<div class="d2l-alert-highlight"></div>
-			<div class="d2l-alert-text">
-				<slot></slot>
-				${this.subtext ? html`<p class="d2l-body-compact d2l-alert-subtext">${this.subtext}</p>` : null}
-			</div>
-			${this.buttonText && this.buttonText.length > 0 ? html`<d2l-button-subtle class="d2l-alert-action" text=${this.buttonText} @click=${this._onButtonClick}></d2l-button-subtle>` : null}
-			${this.hasCloseButton ? html`<d2l-button-icon class="d2l-alert-action" icon="d2l-tier1:close-default" text="${this.localize('close')}" @click=${this.close}></d2l-button-icon>` : null}
-		`;
-	}
 }
 
 customElements.define('d2l-alert', Alert);

--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -24,11 +24,6 @@ export const ButtonMixin = superclass => class extends superclass {
 		this.type = 'button';
 	}
 
-	focus() {
-		const button = this.shadowRoot.querySelector('button');
-		if (button) button.focus();
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 		this.addEventListener('click', this._handleClick, true);
@@ -37,6 +32,11 @@ export const ButtonMixin = superclass => class extends superclass {
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.removeEventListener('click', this._handleClick, true);
+	}
+
+	focus() {
+		const button = this.shadowRoot.querySelector('button');
+		if (button) button.focus();
 	}
 
 	_getType() {

--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -122,14 +122,24 @@ class FloatingButtons extends RtlMixin(LitElement) {
 		this._startObserver();
 	}
 
-	_startObserver() {
-		this._resizeObserver = this._resizeObserver || new ResizeObserver(entries => {
-			for (let i = 0; i < entries.length; i++) {
-				this._calcContainerPosition();
-			}
-		});
-		const htmlElem = document.documentElement;
-		this._resizeObserver.observe(htmlElem);
+	render() {
+		const containerStyle = {
+			marginLeft: this._containerMarginLeft,
+			marginRight: this._containerMarginRight
+		};
+
+		const innerContainerStyle = {
+			marginLeft: this._innerContainerLeft,
+			marginRight: this._innerContainerRight
+		};
+
+		return html`
+			<div class="d2l-floating-buttons-container" style=${styleMap(containerStyle)}>
+				<div class="d2l-floating-buttons-inner-container" style=${styleMap(innerContainerStyle)}>
+					<slot></slot>
+				</div>
+			</div>
+		`;
 	}
 
 	_calcContainerPosition() {
@@ -196,25 +206,16 @@ class FloatingButtons extends RtlMixin(LitElement) {
 		}
 	}
 
-	render() {
-		const containerStyle = {
-			marginLeft: this._containerMarginLeft,
-			marginRight: this._containerMarginRight
-		};
-
-		const innerContainerStyle = {
-			marginLeft: this._innerContainerLeft,
-			marginRight: this._innerContainerRight
-		};
-
-		return html`
-			<div class="d2l-floating-buttons-container" style=${styleMap(containerStyle)}>
-				<div class="d2l-floating-buttons-inner-container" style=${styleMap(innerContainerStyle)}>
-					<slot></slot>
-				</div>
-			</div>
-		`;
+	_startObserver() {
+		this._resizeObserver = this._resizeObserver || new ResizeObserver(entries => {
+			for (let i = 0; i < entries.length; i++) {
+				this._calcContainerPosition();
+			}
+		});
+		const htmlElem = document.documentElement;
+		this._resizeObserver.observe(htmlElem);
 	}
+
 }
 
 customElements.define('d2l-floating-buttons', FloatingButtons);

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -432,20 +432,6 @@ class Calendar extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 		});
 	}
 
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		changedProperties.forEach((oldVal, prop) => {
-			if (prop === '_shownMonth' && this._keyboardTriggeredMonthChange) {
-				this._focusDateAddFocus();
-			} else if (prop === 'selectedValue') {
-				if (this.selectedValue) this._focusDate = getDateFromISODate(this.selectedValue);
-				else if (this._today.getMonth() === this._shownMonth && this._today.getFullYear() === this._shownYear) this._focusDate = new Date(this._today);
-				else this._focusDate = new Date(this._shownYear, this._shownMonth, 1);
-			}
-		});
-	}
-
 	render() {
 		if (this._shownMonth === undefined || !this._shownYear) {
 			return html``;
@@ -539,6 +525,20 @@ class Calendar extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 				<slot></slot>
 			</div>
 		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((oldVal, prop) => {
+			if (prop === '_shownMonth' && this._keyboardTriggeredMonthChange) {
+				this._focusDateAddFocus();
+			} else if (prop === 'selectedValue') {
+				if (this.selectedValue) this._focusDate = getDateFromISODate(this.selectedValue);
+				else if (this._today.getMonth() === this._shownMonth && this._today.getFullYear() === this._shownYear) this._focusDate = new Date(this._today);
+				else this._focusDate = new Date(this._shownYear, this._shownMonth, 1);
+			}
+		});
 	}
 
 	focus() {

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -24,13 +24,6 @@ class CodeView extends LitElement {
 		this._dependenciesPromise = Promise.resolve();
 	}
 
-	render() {
-		return html`
-			<div class="d2l-code-view-src"><slot @slotchange="${this._handleSlotChange}"></slot></div>
-			<div language="${this.language}" class="d2l-code-view-code">${this._codeTemplate}</div>
-		`;
-	}
-
 	attributeChangedCallback(name, oldval, newval) {
 		if (name !== 'language' || oldval === newval) return;
 		const language = this._getLanguage(newval);
@@ -49,6 +42,13 @@ class CodeView extends LitElement {
 
 	firstUpdated() {
 		this._updateCode(this.shadowRoot.querySelector('slot'));
+	}
+
+	render() {
+		return html`
+			<div class="d2l-code-view-src"><slot @slotchange="${this._handleSlotChange}"></slot></div>
+			<div language="${this.language}" class="d2l-code-view-code">${this._codeTemplate}</div>
+		`;
 	}
 
 	get _codeTemplate() {

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -23,6 +23,10 @@ class DemoSnippet extends LitElement {
 		this._dirButton = this._dir === 'rtl' ? 'ltr' : 'rtl';
 	}
 
+	firstUpdated() {
+		this._updateCode(this.shadowRoot.querySelector('slot:not([name="_demo"])'));
+	}
+
 	render() {
 		return html`
 			<div class="d2l-demo-snippet-demo" dir="${this._dir}">
@@ -34,10 +38,6 @@ class DemoSnippet extends LitElement {
 			</div>
 			<d2l-code-view language="html" hide-language>${this._code}</d2l-code-view>
 		`;
-	}
-
-	firstUpdated() {
-		this._updateCode(this.shadowRoot.querySelector('slot:not([name="_demo"])'));
 	}
 
 	_formatCode(text) {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -133,16 +133,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		}
 	}
 
-	async _focusOpener() {
-		if (this._opener && this._opener.focus) {
-			// wait for inactive focus trap
-			requestAnimationFrame(() => {
-				this._opener.focus();
-				this._opener = null;
-			});
-		}
-	}
-
 	_focusFirst() {
 		const content = this.shadowRoot.querySelector('.d2l-dialog-content');
 		if (content) {
@@ -157,6 +147,16 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 	_focusInitial() {
 		this._focusFirst();
+	}
+
+	async _focusOpener() {
+		if (this._opener && this._opener.focus) {
+			// wait for inactive focus trap
+			requestAnimationFrame(() => {
+				this._opener.focus();
+				this._opener = null;
+			});
+		}
 	}
 
 	_getHeight() {
@@ -225,13 +225,13 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		));
 	}
 
-	_handleDialogOpen(e) {
-		this._nestedShowing = true;
+	_handleDialogClose(e) {
+		this._nestedShowing = false;
 		e.stopPropagation();
 	}
 
-	_handleDialogClose(e) {
-		this._nestedShowing = false;
+	_handleDialogOpen(e) {
+		this._nestedShowing = true;
 		e.stopPropagation();
 	}
 

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -34,17 +34,17 @@ class DropdownMenu extends DropdownContentMixin(LitElement) {
 		`;
 	}
 
-	_onMenuResize(e) {
-		this.__position(!this._initializingHeight, e.detail);
-		this._initializingHeight = false;
+	__getMenuElement() {
+		return this.shadowRoot.querySelector('.d2l-dropdown-content-slot')
+			.assignedNodes().filter(node => node.hasAttribute
+				&& (node.getAttribute('role') === 'menu' || node.getAttribute('role') === 'listbox'))[0];
+	}
 
-		const menu = this.__getMenuElement();
-		if (menu.getMenuType() === 'menu-radio') {
-			const selected = menu.querySelector('[selected]');
-			if (selected !== null) {
-				setTimeout(() => selected.scrollIntoView({ block: 'nearest'}), 0);
-			}
+	_onChange(e) {
+		if (e.target.getAttribute('role') !== 'menuitemradio') {
+			return;
 		}
+		this.close();
 	}
 
 	_onClose(e) {
@@ -56,6 +56,23 @@ class DropdownMenu extends DropdownContentMixin(LitElement) {
 		// reset to root view
 		const menu = this.__getMenuElement();
 		menu.show({ preventFocus: true });
+	}
+
+	_onFocus() {
+		this.__getMenuElement().focus();
+	}
+
+	_onMenuResize(e) {
+		this.__position(!this._initializingHeight, e.detail);
+		this._initializingHeight = false;
+
+		const menu = this.__getMenuElement();
+		if (menu.getMenuType() === 'menu-radio') {
+			const selected = menu.querySelector('[selected]');
+			if (selected !== null) {
+				setTimeout(() => selected.scrollIntoView({ block: 'nearest'}), 0);
+			}
+		}
 	}
 
 	_onOpen(e) {
@@ -74,28 +91,11 @@ class DropdownMenu extends DropdownContentMixin(LitElement) {
 		}
 	}
 
-	_onChange(e) {
-		if (e.target.getAttribute('role') !== 'menuitemradio') {
-			return;
-		}
-		this.close();
-	}
-
-	_onFocus() {
-		this.__getMenuElement().focus();
-	}
-
 	_onSelect(e) {
 		if (e.target.tagName !== 'D2L-MENU-ITEM') {
 			return;
 		}
 		this.close();
-	}
-
-	__getMenuElement() {
-		return this.shadowRoot.querySelector('.d2l-dropdown-content-slot')
-			.assignedNodes().filter(node => node.hasAttribute
-				&& (node.getAttribute('role') === 'menu' || node.getAttribute('role') === 'listbox'))[0];
 	}
 
 }

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -27,13 +27,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.__onMouseUp = this.__onMouseUp.bind(this);
 	}
 
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
-
-		this.addEventListener('d2l-dropdown-open', this.__onOpened);
-		this.addEventListener('d2l-dropdown-close', this.__onClosed);
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 
@@ -58,6 +51,13 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		}
 		opener.removeEventListener('keypress', this.__onKeyPress);
 		opener.removeEventListener('mouseup', this.__onMouseUp);
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+
+		this.addEventListener('d2l-dropdown-open', this.__onOpened);
+		this.addEventListener('d2l-dropdown-close', this.__onClosed);
 	}
 
 	focus() {
@@ -92,6 +92,15 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		return this.shadowRoot.querySelector('slot').assignedNodes().filter(node => node.hasAttribute && node.hasAttribute('dropdown-content'))[0];
 	}
 
+	__onClosed() {
+		const opener = this.getOpenerElement();
+		if (!opener) {
+			return;
+		}
+		opener.setAttribute('aria-expanded', 'false');
+		opener.removeAttribute('active');
+	}
+
 	__onKeyPress(e) {
 		if (e.keyCode !== 13) return;
 		if (this.noAutoOpen) return;
@@ -110,15 +119,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		}
 		opener.setAttribute('aria-expanded', 'true');
 		opener.setAttribute('active', 'true');
-	}
-
-	__onClosed() {
-		const opener = this.getOpenerElement();
-		if (!opener) {
-			return;
-		}
-		opener.setAttribute('aria-expanded', 'false');
-		opener.removeAttribute('active');
 	}
 
 };

--- a/components/dropdown/dropdown-tabs.js
+++ b/components/dropdown/dropdown-tabs.js
@@ -29,6 +29,12 @@ class DropdownTabs extends DropdownContentMixin(LitElement) {
 		`;
 	}
 
+	_getTabsElement() {
+		return this.shadowRoot.querySelector('.d2l-dropdown-content-container > slot')
+			.assignedNodes()
+			.filter(node => node.hasAttribute && node.tagName === 'D2L-TABS')[0];
+	}
+
 	_onMenuResize(e) {
 		const tabs = this._getTabsElement();
 		const tabListRect = tabs.getTabListRect();
@@ -48,12 +54,6 @@ class DropdownTabs extends DropdownContentMixin(LitElement) {
 
 	_onTabSelected() {
 		this.__position(false);
-	}
-
-	_getTabsElement() {
-		return this.shadowRoot.querySelector('.d2l-dropdown-content-container > slot')
-			.assignedNodes()
-			.filter(node => node.hasAttribute && node.tagName === 'D2L-TABS')[0];
 	}
 
 }

--- a/components/expand-collapse/expand-collapse-content.js
+++ b/components/expand-collapse/expand-collapse-content.js
@@ -69,14 +69,6 @@ class ExpandCollapseContent extends LitElement {
 		this._state = states.COLLAPSED;
 	}
 
-	updated(changedProperties) {
-		super.updated(changedProperties);
-		if (changedProperties.has('expanded')) {
-			this._expandedChanged(this.expanded, this._isFirstUpdate);
-			this._isFirstUpdate = false;
-		}
-	}
-
 	render() {
 		const styles = { height: this._height };
 		return html`
@@ -86,6 +78,14 @@ class ExpandCollapseContent extends LitElement {
 				</div>
 			</div>
 		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (changedProperties.has('expanded')) {
+			this._expandedChanged(this.expanded, this._isFirstUpdate);
+			this._isFirstUpdate = false;
+		}
 	}
 
 	async _expandedChanged(val, firstUpdate) {

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -38,10 +38,6 @@ class FocusTrap extends LitElement {
 		document.body.removeEventListener('focus', this._handleBodyFocus, true);
 	}
 
-	focus() {
-		this.shadowRoot.querySelector('.d2l-focus-trap-start').focus();
-	}
-
 	render() {
 		const tabindex = this.trap ? '0' : undefined;
 		return html`
@@ -49,6 +45,10 @@ class FocusTrap extends LitElement {
 			<slot></slot>
 			<span class="d2l-focus-trap-end" @focusin="${this._handleEndFocusIn}" tabindex="${ifDefined(tabindex)}"></span>
 		`;
+	}
+
+	focus() {
+		this.shadowRoot.querySelector('.d2l-focus-trap-start').focus();
 	}
 
 	_focusFirst() {

--- a/components/inputs/demo/input-radio-solo-test.js
+++ b/components/inputs/demo/input-radio-solo-test.js
@@ -15,11 +15,6 @@ class TestInputRadioSolo extends LitElement {
 		return radioStyles;
 	}
 
-	focus() {
-		const elem = this.shadowRoot.querySelector('input');
-		if (elem) elem.focus();
-	}
-
 	render() {
 		const invalid = this.invalid ? 'true' : 'false';
 		return html`
@@ -31,6 +26,11 @@ class TestInputRadioSolo extends LitElement {
 				?disabled="${this.disabled}"
 				type="radio">
 		`;
+	}
+
+	focus() {
+		const elem = this.shadowRoot.querySelector('input');
+		if (elem) elem.focus();
 	}
 
 }

--- a/components/inputs/demo/input-select-test.js
+++ b/components/inputs/demo/input-select-test.js
@@ -25,11 +25,6 @@ class TestInputSelect extends RtlMixin(LitElement) {
 		];
 	}
 
-	focus() {
-		const elem = this.shadowRoot.querySelector('select');
-		if (elem) elem.focus();
-	}
-
 	render() {
 		const invalid = this.invalid ? 'true' : 'false';
 		return html`
@@ -43,6 +38,11 @@ class TestInputSelect extends RtlMixin(LitElement) {
 				<option>Deinonychus</option>
 			</select>
 		`;
+	}
+
+	focus() {
+		const elem = this.shadowRoot.querySelector('select');
+		if (elem) elem.focus();
 	}
 
 }

--- a/components/inputs/demo/input-textarea-test.js
+++ b/components/inputs/demo/input-textarea-test.js
@@ -23,11 +23,6 @@ class TestInputTextarea extends LitElement {
 		];
 	}
 
-	focus() {
-		const elem = this.shadowRoot.querySelector('textarea');
-		if (elem) elem.focus();
-	}
-
 	render() {
 		const invalid = this.invalid ? 'true' : 'false';
 		return html`
@@ -37,6 +32,11 @@ class TestInputTextarea extends LitElement {
 				?disabled="${this.disabled}"
 				placeholder="${ifDefined(this.placeholder)}">${this.value}</textarea>
 		`;
+	}
+
+	focus() {
+		const elem = this.shadowRoot.querySelector('textarea');
+		if (elem) elem.focus();
 	}
 
 }

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -70,22 +70,6 @@ class InputDateTime extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 		}
 	}
 
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		changedProperties.forEach((oldVal, prop) => {
-			if (prop === 'value') {
-				try {
-					this._parsedDateTime = getLocalDateTimeFromUTCDateTime(this.value);
-				} catch (e) {
-					// set value to empty if invalid value
-					this.value = '';
-					this._parsedDateTime = '';
-				}
-			}
-		});
-	}
-
 	render() {
 		const timeHidden = !this._parsedDateTime;
 		return html`
@@ -110,9 +94,32 @@ class InputDateTime extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 		`;
 	}
 
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((oldVal, prop) => {
+			if (prop === 'value') {
+				try {
+					this._parsedDateTime = getLocalDateTimeFromUTCDateTime(this.value);
+				} catch (e) {
+					// set value to empty if invalid value
+					this.value = '';
+					this._parsedDateTime = '';
+				}
+			}
+		});
+	}
+
 	focus() {
 		const elem = this.shadowRoot.querySelector('d2l-input-date');
 		if (elem) elem.focus();
+	}
+
+	_dispatchChangeEvent() {
+		this.dispatchEvent(new CustomEvent(
+			'change',
+			{ bubbles: true, composed: false }
+		));
 	}
 
 	_handleDateChange(e) {
@@ -129,13 +136,6 @@ class InputDateTime extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 	_handleTimeChange(e) {
 		this.value = getUTCDateTimeFromLocalDateTime(this._parsedDateTime, e.target.value);
 		this._dispatchChangeEvent();
-	}
-
-	_dispatchChangeEvent() {
-		this.dispatchEvent(new CustomEvent(
-			'change',
-			{ bubbles: true, composed: false }
-		));
 	}
 
 }

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -244,10 +244,6 @@ class InputDate extends LocalizeStaticMixin(LitElement) {
 		`;
 	}
 
-	focus() {
-		if (this._textInput) this._textInput.focus();
-	}
-
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
@@ -258,24 +254,12 @@ class InputDate extends LocalizeStaticMixin(LitElement) {
 		});
 	}
 
+	focus() {
+		if (this._textInput) this._textInput.focus();
+	}
+
 	_handleBlur() {
 		this._setFormattedValue();
-	}
-
-	async _handleFocusTrapEnter() {
-		this._calendar.focus();
-	}
-
-	async _handleKeydown(e) {
-		// open dropdown on down arrow or enter and focus on calendar focus date
-		if (e.keyCode === 40 || e.keyCode === 13) {
-			this._dropdown.open();
-			await this._handleChange();
-			this._calendar.focus();
-			this._setFormattedValue();
-
-			if (e.keyCode === 40) e.preventDefault();
-		}
 	}
 
 	async _handleChange() {
@@ -328,8 +312,24 @@ class InputDate extends LocalizeStaticMixin(LitElement) {
 		this._dropdownOpened = true;
 	}
 
+	async _handleFocusTrapEnter() {
+		this._calendar.focus();
+	}
+
 	_handleInputTextFocus() {
 		this._formattedValue = this.value ? formatISODateInUserCalDescriptor(this.value) : '';
+	}
+
+	async _handleKeydown(e) {
+		// open dropdown on down arrow or enter and focus on calendar focus date
+		if (e.keyCode === 40 || e.keyCode === 13) {
+			this._dropdown.open();
+			await this._handleChange();
+			this._calendar.focus();
+			this._setFormattedValue();
+
+			if (e.keyCode === 40) e.preventDefault();
+		}
 	}
 
 	_handleMouseup() {

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -102,10 +102,19 @@ class InputSearch extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 
 	get lastSearchValue() { return this._lastSearchValue; }
 	set lastSearchValue(val) {}
-	_setLastSearchValue(val) {
-		const oldVal = this._lastSearchValue;
-		this._lastSearchValue = val;
-		this.requestUpdate('lastSearchValue', oldVal);
+
+	connectedCallback() {
+		super.connectedCallback();
+		if (this.value !== undefined && this.value !== null) {
+			this._setLastSearchValue(this.value);
+		}
+		this.addEventListener('blur', this._handleBlur);
+		this.addEventListener('focus', this._handleFocus);
+	}
+
+	disconnectedCallback() {
+		this.removeEventListener('blur', this._handleBlur);
+		this.removeEventListener('focus', this._handleFocus);
 	}
 
 	render() {
@@ -140,20 +149,6 @@ class InputSearch extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 						text="${this.localize('clear')}"></d2l-button-icon>`}
 			</div>
 		`;
-	}
-
-	connectedCallback() {
-		super.connectedCallback();
-		if (this.value !== undefined && this.value !== null) {
-			this._setLastSearchValue(this.value);
-		}
-		this.addEventListener('blur', this._handleBlur);
-		this.addEventListener('focus', this._handleFocus);
-	}
-
-	disconnectedCallback() {
-		this.removeEventListener('blur', this._handleBlur);
-		this.removeEventListener('focus', this._handleFocus);
 	}
 
 	focus() {
@@ -222,6 +217,12 @@ class InputSearch extends LocalizeStaticMixin(RtlMixin(LitElement)) {
 
 	_handleMouseLeave() {
 		this._hovered = false;
+	}
+
+	_setLastSearchValue(val) {
+		const oldVal = this._lastSearchValue;
+		this._lastSearchValue = val;
+		this.requestUpdate('lastSearchValue', oldVal);
 	}
 
 }

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -106,16 +106,6 @@ class InputText extends RtlMixin(LitElement) {
 		this.addEventListener('mouseout', this._handleMouseLeave);
 	}
 
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		changedProperties.forEach((oldVal, prop) => {
-			if (prop === 'value') {
-				this._prevValue = (oldVal === undefined) ? '' : oldVal;
-			}
-		});
-	}
-
 	render() {
 		const isFocusedOrHovered = !this.disabled && (this._focused || this._hovered);
 		const inputClasses = {
@@ -176,6 +166,16 @@ class InputText extends RtlMixin(LitElement) {
 		return input;
 	}
 
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((oldVal, prop) => {
+			if (prop === 'value') {
+				this._prevValue = (oldVal === undefined) ? '' : oldVal;
+			}
+		});
+	}
+
 	async focus() {
 		const elem = this.shadowRoot.querySelector('.d2l-input');
 		if (elem) {
@@ -233,16 +233,16 @@ class InputText extends RtlMixin(LitElement) {
 		return true;
 	}
 
+	_handleInvalid(e) {
+		e.preventDefault();
+	}
+
 	_handleKeypress(e) {
 		if (this.preventSubmit && e.keyCode === 13) {
 			e.preventDefault();
 			return false;
 		}
 		return true;
-	}
-
-	_handleInvalid(e) {
-		e.preventDefault();
 	}
 
 	_handleMouseEnter() {

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -154,6 +154,19 @@ class InputTime extends LitElement {
 		this.requestUpdate('value', oldValue);
 	}
 
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		if (this.label === null) {
+			console.warn('d2l-input-time component requires label text');
+		}
+
+		if (this.value === undefined) {
+			const time = getDefaultTime(this.defaultValue);
+			this._value = formatValue(time);
+			this._formattedValue = formatTime(time);
+		}
+	}
+
 	render() {
 		initIntervals(this.timeInterval);
 		const input = html`
@@ -205,19 +218,6 @@ class InputTime extends LitElement {
 			</d2l-dropdown>
 		`;
 		return input;
-	}
-
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
-		if (this.label === null) {
-			console.warn('d2l-input-time component requires label text');
-		}
-
-		if (this.value === undefined) {
-			const time = getDefaultTime(this.defaultValue);
-			this._value = formatValue(time);
-			this._formattedValue = formatTime(time);
-		}
 	}
 
 	focus() {

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -238,11 +238,6 @@ class ListItem extends RtlMixin(LitElement) {
 		ro.unobserve(this);
 	}
 
-	focus() {
-		const node = getFirstFocusableDescendant(this);
-		if (node) node.focus();
-	}
-
 	render() {
 
 		const label = this.selectable ? html`<label class="d2l-list-item-label" for="${this._checkBoxId}" aria-labelledby="${this._contentId}"></label>` : null;
@@ -276,6 +271,23 @@ class ListItem extends RtlMixin(LitElement) {
 
 	}
 
+	updated(changedProperties) {
+		if (changedProperties.has('key')) {
+			const oldValue = changedProperties.get('key');
+			if (typeof oldValue !== 'undefined') {
+				this.setSelected(undefined, true);
+			}
+		}
+		if (changedProperties.has('breakpoints')) {
+			this.resizedCallback(this.offsetWidth);
+		}
+	}
+
+	focus() {
+		const node = getFirstFocusableDescendant(this);
+		if (node) node.focus();
+	}
+
 	resizedCallback(width) {
 		const lastBreakpointIndexToCheck = 3;
 		this.breakpoints.some((breakpoint, index) => {
@@ -289,18 +301,6 @@ class ListItem extends RtlMixin(LitElement) {
 	setSelected(selected, suppressEvent) {
 		this.selected = selected;
 		if (!suppressEvent) this._dispatchSelected(selected);
-	}
-
-	updated(changedProperties) {
-		if (changedProperties.has('key')) {
-			const oldValue = changedProperties.get('key');
-			if (typeof oldValue !== 'undefined') {
-				this.setSelected(undefined, true);
-			}
-		}
-		if (changedProperties.has('breakpoints')) {
-			this.resizedCallback(this.offsetWidth);
-		}
 	}
 
 	_dispatchSelected(value) {

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -33,6 +33,14 @@ class List extends LitElement {
 		});
 	}
 
+	render() {
+		return html`
+			<div role="list" class="d2l-list-container">
+				<slot></slot>
+			</div>
+		`;
+	}
+
 	getSelectionInfo() {
 		const items = this._getItems();
 		const selectedItems = items.filter(item => item.selected);
@@ -47,14 +55,6 @@ class List extends LitElement {
 			keys: selectedItems.map(item => item.key),
 			state: state
 		};
-	}
-
-	render() {
-		return html`
-			<div role="list" class="d2l-list-container">
-				<slot></slot>
-			</div>
-		`;
 	}
 
 	toggleSelectAll() {

--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -51,6 +51,19 @@ export const MenuItemMixin = superclass => class extends superclass {
 		});
 	}
 
+	__action() {
+		if (this.disabled) {
+			return;
+		}
+
+		if (this.__children && this.__children.length > 0 && this.__children[0].hierarchicalView) {
+			// assumption: single, focusable child view
+			this.__children[0].show();
+		} else {
+			this.dispatchEvent(new CustomEvent('d2l-menu-item-select', { bubbles: true, composed: true }));
+		}
+	}
+
 	__initializeItem() {
 		const slot = this.shadowRoot.querySelector('slot');
 		if (!slot) {
@@ -69,20 +82,6 @@ export const MenuItemMixin = superclass => class extends superclass {
 				this.__children[0].label = this.text;
 				break;
 			}
-		}
-	}
-
-	__action() {
-
-		if (this.disabled) {
-			return;
-		}
-
-		if (this.__children && this.__children.length > 0 && this.__children[0].hierarchicalView) {
-			// assumption: single, focusable child view
-			this.__children[0].show();
-		} else {
-			this.dispatchEvent(new CustomEvent('d2l-menu-item-select', { bubbles: true, composed: true }));
 		}
 	}
 
@@ -105,10 +104,6 @@ export const MenuItemMixin = superclass => class extends superclass {
 		this.focus();
 	}
 
-	_onHidden() {
-		this.dispatchEvent(new CustomEvent('d2l-menu-item-visibility-change', { bubbles: true, composed: true }));
-	}
-
 	__onKeyDown(e) {
 		if (e.target !== this) {
 			return;
@@ -124,6 +119,10 @@ export const MenuItemMixin = superclass => class extends superclass {
 			this.__action();
 			return;
 		}
+	}
+
+	_onHidden() {
+		this.dispatchEvent(new CustomEvent('d2l-menu-item-visibility-change', { bubbles: true, composed: true }));
 	}
 
 };

--- a/components/menu/menu-item-radio-mixin.js
+++ b/components/menu/menu-item-radio-mixin.js
@@ -13,15 +13,16 @@ export const MenuItemRadioMixin = superclass => class extends MenuItemSelectable
 		this.addEventListener('d2l-menu-item-select', this._onSelectRadio);
 	}
 
-	_onSelectRadio(e) {
-		this.selected = true;
-		this.__onSelect(e);
-	}
-
 	_onChange(e) {
 		const items = this.parentNode.querySelectorAll('[role="menuitemradio"]');
 		for (let i = 0; i < items.length; i++) {
 			items[i].selected = items[i].value === e.detail.value;
 		}
 	}
+
+	_onSelectRadio(e) {
+		this.selected = true;
+		this.__onSelect(e);
+	}
+
 };

--- a/components/menu/menu-item-return.js
+++ b/components/menu/menu-item-return.js
@@ -97,6 +97,13 @@ class MenuItemReturn extends RtlMixin(LocalizeStaticMixin(MenuItemMixin(LitEleme
 		this.setAttribute('aria-label', this.localize('return'));
 	}
 
+	render() {
+		return html`
+			<d2l-icon icon="tier1:chevron-left"></d2l-icon>
+			<span aria-hidden="true">${this.text}</span>
+		`;
+	}
+
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
@@ -107,12 +114,6 @@ class MenuItemReturn extends RtlMixin(LocalizeStaticMixin(MenuItemMixin(LitEleme
 		});
 	}
 
-	render() {
-		return html`
-			<d2l-icon icon="tier1:chevron-left"></d2l-icon>
-			<span aria-hidden="true">${this.text}</span>
-		`;
-	}
 }
 
 customElements.define('d2l-menu-item-return', MenuItemReturn);

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -76,6 +76,29 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 		this.setAttribute('role', this.role);
 	}
 
+	render() {
+		return html`
+			<div class="d2l-menu-items d2l-hierarchical-view-content">
+				<slot></slot>
+			</div>
+		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((oldValue, propName) => {
+			if (propName === 'label') this._labelChanged();
+
+			if (propName === 'childView' && this.childView) {
+				const items = this.shadowRoot.querySelector('.d2l-menu-items');
+				items.insertBefore(this._createReturnItem(), items.childNodes[0]);
+
+				this._onMenuItemsChanged();
+			}
+		});
+	}
+
 	focus() {
 		if (this.getMenuType() === 'menu-radio') {
 			this._focusSelected();
@@ -100,29 +123,6 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 			default:
 				return 'menu';
 		}
-	}
-
-	render() {
-		return html`
-			<div class="d2l-menu-items d2l-hierarchical-view-content">
-				<slot></slot>
-			</div>
-		`;
-	}
-
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		changedProperties.forEach((oldValue, propName) => {
-			if (propName === 'label') this._labelChanged();
-
-			if (propName === 'childView' && this.childView) {
-				const items = this.shadowRoot.querySelector('.d2l-menu-items');
-				items.insertBefore(this._createReturnItem(), items.childNodes[0]);
-
-				this._onMenuItemsChanged();
-			}
-		});
 	}
 
 	_createReturnItem() {
@@ -150,6 +150,11 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 		item ? item.focus() : this._focusFirst();
 	}
 
+	_focusPrevious(item) {
+		item = this._tryGetPreviousFocusable(item);
+		item ? item.focus() : this._focusLast();
+	}
+
 	_focusSelected() {
 		const selected = this.querySelector('[selected]');
 		if (selected) {
@@ -157,11 +162,6 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 		} else {
 			this._focusFirst();
 		}
-	}
-
-	_focusPrevious(item) {
-		item = this._tryGetPreviousFocusable(item);
-		item ? item.focus() : this._focusLast();
 	}
 
 	_getFirstVisibleItem() {
@@ -182,6 +182,10 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 		return null;
 	}
 
+	_getMenuItemReturn() {
+		return this.shadowRoot.querySelector('d2l-menu-item-return');
+	}
+
 	_getMenuItems() {
 		const slot = this.shadowRoot.querySelector('slot');
 		if (!slot) return;
@@ -195,10 +199,6 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 			const role = item.getAttribute('role');
 			return (role === 'menuitem' || role === 'menuitemcheckbox' || role === 'menuitemradio' || item.tagName === 'D2L-MENU-ITEM-RETURN');
 		});
-	}
-
-	_getMenuItemReturn() {
-		return this.shadowRoot.querySelector('d2l-menu-item-return');
 	}
 
 	_isFocusable(item) {
@@ -317,25 +317,6 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 		this.active = this.isActive();
 	}
 
-	_tryGetPreviousFocusable(item) {
-		const focusableItems = this._items.filter(this._isFocusable, this);
-		if (!focusableItems || focusableItems.length === 0) {
-			return;
-		}
-
-		if (!item) {
-			return focusableItems[focusableItems.length - 1];
-		}
-
-		const itemIndex = focusableItems.indexOf(item);
-		if (itemIndex === 0) {
-			return;
-		}
-
-		return focusableItems[itemIndex - 1];
-
-	}
-
 	_tryGetNextFocusable(item) {
 		const focusableItems = this._items.filter(this._isFocusable, this);
 		if (!focusableItems || focusableItems.length === 0) {
@@ -352,6 +333,25 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 		}
 
 		return focusableItems[itemIndex + 1];
+
+	}
+
+	_tryGetPreviousFocusable(item) {
+		const focusableItems = this._items.filter(this._isFocusable, this);
+		if (!focusableItems || focusableItems.length === 0) {
+			return;
+		}
+
+		if (!item) {
+			return focusableItems[focusableItems.length - 1];
+		}
+
+		const itemIndex = focusableItems.indexOf(item);
+		if (itemIndex === 0) {
+			return;
+		}
+
+		return focusableItems[itemIndex - 1];
 
 	}
 

--- a/components/meter/meter-mixin.js
+++ b/components/meter/meter-mixin.js
@@ -37,6 +37,11 @@ export const MeterMixin = superclass => class extends LocalizeStaticMixin(superc
 		this.value = 0;
 	}
 
+	_ariaLabel(primary, secondary) {
+		const mainLabel = this.localize('commaSeperatedAria', 'term1', primary, 'term2', this.localize('progressIndicator'));
+		return secondary ? this.localize('commaSeperatedAria', 'term1', secondary, 'term2', mainLabel) : mainLabel;
+	}
+
 	_primary(value, max, dir) {
 		const percentage = max > 0 ? value / max : 0;
 
@@ -59,8 +64,4 @@ export const MeterMixin = superclass => class extends LocalizeStaticMixin(superc
 		return context;
 	}
 
-	_ariaLabel(primary, secondary) {
-		const mainLabel = this.localize('commaSeperatedAria', 'term1', primary, 'term2', this.localize('progressIndicator'));
-		return secondary ? this.localize('commaSeperatedAria', 'term1', secondary, 'term2', mainLabel) : mainLabel;
-	}
 };

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -33,6 +33,21 @@ export const TabPanelMixin = superclass => class extends superclass {
 		this.role = 'tabpanel';
 	}
 
+	async attributeChangedCallback(name, oldval, newval) {
+		super.attributeChangedCallback(name, oldval, newval);
+		if (name === 'text') {
+			this.setAttribute('aria-label', this.text);
+			this.dispatchEvent(new CustomEvent(
+				'd2l-tab-panel-text-changed', { bubbles: true, composed: true, detail: { text: this.text } }
+			));
+		}
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		if (this.id.length === 0) this.id = getUniqueId();
+	}
+
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
@@ -47,21 +62,6 @@ export const TabPanelMixin = superclass => class extends superclass {
 				}
 			}
 		});
-	}
-
-	async attributeChangedCallback(name, oldval, newval) {
-		super.attributeChangedCallback(name, oldval, newval);
-		if (name === 'text') {
-			this.setAttribute('aria-label', this.text);
-			this.dispatchEvent(new CustomEvent(
-				'd2l-tab-panel-text-changed', { bubbles: true, composed: true, detail: { text: this.text } }
-			));
-		}
-	}
-
-	connectedCallback() {
-		super.connectedCallback();
-		if (this.id.length === 0) this.id = getUniqueId();
 	}
 
 };

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -350,12 +350,6 @@ class Tooltip extends RtlMixin(LitElement) {
 		this._dismissibleId = null;
 	}
 
-	hide() {
-		this._isHovering = false;
-		this._isFocusing = false;
-		this._updateShowing();
-	}
-
 	render() {
 		const tooltipPositionStyle = {
 			maxWidth: this._maxWidth ? `${this._maxWidth}px` : null
@@ -384,10 +378,6 @@ class Tooltip extends RtlMixin(LitElement) {
 		;
 	}
 
-	show() {
-		this.showing = true;
-	}
-
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
@@ -398,6 +388,16 @@ class Tooltip extends RtlMixin(LitElement) {
 				this._updateShowing();
 			}
 		});
+	}
+
+	hide() {
+		this._isHovering = false;
+		this._isFocusing = false;
+		this._updateShowing();
+	}
+
+	show() {
+		this.showing = true;
 	}
 
 	async updatePosition() {

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -12,11 +12,11 @@ import {
 
 const testElemTag = defineCE(
 	class extends LitElement {
-		getContainer() {
-			return this.shadowRoot.querySelector('#container');
-		}
 		render() {
 			return html`<div id="container"><slot id="slot1"></slot></div>`;
+		}
+		getContainer() {
+			return this.shadowRoot.querySelector('#container');
 		}
 	},
 );

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -12,15 +12,6 @@ import { LitElement } from 'lit-element/lit-element.js';
 
 const testElemTag = defineCE(
 	class extends LitElement {
-		getContent() {
-			return this.shadowRoot.querySelector('#content');
-		}
-		getShadow1() {
-			return this.shadowRoot.querySelector('#shadow1');
-		}
-		getShadow2() {
-			return this.shadowRoot.querySelector('#shadow2');
-		}
 		render() {
 			return html`
 				<div>
@@ -29,6 +20,15 @@ const testElemTag = defineCE(
 					<div><a id="shadow2" href="javascript:void(0);"></a></div>
 				</div>
 			`;
+		}
+		getContent() {
+			return this.shadowRoot.querySelector('#content');
+		}
+		getShadow1() {
+			return this.shadowRoot.querySelector('#shadow1');
+		}
+		getShadow2() {
+			return this.shadowRoot.querySelector('#shadow2');
 		}
 	},
 );

--- a/mixins/arrow-keys-mixin.js
+++ b/mixins/arrow-keys-mixin.js
@@ -34,34 +34,6 @@ export const ArrowKeysMixin = superclass => class extends superclass {
 		return [...this.shadowRoot.querySelectorAll('.d2l-arrowkeys-focusable')];
 	}
 
-	_handleArrowKeys(e) {
-		const target = e.target;
-		if (this.arrowKeysDirection.indexOf('left') >= 0 && e.keyCode === keyCodes.LEFT) {
-			if (getComputedStyle(this).direction === 'rtl') {
-				this._focusNext(target);
-			} else {
-				this._focusPrevious(target);
-			}
-		} else if (this.arrowKeysDirection.indexOf('right') >= 0 && e.keyCode === keyCodes.RIGHT) {
-			if (getComputedStyle(this).direction === 'rtl') {
-				this._focusPrevious(target);
-			} else {
-				this._focusNext(target);
-			}
-		} else if (this.arrowKeysDirection.indexOf('up') >= 0 && e.keyCode === keyCodes.UP) {
-			this._focusPrevious(target);
-		} else if (this.arrowKeysDirection.indexOf('down') >= 0 && e.keyCode === keyCodes.DOWN) {
-			this._focusNext(target);
-		} else if (e.keyCode === keyCodes.HOME) {
-			this._focusFirst();
-		} else if (e.keyCode === keyCodes.END) {
-			this._focusLast();
-		} else {
-			return;
-		}
-		e.preventDefault();
-	}
-
 	async _focus(elem) {
 		if (elem) {
 			if (this.arrowKeysOnBeforeFocus) await this.arrowKeysOnBeforeFocus(elem);
@@ -91,6 +63,34 @@ export const ArrowKeysMixin = superclass => class extends superclass {
 		return this._focus(previous);
 	}
 
+	_handleArrowKeys(e) {
+		const target = e.target;
+		if (this.arrowKeysDirection.indexOf('left') >= 0 && e.keyCode === keyCodes.LEFT) {
+			if (getComputedStyle(this).direction === 'rtl') {
+				this._focusNext(target);
+			} else {
+				this._focusPrevious(target);
+			}
+		} else if (this.arrowKeysDirection.indexOf('right') >= 0 && e.keyCode === keyCodes.RIGHT) {
+			if (getComputedStyle(this).direction === 'rtl') {
+				this._focusPrevious(target);
+			} else {
+				this._focusNext(target);
+			}
+		} else if (this.arrowKeysDirection.indexOf('up') >= 0 && e.keyCode === keyCodes.UP) {
+			this._focusPrevious(target);
+		} else if (this.arrowKeysDirection.indexOf('down') >= 0 && e.keyCode === keyCodes.DOWN) {
+			this._focusNext(target);
+		} else if (e.keyCode === keyCodes.HOME) {
+			this._focusFirst();
+		} else if (e.keyCode === keyCodes.END) {
+			this._focusLast();
+		} else {
+			return;
+		}
+		e.preventDefault();
+	}
+
 	_tryGetNextFocusable(elems, elem) {
 		if (!elems || elems.length === 0) return;
 
@@ -112,4 +112,5 @@ export const ArrowKeysMixin = superclass => class extends superclass {
 		}
 		return elems[index - 1];
 	}
+
 };

--- a/mixins/async-container/test/async-item.js
+++ b/mixins/async-container/test/async-item.js
@@ -31,10 +31,6 @@ class AsyncItem extends LitElement {
 		this.key = null;
 	}
 
-	reject() {
-		setTimeout(() => this._reject('error'), 0);
-	}
-
 	render() {
 		return html`${runAsync(this.key, (key) => this._getContent(key), {
 			initial: () => html`<div>init</div>`,
@@ -42,6 +38,10 @@ class AsyncItem extends LitElement {
 			success: (content) => content,
 			failure: () => html`<div>failure</div>`
 		})}`;
+	}
+
+	reject() {
+		setTimeout(() => this._reject('error'), 0);
 	}
 
 	resolve() {

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -41,16 +41,6 @@ export const LocalizeMixin = superclass => class extends superclass {
 
 	}
 
-	async _getUpdateComplete() {
-		await super._getUpdateComplete();
-		const hasResources = this._hasResources();
-		const resourcesLoaded = (this.__language !== undefined && this.__resources !== undefined);
-		if (!hasResources || resourcesLoaded) {
-			return;
-		}
-		await this.__resourcesLoadedPromise;
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 		this.__documentLocaleSettings.addChangeListener(this.__languageChangeCallback);
@@ -151,6 +141,16 @@ export const LocalizeMixin = superclass => class extends superclass {
 		langs.add('en');
 
 		return Array.from(langs);
+	}
+
+	async _getUpdateComplete() {
+		await super._getUpdateComplete();
+		const hasResources = this._hasResources();
+		const resourcesLoaded = (this.__language !== undefined && this.__resources !== undefined);
+		if (!hasResources || resourcesLoaded) {
+			return;
+		}
+		await this.__resourcesLoadedPromise;
 	}
 
 	_hasResources() {

--- a/mixins/test/localize-mixin.test.js
+++ b/mixins/test/localize-mixin.test.js
@@ -36,16 +36,6 @@ const asyncTag = defineCE(
 				}
 			});
 		}
-		updated(changedProperties) {
-			super.updated(changedProperties);
-			this.dispatchEvent(new CustomEvent('d2l-test-localize-updated', {
-				bubbles: false,
-				composed: false,
-				detail: {
-					props: changedProperties
-				}
-			}));
-		}
 		render() {
 			requestAnimationFrame(
 				() => this.dispatchEvent(new CustomEvent('d2l-test-localize-render', {
@@ -56,6 +46,16 @@ const asyncTag = defineCE(
 			return html`
 				<p>${this.localize('hello', {name: this.name})}</p>
 			`;
+		}
+		updated(changedProperties) {
+			super.updated(changedProperties);
+			this.dispatchEvent(new CustomEvent('d2l-test-localize-updated', {
+				bubbles: false,
+				composed: false,
+				detail: {
+					props: changedProperties
+				}
+			}));
 		}
 	}
 );

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "deepmerge": "^4.2.2",
     "es-dev-server": "^1",
     "eslint": "^7",
-    "eslint-config-brightspace": "^0.7.0",
+    "eslint-config-brightspace": "^0.8.0",
     "eslint-plugin-html": "^6",
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",


### PR DESCRIPTION
Fixes sort order of class members that didn't get detected as a result of incorrectly specified groups for private members.  All changes are just reordering the members.

Corresponding change to: [eslint-config-brightspace](https://github.com/Brightspace/eslint-config-brightspace/pull/33/files).  This PR will fail linting until the config PR is merged and released.

Not big on the double underscores in a few places.  We also have some inconsistent use of `_on` vs `_handle` in the same files, but didn't want to introduce unnecessary risk given how many files this touches.

Let me know if you have any second thoughts about the order.