### PR TITLE
Lit analyzer dialogs

### DIFF
--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -2,7 +2,7 @@
 
 ## d2l-dialog
 
-The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary content, and a `footer` slot for workflow buttons. Apply the `dialog-action` attribute to workflow buttons to automatically close the dialog with the action value.
+The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary content, and a `footer` slot for workflow buttons. Apply the `data-dialog-action` attribute to workflow buttons to automatically close the dialog with the action value.
 
 ![Dialog](./screenshots/dialog.png?raw=true)
 
@@ -15,8 +15,8 @@ The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary 
 
 <d2l-dialog title-text="Dialog Title">
   <div>Some dialog content</div>
-  <d2l-button slot="footer" primary dialog-action="done">Done</d2l-button>
-  <d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+  <d2l-button slot="footer" primary data-dialog-action="done">Done</d2l-button>
+  <d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
 </d2l-dialog>
 ```
 Open the dialog declaratively using a boolean attribute `opened`:
@@ -56,7 +56,7 @@ document.querySelector('d2l-dialog').addEventListener('d2l-dialog-close', (e) =>
 });
 ```
 
-*Note:* The user may close the dialog in a few different ways: clicking the dialog workflow buttons (marked up with `dialog-action`), by clicking the `[x]` button in the top-right corner, or by pressing the `escape` key. It is possible to listen for click events directly on the workflow buttons, however to be notified in any of these scenarios, it is best to either wait for the `open` method's promise, or listen for the `d2l-dialog-close` event:
+*Note:* The user may close the dialog in a few different ways: clicking the dialog workflow buttons (marked up with `data-dialog-action`), by clicking the `[x]` button in the top-right corner, or by pressing the `escape` key. It is possible to listen for click events directly on the workflow buttons, however to be notified in any of these scenarios, it is best to either wait for the `open` method's promise, or listen for the `d2l-dialog-close` event:
 
 ```html
 <d2l-dialog @d2l-dialog-close="${(e)=> console.log('dialog action:', e.detail.action)}">
@@ -81,7 +81,7 @@ document.querySelector('d2l-dialog').addEventListener('d2l-dialog-close', (e) =>
 
 ## d2l-dialog-confirm
 
-The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting the user. It provides properties for specifying the required `text` and optional `title-text`, and a `footer` slot for workflow buttons. Apply the `dialog-action` attribute to workflow buttons to automatically close the confirm dialog with the action value.
+The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting the user. It provides properties for specifying the required `text` and optional `title-text`, and a `footer` slot for workflow buttons. Apply the `data-dialog-action` attribute to workflow buttons to automatically close the confirm dialog with the action value.
 
 ![Confirmation Dialog](./screenshots/dialog-confirm.png?raw=true)
 
@@ -93,8 +93,8 @@ The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting t
 <d2l-button id="open">Show Confirm</d2l-button>
 
 <d2l-dialog-confirm title-text="Confirm Title" text="Are you sure?">
-  <d2l-button slot="footer" primary dialog-action="yes">Yes</d2l-button>
-  <d2l-button slot="footer" dialog-action>No</d2l-button>
+  <d2l-button slot="footer" primary data-dialog-action="yes">Yes</d2l-button>
+  <d2l-button slot="footer" data-dialog-action>No</d2l-button>
 </d2l-dialog-confirm>
 ```
 

--- a/components/dialog/demo/dialog-async.html
+++ b/components/dialog/demo/dialog-async.html
@@ -24,8 +24,8 @@
 					<d2l-button id="open">Show Dialog</d2l-button>
 					<d2l-dialog id="dialog" title-text="Dialog Title" async>
 						<d2l-dialog-demo-async-content></d2l-dialog-demo-async-content>
-						<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
-						<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+						<d2l-button slot="footer" primary data-dialog-action="ok">Click Me!</d2l-button>
+						<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
 					</d2l-dialog>
 					<script>
 						document.querySelector('#open').addEventListener('click', () => {

--- a/components/dialog/demo/dialog-container.js
+++ b/components/dialog/demo/dialog-container.js
@@ -20,8 +20,8 @@ class DialogContainer extends LitElement {
 			<d2l-button @click="${this._open}">Show Dialog</d2l-button>
 			<d2l-dialog title-text="Dialog Title" ?opened="${this.opened}" @d2l-dialog-close="${this._handleClose}">
 				<div>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker.</div>
-				<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
-				<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+				<d2l-button slot="footer" primary data-dialog-action="ok">Click Me!</d2l-button>
+				<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
 			</d2l-dialog>
 		`;
 	}

--- a/components/dialog/demo/dialog-nested.html
+++ b/components/dialog/demo/dialog-nested.html
@@ -43,13 +43,13 @@
 									Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.
 									Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.
 								</div>
-								<d2l-button slot="footer" primary dialog-action="child ok">Child</d2l-button>
-								<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+								<d2l-button slot="footer" primary data-dialog-action="child ok">Child</d2l-button>
+								<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
 							</d2l-dialog>
 
 						</div>
-						<d2l-button slot="footer" primary dialog-action="ok">Parent</d2l-button>
-						<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+						<d2l-button slot="footer" primary data-dialog-action="ok">Parent</d2l-button>
+						<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
 					</d2l-dialog>
 
 					<script>

--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -36,8 +36,8 @@
 							<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
 							<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
 						</div>
-						<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
-						<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+						<d2l-button slot="footer" primary data-dialog-action="ok">Click Me!</d2l-button>
+						<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
 					</d2l-dialog>
 					<script>
 						document.querySelector('#open').addEventListener('click', () => {
@@ -64,8 +64,8 @@
 							<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
 							<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
 						</div>
-						<d2l-button slot="footer" primary dialog-action="ok">Click Me!</d2l-button>
-						<d2l-button slot="footer" dialog-action>Cancel</d2l-button>
+						<d2l-button slot="footer" primary data-dialog-action="ok">Click Me!</d2l-button>
+						<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
 					</d2l-dialog>
 					<script>
 						document.querySelector('#openPromise').addEventListener('click', async() => {
@@ -90,8 +90,8 @@
 				<template>
 					<d2l-button id="openConfirm">Show Confirm</d2l-button>
 					<d2l-dialog-confirm id="confirm" title-text="Confirm Title" text="Are you sure you want more cookies?">
-						<d2l-button slot="footer" primary dialog-action="ok">Yes</d2l-button>
-						<d2l-button slot="footer" dialog-action>No</d2l-button>
+						<d2l-button slot="footer" primary data-dialog-action="ok">Yes</d2l-button>
+						<d2l-button slot="footer" data-dialog-action>No</d2l-button>
 					</d2l-dialog-confirm>
 					<script>
 						document.querySelector('#openConfirm').addEventListener('click', () => {
@@ -110,8 +110,8 @@
 				<template>
 					<d2l-button id="openConfirmNoTitle">Show Confirm</d2l-button>
 					<d2l-dialog-confirm id="confirmNoTitle" text="Are you sure you want more cookies?">
-						<d2l-button slot="footer" primary dialog-action="ok">Yes</d2l-button>
-						<d2l-button slot="footer" dialog-action>No</d2l-button>
+						<d2l-button slot="footer" primary data-dialog-action="ok">Yes</d2l-button>
+						<d2l-button slot="footer" data-dialog-action>No</d2l-button>
 					</d2l-dialog-confirm>
 					<script>
 						document.querySelector('#openConfirmNoTitle').addEventListener('click', () => {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -201,8 +201,9 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	}
 
 	_handleClick(e) {
-		if (!e.target.hasAttribute('dialog-action')) return;
-		const action = e.target.getAttribute('dialog-action');
+		// handle "dialog-action" for backwards-compatibility
+		if (!e.target.hasAttribute('data-dialog-action') && !e.target.hasAttribute('dialog-action')) return;
+		const action = e.target.getAttribute('data-dialog-action') || e.target.getAttribute('dialog-action');
 		e.stopPropagation();
 		this._close(action);
 	}

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -3,6 +3,7 @@ import { allowBodyScroll, preventBodyScroll } from '../backdrop/backdrop.js';
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
 import { getComposedActiveElement, getNextFocusable } from '../../helpers/focus.js';
+import { classMap} from 'lit-html/directives/class-map.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -308,6 +309,14 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		if (this._width) styles.width = `${this._width}px`;
 		else styles.width = 'auto';
 
+		const dialogOuterClasses = {
+			'd2l-dialog-outer': true,
+			'd2l-dialog-outer-overflow-bottom': this._overflowBottom,
+			'd2l-dialog-outer-overflow-top': this._overflowTop,
+			'd2l-dialog-outer-nested': !this._useNative && this._parentDialog,
+			'd2l-dialog-outer-nested-showing': !this._useNative && this._nestedShowing
+		};
+
 		inner = html`<d2l-focus-trap
 			@d2l-focus-trap-enter="${this._handleFocusTrapEnter}"
 			?trap="${this.opened}">
@@ -318,13 +327,11 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			html`<dialog
 				aria-describedby="${ifDefined(info.descId)}"
 				aria-labelledby="${info.labelId}"
-				class="d2l-dialog-outer"
+				class="${classMap(dialogOuterClasses)}"
 				@click="${this._handleClick}"
 				@close="${this._handleClose}"
 				id="${this._dialogId}"
 				@keydown="${this._handleKeyDown}"
-				?overflow-bottom="${this._overflowBottom}"
-				?overflow-top="${this._overflowTop}"
 				role="${info.role}"
 				style=${styleMap(styles)}>
 					${inner}
@@ -332,15 +339,11 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			html`<div
 				aria-describedby="${ifDefined(info.descId)}"
 				aria-labelledby="${info.labelId}"
-				class="d2l-dialog-outer"
+				class="${classMap(dialogOuterClasses)}"
 				@click="${this._handleClick}"
 				@d2l-dialog-close="${this._handleDialogClose}"
 				@d2l-dialog-open="${this._handleDialogOpen}"
 				id="${this._dialogId}"
-				?nested="${this._parentDialog}"
-				?nested-showing="${this._nestedShowing}"
-				?overflow-bottom="${this._overflowBottom}"
-				?overflow-top="${this._overflowTop}"
 				role="${info.role}"
 				style=${styleMap(styles)}>
 					${inner}

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -23,7 +23,7 @@ export const dialogStyles = css`
 		transition: transform 200ms ease-in;
 	}
 
-	[nested-showing].d2l-dialog-outer {
+	.d2l-dialog-outer.d2l-dialog-outer-nested-showing {
 		border-color: rgba(205, 213, 220, 0.35);
 		box-shadow: none;
 	}
@@ -36,7 +36,7 @@ export const dialogStyles = css`
 		z-index: 1000;
 	}
 
-	div[nested].d2l-dialog-outer {
+	.d2l-dialog-outer.d2l-dialog-outer-nested {
 		top: 0;
 	}
 
@@ -78,7 +78,7 @@ export const dialogStyles = css`
 		padding: 19px 30px 23px 30px;
 	}
 
-	[overflow-top] .d2l-dialog-header {
+	.d2l-dialog-outer.d2l-dialog-outer-overflow-top .d2l-dialog-header {
 		box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.05);
 	}
 
@@ -104,7 +104,7 @@ export const dialogStyles = css`
 		padding: 30px 30px 12px 30px; /* 18px margin below footer children */
 	}
 
-	[overflow-bottom] .d2l-dialog-footer {
+	.d2l-dialog-outer.d2l-dialog-outer-overflow-bottom .d2l-dialog-footer {
 		box-shadow: 0 -3px 3px 0 rgba(0, 0, 0, 0.05);
 	}
 


### PR DESCRIPTION
The CSS change seems clean enough. The `data-dialog-action` stuff makes me feel a little bit sad, but the only way around this that I can think of would be to add `dialog-action` as a supported attribute on all our clickable things (`d2l-button`, etc.), which seems far worse.