### PR TITLE
Improve alert-toast Accessibility

### DIFF
--- a/components/alert/README.md
+++ b/components/alert/README.md
@@ -47,7 +47,7 @@ a pop-up at the bottom of the screen that automatically dismisses itself by defa
 
 - `button-text` (optional, String): text that is displayed within the alert's action button. If no text is provided the button is not displayed.
 - `hide-close-button` (Boolean, default: `false`) hide the close button to prevent users from manually closing the alert.
-- `no-auto-close` (Boolean, default: `false`) prevents the alert from automatically closing 2.5 seconds after opening.
+- `no-auto-close` (Boolean, default: `false`) prevents the alert from automatically closing 4 seconds after opening.
 - `open` (Boolean, default: `false`): open or close the toast alert.
 - `subtext` (optional, String) The text that is displayed below the main alert message.
 - `type` (String, default: `'default'`): type of the alert being displayed. Can be one of  `default`, `critical`, `success` , `warning`

--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -149,7 +149,7 @@ class AlertToast extends LitElement {
 					this._state = states.OPEN;
 				}
 			}
-			this.setAttribute('role', 'status');
+			this.setAttribute('role', 'alert');
 		} else {
 			if (reduceMotion || this._state === states.PREOPENING) {
 				cancelAnimationFrame(this._preopenFrame);
@@ -166,9 +166,10 @@ class AlertToast extends LitElement {
 		clearTimeout(this._setTimeoutId);
 		if (newState === states.OPEN) {
 			if (!this.noAutoClose) {
+				const duration = this.buttonText ? 10000 : 4000;
 				this._setTimeoutId = setTimeout(() => {
 					this.open = false;
-				}, 2250);
+				}, duration);
 			}
 		}
 	}

--- a/components/alert/test/alert-toast.axe.js
+++ b/components/alert/test/alert-toast.axe.js
@@ -23,9 +23,9 @@ describe('d2l-alert-toast', () => {
 		await expect(el).to.be.accessible();
 	});
 
-	it('should have status role when open', async() => {
+	it('should have status alert when open', async() => {
 		const el = await fixture(html`<d2l-alert-toast open>message</d2l-alert-toast>`);
-		expect(el.getAttribute('role')).to.equal('status');
+		expect(el.getAttribute('role')).to.equal('alert');
 	});
 
 });


### PR DESCRIPTION
# Changes
- Change role from status to alert so it will be announced more consistently
- Change the timeout to 4s by default or 10s if there is a button action

This change will merge cleanly with @Scy-D2L 's change so it should be fine to merge it directly to `master`.