### PR TITLE
Update dialog mixin to use updated callback.

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -60,29 +60,28 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._updateOverflow = this._updateOverflow.bind(this);
 	}
 
-	async attributeChangedCallback(name, oldval, newval) {
-		super.attributeChangedCallback(name, oldval, newval);
-		if (name === 'opened' && oldval !== newval) {
-			if (this.opened) {
-				if (this._ifrauDialogService) {
-					this._ifrauContextInfo = await this._ifrauDialogService.showBackdrop();
-				}
-				this._open();
-			} else {
-				if (this._ifrauDialogService) {
-					this._ifrauDialogService.hideBackdrop();
-					this._ifrauContextInfo = null;
-				}
-				this._close();
-			}
-		}
-	}
-
 	async connectedCallback() {
 		super.connectedCallback();
 		if (!window.ifrauclient) return;
 		const ifrauClient = await window.ifrauclient().connect();
 		this._ifrauDialogService = await ifrauClient.getService('dialogWC', '0.1');
+	}
+
+	async updated(changedProperties) {
+		super.updated(changedProperties);
+		if (!changedProperties.has('opened')) return;
+		if (this.opened) {
+			if (this._ifrauDialogService) {
+				this._ifrauContextInfo = await this._ifrauDialogService.showBackdrop();
+			}
+			this._open();
+		} else {
+			if (this._ifrauDialogService) {
+				this._ifrauDialogService.hideBackdrop();
+				this._ifrauContextInfo = null;
+			}
+			this._close();
+		}
 	}
 
 	open() {

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -137,6 +137,7 @@ class Dialog extends LocalizeStaticMixin(AsyncContainerMixin(DialogMixin(LitElem
 	}
 
 	updated(changedProperties) {
+		super.updated(changedProperties);
 		if (!changedProperties.has('asyncState')) return;
 		if (this.asyncState === asyncStates.complete) {
 			this.resize();


### PR DESCRIPTION
* use updated callback instead of attributeChangedCallback
* allows dialog to be initially rendered in `opened` state