### PR TITLE
input-date: read selected value when changes

### DIFF
--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -208,6 +208,7 @@ class InputDate extends LocalizeStaticMixin(LitElement) {
 			</div>
 			<d2l-dropdown ?disabled="${this.disabled}" no-auto-open>
 				<d2l-input-text
+					atomic="true"
 					@change="${this._handleChange}"
 					class="d2l-dropdown-opener"
 					?disabled="${this.disabled}"
@@ -215,6 +216,7 @@ class InputDate extends LocalizeStaticMixin(LitElement) {
 					@keydown="${this._handleKeydown}"
 					label="${ifDefined(this.label)}"
 					?label-hidden="${this.labelHidden}"
+					live="assertive"
 					@mouseup="${this._handleMouseup}"
 					placeholder="${shortDateFormat}"
 					style="${styleMap({maxWidth: inputTextWidth})}"

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -13,11 +13,13 @@ class InputText extends RtlMixin(LitElement) {
 		return {
 			ariaHaspopup: { type: String, attribute: 'aria-haspopup'},
 			ariaInvalid: { type: String, attribute: 'aria-invalid' },
+			atomic: { type: Boolean },
 			autocomplete: { type: String },
 			autofocus: { type: Boolean },
 			disabled: { type: Boolean, reflect: true },
 			label: { type: String },
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
+			live: { type: String },
 			max: { type: String },
 			maxlength: { type: Number },
 			min: { type: String },
@@ -126,9 +128,11 @@ class InputText extends RtlMixin(LitElement) {
 
 		const input = html`
 			<div class="d2l-input-text-container">
-				<input aria-haspopup="${ifDefined(this.ariaHaspopup)}"
+				<input aria-atomic="${ifDefined(this.atomic)}"
+					aria-haspopup="${ifDefined(this.ariaHaspopup)}"
 					aria-invalid="${ifDefined(this.ariaInvalid)}"
 					aria-label="${ifDefined(this._getAriaLabel())}"
+					aria-live="${ifDefined(this.live)}"
 					aria-required="${ifDefined(ariaRequired)}"
 					autocomplete="${ifDefined(this.autocomplete)}"
 					?autofocus="${this.autofocus}"

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -13,7 +13,7 @@ class InputText extends RtlMixin(LitElement) {
 		return {
 			ariaHaspopup: { type: String, attribute: 'aria-haspopup'},
 			ariaInvalid: { type: String, attribute: 'aria-invalid' },
-			atomic: { type: Boolean },
+			atomic: { type: String },
 			autocomplete: { type: String },
 			autofocus: { type: Boolean },
 			disabled: { type: Boolean, reflect: true },


### PR DESCRIPTION
Carin suggested that when a value is selected in the calendar, it should be announced first when the calendar closes, rather than later on during the screen reader reading.

I added `atomic` and `live` properties to `input-text` so I could pass those through from `input-date`. I did not call them `aria-atomic` and `aria-live` because that caused strange behaviour with Safari and Voiceover. If this seems okay I'll add it to the README.

Note that this does not fix this behaviour on JAWS and I have not been able to figure that out, so I'm open to suggestions there (e.g., I also tried announce, just for fun added a visible div in input-date with aria-live containing the date, nothing worked). JAWS seems to really want to read the title first (so maybe this is something we can revisit when we are looking into the validation and accessibility related to empty-text later on). This works well on NVDA and Safari w/ voiceover.