### PR TITLE
Remove img from list of focusable elements.

### DIFF
--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -6,7 +6,6 @@ const focusableElements = {
 	button: true,
 	frame: true,
 	iframe: true,
-	img: true,
 	input: true,
 	isindex: true,
 	object: true,


### PR DESCRIPTION
The `img` tag should not be included in this list.  It causes image elements to get the focus even though they shouldn't, for example when placed inside dialogs before other focusable content. From a user perspective, the focus is _seemingly_ lost.  This has come up as an issue twice so far very recently.  This originally comes from legacy-land (at least 10 years ago), possibly with the intended usage of image maps.