### PR TITLE
Spike: Displaying Error State with an Icon in the Element via CSS

### DIFF
--- a/components/inputs/input-select-styles.js
+++ b/components/inputs/input-select-styles.js
@@ -41,7 +41,7 @@ export const selectStyles = css`
 	.d2l-input-select:hover:disabled,
 	.d2l-input-select:focus:disabled {
 		background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iNyIgdmlld0JveD0iMCAwIDExIDciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEgMmw0LjUgNE0xMCAyTDUuNSA2IiBzdHJva2U9IiM1NjVBNUMiIHN0cm9rZS13aWR0aD0iMiIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KPC9zdmc+");
-		padding-right: calc(0.5rem + 11px + 16px);
+		padding-right: calc(0.5rem + 11px + 16px + 18px);
 	}
 	:host([dir='rtl']) .d2l-input-select,
 	:host([dir='rtl']) .d2l-input-select:disabled,
@@ -57,7 +57,7 @@ export const selectStyles = css`
 		outline-style: none; /* Safari */
 		outline-width: 0;
 		padding: calc(0.4rem - 1px) calc(0.75rem - 1px);
-		padding-right: calc(0.5rem + 11px + 16px - 1px);
+		padding-right: calc(0.5rem + 11px + 16px + 18px - 1px);
 	}
 	:host([dir='rtl']) .d2l-input-select:hover,
 	:host([dir='rtl']) .d2l-input-select:focus {
@@ -66,6 +66,10 @@ export const selectStyles = css`
 	}
 	.d2l-input-select[aria-invalid='true'] {
 		border-color: var(--d2l-color-cinnabar);
+		background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iNyIgdmlld0JveD0iMCAwIDExIDciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEgMmw0LjUgNE0xMCAyTDUuNSA2IiBzdHJva2U9IiM1NjVBNUMiIHN0cm9rZS13aWR0aD0iMiIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KPC9zdmc+"), url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' preserveAspectRatio='xMidYMid meet' focusable='false'%3E%3Cpath fill='%23cd2026' d='M17.79 15.11l-7-14a2 2 0 0 0-3.58 0l-7 14a1.975 1.975 0 0 0 .09 1.94A2 2 0 0 0 2 18h14a1.994 1.994 0 0 0 1.7-.95 1.967 1.967 0 0 0 .09-1.94zM9 16a1.5 1.5 0 1 1 1.5-1.5A1.5 1.5 0 0 1 9 16zm.98-4.806a1 1 0 0 1-1.96 0l-.99-5A1 1 0 0 1 8.01 5h1.983a1 1 0 0 1 .98 1.194z'%3E%3C/path%3E%3C/svg%3E");
+		background-position: center right 17px, center right 35px;
+		background-size: 11px 7px, 18px 18px;
+		background-repeat: no-repeat, no-repeat;
 	}
 	.d2l-input-select:disabled {
 		opacity: 0.5;

--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -54,6 +54,11 @@ export const inputStyles = css`
 	[aria-invalid="true"].d2l-input,
 	.d2l-input:invalid {
 		border-color: var(--d2l-color-cinnabar);
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' preserveAspectRatio='xMidYMid meet' focusable='false'%3E%3Cpath fill='%23cd2026' d='M17.79 15.11l-7-14a2 2 0 0 0-3.58 0l-7 14a1.975 1.975 0 0 0 .09 1.94A2 2 0 0 0 2 18h14a1.994 1.994 0 0 0 1.7-.95 1.967 1.967 0 0 0 .09-1.94zM9 16a1.5 1.5 0 1 1 1.5-1.5A1.5 1.5 0 0 1 9 16zm.98-4.806a1 1 0 0 1-1.96 0l-.99-5A1 1 0 0 1 8.01 5h1.983a1 1 0 0 1 .98 1.194z'%3E%3C/path%3E%3C/svg%3E");
+		padding-right: calc(0.5rem + 11px + 16px);
+		background-position: right 17px center;
+		background-repeat: no-repeat;
+		background-size: 18px 18px;
 	}
 	.d2l-input:disabled {
 		opacity: 0.5;
@@ -77,9 +82,13 @@ export const inputStyles = css`
 		padding-top: 0.5rem;
 		padding-bottom: 0.5rem;
 	}
+	textarea[aria-invalid="true"].d2l-input {
+		background-position: right 17px top 17px;
+	}
 	textarea.d2l-input:hover,
 	textarea.d2l-input:focus {
 		padding-top: calc(0.5rem - 1px);
 		padding-bottom: calc(0.5rem - 1px);
+		background-position: right 16px top 16px;
 	}
 `;


### PR DESCRIPTION
# Changes
- Add error icons using CSS to `select`, `textarea`, and `input`
## Notes
- This spike only includes rough positioning and will need to be polished when actually implemented.
- `textarea` can get a bit cramped if the scrollbar is visible since it can't shift the icon but this should be a rare occurrence.
- `d2l-input-text` will clobber the icon if the `right` slot is used. We'll have to build the icon into the component to account for this.
- `select` will need additional space for the error icon. This might cause layout issues for existing pages if the width changes.

# Screenshots
## `input`
![d2l-input-text-wc-invalid](https://user-images.githubusercontent.com/11379933/83652400-96103000-a588-11ea-94b1-1ebb6e86d9bc.png)

## `textarea`
![d2l-input-textarea-wc-invalid-focus](https://user-images.githubusercontent.com/11379933/83652416-9d373e00-a588-11ea-99e8-a4041f793fc7.png)

## `select`
![d2l-input-select-wc-invalid](https://user-images.githubusercontent.com/11379933/83652458-ab855a00-a588-11ea-9a0a-d5281007444f.png)
