### PR TITLE
Fix window layout

### DIFF
--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -50,10 +50,15 @@ class ListItemDragHandle extends LitElement {
 			:host([hidden]) {
 				display: none;
 			}
-			.d2l-list-item-drag-handle-dragger-button,
+			.d2l-list-item-drag-handle-dragger-button {
+				display: block;
+			}
 			.d2l-list-item-drag-handle-keyboard-button {
 				display: grid;
 				grid-auto-rows: 1fr 1fr;
+			}
+			.d2l-list-item-drag-handle-dragger-button,
+			.d2l-list-item-drag-handle-keyboard-button {
 				margin: 0;
 				min-height: 1.8rem;
 				padding: 0;


### PR DESCRIPTION
In windows the grid doesn't work the same as in macOS. Weirdly, this doesn't seem to be a problem with specific browsers but what OS they are on.

Basically on all browsers in windows this drag handle shows up like this: 
![image](https://user-images.githubusercontent.com/13232226/84057780-2b933180-a986-11ea-85af-073a24e46818.png)

This PR fixes it so it shows up properly. 
