### PR TITLE
removing entry for Turkish

### DIFF
--- a/lang/localize-core-element.js
+++ b/lang/localize-core-element.js
@@ -42,9 +42,6 @@ export const LocalizeCoreElement = superclass => class extends LocalizeMixin(sup
 				case 'tr':
 					translations = await import('./tr.js');
 					break;
-				case 'zh-cn':
-					translations = await import('./zh-cn.js');
-					break;
 				case 'zh-tw':
 					translations = await import('./zh-tw.js');
 					break;

--- a/lang/localize-core-element.js
+++ b/lang/localize-core-element.js
@@ -39,9 +39,6 @@ export const LocalizeCoreElement = superclass => class extends LocalizeMixin(sup
 				case 'sv':
 					translations = await import('./sv.js');
 					break;
-				case 'tr-tr':
-					translations = await import('./tr-tr.js');
-					break;
 				case 'tr':
 					translations = await import('./tr.js');
 					break;


### PR DESCRIPTION
Noticed that Polymer builds were failing with this error:
> Promise rejection: Error: ENOENT: no such file or directory, open '/home/travis/build/Brightspace/awards-leaderboard-ui/node_modules/@brightspace-ui/core/lang/tr-tr.js'