### PR TITLE
Tooltip: Positioning and Width Bug Fixes Backport

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -416,7 +416,7 @@ class Tooltip extends RtlMixin(LitElement) {
 
 		const contentRect = content.getBoundingClientRect();
 		// + 1 because scrollWidth does not give sub-pixel measurements and half a pixel may cause text to unexpectedly wrap
-		this._maxWidth = content.scrollWidth + 2 * contentBorderSize + 1;
+		this._maxWidth = Math.min(content.scrollWidth + 2 * contentBorderSize, 350) + 1;
 		this._openDir = space.dir;
 
 		// Compute the x and y position of the tooltip relative to its target

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -405,9 +405,9 @@ class Tooltip extends RtlMixin(LitElement) {
 		if (!this._target) {
 			return;
 		}
-
+		const offsetParent = getOffsetParent(this);
 		const targetRect = this._target.getBoundingClientRect();
-		const spaceAround = this._computeSpaceAround(targetRect);
+		const spaceAround = this._computeSpaceAround(offsetParent, targetRect);
 
 		// Compute the size of the spaces above, below, left and right and find which space to fit the tooltip in
 		const content = this._getContent();
@@ -420,9 +420,18 @@ class Tooltip extends RtlMixin(LitElement) {
 		this._openDir = space.dir;
 
 		// Compute the x and y position of the tooltip relative to its target
-		const tooltipRect = this.getBoundingClientRect();
-		const top = targetRect.top - tooltipRect.top + this.offsetTop;
-		const left = targetRect.left - tooltipRect.left + this.offsetLeft;
+		let parentTop;
+		let parentLeft;
+		if (offsetParent) {
+			const parentRect = offsetParent.getBoundingClientRect();
+			parentTop = parentRect.top + offsetParent.clientTop;
+			parentLeft = parentRect.left + offsetParent.clientLeft;
+		} else {
+			parentTop = 0;
+			parentLeft = 0;
+		}
+		const top = targetRect.top - parentTop;
+		const left = targetRect.left - parentLeft;
 
 		let positionRect;
 		if (this._isAboveOrBelow()) {
@@ -509,14 +518,13 @@ class Tooltip extends RtlMixin(LitElement) {
 		return spaces;
 	}
 
-	_computeSpaceAround(targetRect) {
+	_computeSpaceAround(offsetParent, targetRect) {
 		const spaceAround = {
 			above: targetRect.top - this._viewportMargin,
 			below: window.innerHeight - (targetRect.top + targetRect.height) - this._viewportMargin,
 			left: targetRect.left - this._viewportMargin,
 			right: document.documentElement.clientWidth - (targetRect.left + targetRect.width) - this._viewportMargin
 		};
-		const offsetParent = getOffsetParent(this);
 		if (this.boundary && offsetParent) {
 			const parentRect = offsetParent.getBoundingClientRect();
 			if (!isNaN(this.boundary.left)) {


### PR DESCRIPTION
# Changes
## [Cert fix for this PR](https://github.com/BrightspaceUI/core/pull/619)
1. Fix bug causing tooltips to be shifted too far if their inner content is forced beyond the `max-width` of `350px` with `no-wrap` text or `min-width` CSS rules.
1. In Chrome `offsetParent` includes positioned nodes in ancestors' shadow DOM. In Firefox `offsetParent` positions relative to these but reports the `offsetParent` as the first positioned ancestor in the same DOM context. This causes `offsetTop` and `offsetLeft`
to be incorrect in Firefox if there is a positioned node in an ancestor's shadow DOM. To fix this, `offsetTop` and `offsetLeft` need to be computed using the `getOffsetParent` DOM helper rather than using the built-in properties.