### PR TITLE
upgrading intl-messageformat

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,11 +67,11 @@
   },
   "dependencies": {
     "@brightspace-ui/intl": "^3",
-    "@formatjs/intl-pluralrules": "^1",
+    "@formatjs/intl-pluralrules": "^2",
     "@open-wc/dedupe-mixin": "^1.2.17",
     "@webcomponents/shadycss": "^1",
     "@webcomponents/webcomponentsjs": "^2",
-    "intl-messageformat": "^7",
+    "intl-messageformat": "^8",
     "lit-element": "^2",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"


### PR DESCRIPTION
I think these two need to be upgraded in lock-step in order to avoid the downstream issues we were seeing earlier. I'll switch `d2l-localize-behavior` as well, then test this out in BSI and `quiz-authoring`.

I've tried testing locally via `npm link` but it doesn't appear to be possible. If it doesn't work, I'll back this out (again).