### PR TITLE
ci: only building master and release branches in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js: node
+branches:
+  only:
+  - master
+  - /^[0-9]+(\.[0-9]+|x)?\.x$/
 addons:
   apt:
     packages:


### PR DESCRIPTION
This should speed our CI builds up a bit. With this change, Travis CI won't run on branches other than release/maintenance branches named things like `1.x`, `1.53.x`, etc.