### PR TITLE
package.json: Add custom-elements.json to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:sauce": "karma start karma.sauce.conf.js"
   },
   "files": [
+    "custom-elements.json",
     "/components",
     "/directives",
     "/generated",


### PR DESCRIPTION
It looks like custom-elements.js does not get included when doing an npm i with the latest core and I think this is why.