### PR TITLE
Fix getOffsetParent with table element and relative-ancestor

### DIFF
--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -91,28 +91,28 @@ export function getOffsetParent(node) {
 		return null;
 	}
 
+	let firstTableElement = null;
 	let currentNode = getComposedParent(node);
 	while (currentNode) {
 		if (currentNode instanceof ShadowRoot) {
 			currentNode = getComposedParent(currentNode);
 		} else if (currentNode instanceof DocumentFragment) {
-			return null;
+			return firstTableElement;
 		} else if (currentNode.tagName === 'BODY') {
-			return currentNode;
+			return firstTableElement || currentNode;
 		}
 
 		const position = window.getComputedStyle(currentNode).position;
 		const tagName = currentNode.tagName;
-		if (
-			(position && position !== 'static') ||
-			position === 'static' && (tagName === 'TD' || tagName === 'TH' || tagName === 'TABLE')
-		) {
+		if (position && position !== 'static') {
 			return currentNode;
+		} else if (firstTableElement === null && position === 'static' && (tagName === 'TD' || tagName === 'TH' || tagName === 'TABLE')) {
+			firstTableElement = currentNode;
 		}
 		currentNode = getComposedParent(currentNode);
 	}
 
-	return null;
+	return firstTableElement;
 
 }
 

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -436,6 +436,57 @@ describe('dom', () => {
 			expect(getOffsetParent(elem)).to.equal(document.body);
 		});
 
+		it('td-with-relative-ancestor', async() => {
+			const elem = await fixture(html`
+				<div>
+					<div class="expected" style="position: relative">
+						<table>
+							<td style="position: static;">
+								<div class="child"></div>
+							</td>
+						</table>
+					</div>
+				</div>
+			`);
+			const child = elem.querySelector('.child');
+			const expected = elem.querySelector('.expected');
+			expect(getOffsetParent(child)).to.equal(expected);
+		});
+
+		it('th-with-relative-ancestor', async() => {
+			const elem = await fixture(html`
+				<div>
+					<div class="expected" style="position: relative">
+						<table>
+							<th style="position: static;">
+								<div class="child"></div>
+							</th>
+						</table>
+					</div>
+				</div>
+			`);
+			const child = elem.querySelector('.child');
+			const expected = elem.querySelector('.expected');
+			expect(getOffsetParent(child)).to.equal(expected);
+		});
+
+		it('table-with-relative-ancestor', async() => {
+			const elem = await fixture(html`
+				<div>
+					<div class="expected" style="position: relative">
+						<div>
+							<table style="position: static;">
+								<tbody class="child"></tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			`);
+			const child = elem.querySelector('.child');
+			const expected = elem.querySelector('.expected');
+			expect(getOffsetParent(child)).to.equal(expected);
+		});
+
 	});
 
 	describe('getNextAncestorSibling', () => {


### PR DESCRIPTION
# Changes
`td`, `th`, and `table` tags are now only considered if there are no positioned ancestors rather than when they are first encountered. This aligns with [how `offsetParent` works according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent).