### PR TITLE
Added NewPositionEventDetails

### DIFF
--- a/components/list/list-item-drag-mixin.js
+++ b/components/list/list-item-drag-mixin.js
@@ -103,8 +103,8 @@ export const ListItemDragMixin = superclass => class extends superclass {
 export class NewPositionEventDetails {
 	constructor(object) {
 		this.node = object.node;
-		this.oldPosition = object.oldPosition;
-		this.position = object.position;
+		this.origin = object.origin;
+		this.destination = object.destination;
 		this.temporaryMovement = object.tempMovement;
 	}
 
@@ -116,30 +116,30 @@ export class NewPositionEventDetails {
 	 *        This optional callback will be passed to announceMove if given.
 	 */
 	reorder(list, announceCallback = null) {
-		if (this.position === undefined || this.position === this.oldPosition) return;
+		if (this.destination === undefined || this.destination === this.origin) return;
 
-		if (list[this.position] === undefined || list[this.oldPosition] === undefined ) {
+		if (list[this.destination] === undefined || list[this.origin] === undefined ) {
 			throw new Error('Reorder failed. Position does not exist in list.');
 		}
 
 		// move the item in the list to a new position in place
-		const item = list[this.oldPosition];
+		const item = list[this.origin];
 		// now that we have a reference to the item, shove everything between the
-		// new position to the oldPosition over one
-		if (this.oldPosition > this.position) {
+		// destination to the origin over one
+		if (this.origin > this.destination) {
 			// shove to the right ♪┗ ( ･o･) ┓♪
-			for (let i = this.oldPosition; i > this.position; i--) {
+			for (let i = this.origin; i > this.destination; i--) {
 				list[i] = list[i - 1];
 			}
 		} else {
 			// shove to the left ♪┏(・o･)┛♪
-			for (let i = this.oldPosition; i < this.position; i++) {
+			for (let i = this.origin; i < this.destination; i++) {
 				list[i] = list[i + 1];
 			}
 		}
 		// there is now a copy of the left or rightmost item where the new
 		// position is; stick the item in this spot.
-		list[this.position] = item;
+		list[this.destination] = item;
 
 		if (announceCallback) {
 			this.announceMove(list, announceCallback);

--- a/components/list/list-item-drag-mixin.js
+++ b/components/list/list-item-drag-mixin.js
@@ -1,3 +1,4 @@
+import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit-element/lit-element.js';
 import { nothing } from 'lit-html';
@@ -98,3 +99,63 @@ export const ListItemDragMixin = superclass => class extends superclass {
 		` : nothing;
 	}
 };
+
+export class NewPositionEventDetails {
+	constructor(object) {
+		this.node = object.node;
+		this.oldPosition = object.oldPosition;
+		this.position = object.position;
+		this.temporaryMovement = object.tempMovement;
+	}
+
+	/**
+	 * Reorders an array in place with the current event information
+	 * @param { Array } list The array to reorder
+	 * @param { function(any, Number): String } [announceCallback] Callback function that returns the announcement text
+	 *        Takes the item in the array and the index as arguments. Should return the text to announce.
+	 *        This optional callback will be passed to announceMove if given.
+	 */
+	reorder(list, announceCallback = null) {
+		if (this.position === undefined || this.position === this.oldPosition) return;
+
+		if (list[this.position] === undefined || list[this.oldPosition] === undefined ) {
+			throw new Error('Reorder failed. Position does not exist in list.');
+		}
+
+		// move the item in the list to a new position in place
+		const item = list[this.oldPosition];
+		// now that we have a reference to the item, shove everything between the
+		// new position to the oldPosition over one
+		if (this.oldPosition > this.position) {
+			// shove to the right ♪┗ ( ･o･) ┓♪
+			for (let i = this.oldPosition; i > this.position; i--) {
+				list[i] = list[i - 1];
+			}
+		} else {
+			// shove to the left ♪┏(・o･)┛♪
+			for (let i = this.oldPosition; i < this.position; i++) {
+				list[i] = list[i + 1];
+			}
+		}
+		// there is now a copy of the left or rightmost item where the new
+		// position is; stick the item in this spot.
+		list[this.position] = item;
+
+		if (announceCallback) {
+			this.announceMove(list, announceCallback);
+		}
+	}
+
+	/**
+	 * Announces a move to screen readers on an array
+	 * @param { Array } list The array to announce the move on.
+	 * @param { function(any, Number): String } announceCallback Callback function that returns the announcement text
+	 *        Takes the item in the array and the index as arguments. Should return the text to announce.
+	 */
+	announceMove(list, announceCallback) {
+		const item = list[this.position];
+		if (!item) throw new Error('Item to announce move not found in given array.');
+		const message = announceCallback(item, this.position);
+		if (message) announce(message);
+	}
+}

--- a/components/list/list-item-drag-mixin.js
+++ b/components/list/list-item-drag-mixin.js
@@ -1,4 +1,4 @@
-import { announce } from '@brightspace-ui/core/helpers/announce.js';
+import { announce } from '../../helpers/announce.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit-element/lit-element.js';
 import { nothing } from 'lit-html';
@@ -101,61 +101,82 @@ export const ListItemDragMixin = superclass => class extends superclass {
 };
 
 export class NewPositionEventDetails {
+	/**
+	 * @param { Object } object An simple object with the position event properties
+	 * @param { String } object.targetKey The item key of the list-item that is moving
+	 * @param { String } object.destinationKey The item key of the list-item in the position we are moving to
+	 * @param { String } object.temporaryMovement Information on whether the item is entering or exiting temporary movement
+	 */
 	constructor(object) {
-		this.node = object.node;
-		this.origin = object.origin;
-		this.destination = object.destination;
-		this.temporaryMovement = object.tempMovement;
+		this.targetKey = object.targetKey;
+		this.destinationKey = object.destinationKey;
+		this.temporaryMovement = object.temporaryMovement;
+	}
+
+	/**
+	 * Announces a move to screen readers on an array
+	 * @param { Array<Node> } list The array to announce the move on.
+	 * @param { function(any, Number): String } announceCallback Callback function that returns the announcement text
+	 *        Takes the item in the array and the index as arguments. Should return the text to announce.
+	 */
+	announceMove(list, announceCallback) {
+		const index = this.fetchPosition(list, this.targetKey);
+		if (index === null) throw new Error('Item to announce move not found in given array.');
+		const item = list[index];
+		const message = announceCallback(item, index);
+		if (message) announce(message);
+	}
+
+	/**
+	 * Fetches an index position within a list given an item key
+	 * @param { Array<Node> } list Array of nodes
+	 * @param { String } key Item key to fetch position of
+	 */
+	fetchPosition(list, key) {
+		const index = list.findIndex(x => x.key === key);
+		return index === -1 ? null : index;
 	}
 
 	/**
 	 * Reorders an array in place with the current event information
-	 * @param { Array } list The array to reorder
+	 * The item will be moved to the position of the destinationKey. Array elements shift
+	 * forward one to make room.
+	 * @param { Array<Node> } list The array to reorder
 	 * @param { function(any, Number): String } [announceCallback] Callback function that returns the announcement text
 	 *        Takes the item in the array and the index as arguments. Should return the text to announce.
 	 *        This optional callback will be passed to announceMove if given.
 	 */
 	reorder(list, announceCallback = null) {
-		if (this.destination === undefined || this.destination === this.origin) return;
+		if (this.destinationKey === undefined || this.destinationKey === this.targetKey) return;
 
-		if (list[this.destination] === undefined || list[this.origin] === undefined ) {
+		const origin = this.fetchPosition(list, this.targetKey);
+		const destination = this.fetchPosition(list, this.destinationKey);
+
+		if (origin === null || destination === null) {
 			throw new Error('Reorder failed. Position does not exist in list.');
 		}
 
 		// move the item in the list to a new position in place
-		const item = list[this.origin];
+		const item = list[origin];
 		// now that we have a reference to the item, shove everything between the
 		// destination to the origin over one
-		if (this.origin > this.destination) {
+		if (origin > destination) {
 			// shove to the right ♪┗ ( ･o･) ┓♪
-			for (let i = this.origin; i > this.destination; i--) {
+			for (let i = origin; i > destination; i--) {
 				list[i] = list[i - 1];
 			}
 		} else {
 			// shove to the left ♪┏(・o･)┛♪
-			for (let i = this.origin; i < this.destination; i++) {
+			for (let i = origin; i < destination; i++) {
 				list[i] = list[i + 1];
 			}
 		}
 		// there is now a copy of the left or rightmost item where the new
 		// position is; stick the item in this spot.
-		list[this.destination] = item;
+		list[destination] = item;
 
 		if (announceCallback) {
 			this.announceMove(list, announceCallback);
 		}
-	}
-
-	/**
-	 * Announces a move to screen readers on an array
-	 * @param { Array } list The array to announce the move on.
-	 * @param { function(any, Number): String } announceCallback Callback function that returns the announcement text
-	 *        Takes the item in the array and the index as arguments. Should return the text to announce.
-	 */
-	announceMove(list, announceCallback) {
-		const item = list[this.position];
-		if (!item) throw new Error('Item to announce move not found in given array.');
-		const message = announceCallback(item, this.position);
-		if (message) announce(message);
 	}
 }

--- a/components/list/test/list-item-drag-mixin.test.js
+++ b/components/list/test/list-item-drag-mixin.test.js
@@ -1,6 +1,6 @@
 import { defineCE, expect, fixture } from '@open-wc/testing';
 import { html, LitElement } from 'lit-element/lit-element.js';
-import { ListItemDragMixin } from '../list-item-drag-mixin.js';
+import { ListItemDragMixin, NewPositionEventDetails } from '../list-item-drag-mixin.js';
 
 const tag = defineCE(
 	class extends ListItemDragMixin(LitElement) {
@@ -17,5 +17,95 @@ describe('ListItemDragMixin', () => {
 	it('Sets checked status to false when no key is given', async() => {
 		const element = await fixture(`<${tag} draggable="true"></${tag}>`);
 		expect(element.draggable).to.be.false;
+	});
+});
+
+describe('NewPositionEventDetails', () => {
+	describe('reorder', () => {
+		const tests = [
+			{
+				description: 'does nothing when new and old position are the same',
+				input: {
+					array: [1, 2, 3],
+					oldPosition: 1,
+					newPosition: 1
+				},
+				expected: [1, 2, 3]
+			},
+			{
+				description: 'moves item forward in the middle of an array',
+				input: {
+					array: [1, 2, 3, 4, 5, 6],
+					oldPosition: 2,
+					newPosition: 4
+				},
+				expected: [1, 2, 4, 5, 3, 6]
+			},
+			{
+				description: 'moves item backward in the middle of an array',
+				input: {
+					array: [1, 2, 3, 4, 5, 6],
+					oldPosition: 4,
+					newPosition: 2
+				},
+				expected: [1, 2, 5, 3, 4, 6]
+			},
+			{
+				description: 'moves item backward to beginning of an array',
+				input: {
+					array: [1, 2, 3, 4, 5, 6],
+					oldPosition: 4,
+					newPosition: 0
+				},
+				expected: [5, 1, 2, 3, 4, 6]
+			},
+			{
+				description: 'moves item forward to end of an array',
+				input: {
+					array: [1, 2, 3, 4, 5, 6],
+					oldPosition: 2,
+					newPosition: 5
+				},
+				expected: [1, 2, 4, 5, 6, 3]
+			},
+			{
+				description: 'moves last item to beginning of an array',
+				input: {
+					array: [1, 2, 3, 4, 5, 6],
+					oldPosition: 5,
+					newPosition: 0
+				},
+				expected: [6, 1, 2, 3, 4, 5]
+			},
+			{
+				description: 'moves first item to end of an array',
+				input: {
+					array: [1, 2, 3, 4, 5, 6],
+					oldPosition: 0,
+					newPosition: 5
+				},
+				expected: [2, 3, 4, 5, 6, 1]
+			}
+		];
+
+		for (const test of tests) {
+			it(`${test.description}`, () => {
+				const event = new NewPositionEventDetails({
+					oldPosition: test.input.oldPosition,
+					position: test.input.newPosition
+				});
+				event.reorder(test.input.array);
+				expect(test.input.array).to.deep.equal(test.expected);
+			});
+		}
+
+		it('throws an error when a position does not exist', () => {
+			const event = new NewPositionEventDetails({
+				oldPosition: 1,
+				position: 10
+			});
+			expect(() => event.reorder([1, 2, 3])).to.throw(Error);
+
+		});
 	});
 });

--- a/components/list/test/list-item-drag-mixin.test.js
+++ b/components/list/test/list-item-drag-mixin.test.js
@@ -91,8 +91,8 @@ describe('NewPositionEventDetails', () => {
 		for (const test of tests) {
 			it(`${test.description}`, () => {
 				const event = new NewPositionEventDetails({
-					oldPosition: test.input.oldPosition,
-					position: test.input.newPosition
+					origin: test.input.oldPosition,
+					destination: test.input.newPosition
 				});
 				event.reorder(test.input.array);
 				expect(test.input.array).to.deep.equal(test.expected);
@@ -101,8 +101,8 @@ describe('NewPositionEventDetails', () => {
 
 		it('throws an error when a position does not exist', () => {
 			const event = new NewPositionEventDetails({
-				oldPosition: 1,
-				position: 10
+				origin: 1,
+				destination: 10
 			});
 			expect(() => event.reorder([1, 2, 3])).to.throw(Error);
 

--- a/components/list/test/list-item-drag-mixin.test.js
+++ b/components/list/test/list-item-drag-mixin.test.js
@@ -24,87 +24,88 @@ describe('NewPositionEventDetails', () => {
 	describe('reorder', () => {
 		const tests = [
 			{
-				description: 'does nothing when new and old position are the same',
+				description: 'does nothing when new and old key are the same',
 				input: {
-					array: [1, 2, 3],
-					oldPosition: 1,
-					newPosition: 1
+					array: ['one', 'two', 'three'],
+					targetKey: 'one',
+					destinationKey: 'one'
 				},
-				expected: [1, 2, 3]
+				expected: ['one', 'two', 'three']
 			},
 			{
 				description: 'moves item forward in the middle of an array',
 				input: {
-					array: [1, 2, 3, 4, 5, 6],
-					oldPosition: 2,
-					newPosition: 4
+					array: ['one', 'two', 'three', 'four', 'five'],
+					targetKey: 'two',
+					destinationKey: 'four'
 				},
-				expected: [1, 2, 4, 5, 3, 6]
+				expected: ['one', 'three', 'four', 'two', 'five']
 			},
 			{
 				description: 'moves item backward in the middle of an array',
 				input: {
-					array: [1, 2, 3, 4, 5, 6],
-					oldPosition: 4,
-					newPosition: 2
+					array: ['one', 'two', 'three', 'four', 'five'],
+					targetKey: 'four',
+					destinationKey: 'two'
 				},
-				expected: [1, 2, 5, 3, 4, 6]
+				expected: ['one', 'four', 'two', 'three', 'five']
 			},
 			{
 				description: 'moves item backward to beginning of an array',
 				input: {
-					array: [1, 2, 3, 4, 5, 6],
-					oldPosition: 4,
-					newPosition: 0
+					array: ['one', 'two', 'three', 'four', 'five'],
+					targetKey: 'four',
+					destinationKey: 'one'
 				},
-				expected: [5, 1, 2, 3, 4, 6]
+				expected: ['four', 'one', 'two', 'three', 'five']
 			},
 			{
 				description: 'moves item forward to end of an array',
 				input: {
-					array: [1, 2, 3, 4, 5, 6],
-					oldPosition: 2,
-					newPosition: 5
+					array: ['one', 'two', 'three', 'four', 'five'],
+					targetKey: 'two',
+					destinationKey: 'five'
 				},
-				expected: [1, 2, 4, 5, 6, 3]
+				expected: ['one', 'three', 'four', 'five', 'two']
 			},
 			{
 				description: 'moves last item to beginning of an array',
 				input: {
-					array: [1, 2, 3, 4, 5, 6],
-					oldPosition: 5,
-					newPosition: 0
+					array: ['one', 'two', 'three', 'four', 'five'],
+					targetKey: 'five',
+					destinationKey: 'one'
 				},
-				expected: [6, 1, 2, 3, 4, 5]
+				expected: ['five', 'one', 'two', 'three', 'four']
 			},
 			{
 				description: 'moves first item to end of an array',
 				input: {
-					array: [1, 2, 3, 4, 5, 6],
-					oldPosition: 0,
-					newPosition: 5
+					array: ['one', 'two', 'three', 'four', 'five'],
+					targetKey: 'one',
+					destinationKey: 'five'
 				},
-				expected: [2, 3, 4, 5, 6, 1]
+				expected: ['two', 'three', 'four', 'five', 'one']
 			}
 		];
 
 		for (const test of tests) {
 			it(`${test.description}`, () => {
 				const event = new NewPositionEventDetails({
-					origin: test.input.oldPosition,
-					destination: test.input.newPosition
+					targetKey: test.input.targetKey,
+					destinationKey: test.input.destinationKey
 				});
-				event.reorder(test.input.array);
-				expect(test.input.array).to.deep.equal(test.expected);
+				const objects = test.input.array.map(x => ({key : x }));
+				event.reorder(objects);
+				expect(objects.map(x => x.key)).to.deep.equal(test.expected);
 			});
 		}
 
 		it('throws an error when a position does not exist', () => {
 			const event = new NewPositionEventDetails({
-				origin: 1,
-				destination: 10
+				targetKey: 'bar',
+				destinationKey: 'foo'
 			});
-			expect(() => event.reorder([1, 2, 3])).to.throw(Error);
+			expect(() => event.reorder([{ key: 'key' }])).to.throw(Error);
 
 		});
 	});

--- a/components/list/test/list-item-drag-mixin.test.js
+++ b/components/list/test/list-item-drag-mixin.test.js
@@ -49,9 +49,9 @@ describe('NewPositionEventDetails', () => {
 			});
 			let msg = '';
 			const fn = (item, index) => {
-				msg = `${item.key} has moved to position ${index + 1}`
+				msg = `${item.key} has moved to position ${index + 1}`;
 				return msg;
-			}
+			};
 			event.announceMove(list, {
 				announceFn: fn,
 				keyFn: keyFn


### PR DESCRIPTION
## Context
[US115496](https://rally1.rallydev.com/#/detail/userstory/383979103344?fdp=true)
[Design Document](https://desire2learn.atlassian.net/wiki/spaces/POL/pages/996083189/US114586+wc-list+Refactor+for+Drag+n+Drop#newPositionEventDetails)

The new `NewPositionEventDetails` class is an event class with helper methods included. Currently, the event is not hooked up to anything - @m6jones 's work will be in tandem. The new class will replace the current `detail` in the 'd2l-list-item-position' event.

Comments will be reduced or eliminated when the drag n drop feature is merged into `master`.

### Event Properties
- `targetKey`: The key of the node that is moving
- `destinationKey`: The key of the item in the position the node is moving to
- `temporaryMovement`: Whether the movement is entering or exiting a temporary movement (for use with keyboard mode - currently not used)

### Event Methods
- `announceMove`: Announces the movement with a given array and a callback function
- `fetchPosition`: Fetches the position of the node given an array and a key
- `reorder`: Reorders a given array in place. Announces the movement if a callback function is given

## Quality
- Added unit tests to ensure reordering works