### PR TITLE
jsdoc comments: tweaks for consistency

### DIFF
--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -13,7 +13,7 @@ const states = {
 };
 
 /**
- * The `d2l-alert-toast` component serves the same purpose as `d2l-alert`; however, it is displayed as a pop-up at the bottom of the screen that automatically dismisses itself by default.
+ *  A component for communicating important information relating to the state of the system and the user's work flow, displayed as a pop-up at the bottom of the screen that automatically dismisses itself by default.
  * @slot - Default content placed inside of the component
  */
 class AlertToast extends LitElement {
@@ -26,27 +26,29 @@ class AlertToast extends LitElement {
 			buttonText: { type: String, attribute: 'button-text' },
 
 			/**
-			 * Hide the close button to prevent users from manually closing the alert.
+			 * Hide the close button to prevent users from manually closing the alert
 			 */
 			hideCloseButton: { type: Boolean, attribute: 'hide-close-button' },
 
 			/**
-			 * Prevents the alert from automatically closing 4 seconds after opening.
+			 * Prevents the alert from automatically closing 4 seconds after opening
 			 */
 			noAutoClose: { type: Boolean, attribute: 'no-auto-close' },
 
 			/**
-			 * Open or close the toast alert.
+			 * Open or close the toast alert
 			 */
 			open: { type: Boolean, reflect: true },
 
 			/**
-			 * The text that is displayed below the main alert message.
+			 * The text that is displayed below the main alert message
 			 */
 			subtext: { type: String },
 
 			/**
-			 * Type of the alert being displayed. Can be one of  `default`, `critical`, `success` , `warning`
+			 * Type of the alert being displayed
+			 * @type {('default'|'critical'|'success'|'warning')}
+			 * @default "default"
 			 */
 			type: { type: String, reflect: true },
 			_state: { type: String }

--- a/components/alert/alert.js
+++ b/components/alert/alert.js
@@ -8,7 +8,7 @@ import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 /**
- * The `d2l-alert` component can be used to communicate important information relating to the state of the system and the user's work flow.
+ * A component for communicating important information relating to the state of the system and the user's work flow.
  * @slot - Default content placed inside of the component
  * @fires d2l-alert-closed - Dispatched when the alert's close button is clicked
  * @fires d2l-alert-button-pressed - Dispatched when the alert's action button is clicked
@@ -23,17 +23,18 @@ class Alert extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			buttonText: { type: String, attribute: 'button-text' },
 
 			/**
-			 * Gives the alert a close button that will close the alert when clicked.
+			 * Gives the alert a close button that will close the alert when clicked
 			 */
 			hasCloseButton: { type: Boolean, attribute: 'has-close-button' },
 
 			/**
-			 * The text that is displayed below the main alert message.
+			 * The text that is displayed below the main alert message
 			 */
 			subtext: { type: String },
 
 			/**
-			 * Type of the alert being displayed. Can be one of  `default`, `critical`, `success` , `warning`
+			 * Type of the alert being displayed
+			 * @type {('default'|'critical'|'success'|'warning')}
 			 */
 			type: { type: String, reflect: true }
 		};

--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -9,14 +9,14 @@ const scrollKeys = [];
 let scrollOverflow = null;
 
 /**
- * The `d2l-backdrop` element is a web component to display a semi-transparent backdrop behind a specified sibling element. It also hides elements other than the target from assistive technologies by applying `role="presentation"` and `aria-hidden="true"`.
+ * A component for displaying a semi-transparent backdrop behind a specified sibling element. It also hides elements other than the target from assistive technologies by applying 'role="presentation"' and 'aria-hidden="true"'.
  */
 class Backdrop extends LitElement {
 
 	static get properties() {
 		return {
 			/**
-			 * id of the target element to display backdrop behind
+			 * REQUIRED: id of the target element to display backdrop behind
 			 */
 			forTarget: { type: String, attribute: 'for-target' },
 

--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -7,29 +7,30 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 /**
- * The `d2l-button-icon` element can be used just like the native `button`, for instances where only an icon is displayed.
+ * A button component that can be used just like the native button for instances where only an icon is displayed.
  */
 class ButtonIcon extends ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement))) {
 
 	static get properties() {
 		return {
 			/**
-			 * Aligns the leading edge of text if value is set to "text".
+			 * Aligns the leading edge of text if value is set to "text"
+			 * @type {('text'|'')}
 			 */
 			hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
 			/**
-			 * Preset icon key (e.g. `tier1:gear`)
+			 * REQUIRED: Preset icon key (e.g. "tier1:gear")
 			 */
 			icon: { type: String, reflect: true },
 
 			/**
-			 * Accessible text for the button
+			 * REQUIRED: Accessible text for the button
 			 */
 			text: { type: String, reflect: true },
 
 			/**
-			 * Indicates to display translucent (ex. on rich backgrounds)
+			 * Indicates to display translucent (e.g., on rich backgrounds)
 			 */
 			translucent: { type: Boolean, reflect: true }
 		};

--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -2,9 +2,21 @@ export const ButtonMixin = superclass => class extends superclass {
 
 	static get properties() {
 		return {
+			/**
+			 * Indicate expansion state of a collapsible element
+			 */
 			ariaExpanded: { type: String, reflect: true, attribute: 'aria-expanded' },
+			/**
+			 * Indicate clicking the button opens a menu
+			 */
 			ariaHaspopup: { type: String, reflect: true, attribute: 'aria-haspopup' },
+			/**
+			 * Acts as a primary label
+			 */
 			ariaLabel: { type: String, reflect: true, attribute: 'aria-label' },
+			/**
+			 * Disables the button
+			 */
 			disabled: { type: Boolean, reflect: true },
 			autofocus: { type: Boolean, reflect: true },
 			form: { type: String, reflect: true },
@@ -14,6 +26,9 @@ export const ButtonMixin = superclass => class extends superclass {
 			formnovalidate: { type: String, reflect: true },
 			formtarget: { type: String, reflect: true },
 			name: { type: String, reflect: true },
+			/**
+			 * Styles the button as a primary button
+			 */
 			primary: { type: Boolean, reflect: true },
 			type: { type: String, reflect: true }
 		};
@@ -21,6 +36,9 @@ export const ButtonMixin = superclass => class extends superclass {
 
 	constructor() {
 		super();
+		this.autofocus = false;
+		this.disabled = false;
+		this.primary = false;
 		this.type = 'button';
 	}
 

--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -7,7 +7,7 @@ import { labelStyles } from '../typography/styles.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 /**
- * The `d2l-button-subtle` element can be used just like the native `button`, but for advanced or de-emphasized actions.
+ * A button component that can be used just like the native button, but for advanced or de-emphasized actions.
  * @slot - Default content placed inside of the button
  */
 class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
@@ -15,17 +15,18 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 	static get properties() {
 		return {
 			/**
-			 * A description to be added to the `button` for accessibility
+			 * A description to be added to the button for accessibility when text on button does not provide enough context
 			 */
 			description: { type: String },
 
 			/**
-			 * Aligns the leading edge of text if value is set to "text".
+			 * Aligns the leading edge of text if value is set to "text"
+			 * @type {('text'|'')}
 			 */
 			hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
 			/**
-			 * Preset icon key (e.g. `tier1:gear`)
+			 * Preset icon key (e.g. "tier1:gear")
 			 */
 			icon: { type: String, reflect: true },
 
@@ -35,7 +36,7 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 			iconRight: { type: Boolean, reflect: true, attribute: 'icon-right' },
 
 			/**
-			 * Text for the button
+			 * REQUIRED: Text for the button
 			 */
 			text: { type: String, reflect: true }
 		};

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -6,7 +6,7 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { labelStyles } from '../typography/styles.js';
 
 /**
- * The `d2l-button` element can be used just like the native button element, but also supports the `primary` attribute for denoting the primary button.
+ * A button component that can be used just like the native button element.
  * @slot - Default content placed inside of the button
  */
 class Button extends ButtonMixin(LitElement) {
@@ -14,7 +14,7 @@ class Button extends ButtonMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * A description to be added to the `button` for accessibility
+			 * A description to be added to the button for accessibility when text on button does not provide enough context
 			 */
 			description: { type: String }
 		};

--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -5,7 +5,7 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
 /**
- * Floating workflow buttons behavior can be added by using the `<d2l-floating-buttons>` custom element. When the normal position of the workflow buttons is below the bottom edge of the viewport, they will dock at the bottom edge. When the normal position becomes visible, they will undock.
+ * A wrapper component to display floating workflow buttons. When the normal position of the workflow buttons is below the bottom edge of the viewport, they will dock at the bottom edge. When the normal position becomes visible, they will undock.
  * @slot - Content to be displayed in the floating container
  */
 class FloatingButtons extends RtlMixin(LitElement) {
@@ -18,7 +18,7 @@ class FloatingButtons extends RtlMixin(LitElement) {
 			alwaysFloat: { type: Boolean, attribute: 'always-float' },
 
 			/**
-			 * The minimum height of the viewport to display floating buttons at (where applicable). If viewport is less than `min-height`, buttons will never appear floating (unless `always-float` is used). If viewport is greater than `min-height` then buttons will float when applicable.
+			 * The minimum height of the viewport to display floating buttons at (where applicable)
 			 */
 			minHeight: { type: String, attribute: 'min-height' },
 			_containerMarginLeft: { type: String },

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -137,7 +137,7 @@ export function getPrevMonth(month) {
 }
 
 /**
- * The "d2l-calendar" component can be used to display a responsively sized calendar that allows for date selection.
+ * A component can be used to display a responsively sized calendar that allows for date selection.
  * @slot - Content displayed under the calendar (e.g., buttons)
  * @fires d2l-calendar-selected - Dispatched when a date is selected through click, space, or enter. "e.detail.date" is in ISO 8601 calendar date format ("YYYY-MM-DD").
  */
@@ -146,22 +146,22 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	static get properties() {
 		return {
 			/**
-			 * Maximum valid date that could be selected by a user.
+			 * Maximum valid date that could be selected by a user
 			 */
 			maxValue: { attribute: 'max-value', reflect: true, type: String },
 
 			/**
-			 * Minimum valid date that could be selected by a user.
+			 * Minimum valid date that could be selected by a user
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 
 			/**
-			 * Currently selected date.
+			 * Currently selected date
 			 */
 			selectedValue: { type: String, attribute: 'selected-value' },
 
 			/**
-			 * Summary of the calendar for accessibility.
+			 * Summary of the calendar for accessibility
 			 */
 			summary: { type: String },
 			_dialog: { type: Boolean },

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -5,7 +5,7 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 import { heading3Styles } from '../typography/styles.js';
 
 /**
- * The "d2l-dialog-confirm" element is a simple confirmation dialog for prompting the user. Apply the "data-dialog-action" attribute to workflow buttons to automatically close the confirm dialog with the action value.
+ * A simple confirmation dialog for prompting the user. Apply the "data-dialog-action" attribute to workflow buttons to automatically close the confirm dialog with the action value.
  * @slot footer - Slot for footer content such as workflow buttons
  * @fires d2l-dialog-open - Dispatched when the dialog is opened
  * @fires d2l-dialog-close - Dispatched with the action value when the dialog is closed for any reason
@@ -15,7 +15,7 @@ class DialogConfirm extends DialogMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * The required text content for the confirmation dialog
+			 * REQUIRED: The text content for the confirmation dialog
 			 */
 			text: { type: String }
 		};

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -32,7 +32,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			opened: { type: Boolean, reflect: true },
 
 			/**
-			 * The optional title for the confirmation dialog
+			 * The optional title for the dialog
 			 */
 			titleText: { type: String, attribute: 'title-text' },
 			_height: { type: Number },

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -10,7 +10,7 @@ import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
 /**
- * The "d2l-dialog" element is a generic dialog that provides a slot for arbitrary content, and a "footer" slot for workflow buttons. Apply the "data-dialog-action" attribute to workflow buttons to automatically close the dialog with the action value.
+ * A generic dialog that provides a slot for arbitrary content and a "footer" slot for workflow buttons. Apply the "data-dialog-action" attribute to workflow buttons to automatically close the dialog with the action value.
  * @slot - Default slot for content inside dialog
  * @slot footer - Slot for footer content such as workflow buttons
  * @fires d2l-dialog-open - Dispatched when the dialog is opened

--- a/components/dropdown/dropdown-button-subtle.js
+++ b/components/dropdown/dropdown-button-subtle.js
@@ -12,7 +12,7 @@ class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * Text for the button (REQUIRED)
+			 * REQUIRED: Text for the button
 			 */
 			text: {
 				type: String

--- a/components/dropdown/dropdown-button.js
+++ b/components/dropdown/dropdown-button.js
@@ -22,7 +22,7 @@ class DropdownButton extends DropdownOpenerMixin(RtlMixin(LitElement)) {
 			},
 
 			/**
-			 * Text for the button (REQUIRED)
+			 * REQUIRED: Text for the button
 			 */
 			text: {
 				type: String

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -11,7 +11,8 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 	static get properties() {
 		return {
 			/**
-			 * Optionally align dropdown to either `start` or `end`. If not set, the dropdown will attempt be centred.
+			 * Optionally align dropdown to either start or end. If not set, the dropdown will attempt be centred.
+			 * @type {('start'|'end')}
 			 */
 			align: {
 				type: String,

--- a/components/dropdown/dropdown-context-menu.js
+++ b/components/dropdown/dropdown-context-menu.js
@@ -13,7 +13,7 @@ class DropdownContextMenu extends DropdownOpenerMixin(VisibleOnAncestorMixin(Lit
 	static get properties() {
 		return {
 			/**
-			 * Label for the context-menu button (REQUIRED for accessibility).
+			 * REQUIRED: Label for the context-menu button
 			 */
 			text: {
 				type: String

--- a/components/dropdown/dropdown-more.js
+++ b/components/dropdown/dropdown-more.js
@@ -13,7 +13,7 @@ class DropdownMore extends DropdownOpenerMixin(VisibleOnAncestorMixin(LitElement
 	static get properties() {
 		return {
 			/**
-			 * Label for the more button (REQUIRED for accessibility).
+			 * REQUIRED: Label for the more button
 			 */
 			text: {
 				type: String

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -20,7 +20,7 @@ class InputDateTime extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * Accessible label for the input (REQUIRED)
+			 * REQUIRED: Accessible label for the input
 			 */
 			label: { type: String },
 			/**

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -33,7 +33,7 @@ class InputDate extends LocalizeCoreElement(LitElement) {
 			 */
 			emptyText: { type: String, attribute: 'empty-text'},
 			/**
-			 * Accessible label for the input (REQUIRED)
+			 * REQUIRED: Accessible label for the input
 			 */
 			label: { type: String },
 			/**
@@ -49,7 +49,7 @@ class InputDate extends LocalizeCoreElement(LitElement) {
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
-			 * Value of the input.
+			 * Value of the input
 			 */
 			value: { type: String },
 			_hiddenContentWidth: { type: String },

--- a/components/inputs/input-fieldset.js
+++ b/components/inputs/input-fieldset.js
@@ -11,7 +11,7 @@ class InputFieldset extends RtlMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * Label for the fieldset (REQUIRED)
+			 * REQUIRED: Label for the fieldset
 			 */
 			label: { type: String },
 			/**

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -20,7 +20,7 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * Accessible label for the input (REQUIRED)
+			 * REQUIRED: Accessible label for the input
 			 */
 			label: { type: String },
 			/**

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -42,11 +42,11 @@ class InputText extends RtlMixin(LitElement) {
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Label for the input (REQUIRED)
+			 * REQUIRED: Label for the input
 			 */
 			label: { type: String },
 			/**
-			 * Hides the label visually (moves it to the input's `aria-label` attribute)
+			 * Hides the label visually (moves it to the input's "aria-label" attribute)
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
 			/**
@@ -106,7 +106,8 @@ class InputText extends RtlMixin(LitElement) {
 			 */
 			title: { type: String },
 			/**
-			 * Can be one of "text", "email", "number", "password", "tel", "url"
+			 * The type of the text input
+			 * @type {('text'|'email'|'number'|'password'|'tel'|'url')}
 			 */
 			type: { type: String },
 			/**

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -89,6 +89,7 @@ class InputTime extends LitElement {
 		return {
 			/**
 			 * Set default value of input. Valid values are times in ISO 8601 time format ("hh:mm:ss"), "startOfDay", "endOfDay".
+			 * @type {('startOfDay'|'endOfDay'|string)}
 			 */
 			defaultValue: { type: String, attribute: 'default-value' },
 			/**
@@ -100,7 +101,7 @@ class InputTime extends LitElement {
 			 */
 			enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
 			/**
-			 * Accessible label for the input (REQUIRED)
+			 * REQUIRED: Accessible label for the input
 			 */
 			label: { type: String },
 			/**
@@ -112,7 +113,8 @@ class InputTime extends LitElement {
 			 */
 			maxHeight: { type: Number, attribute: 'max-height' },
 			/**
-			 * Number of minutes between times shown in dropdown. Valid values are "five", "ten", "fifteen", "twenty", "thirty", "sixty".
+			 * Number of minutes between times shown in dropdown
+			 * @type {('five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty')}
 			 */
 			timeInterval: { type: String, attribute: 'time-interval' },
 			/**

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -41,7 +41,7 @@ class Link extends LitElement {
 			 */
 			download: { type: Boolean },
 			/**
-			 * URL or URL fragment of the link (REQUIRED)
+			 * REQUIRED: URL or URL fragment of the link
 			 */
 			href: { type: String },
 			/**

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -26,6 +26,8 @@ class List extends LitElement {
 			grid: { type: Boolean },
 			/**
 			 * Display separators. Valid values are "all" (default), "between", "none"
+			 * @type {('all'|'between'|'none')}
+			 * @default "all"
 			 */
 			separators: { type: String, reflect: true }
 		};
@@ -42,6 +44,7 @@ class List extends LitElement {
 	constructor() {
 		super();
 		this.extendSeparators = false;
+		this.grid = false;
 	}
 
 	firstUpdated() {

--- a/components/loading-spinner/loading-spinner.js
+++ b/components/loading-spinner/loading-spinner.js
@@ -9,16 +9,17 @@ class LoadingSpinner extends LitElement {
 	static get properties() {
 		return {
 			/**
-			 * Color of the animated bar. Default is "--d2l-color-celestine".
+			 * Color of the animated bar
+			 * @default "--d2l-color-celestine"
 			 */
 			color: { type: String },
 			/**
-			 * Height and width (px) of the spinner. Default is 50.
+			 * Height and width (px) of the spinner
+			 * @default 50
 			 */
 			size: { type: Number }
 		};
 	}
-
 	static get styles() {
 		return css`
 

--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -31,7 +31,7 @@ export const MenuItemMixin = superclass => class extends superclass {
 			 */
 			tabindex: { type: String, reflect: true },
 			/**
-			 * Text displayed by the menu item (REQUIRED)
+			 * REQUIRED: Text displayed by the menu item
 			 */
 			text: { type: String }
 		};

--- a/components/menu/menu-item-selectable-mixin.js
+++ b/components/menu/menu-item-selectable-mixin.js
@@ -5,7 +5,7 @@ export const MenuItemSelectableMixin = superclass => class extends MenuItemMixin
 	static get properties() {
 		return {
 			/**
-			 * This will set the item to be selected by default.
+			 * This will set the item to be selected by default
 			 */
 			selected: { type: Boolean, reflect: true },
 			/**

--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -98,6 +98,11 @@ class MeterLinear extends MeterMixin(RtlMixin(LitElement)) {
 		`];
 	}
 
+	constructor() {
+		super();
+		this.textInline = false;
+	}
+
 	render() {
 		let percentage = this.max > 0 ? this.value / this.max * 100 : 0;
 		if (percentage < 0.5) {

--- a/components/meter/meter-mixin.js
+++ b/components/meter/meter-mixin.js
@@ -19,7 +19,7 @@ export const MeterMixin = superclass => class extends LocalizeCoreElement(superc
 			 */
 			text: { type: String },
 			/**
-			 * (REQUIRED) Current number of completed units.
+			 * REQUIRED: Current number of completed units.
 			 * Valid values: A number between 0 and max
 			 */
 			value: { type: Number }

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -9,7 +9,7 @@ import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
 /**
- * The `d2l-more-less` element can be used to minimize the display of long content, while providing a way to reveal the full content.
+ * A component used to minimize the display of long content, while providing a way to reveal the full content.
  * @slot - Default content placed inside of the component
  * @fires d2l-more-less-render - Dispatched when the component finishes rendering
  */
@@ -18,27 +18,28 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * The gradient color of the blurring effect.
+			 * The gradient color of the blurring effect
 			 */
 			blurColor: { type: String, attribute: 'blur-color' },
 
 			/**
-			 * Indicates whether element is in "more" state.
+			 * Indicates whether element is in "more" state
 			 */
 			expanded: { type: Boolean, reflect: true },
 
 			/**
-			 * The h-align property of the more-less button.
+			 * The h-align property of the more-less button
+			 * @type {('text'|'')}
 			 */
 			hAlign: { type: String, attribute: 'h-align' },
 
 			/**
-			 * The maximum height of the content when in "less" state.
+			 * The maximum height of the content when in "less" state
 			 */
 			height: { type: String },
 
 			/**
-			 * Whether the component is active or inactive.
+			 * Whether the component is active or inactive
 			 */
 			inactive: { type: Boolean, reflect: true },
 			__blurBackground: { type: String },

--- a/components/status-indicator/status-indicator.js
+++ b/components/status-indicator/status-indicator.js
@@ -17,7 +17,7 @@ class StatusIndicator extends LitElement {
 				reflect: true
 			},
 			/**
-			 * (REQUIRED) The text that is displayed within the status indicator
+			 * REQUIRED: The text that is displayed within the status indicator
 			 */
 			text: {
 				type: String

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -18,7 +18,7 @@ export const TabPanelMixin = superclass => class extends superclass {
 			 */
 			selected: { type: Boolean, reflect: true },
 			/**
-			 * The text used for the tab, as well as labelling the panel (REQUIRED)
+			 * REQUIRED: The text used for the tab, as well as labelling the panel
 			 */
 			text: { type: String }
 		};

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -108,7 +108,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			 */
 			disableFocusLock: { type: Boolean, attribute: 'disable-focus-lock' },
 			/**
-			 * (REQUIRED) The "id" of the tooltip's target element. Both elements must be within the same shadow root. If not provided, the tooltip's parent element will be used as its target.
+			 * REQUIRED: The "id" of the tooltip's target element. Both elements must be within the same shadow root. If not provided, the tooltip's parent element will be used as its target.
 			 */
 			for: { type: String },
 			/**
@@ -121,7 +121,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			 */
 			forType: { type: String, attribute: 'for-type' },
 			/**
-			 * Adjust the size of the gap between the tooltip and its target.
+			 * Adjust the size of the gap between the tooltip and its target
 			 */
 			offset: { type: Number }, /* tooltipOffset */
 			/**
@@ -134,7 +134,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			 */
 			showing: { type: Boolean, reflect: true },
 			/**
-			 * The style of the tooltip based on the type of information it displays.
+			 * The style of the tooltip based on the type of information it displays
 			 * @type {('info'|'error')}
 			 */
 			state: { type: String, reflect: true },

--- a/mixins/async-container/async-container-mixin.js
+++ b/mixins/async-container/async-container-mixin.js
@@ -9,7 +9,13 @@ export const AsyncContainerMixin = superclass => class extends superclass {
 
 	static get properties() {
 		return {
+			/**
+			 * @ignore
+			 */
 			asyncPendingDelay: { type: Number, attribute: 'async-pending-delay' },
+			/**
+			 * @ignore
+			 */
 			asyncState: { type: String }
 		};
 	}

--- a/mixins/visible-on-ancestor-mixin.js
+++ b/mixins/visible-on-ancestor-mixin.js
@@ -35,7 +35,7 @@ export const VisibleOnAncestorMixin = superclass => class extends superclass {
 	static get properties() {
 		return {
 			/**
-			 * Component is initially hidden and becomes visible when user hovers or focuses within an ancestor marked with the `d2l-visible-on-ancestor-target` class.
+			 * @ignore
 			 */
 			visibleOnAncestor: { type: Boolean, reflect: true, attribute: 'visible-on-ancestor' },
 			__voaState: { type: String, reflect: true, attribute: '__voa-state' }

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -13,8 +13,8 @@ class TemplatePrimarySecondary extends LitElement {
 	static get properties() {
 		return {
 			/**
-			 * Whether content fills the screen or not.
-			 * Valid values: "fullscreen", "normal"
+			 * Whether content fills the screen or not
+			 * @type {('fullscreen'|'normal')}
 			 */
 			widthType: { type: String, attribute: 'width-type', reflect: true },
 			_hasFooter: { type: Boolean }


### PR DESCRIPTION
- remove periods at ends of small sentences
- change required fields to have "REQUIRED:" at start
- use `@type` and `@default` where applicable
- simplify component descriptions where possible

For quotation marks, I used `"` when defining a `@default` since that's what the analyzer does with defaults it finds and I wanted to keep that consistent. For defining `@type` I used `'` because when displayed in the documentation table they look quite bulky with the double quote. However, this does take away some consistency.