### PR TITLE
demo snippet: add public functionality for forcing the code to update

### DIFF
--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -51,6 +51,10 @@ class CodeView extends LitElement {
 		`;
 	}
 
+	forceUpdate() {
+		this._updateCode(this.shadowRoot.querySelector('slot'));
+	}
+
 	get _codeTemplate() {
 		return html`<pre class="language-${this.language}"><code class="language-${this.language}">${unsafeHTML(this._code)}</code></pre>`;
 	}

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -41,6 +41,18 @@ class DemoSnippet extends LitElement {
 		`;
 	}
 
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((_, prop) => {
+			if (prop === '_code') this.shadowRoot.querySelector('d2l-code-view').forceUpdate();
+		});
+	}
+
+	forceCodeUpdate() {
+		this._updateCode(this.shadowRoot.querySelector('slot:not([name="_demo"])'));
+	}
+
 	_formatCode(text) {
 
 		if (!text) return text;


### PR DESCRIPTION
The scenario is for live demos - have the code update when the component demoing changes.

`slotchange` doesn't seem to work for this and I wasn't sure how to force it to, but overall this seems to work.