### PR TITLE
Fix positioning defect with body as offsetParent

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -468,7 +468,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		// Compute the x and y position of the tooltip relative to its target
 		let parentTop;
 		let parentLeft;
-		if (offsetParent) {
+		if (offsetParent && offsetParent.tagName !== 'BODY') {
 			const parentRect = offsetParent.getBoundingClientRect();
 			parentTop = parentRect.top + offsetParent.clientTop;
 			parentLeft = parentRect.left + offsetParent.clientLeft;


### PR DESCRIPTION
# Changes
This is necessary because browsers include margin in `offsetTop` and `offsetLeft` when the `offsetParent` is the `body`. To avoid positioning incorrectly in this case we need to set `parentTop` and `parentLeft` to `0` so any `margin` will be included in the calculation. Only using the `offsetParent`'s bounding client rect excludes `margin`.