### PR TITLE
fix: introducing a delay of 800ms to the shim before the fade transition starts

### DIFF
--- a/components/backdrop/README.md
+++ b/components/backdrop/README.md
@@ -30,6 +30,7 @@ button.addEventListener('click', () => {
 - `shown` (Boolean): used to control whether the backdrop is shown
 - `slow-transition` (Boolean): Increases the fade transition time to 1200ms (default is 200ms)
 - `no-animate-hide` (Boolean): disables the fade-out transition while the backdrop is being hidden
+- `delay-transition` (Boolean): Introduces a delay (800ms) between the shim rendering and the fade starting
 
 ## Future Enhancements
 

--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -26,6 +26,11 @@ class Backdrop extends LitElement {
 			noAnimateHide: { type: Boolean, attribute: 'no-animate-hide' },
 
 			/**
+			 * Introduces a delay between the shim rendering and the fade starting
+			 */
+			delayTransition: { type: Boolean, attribute: 'delay-transition'},
+
+			/**
 			 * Used to control whether the backdrop is shown
 			 */
 			shown: { type: Boolean },
@@ -48,6 +53,9 @@ class Backdrop extends LitElement {
 			}
 			:host([slow-transition]) {
 				transition: opacity 1200ms ease-in;
+			}
+			:host([delay-transition]) {
+				transition-delay: 800ms;
 			}
 			:host([_state=null][no-animate-hide]) {
 				transition: none;

--- a/components/backdrop/demo/backdrop.html
+++ b/components/backdrop/demo/backdrop.html
@@ -34,6 +34,10 @@
 						<input type="checkbox" id="no-animate-hide" name="no-animate-hide">
 						<label for="no-animate-hide">no animation on hide</label>
 					</div>
+					<div>
+						<input type="checkbox" id="delay-transition" name="delay-transition">
+						<label for="delay-transition">delay transition</label>
+					</div>
 					<d2l-backdrop for-target="target"></d2l-backdrop>
 					<script>
 						const backdrop = document.querySelector('d2l-backdrop');
@@ -48,6 +52,13 @@
 								backdrop.setAttribute('slow-transition', true);
 							} else {
 								backdrop.removeAttribute('slow-transition');
+							}
+						});
+						document.querySelector('#delay-transition').addEventListener('change', e => {
+							if (e.target.checked) {
+								backdrop.setAttribute('delay-transition', true);
+							} else {
+								backdrop.removeAttribute('delay-transition');
 							}
 						});
 					</script>


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/detail/defect/398651793780?fdp=true

adding a 800ms delay to the shim after which the fade transition will start. 

Use case in FACE: When the shim is activated after the 'Save and Close' button is clicked the first time on the Edit Assignment page, it blocks all user interactions and so this solves the problem of clicking 'save and close' multiple times resulting in multiple copies of the file being attached to an assignment - while also maintaining the delay required by design between clicking 'Save and Close' and being directed to the 'Manage Assignments' page. 