### PR TITLE
Integrate mixins into d2l-list-item (Part 1)

### DIFF
--- a/components/list/README.md
+++ b/components/list/README.md
@@ -21,6 +21,7 @@ The `d2l-list` is the container to create a styled list of items using `d2l-list
 
 **Properties:**
 
+- `grid` (Boolean): Enables keyboard grid for supported list items
 - `separators` (String): Display separators (`all` (default), `between`, `none`)
 - `extend-separators` (Boolean): Whether to extend the separators beyond the content's edge
 
@@ -93,7 +94,6 @@ The `d2l-list-item-content` provides additional consistent layout for primary an
 
 ## Future Enhancements
 
-- Use grid to manage focus with arrow keys
 - Drag & drop support
 - Paging: integration with "load more", "scroll" and "numeric" paging mechanisms
 - Header with support for search, selected count, select-all

--- a/components/list/demo/list.html
+++ b/components/list/demo/list.html
@@ -306,6 +306,36 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>List (selectable with href and grid-enabled)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list grid>
+						<d2l-list-item href="http://www.d2l.com" selectable key="1">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Introductory Earth Sciences</div>
+								<div slot="secondary">This course explores the geological process of the Earth's interior and surface. These include volcanism, earthquakes, mountains...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item href="http://www.d2l.com" selectable key="2" selected>
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Engineering Materials for Energy Systems</div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item href="http://www.d2l.com" selectable key="3">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
+							<d2l-list-item-content>
+								<div>Geomorphology and GIS </div>
+								<div slot="secondary">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
+			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 	</body>
 </html>

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -9,9 +9,21 @@ export const ListItemCheckboxMixin = superclass => class extends superclass {
 
 	static get properties() {
 		return {
+			/**
+			 * Disables the checkbox
+			 */
 			disabled: { type: Boolean },
+			/**
+			 * Value to identify item if selectable
+			 */
 			key: { type: String, reflect: true },
+			/**
+			 * Indicates a checkbox should be rendered for selecting the item
+			 */
 			selectable: {type: Boolean },
+			/**
+			 * Whether the item is selected
+			 */
 			selected: { type: Boolean, reflect: true }
 		};
 	}

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -39,7 +39,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 					[start outside-control-start] minmax(0, min-content)
 					[control-start outside-control-end] minmax(0, min-content)
 					[control-end content-start] auto
-					[content-end actions-start] auto
+					[content-end actions-start] minmax(0, max-content)
 					[end actions-end];
 			}
 			::slotted([slot="outside-control"]),
@@ -49,12 +49,12 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 				grid-row: 1 / 2;
 			}
 			::slotted([slot="outside-control"]) {
-				width: 40px;
+				width: 42px;
 				grid-column: outside-control-start / outside-control-end;
 			}
 
 			::slotted([slot="control"]) {
-				width: 40px;
+				width: 42px;
 				grid-column: control-start / control-end;
 			}
 

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -67,12 +67,12 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 				grid-row: 1 / 2;
 			}
 			::slotted([slot="outside-control"]) {
-				width: 1.4rem;
+				width: 2.1rem;
 				grid-column: outside-control-start / outside-control-end;
 			}
 
 			::slotted([slot="control"]) {
-				width: 1.4rem;
+				width: 2.1rem;
 				grid-column: control-start / control-end;
 			}
 
@@ -101,13 +101,6 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			::slotted([slot="content-action"]) {
 				grid-column: content-start / end;
 				z-index: 3;
-			}
-
-			@media screen and (min-width: 615px) {
-				::slotted([slot="outside-control"]),
-				::slotted([slot="control"]) {
-					width: 2.1rem;
-				}
 			}
 		`;
 	}

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -22,11 +22,29 @@ const keyCodes = {
 	UP: 38
 };
 
+/**
+ * A component for generating a list item's layout with forced focus ordering and grid support.
+ * Focusable items placed in the "content" slot will have their focus removed; use the content-action
+ * slot for such items.
+ * @slot outside-control - Control associated on the far left, e.g., a drag-n-drop handle
+ * @slot outside-control-action - An action area associated with the outside control
+ * @slot control - Main control beside the outside control, e.g., a checkbox
+ * @slot control-action - Action area associated with the main control
+ * @slot content - Content of the list item, such as that in a list-item-content component.
+ * @slot content-action - Action associated with the content, such as a navigation link
+ * @slot actions - Other actions for the list item on the far right, such as a context menu
+ */
 class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 	static get properties() {
 		return {
+			/**
+			 * @ignore
+			 */
 			role: { type: String, reflect: true },
+			/**
+			 * Whether the keyboard grid is active
+			 */
 			gridActive: { type: Boolean, attribute: 'grid-active' }
 		};
 	}
@@ -206,13 +224,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 	_focusNextRow(previous = false, num = 1) {
 		let listItem = previous ?
-<<<<<<< HEAD
-			getPreviousAncestorSibling(this, (node) => node.tagName === 'D2L-LIST-ITEM') :
-			getNextAncestorSibling(this, (node) => node.tagName === 'D2L-LIST-ITEM');
-=======
 			getPreviousAncestorSibling(this, (node) => node.role === 'rowgroup') :
 			getNextAncestorSibling(this, (node) => node.role === 'rowgroup');
->>>>>>> polaris/updateListItem
 		if (!listItem || !listItem.shadowRoot) return;
 		while (num > 1) {
 			const nextItem = previous ? listItem.previousElementSibling : listItem.nextElementSibling;

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -206,8 +206,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 	_focusNextRow(previous = false, num = 1) {
 		let listItem = previous ?
-			getPreviousAncestorSibling(this, (node) => node.tagName === 'D2L-LIST-ITEM-SAMPLE') :
-			getNextAncestorSibling(this, (node) => node.tagName === 'D2L-LIST-ITEM-SAMPLE');
+			getPreviousAncestorSibling(this, (node) => node.tagName === 'D2L-LIST-ITEM') :
+			getNextAncestorSibling(this, (node) => node.tagName === 'D2L-LIST-ITEM');
 		if (!listItem || !listItem.shadowRoot) return;
 		while (num > 1) {
 			const nextItem = previous ? listItem.previousElementSibling : listItem.nextElementSibling;

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -67,12 +67,12 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 				grid-row: 1 / 2;
 			}
 			::slotted([slot="outside-control"]) {
-				width: 42px;
+				width: 1.4rem;
 				grid-column: outside-control-start / outside-control-end;
 			}
 
 			::slotted([slot="control"]) {
-				width: 42px;
+				width: 1.4rem;
 				grid-column: control-start / control-end;
 			}
 
@@ -101,6 +101,13 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			::slotted([slot="content-action"]) {
 				grid-column: content-start / end;
 				z-index: 3;
+			}
+
+			@media screen and (min-width: 615px) {
+				::slotted([slot="outside-control"]),
+				::slotted([slot="control"]) {
+					width: 2.1rem;
+				}
 			}
 		`;
 	}

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -4,6 +4,9 @@ export const ListItemMixin = superclass => class extends superclass {
 
 	static get properties() {
 		return {
+			/**
+			 * @ignore
+			 */
 			role: { type: String, reflect: true }
 		};
 	}
@@ -13,6 +16,11 @@ export const ListItemMixin = superclass => class extends superclass {
 
 		const parent = findComposedAncestor(this.parentNode, node => node && node.tagName === 'D2L-LIST');
 		if (!parent) return;
+
+		const separators = parent.getAttribute('separators');
+
 		this.role = parent.grid ? 'rowgroup' : 'listitem';
+		this._separators = separators || undefined;
+		this._extendSeparators = parent.hasAttribute('extend-separators');
 	}
 };

--- a/components/list/list-item-role-mixin.js
+++ b/components/list/list-item-role-mixin.js
@@ -1,6 +1,6 @@
 import { findComposedAncestor } from '../../helpers/dom.js';
 
-export const ListItemMixin = superclass => class extends superclass {
+export const ListItemRoleMixin = superclass => class extends superclass {
 
 	static get properties() {
 		return {

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -41,6 +41,9 @@ class ListItem extends RtlMixin(LitElement) {
 			 * Disables the checkbox
 			 */
 			disabled: {type: Boolean },
+			/**
+			 * Indicates a drag handle should be rendered for reordering an item
+			 */
 			draggable: { type: Boolean },
 			/**
 			 * Address of item link if navigable

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -188,12 +188,14 @@ class ListItem extends RtlMixin(LitElement) {
 			:host([selectable]:not([disabled])) d2l-list-item-generic-layout.focusing {
 				background-color: var(--d2l-color-regolith);
 			}
-			:host([selected]:not([disabled]):hover) d2l-list-item-generic-layout,
-			:host([selected]:not([disabled])) d2l-list-item-generic-layout.focusing {
+			:host([selected]:not([disabled])) d2l-list-item-generic-layout {
 				background-color: #F3FBFF;
+			}
+			:host([selected]:not([disabled])) d2l-list-item-generic-layout,
+			:host([selected]:not([disabled])) d2l-list-item-generic-layout.focusing {
 				border-color: #79B5DF;
 			}
-			:host([selected]:not([disabled]):hover) .d2l-list-item-active-border,
+			:host([selected]:not([disabled])) .d2l-list-item-active-border,
 			:host([selected]:not([disabled])) d2l-list-item-generic-layout.focusing + .d2l-list-item-active-border {
 				position: absolute;
 				width: 100%;

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -6,7 +6,7 @@ import { getFirstFocusableDescendant } from '../../helpers/focus.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { ListItemCheckboxMixin } from './list-item-checkbox-mixin.js';
-import { ListItemMixin } from './list-item-mixin.js';
+import { ListItemRoleMixin } from './list-item-role-mixin.js';
 import { nothing } from 'lit-html';
 import ResizeObserver from 'resize-observer-polyfill';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
@@ -29,7 +29,7 @@ const defaultBreakpoints = [842, 636, 580, 0];
  * @slot actions - Actions (e.g., button icons) associated with the listen item located at the right of the item
  * @fires d2l-list-item-selected - Dispatched when the component item is selected
  */
-class ListItem extends ListItemCheckboxMixin(ListItemMixin(RtlMixin(LitElement))) {
+class ListItem extends ListItemCheckboxMixin(ListItemRoleMixin(RtlMixin(LitElement))) {
 
 	static get properties() {
 		return {

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -1,11 +1,13 @@
 import '../colors/colors.js';
+import './list-item-generic-layout.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { checkboxStyles } from '../inputs/input-checkbox-styles.js';
-import { classMap} from 'lit-html/directives/class-map.js';
+import { classMap } from 'lit-html/directives/class-map.js';
 import { findComposedAncestor } from '../../helpers/dom.js';
 import { getFirstFocusableDescendant } from '../../helpers/focus.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { nothing } from 'lit-html';
 import ResizeObserver from 'resize-observer-polyfill';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
@@ -39,6 +41,7 @@ class ListItem extends RtlMixin(LitElement) {
 			 * Disables the checkbox
 			 */
 			disabled: {type: Boolean },
+			draggable: { type: Boolean },
 			/**
 			 * Address of item link if navigable
 			 */
@@ -59,167 +62,126 @@ class ListItem extends RtlMixin(LitElement) {
 			 * Whether the item is selected
 			 */
 			selected: { type: Boolean, reflect: true },
-			_breakpoint: { type: Number }
+			_breakpoint: { type: Number },
+			_hovering: { type: Boolean },
+			_focusing: { type: Boolean }
 		};
 	}
 
 	static get styles() {
 
-		return [ checkboxStyles,  css`
-
+		return [ checkboxStyles, css`
 			:host {
 				display: block;
 				margin-top: -1px;
 			}
-
 			:host[hidden] {
 				display: none;
 			}
-
-			.d2l-list-item-flex {
-				display: flex;
-				position: relative;
+			:host([href]) {
+				--d2l-list-item-content-text-color: var(--d2l-color-celestine);
 			}
-
-			.d2l-list-item-content {
+			:host(:first-child) d2l-list-item-generic-layout[data-separators="between"] {
+				border-top: 1px solid transparent;
+			}
+			:host(:last-child) d2l-list-item-generic-layout[data-separators="between"] {
+				border-bottom: 1px solid transparent;
+			}
+			d2l-list-item-generic-layout[data-separators="none"] {
+				border-top: 1px solid transparent;
+				border-bottom: 1px solid transparent;
+			}
+			d2l-list-item-generic-layout {
 				border-bottom: 1px solid transparent;
 				border-bottom: 1px solid var(--d2l-color-mica);
 				border-top: 1px solid var(--d2l-color-mica);
-				width: 100%;
 			}
-
-			:host(:first-child) .d2l-list-item-content[data-separators="between"] {
-				border-top: 1px solid transparent;
-			}
-
-			:host(:last-child) .d2l-list-item-content[data-separators="between"] {
-				border-bottom: 1px solid transparent;
-			}
-
-			.d2l-list-item-content[data-separators="none"] {
-				border-top: 1px solid transparent;
-				border-bottom: 1px solid transparent;
-			}
-
-			.d2l-list-item-content-flex {
-				display: flex;
-				justify-content: stretch;
-				padding: 0.55rem 0;
-			}
-
-			.d2l-list-item-content.d2l-list-item-content-extend-separators .d2l-list-item-content-flex {
+			[slot="content"].d2l-list-item-content-extend-separators {
 				padding-left: 0.9rem;
 				padding-right: 0.9rem;
 			}
-
-			input[type="checkbox"].d2l-input-checkbox {
+			a[href].d2l-list-item-link {
+				width: 100%;
+				height: 100%;
+			}
+			.d2l-list-item-content ::slotted(*) {
+				margin-top: 0.05rem;
+			}
+			.d2l-list-item-content.hovering,
+			.d2l-list-item-content.focusing {
+				--d2l-list-item-content-text-decoration: underline;
+			}
+			[slot="content-action"]:focus {
+				outline: none;
+			}
+			[slot="content"] {
+				justify-content: stretch;
+				padding: 0.55rem 0px;
+				display: flex;
+			}
+			[slot="content"] ::slotted([slot="illustration"]) {
+				margin: 0.15rem 0.9rem 0.15rem 0;
+				max-height: 2.6rem;
+				max-width: 4.5rem;
+				border-radius: 6px;
+				overflow: hidden;
 				flex-grow: 0;
 				flex-shrink: 0;
-				margin: 0.6rem 0.9rem 0.6rem 0;
+			}
+			:host([dir="rtl"]) [slot="content"] ::slotted([slot="illustration"]) {
+				margin-left: 0.9rem;
+				margin-right: 0;
+			}
+			.d2l-list-item-actions-container {
+				padding: 0.55rem 0;
+			}
+			::slotted([slot="actions"]) {
+				display: grid;
+				grid-auto-columns: 1fr;
+				grid-auto-flow: column;
+				gap: 0.3rem;
+				margin: 0.15rem 0;
+			}
+
+			[data-breakpoint="1"] ::slotted([slot="illustration"]),
+			[data-breakpoint="1"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
+				margin-right: 1rem;
+				max-height: 3.55rem;
+				max-width: 6rem;
+			}
+			:host([dir="rtl"]) [data-breakpoint="1"] ::slotted([slot="illustration"]) {
+				margin-left: 1rem;
+				margin-right: 0;
+			}
+			[data-breakpoint="2"] ::slotted([slot="illustration"]) {
+				margin-right: 1rem;
+				max-height: 5.1rem;
+				max-width: 9rem;
+			}
+
+			:host([dir="rtl"]) [data-breakpoint="2"] ::slotted([slot="illustration"]) {
+				margin-left: 1rem;
+				margin-right: 0;
+			}
+			[data-breakpoint="3"] ::slotted([slot="illustration"]) {
+				margin-right: 1rem;
+				max-height: 6rem;
+				max-width: 10.8rem;
+			}
+
+			:host([dir="rtl"]) [data-breakpoint="3"] ::slotted([slot="illustration"]) {
+				margin-left: 1rem;
+				margin-right: 0;
+			}
+
+			input[type="checkbox"].d2l-input-checkbox {
+				margin: 1.15rem 0.9rem 1.15rem 0;
 			}
 
 			:host([dir="rtl"]) input[type="checkbox"].d2l-input-checkbox {
 				margin-left: 0.9rem;
 				margin-right: 0;
 			}
-
-			.d2l-list-item-container ::slotted([slot="illustration"]),
-			.d2l-list-item-content-flex ::slotted([slot="illustration"]) {
-				flex-grow: 0;
-				flex-shrink: 0;
-				margin: 0.15rem 0.9rem 0.15rem 0;
-				max-height: 2.6rem;
-				max-width: 4.5rem;
-				border-radius: 6px;
-				overflow: hidden;
-			}
-
-			:host([dir="rtl"]) .d2l-list-item-container ::slotted([slot="illustration"]),
-			:host([dir="rtl"]) .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
-				margin-left: 0.9rem;
-				margin-right: 0;
-			}
-
-			.d2l-list-item-main {
-				flex-grow: 1;
-				margin-top: 0.05rem;
-			}
-
-			.d2l-list-item-content-flex ::slotted([slot="actions"]) {
-				align-self: flex-start;
-				display: grid;
-				flex-grow: 0;
-				grid-auto-columns: 1fr;
-				grid-auto-flow: column;
-				grid-gap: 0.3rem;
-				margin: 0.15rem 0;
-				z-index: 4;
-			}
-
-			a, label {
-				height: 100%;
-				position: absolute;
-				width: 100%;
-				z-index: 2;
-			}
-
-			:host([href]) label {
-				width: 2.1rem;
-				z-index: 3;
-			}
-
-			:host([href]) {
-				--d2l-list-item-content-text-color: var(--d2l-color-celestine);
-			}
-
-			a[href]:focus + .d2l-list-item-content,
-			a[href]:hover + .d2l-list-item-content {
-				--d2l-list-item-content-text-decoration: underline;
-			}
-
-			:host([href]) .d2l-list-item-link:focus {
-				outline: none;
-			}
-
-			.d2l-list-item-container[data-breakpoint="1"] ::slotted([slot="illustration"]),
-			.d2l-list-item-container[data-breakpoint="1"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
-				margin-right: 1rem;
-				max-height: 3.55rem;
-				max-width: 6rem;
-			}
-
-			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="1"] ::slotted([slot="illustration"]),
-			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="1"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
-				margin-left: 1rem;
-				margin-right: 0;
-			}
-
-			.d2l-list-item-container[data-breakpoint="2"] ::slotted([slot="illustration"]),
-			.d2l-list-item-container[data-breakpoint="2"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
-				margin-right: 1rem;
-				max-height: 5.1rem;
-				max-width: 9rem;
-			}
-
-			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="2"] ::slotted([slot="illustration"]),
-			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="2"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
-				margin-left: 1rem;
-				margin-right: 0;
-			}
-
-			.d2l-list-item-container[data-breakpoint="3"] ::slotted([slot="illustration"]),
-			.d2l-list-item-container[data-breakpoint="3"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
-				margin-right: 1rem;
-				max-height: 6rem;
-				max-width: 10.8rem;
-			}
-
-			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="3"] ::slotted([slot="illustration"]),
-			:host([dir="rtl"]) .d2l-list-item-container[data-breakpoint="3"] .d2l-list-item-content-flex ::slotted([slot="illustration"]) {
-				margin-left: 1rem;
-				margin-right: 0;
-			}
-
 		`];
 	}
 
@@ -228,7 +190,6 @@ class ListItem extends RtlMixin(LitElement) {
 		this._breakpoint = 0;
 		this.breakpoints = defaultBreakpoints;
 		this.disabled = false;
-		this.role = 'listitem';
 		this.selected = false;
 		this.selectable = false;
 		this._contentId = getUniqueId();
@@ -268,37 +229,51 @@ class ListItem extends RtlMixin(LitElement) {
 	}
 
 	render() {
-
-		const label = this.selectable ? html`<label class="d2l-list-item-label" for="${this._checkBoxId}" aria-labelledby="${this._contentId}"></label>` : null;
-		const link = this.href ? html`<a class="d2l-list-item-link" href="${ifDefined(this.href)}" aria-labelledby="${this._contentId}"></a>` : null;
-		const beforeContent = this.selectable
-			? html`<input id="${this._checkBoxId}" class="d2l-input-checkbox" @change="${this._handleCheckboxChange}" type="checkbox" .checked="${this.selected}" ?disabled="${this.disabled}"><slot name="illustration"></slot>`
-			: html`<slot name="illustration"></slot>`;
-
 		const classes = {
-			'd2l-list-item-container': true,
-			'd2l-list-item-flex': label || link,
 			'd2l-visible-on-ancestor-target': true
 		};
 		const contentClasses = {
 			'd2l-list-item-content': true,
-			'd2l-list-item-content-extend-separators': this._extendSeparators
+			'd2l-list-item-content-extend-separators': this._extendSeparators,
+			'hovering': this._hovering,
+			'focusing': this._focusing,
 		};
 
 		return html`
-			<div class="${classMap(classes)}" data-breakpoint="${this._breakpoint}">
-				${label}
-				${link}
-				<div id="${this._contentId}"
-					class="${classMap(contentClasses)}"
-					data-separators="${ifDefined(this._separators)}">
-					<div class="d2l-list-item-content-flex">
-						${beforeContent}
-						<div class="d2l-list-item-main"><slot></slot></div>
-						<slot name="actions"></slot>
-					</div>
+			<d2l-list-item-generic-layout
+				class="${classMap(classes)}"
+				data-breakpoint="${this._breakpoint}"
+				data-separators="${ifDefined(this._separators)}"
+				?grid-active="${this.role === 'rowgroup'}">
+				${ this.draggable ? html`
+				<div slot="outside-control"></div>
+				` : nothing }
+				${this.selectable ? html`
+				<div slot="control">
+					<input id="${this._checkBoxId}" class="d2l-input-checkbox" @change="${this._handleCheckboxChange}" type="checkbox" .checked="${this.selected}" ?disabled="${this.disabled}">
 				</div>
-			</div>
+				<div slot="control-action"></div>
+				` : nothing }
+				${ this.href ? html`
+				<a slot="content-action"
+					href="${this.href}"
+					aria-labelledby="${this._contentId}"
+					@mouseenter="${this._handleMouseEnter}"
+					@mouseleave="${this._handleMouseLeave}"
+					@focus="${this._handleFocus}"
+					@blur="${this._handleBlur}"></a>
+				` : nothing }
+				<div slot="content"
+					class="${classMap(contentClasses)}"
+					id="${this._contentId}">
+					<slot name="illustration"></slot>
+					<slot></slot>
+				</div>
+
+				<div class="d2l-list-item-actions-container" slot="actions">
+					<slot name="actions"></slot>
+				</div>
+			</d2l-list-item-generic-layout>
 		`;
 
 	}
@@ -344,6 +319,22 @@ class ListItem extends RtlMixin(LitElement) {
 
 	_handleCheckboxChange(e) {
 		this.setSelected(e.target.checked);
+	}
+
+	_handleBlur() {
+		this._focusing = false;
+	}
+
+	_handleFocus() {
+		this._focusing = true;
+	}
+
+	_handleMouseEnter() {
+		this._hovering = true;
+	}
+
+	_handleMouseLeave() {
+		this._hovering = false;
 	}
 
 }

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -66,8 +66,9 @@ class ListItem extends RtlMixin(LitElement) {
 			 */
 			selected: { type: Boolean, reflect: true },
 			_breakpoint: { type: Number },
-			_hovering: { type: Boolean },
-			_focusing: { type: Boolean }
+			_hoveringLink: { type: Boolean },
+			_focusing: { type: Boolean },
+			_focusingLink: { type: Boolean }
 		};
 	}
 
@@ -76,6 +77,7 @@ class ListItem extends RtlMixin(LitElement) {
 		return [ checkboxStyles, css`
 			:host {
 				display: block;
+				position: relative;
 				margin-top: -1px;
 			}
 			:host[hidden] {
@@ -95,6 +97,7 @@ class ListItem extends RtlMixin(LitElement) {
 				border-bottom: 1px solid transparent;
 			}
 			d2l-list-item-generic-layout {
+				position: relative;
 				border-bottom: 1px solid transparent;
 				border-bottom: 1px solid var(--d2l-color-mica);
 				border-top: 1px solid var(--d2l-color-mica);
@@ -161,7 +164,6 @@ class ListItem extends RtlMixin(LitElement) {
 				max-height: 5.1rem;
 				max-width: 9rem;
 			}
-
 			:host([dir="rtl"]) [data-breakpoint="2"] ::slotted([slot="illustration"]) {
 				margin-left: 1rem;
 				margin-right: 0;
@@ -171,20 +173,36 @@ class ListItem extends RtlMixin(LitElement) {
 				max-height: 6rem;
 				max-width: 10.8rem;
 			}
-
 			:host([dir="rtl"]) [data-breakpoint="3"] ::slotted([slot="illustration"]) {
 				margin-left: 1rem;
 				margin-right: 0;
 			}
-
 			input[type="checkbox"].d2l-input-checkbox {
 				margin: 1.15rem 0.9rem 1.15rem 0;
 			}
-
 			:host([dir="rtl"]) input[type="checkbox"].d2l-input-checkbox {
 				margin-left: 0.9rem;
 				margin-right: 0;
 			}
+			:host([selectable]:not([disabled]):hover) d2l-list-item-generic-layout,
+			:host([selectable]:not([disabled])) d2l-list-item-generic-layout.focusing {
+				background-color: var(--d2l-color-regolith);
+			}
+			:host([selected]:not([disabled]):hover) d2l-list-item-generic-layout,
+			:host([selected]:not([disabled])) d2l-list-item-generic-layout.focusing {
+				background-color: #F3FBFF;
+				border-color: #79B5DF;
+			}
+			:host([selected]:not([disabled]):hover) .d2l-list-item-active-border,
+			:host([selected]:not([disabled])) d2l-list-item-generic-layout.focusing + .d2l-list-item-active-border {
+				position: absolute;
+				width: 100%;
+				bottom: 0;
+				height: 1px;
+				z-index: 5;
+				background: #79B5DF;
+			}
+
 		`];
 	}
 
@@ -233,17 +251,20 @@ class ListItem extends RtlMixin(LitElement) {
 
 	render() {
 		const classes = {
-			'd2l-visible-on-ancestor-target': true
+			'd2l-visible-on-ancestor-target': true,
+			'focusing': this._focusing,
 		};
 		const contentClasses = {
 			'd2l-list-item-content': true,
 			'd2l-list-item-content-extend-separators': this._extendSeparators,
-			'hovering': this._hovering,
-			'focusing': this._focusing,
+			'hovering': this._hoveringLink,
+			'focusing': this._focusingLink,
 		};
 
 		return html`
 			<d2l-list-item-generic-layout
+				@focusin="${this._handleFocusIn}"
+				@focusout="${this._handleFocusOut}"
 				class="${classMap(classes)}"
 				data-breakpoint="${this._breakpoint}"
 				data-separators="${ifDefined(this._separators)}"
@@ -261,10 +282,10 @@ class ListItem extends RtlMixin(LitElement) {
 				<a slot="content-action"
 					href="${this.href}"
 					aria-labelledby="${this._contentId}"
-					@mouseenter="${this._handleMouseEnter}"
-					@mouseleave="${this._handleMouseLeave}"
-					@focus="${this._handleFocus}"
-					@blur="${this._handleBlur}"></a>
+					@mouseenter="${this._handleMouseEnterLink}"
+					@mouseleave="${this._handleMouseLeaveLink}"
+					@focus="${this._handleFocusLink}"
+					@blur="${this._handleBlurLink}"></a>
 				` : nothing }
 				<div slot="content"
 					class="${classMap(contentClasses)}"
@@ -277,6 +298,7 @@ class ListItem extends RtlMixin(LitElement) {
 					<slot name="actions"></slot>
 				</div>
 			</d2l-list-item-generic-layout>
+			<div class="d2l-list-item-active-border"></div>
 		`;
 
 	}
@@ -320,24 +342,32 @@ class ListItem extends RtlMixin(LitElement) {
 		}));
 	}
 
+	_handleBlurLink() {
+		this._focusingLink = false;
+	}
+
 	_handleCheckboxChange(e) {
 		this.setSelected(e.target.checked);
 	}
 
-	_handleBlur() {
-		this._focusing = false;
-	}
-
-	_handleFocus() {
+	_handleFocusIn() {
 		this._focusing = true;
 	}
 
-	_handleMouseEnter() {
-		this._hovering = true;
+	_handleFocusLink() {
+		this._focusingLink = true;
 	}
 
-	_handleMouseLeave() {
-		this._hovering = false;
+	_handleFocusOut() {
+		this._focusing = false;
+	}
+
+	_handleMouseEnterLink() {
+		this._hoveringLink = true;
+	}
+
+	_handleMouseLeaveLink() {
+		this._hoveringLink = false;
 	}
 
 }

--- a/components/list/test/list-item-generic-layout.test.js
+++ b/components/list/test/list-item-generic-layout.test.js
@@ -1,71 +1,70 @@
 import '../list.js';
-import '../demo/list-item-sample.js';
+import '../list-item.js';
 import '../../button/button-icon.js';
 
 import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
-// todo: d2l-list-item-sample should become d2l-list-item when it has been altered to use generic-layout
 const normalFixture = html`
 	<d2l-list grid>
-		<d2l-list-item-sample selectable key="item1">
+		<d2l-list-item selectable key="item1">
 			<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample>
+		</d2l-list-item>
+		<d2l-list-item>
 			<div class="d2l-list-item-text d2l-body-compact">Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.1</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample>
+		</d2l-list-item>
+		<d2l-list-item>
 			<div class="d2l-list-item-text d2l-body-compact">Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.2</div>
-		</d2l-list-item-sample>
+		</d2l-list-item>
 	</d2l-list>
 `;
 
 const nonGridFixture = html`
 	<d2l-list>
-		<d2l-list-item-sample>
+		<d2l-list-item>
 			<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample>
+		</d2l-list-item>
+		<d2l-list-item>
 			<div class="d2l-list-item-text d2l-body-compact">Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.1</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample>
+		</d2l-list-item>
+		<d2l-list-item>
 			<div class="d2l-list-item-text d2l-body-compact">Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.2</div>
-		</d2l-list-item-sample>
+		</d2l-list-item>
 	</d2l-list>
 `;
 
 const longFixture = html`
 	<d2l-list grid>
-		<d2l-list-item-sample selectable href="http://d2l.com" key="item1">
+		<d2l-list-item selectable href="http://d2l.com" key="item1">
 			<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>
 			<div slot="actions">
 				<d2l-button-icon text="My Button" icon="tier1:more"></d2l-button-icon>
 			</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample selectable href="http://d2l.com" key="item2">
+		</d2l-list-item>
+		<d2l-list-item selectable href="http://d2l.com" key="item2">
 			<div class="d2l-list-item-text d2l-body-compact">Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.1</div>
 			<div slot="actions">
 				<d2l-button-icon text="My Button" icon="tier1:more"></d2l-button-icon>
 			</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample selectable href="http://d2l.com" key="item3">
+		</d2l-list-item>
+		<d2l-list-item selectable href="http://d2l.com" key="item3">
 			<div class="d2l-list-item-text d2l-body-compact">Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.2</div>
 			<div slot="actions">
 				<d2l-button-icon text="My Button" icon="tier1:more"></d2l-button-icon>
 				<d2l-button-icon text="My Button" icon="tier1:more"></d2l-button-icon>
 			</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample selectable key="item4">
+		</d2l-list-item>
+		<d2l-list-item selectable key="item4">
 			<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>
 			<div slot="actions">
@@ -74,29 +73,29 @@ const longFixture = html`
 				<d2l-button-icon text="My Button" icon="tier1:preview"></d2l-button-icon>
 				<d2l-button-icon text="My Button" icon="tier1:preview"></d2l-button-icon>
 			</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample selectable href="http://d2l.com" key="item5">
+		</d2l-list-item>
+		<d2l-list-item selectable href="http://d2l.com" key="item5">
 			<div class="d2l-list-item-text d2l-body-compact">Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.1</div>
 			<div slot="actions">
 				<d2l-button-icon text="My Button" icon="tier1:more"></d2l-button-icon>
 				<d2l-button-icon text="My Button" icon="tier1:more"></d2l-button-icon>
 			</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample selectable key="item6">
+		</d2l-list-item>
+		<d2l-list-item selectable key="item6">
 			<div class="d2l-list-item-text d2l-body-compact">Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.2</div>
 			<div slot="actions">
 				<d2l-button-icon text="My Button" icon="tier1:more"></d2l-button-icon>
 			</div>
-		</d2l-list-item-sample>
-		<d2l-list-item-sample selectable key="item7">
+		</d2l-list-item>
+		<d2l-list-item selectable key="item7">
 			<div class="d2l-list-item-text d2l-body-compact">Retain objects of various shapes and sizes in different ways, while moving around others and equipment</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.2</div>
 			<div slot="actions">
 				<d2l-button-icon text="My Button" icon="tier1:more"></d2l-button-icon>
 			</div>
-		</d2l-list-item-sample>
+		</d2l-list-item>
 	</d2l-list>
 `;
 

--- a/components/list/test/list-item-role-mixin.test.js
+++ b/components/list/test/list-item-role-mixin.test.js
@@ -1,14 +1,14 @@
 import '../list.js';
 import { defineCE, expect, fixture } from '@open-wc/testing';
-import { ListItemMixin } from '../list-item-mixin.js';
+import { ListItemRoleMixin } from '../list-item-role-mixin.js';
 import { LitElement } from 'lit-element/lit-element.js';
 
 const tag = defineCE(
-	class extends ListItemMixin(LitElement) {
+	class extends ListItemRoleMixin(LitElement) {
 	}
 );
 
-describe('ListItemMixin', () => {
+describe('ListItemRoleMixin', () => {
 	it('leaves role as undefined if not a child of d2l-list', async() => {
 		const el = await fixture(`<div><${tag}></${tag}></div>`);
 		expect(el.querySelector(tag).role).to.be.undefined;


### PR DESCRIPTION
## Context
[US115502](https://rally1.rallydev.com/#/detail/userstory/384002687644?fdp=true)
[Design Document](https://desire2learn.atlassian.net/wiki/spaces/POL/pages/996083189/US114586+wc-list+Refactor+for+Drag+n+Drop#d2l-list-item)

- Adds the `ListItemMixin` and `ListItemCheckboxMixin` to the `ListItem`
- Removes the logic now contained in these mixins from the `ListItem`
- Grid can now be enabled on default lists using the `grid` property
  - New demo snippet showing grid enabled added

### Upcoming Changes
- `ListItemDragMixin` will be integrated when it is finished and tested
- Fixes for NVDA screen reading with grid (currently doesn't play nicely)

## UX Result
![Kapture 2020-07-03 at 15 24 36](https://user-images.githubusercontent.com/2412740/86494620-df000380-bd43-11ea-83b5-8fd7d58a19cc.gif)

## Quality
- Unit tests for generic list item were changed to use `d2l-list-item`
- New demo snippet allows for manual testing