### PR TITLE
Add translations for d2l-switch-visibility.

### DIFF
--- a/components/switch/switch-visibility.js
+++ b/components/switch/switch-visibility.js
@@ -1,12 +1,20 @@
 import '../icons/icon.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
+import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { SwitchMixin } from './switch-mixin.js';
 
-class VisibilitySwitch extends SwitchMixin(LitElement) {
+class VisibilitySwitch extends LocalizeCoreElement(SwitchMixin(LitElement)) {
 
-	constructor() {
-		super();
-		this.text = 'Visibility';
+	get text() {
+		return (this._text ? this._text : this.localize('components.switch.visibility'));
+	}
+
+	set text(val) {
+		const oldVal = this._text;
+		if (oldVal !== val) {
+			this._text = val;
+			this.requestUpdate('text', oldVal);
+		}
 	}
 
 	get offIcon() {

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "مؤشر التقدم",
 	"components.more-less.less": "أقل",
 	"components.more-less.more": "المزيد",
+	"components.switch.visibility": "الرؤية",
 	"components.tabs.next": "التمرير إلى الأمام",
 	"components.tabs.previous": "التمرير إلى الخلف"
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "Statusindikator",
 	"components.more-less.less": "færre",
 	"components.more-less.more": "flere",
+	"components.switch.visibility": "Synlighed",
 	"components.tabs.next": "Rul frem",
 	"components.tabs.previous": "Rul tilbage"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "Fortschrittsanzeige",
 	"components.more-less.less": "Weniger",
 	"components.more-less.more": "mehr",
+	"components.switch.visibility": "Sichtbarkeit",
 	"components.tabs.next": "Weiterblättern",
 	"components.tabs.previous": "Zurückblättern"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "Progress Indicator",
 	"components.more-less.less": "less",
 	"components.more-less.more": "more",
+	"components.switch.visibility": "Visibility",
 	"components.tabs.next": "Scroll Forward",
 	"components.tabs.previous": "Scroll Backward"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "Indicador de progreso",
 	"components.more-less.less": "menos",
 	"components.more-less.more": "más",
+	"components.switch.visibility": "Visibilidad",
 	"components.tabs.next": "Desplazarse hacia adelante",
 	"components.tabs.previous": "Desplazarse hacia atrás"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "Indicateur de progrès",
 	"components.more-less.less": "moins",
 	"components.more-less.more": "plus",
+	"components.switch.visibility": "Visibilité",
 	"components.tabs.next": "Défilement avant",
 	"components.tabs.previous": "Défilement arrière"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "進捗状況インジケータ",
 	"components.more-less.less": "減らす",
 	"components.more-less.more": "増やす",
+	"components.switch.visibility": "表示",
 	"components.tabs.next": "前方にスクロール",
 	"components.tabs.previous": "後方にスクロール"
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "진도 표시기",
 	"components.more-less.less": "축소",
 	"components.more-less.more": "더 보기",
+	"components.switch.visibility": "표시여부",
 	"components.tabs.next": "앞으로 스크롤",
 	"components.tabs.previous": "뒤로 스크롤"
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "Voortgangsindicator",
 	"components.more-less.less": "minder",
 	"components.more-less.more": "meer",
+	"components.switch.visibility": "Zichtbaarheid",
 	"components.tabs.next": "Naar voren scrollen",
 	"components.tabs.previous": "Naar achteren scrollen"
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "Indicador de progresso",
 	"components.more-less.less": "menos",
 	"components.more-less.more": "mais",
+	"components.switch.visibility": "Visibilidade",
 	"components.tabs.next": "Ir para frente",
 	"components.tabs.previous": "Ir para trás"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "Förloppsindikator",
 	"components.more-less.less": "mindre",
 	"components.more-less.more": "mer",
+	"components.switch.visibility": "Synlighet",
 	"components.tabs.next": "Bläddra framåt",
 	"components.tabs.previous": "Bläddra bakåt"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "Gelişim Göstergesi",
 	"components.more-less.less": "daha az",
 	"components.more-less.more": "daha fazla",
+	"components.switch.visibility": "Görünürlük",
 	"components.tabs.next": "İleri Kaydır",
 	"components.tabs.previous": "Geri Kaydır"
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "進度指示器",
 	"components.more-less.less": "較少",
 	"components.more-less.more": "較多",
+	"components.switch.visibility": "能見度",
 	"components.tabs.next": "向前捲動",
 	"components.tabs.previous": "向後捲動"
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -30,6 +30,7 @@ export default {
 	"components.meter-mixin.progressIndicator": "进度指示符",
 	"components.more-less.less": "更少",
 	"components.more-less.more": "更多",
+	"components.switch.visibility": "可见性",
 	"components.tabs.next": "向前滚动",
 	"components.tabs.previous": "向后滚动"
 };


### PR DESCRIPTION
This PR adds translations for the "Visibility" verbiage.  We were previously holding off on this in case Design required something different.

The `VisibilitySwitch` provides a custom getter/setter for the `text` property to check for custom text, and if none provided, will localize the default text.