### PR TITLE
Fix NVDA keyboard shortcuts behavior when gird is on list

### DIFF
--- a/components/list/list.js
+++ b/components/list/list.js
@@ -1,5 +1,4 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 export const listSelectionStates = {
 	none: 'none',
@@ -59,7 +58,7 @@ class List extends LitElement {
 	render() {
 		const role = !this.grid ? 'list' : 'application';
 		return html`
-			<div role="${ifDefined(role)}" class="d2l-list-container">
+			<div role="${role}" class="d2l-list-container">
 				<slot></slot>
 			</div>
 		`;

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -57,7 +57,7 @@ class List extends LitElement {
 	}
 
 	render() {
-		const role = !this.grid ? 'list' : undefined;
+		const role = !this.grid ? 'list' : 'application';
 		return html`
 			<div role="${ifDefined(role)}" class="d2l-list-container">
 				<slot></slot>


### PR DESCRIPTION
Context:
US118212 - https://rally1.rallydev.com/#/357252966636d/detail/userstory/402324092656
This PR fixes the NDVA weird behavior that was reading out cells letter by letter. 
Adding application seems to fix it because it indicates to NDVA that the list and all of its children should be treated similarly to an application.
In addition, `application=role` will be applied to the list when the grid flag is on. 

Quality:
I tested it in http://localhost:8000/components/list/demo/list-item-sample.html