### PR TITLE
input-text: add tooltip

### DIFF
--- a/components/inputs/demo/input-text.html
+++ b/components/inputs/demo/input-text.html
@@ -107,6 +107,13 @@
 					</d2l-input-text>
 				</template>
 			</d2l-demo-snippet>
+
+			<h2>Tooltip</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-input-text label="Name" tooltip-text="Test Tooltip Text"></d2l-input-text>
+				</template>
+			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>
 </html>

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -1,3 +1,4 @@
+import '../tooltip/tooltip.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
@@ -105,6 +106,26 @@ class InputText extends RtlMixin(LitElement) {
 			 * Text for additional screenreader and mouseover context
 			 */
 			title: { type: String },
+			/**
+			 * Align the tooltip with either the start or end of its target. If not set, the tooltip will attempt be centered.
+			 * @type {('start'|'end')}
+			 */
+			tooltipAlign: { attribute: 'tooltip-align', reflect: true, type: String },
+			/**
+			 * Force the tooltip to open in a certain direction. If no position is provided, the tooltip will open in the first position that has enough space for it in the order: bottom, top, right, left.
+			 * @type {('top'|'bottom'|'left'|'right')}
+			 */
+			tooltipPosition: { attribute: 'tooltip-position', reflect: true, type: String },
+			/**
+			 * The style of the tooltip based on the type of information it displays
+			 * @type {('info'|'error')}
+			 * @default "info"
+			 */
+			tooltipState: { attribute: 'tooltip-state', reflect: true, type: String },
+			/**
+			 * Inner text content of tooltip. Setting this causes tooltip to be displayed when applicable.
+			 */
+			tooltipText: { attribute: 'tooltip-text', reflect: true, type: String },
 			/**
 			 * The type of the text input
 			 * @type {('text'|'email'|'number'|'password'|'tel'|'url')}
@@ -220,7 +241,18 @@ class InputText extends RtlMixin(LitElement) {
 		const invalidIconStyles = {
 			[invalidIconSide]: `${invalidIconOffset}px`
 		};
+
+		const tooltip = this.tooltipText
+			? html`<d2l-tooltip
+				for="${this._inputId}"
+				align="${ifDefined(this.tooltipAlign)}"
+				position="${ifDefined(this.tooltipPosition)}"
+				state="${ifDefined(this.tooltipState)}">
+					${this.tooltipText}
+				</d2l-tooltip>`
+			: null;
 		const input = html`
+			${tooltip}
 			<div class="d2l-input-text-container">
 				<input aria-atomic="${ifDefined(this.atomic)}"
 					aria-haspopup="${ifDefined(this.ariaHaspopup)}"

--- a/components/inputs/test/input-text.visual-diff.html
+++ b/components/inputs/test/input-text.visual-diff.html
@@ -144,6 +144,15 @@
 				</d2l-input-text>
 			</div>
 			<div class="visual-diff">
+				<d2l-input-text id="wc-tooltip" tooltip-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit"></d2l-input-text>
+			</div>
+			<div class="visual-diff">
+				<d2l-input-text id="wc-tooltip-error" tooltip-state="error" tooltip-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit"></d2l-input-text>
+			</div>
+			<div class="visual-diff">
+				<d2l-input-text id="wc-tooltip-position" tooltip-position="right" tooltip-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit"></d2l-input-text>
+			</div>
+			<div class="visual-diff">
 				<input id="sass-basic" class="d2l-test-input-text" type="text" value="text">
 			</div>
 			<div class="visual-diff">

--- a/components/inputs/test/input-text.visual-diff.js
+++ b/components/inputs/test/input-text.visual-diff.js
@@ -77,4 +77,50 @@ describe('d2l-input-text', () => {
 		});
 	});
 
+	[
+		'wc-tooltip',
+		'wc-tooltip-error',
+		'wc-tooltip-position'
+	].forEach((name) => {
+		afterEach(async() => {
+			await page.reload();
+		});
+
+		it(name, async function() {
+			const selector = `#${name}`;
+			await showTooltip(page, selector);
+			const rect = await getRect(page, selector);
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+	});
+
+	function getRect(page, selector) {
+		return page.$eval(selector, (elem) => {
+			const content = elem.shadowRoot.querySelector('d2l-tooltip');
+			const contentWidth = content.shadowRoot.querySelector('.d2l-tooltip-content');
+			const openerRect = elem.getBoundingClientRect();
+			const contentRect = contentWidth.getBoundingClientRect();
+			const x = Math.min(openerRect.x, contentRect.x);
+			const y = Math.min(openerRect.y, contentRect.y);
+			const width = Math.max(openerRect.right, contentRect.right) - x;
+			const height = Math.max(openerRect.bottom, contentRect.bottom) - y;
+			return {
+				x: x - 10,
+				y: y - 10,
+				width: width + 20,
+				height: height + 20
+			};
+		});
+	}
+
+	async function showTooltip(page, selector) {
+		await page.$eval(selector, (elem) => {
+			const tooltip = elem.shadowRoot.querySelector('d2l-tooltip');
+			return new Promise((resolve) => {
+				tooltip.addEventListener('d2l-tooltip-show', () => resolve(), { once: true });
+				tooltip.show();
+			});
+		});
+	}
+
 });

--- a/karma.sauce.conf.js
+++ b/karma.sauce.conf.js
@@ -56,7 +56,7 @@ module.exports = config => {
 			browsers: Object.keys(customLaunchers),
 			reporters: ['dots', 'saucelabs'],
 			singleRun: true,
-			browserDisconnectTimeout : 10000, // default 2000
+			browserDisconnectTimeout : 20000, // default 2000
 			browserDisconnectTolerance : 1, // default 0
 			browserNoActivityTimeout: 120000, // default 10000
 			captureTimeout: 120000, // default 60000


### PR DESCRIPTION
I added the d2l-tooltip to input-text in order for it to be used in validation. I only added minimal properties that I thought could be necessary from the start.

To do:
- [ ] add properties to readme if they seem good to go