### PR TITLE
Add requestValidate to FormElementMixin

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -109,6 +109,12 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		return this.localize('components.form-element-mixin.defaultFieldLabel');
 	}
 
+	async requestValidate() {
+		if (this.dispatchEvent(new CustomEvent('d2l-form-element-should-validate', { cancelable: true }))) {
+			await this.validate();
+		}
+	}
+
 	setCustomValidity(message) {
 		this._validity = new FormElementValidityState({ customError: true });
 		this._validationMessage = message;

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -109,4 +109,14 @@ describe('form-element', () => {
 
 	});
 
+	describe('requestValidate', () => {
+
+		it('should not validate if canceled', async() => {
+			formElement.addEventListener('d2l-form-element-should-validate', e => e.preventDefault());
+			await formElement.requestValidate();
+			expect(formElement.validationError).to.be.null;
+		});
+
+	});
+
 });


### PR DESCRIPTION
# Changes
- Add `requestValidate` to allow ancestors to prevent their children from auto-validating.
- Rather than calling `validate` directly, form elements will call `requestValidate`, this allows ancestor elements to allow or prevent descendants from validating themselves by cancelling the `d2l-form-element-should-validate` event.