### PR TITLE
Add invalid and force-invalid to FormElementMixin

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -77,7 +77,11 @@ export class FormElementValidityState {
 export const FormElementMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
 	static get properties() {
-		return { validationError: { attribute: false, type: String } };
+		return {
+			forceInvalid: { type: Boolean, attribute: false },
+			invalid: { type: Boolean, reflect: true },
+			validationError: { type: String, attribute: false },
+		};
 	}
 
 	constructor() {
@@ -85,11 +89,20 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		this._validationCustoms = new Set();
 		this._validationMessage = '';
 		this._validity = new FormElementValidityState({});
+		this.forceInvalid = false;
 		this.formValue = null;
 		this.validationError = null;
 
 		this.addEventListener('d2l-validation-custom-connected', this._validationCustomConnected);
 		this.addEventListener('d2l-validation-custom-disconnected', this._validationCustomDisconnected);
+	}
+
+	updated(changedProperties) {
+		changedProperties.forEach((_, propName) => {
+			if (propName === 'forceInvalid' || propName === 'validationError') {
+				this.invalid = this.forceInvalid || this.validationError !== null;
+			}
+		});
 	}
 
 	checkValidity() {

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -91,6 +91,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		this._validity = new FormElementValidityState({});
 		this.forceInvalid = false;
 		this.formValue = null;
+		this.invalid = false;
 		this.validationError = null;
 
 		this.addEventListener('d2l-validation-custom-connected', this._validationCustomConnected);

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -44,6 +44,26 @@ describe('form-element', () => {
 		formElement = form.shadowRoot.querySelector('#my-ele');
 	});
 
+	describe('invalid', () => {
+
+		[
+			{ forceInvalid: true, validationError: 'Oh no' },
+			{ forceInvalid: false, validationError: 'Oh no' },
+			{ forceInvalid: true, validationError: null },
+			{ forceInvalid: false, validationError: null },
+		].forEach(({ forceInvalid, validationError }) => {
+
+			it('should be invalid if force validate is true or there is a validation error ', async() => {
+				formElement.forceInvalid = forceInvalid;
+				formElement.validationError = validationError;
+				await formElement.updateComplete;
+				expect(formElement.hasAttribute('invalid')).to.equal(forceInvalid || validationError !== null);
+			});
+
+		});
+
+	});
+
 	describe('message', () => {
 
 		it('should set validation message if validate has errors', async() => {


### PR DESCRIPTION
# Changes
- The `invalid` attribute is used to style custom form-elements error state. All error styling should be based on this attribute. Previously this was done using `aria-invalid`.
- The `forceInvalid` property was added so that custom form elements can be forced into an invalid state even if they didn't fail validation. An example use case is in the `input-date-range` component when the start date is later than the end date. Even though neither of the inner `date-range` components failed validation we want to be able to show them in their error state.
