### PR TITLE
Add showErrors to FormElementMixin validate

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -123,7 +123,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		return this.localize('components.form-element-mixin.defaultFieldLabel');
 	}
 
-	async requestValidate(showErrors) {
+	async requestValidate(showErrors = true) {
 		if (this.dispatchEvent(new CustomEvent('d2l-form-element-should-validate', { cancelable: true }))) {
 			await this.validate(showErrors);
 		}

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -123,9 +123,9 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		return this.localize('components.form-element-mixin.defaultFieldLabel');
 	}
 
-	async requestValidate() {
+	async requestValidate(showErrors) {
 		if (this.dispatchEvent(new CustomEvent('d2l-form-element-should-validate', { cancelable: true }))) {
-			await this.validate();
+			await this.validate(showErrors);
 		}
 	}
 
@@ -143,7 +143,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		this._validationMessage = null;
 	}
 
-	async validate() {
+	async validate(showErrors) {
 		await this.updateComplete;
 		const customs = [...this._validationCustoms];
 		const results = await Promise.all(customs.map(custom => custom.validate()));
@@ -151,11 +151,12 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		if (!this.checkValidity()) {
 			errors.unshift(this.validationMessage);
 		}
-		if (errors.length > 0) {
-			this.validationError = errors[0];
-		} else {
+		if (errors.length === 0) {
 			this.validationError = null;
+		} else if (showErrors || this.validationError) {
+			this.validationError = errors[0];
 		}
+
 		return errors;
 	}
 

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -67,16 +67,32 @@ describe('form-element', () => {
 	describe('message', () => {
 
 		it('should set validation message if validate has errors', async() => {
-			await formElement.validate();
+			await formElement.validate(true);
 			expect(formElement.validationError).to.equal('Test form element is required.');
 		});
 
-		it('should remove message if validate has no errors', async() => {
-			await formElement.validate();
+		it('should not set validation message if validate has errors and show errors is false', async() => {
+			await formElement.validate(false);
+			expect(formElement.validationError).to.be.null;
+		});
+
+		[true, false].forEach(showErrors => {
+			it('should remove message if validate has no errors', async() => {
+				await formElement.validate(true);
+				expect(formElement.validationError).to.equal('Test form element is required.');
+				formElement.value = 'Non-empty';
+				await formElement.validate(showErrors);
+				expect(formElement.validationError).to.null;
+			});
+		});
+
+		it('should update the validation message if validate has errors and show errors is false', async() => {
+			await formElement.validate(true);
 			expect(formElement.validationError).to.equal('Test form element is required.');
 			formElement.value = 'Non-empty';
-			await formElement.validate();
-			expect(formElement.validationError).to.null;
+			formElement.isValidationCustomValid = false;
+			await formElement.validate(false);
+			expect(formElement.validationError).to.equal('Internal custom validation failed');
 		});
 
 	});
@@ -85,13 +101,13 @@ describe('form-element', () => {
 
 		it('should validate internal validation-customs', async() => {
 			formElement.isValidationCustomValid = false;
-			const errors = await formElement.validate();
+			const errors = await formElement.validate(true);
 			expect(errors).to.include.members(['Internal custom validation failed']);
 		});
 
 		it('should validate external validation-customs', async() => {
 			form.isValidationCustomValid = false;
-			const errors = await formElement.validate();
+			const errors = await formElement.validate(true);
 			expect(errors).to.include.members(['External custom validation failed']);
 		});
 
@@ -103,28 +119,35 @@ describe('form-element', () => {
 		it('should validate with default validity state message', async() => {
 			formElement.value = 'Non-empty';
 			formElement.setValidity({ badInput: true });
-			const errors = await formElement.validate();
+			const errors = await formElement.validate(true);
 			expect(errors).to.include.members(['Test form element is invalid.']);
 		});
 
 		it('should validate with overridden validity state message', async() => {
 			formElement.value = 'Non-empty';
 			formElement.setValidity({ rangeOverflow: true });
-			const errors = await formElement.validate();
+			const errors = await formElement.validate(true);
 			expect(errors).to.include.members(['Test form element failed with an overridden validation message']);
 		});
 
 		it('should validate with custom validity state message', async() => {
 			formElement.value = 'Non-empty';
 			formElement.setCustomValidity('Validation failed for custom validity');
-			const errors = await formElement.validate();
+			const errors = await formElement.validate(true);
 			expect(errors).to.include.members(['Validation failed for custom validity']);
 		});
 
 		it('should pass validation when no errors', async() => {
 			formElement.value = 'Non-empty';
-			const errors = await formElement.validate();
+			const errors = await formElement.validate(true);
 			expect(errors).to.be.empty;
+		});
+
+		it('should not be marked as invalid when show errors is false', async() => {
+			const errors = await formElement.validate(false);
+			expect(errors).to.not.be.empty;
+			expect(formElement.invalid).to.be.false;
+			expect(formElement.validationError).to.be.null;
 		});
 
 	});
@@ -133,7 +156,7 @@ describe('form-element', () => {
 
 		it('should not validate if canceled', async() => {
 			formElement.addEventListener('d2l-form-element-should-validate', e => e.preventDefault());
-			await formElement.requestValidate();
+			await formElement.requestValidate(true);
 			expect(formElement.validationError).to.be.null;
 		});
 

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -112,7 +112,7 @@ describe('form-element', () => {
 		});
 
 		it('should validate native element validity state', async() => {
-			const errors = await formElement.validate();
+			const errors = await formElement.validate(true);
 			expect(errors).to.include.members(['Test form element is required.']);
 		});
 
@@ -158,6 +158,11 @@ describe('form-element', () => {
 			formElement.addEventListener('d2l-form-element-should-validate', e => e.preventDefault());
 			await formElement.requestValidate(true);
 			expect(formElement.validationError).to.be.null;
+		});
+
+		it('should show validation errors by default', async() => {
+			await formElement.requestValidate();
+			expect(formElement.validationError).to.equal('Test form element is required.');
 		});
 
 	});


### PR DESCRIPTION
# Changes
- This allows validate to be called during live validation to remove errors if the component becomes valid but not show new errors if the component goes from a valid to an invalid state.
- This is required because our designs for live validation only have new errors shown on focus out.

## Example
- For a `d2l-input-text` the usage would look something like this with `requestValidate(false)` when the text value changes and `requestValidate(true)` on blur.
```
updated(changedProperties) {
	super.updated(changedProperties);

	changedProperties.forEach((oldVal, prop) => {
		if (prop === 'value') {
			this._prevValue = (oldVal === undefined) ? '' : oldVal;
			this.requestValidate(false); // don't show new errors but clear existing errors if we go from invalid to valid
		}
	});
}

_handleBlur(e) {
	this._focused = false;

	const browserType = window.navigator.userAgent;
	if (this._prevValue !== e.target.value && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
		this._handleChange();
	}
	this.requestValidate(true); // show errors and enter an invalid state if validation fails 
}

```