### PR TITLE
fix: Click Focus, Click Keyboard

### DIFF
--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -34,6 +34,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 			_dropLocation: { type: Number },
 			_focusingDragHandle: { type: Boolean },
 			_hovering: { type: Boolean },
+			_isActivitingKeyboardMode: {type: Boolean },
 			_keyboardActive: { type: Boolean }
 		};
 	}
@@ -172,8 +173,14 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		});
 	}
 
-	_onDragTargetClick(e) {
+	_onDragTargetClickFocus(e) {
+		this.shadowRoot.querySelector(`#${this._itemDragId}`).focus();
+		e.preventDefault();
+	}
+
+	_onDragTargetClickKeyboardActivate(e) {
 		this.shadowRoot.querySelector(`#${this._itemDragId}`).activateKeyboardMode();
+		this._isActivitingKeyboardMode = false;
 		e.preventDefault();
 	}
 
@@ -216,6 +223,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 
 	_onFocusinDragHandle() {
 		this._focusingDragHandle = true;
+		this._isActivitingKeyboardMode = true;
 	}
 
 	_onFocusoutDragHandle() {
@@ -268,7 +276,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 			<div
 				class="d2l-list-item-drag-area"
 				draggable="true"
-				@click="${this._onDragTargetClick}"
+				@click="${this._isActivitingKeyboardMode ? this._onDragTargetClickKeyboardActivate : this._onDragTargetClickFocus}"
 				@dragstart="${this._onDragStart}"
 				@dragend="${this._onDragEnd}"
 				>

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -173,18 +173,19 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 	}
 
 	_onDragTargetClick(e) {
-		if (this._focusingDragHandle) {
+		if (this._keyboardActiveOnNextClick) {
 			this.shadowRoot.querySelector(`#${this._itemDragId}`).activateKeyboardMode();
 		} else {
 			this.shadowRoot.querySelector(`#${this._itemDragId}`).focus();
 		}
 
+		this._keyboardActiveOnNextClick = false;
 		e.preventDefault();
 		e.stopPropagation();
 	}
 
-	_onDragTargetMouseDown(e) {
-		e.preventDefault();
+	_onDragTargetMouseDown() {
+		this._keyboardActiveOnNextClick = this._focusingDragHandle;
 	}
 
 	_onDrop() {

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -461,6 +461,11 @@ export class NewPositionEventDetails {
 	 */
 	reorder(list, {announceFn, keyFn}) {
 		if (this.dropTargetKey === undefined || this.dropTargetKey === this.dragTargetKey) return;
+
+		if (announceFn) {
+			this.announceMove(list, {announceFn, keyFn});
+		}
+
 		const origin = this.fetchPosition(list, this.dragTargetKey, keyFn);
 
 		if (origin === null) {
@@ -486,10 +491,6 @@ export class NewPositionEventDetails {
 			}
 		}
 		list[destination] = item;
-
-		if (announceFn) {
-			this.announceMove(list, {announceFn, keyFn});
-		}
 	}
 
 	_fetchDropTargetPosition(list, originPosition, keyFn) {

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -34,7 +34,6 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 			_dropLocation: { type: Number },
 			_focusingDragHandle: { type: Boolean },
 			_hovering: { type: Boolean },
-			_isActivitingKeyboardMode: {type: Boolean },
 			_keyboardActive: { type: Boolean }
 		};
 	}
@@ -173,14 +172,18 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		});
 	}
 
-	_onDragTargetClickFocus(e) {
-		this.shadowRoot.querySelector(`#${this._itemDragId}`).focus();
+	_onDragTargetClick(e) {
+		if (this._focusingDragHandle) {
+			this.shadowRoot.querySelector(`#${this._itemDragId}`).activateKeyboardMode();
+		} else {
+			this.shadowRoot.querySelector(`#${this._itemDragId}`).focus();
+		}
+
 		e.preventDefault();
+		e.stopPropagation();
 	}
 
-	_onDragTargetClickKeyboardActivate(e) {
-		this.shadowRoot.querySelector(`#${this._itemDragId}`).activateKeyboardMode();
-		this._isActivitingKeyboardMode = false;
+	_onDragTargetMouseDown(e) {
 		e.preventDefault();
 	}
 
@@ -223,7 +226,6 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 
 	_onFocusinDragHandle() {
 		this._focusingDragHandle = true;
-		this._isActivitingKeyboardMode = true;
 	}
 
 	_onFocusoutDragHandle() {
@@ -276,9 +278,10 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 			<div
 				class="d2l-list-item-drag-area"
 				draggable="true"
-				@click="${this._isActivitingKeyboardMode ? this._onDragTargetClickKeyboardActivate : this._onDragTargetClickFocus}"
+				@click="${this._onDragTargetClick}"
 				@dragstart="${this._onDragStart}"
 				@dragend="${this._onDragEnd}"
+				@mousedown="${this._onDragTargetMouseDown}"
 				>
 			</div>
 		`) : nothing;

--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -198,6 +198,7 @@ class ListItemDragHandle extends LocalizeCoreElement(LitElement) {
 		}
 		this._keyboardActive = false;
 		this._dispatchAction(dragActions.save);
+		e.stopPropagation();
 	}
 
 	_onInactiveKeyboard(e) {


### PR DESCRIPTION
Abbie: Re: Clicking the drag handle -- I’m thinking we should only make it change to keyboard on click if it’s already focused. I don’t want mouse users to get disoriented if they click right on the drag handle the first time.

![Kapture 2020-07-16 at 2 55 37](https://user-images.githubusercontent.com/13232226/87637182-ddedaf80-c70f-11ea-929e-d9d1c9c2da7f.gif)
