### PR TITLE
jsdoc type fix: remove brackets wrapping type values

### DIFF
--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -47,7 +47,7 @@ class AlertToast extends LitElement {
 
 			/**
 			 * Type of the alert being displayed
-			 * @type {('default'|'critical'|'success'|'warning')}
+			 * @type {'default'|'critical'|'success'|'warning'}
 			 * @default "default"
 			 */
 			type: { type: String, reflect: true },

--- a/components/alert/alert.js
+++ b/components/alert/alert.js
@@ -34,7 +34,7 @@ class Alert extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 			/**
 			 * Type of the alert being displayed
-			 * @type {('default'|'critical'|'success'|'warning')}
+			 * @type {'default'|'critical'|'success'|'warning'}
 			 */
 			type: { type: String, reflect: true }
 		};

--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -15,7 +15,7 @@ class ButtonIcon extends ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement)
 		return {
 			/**
 			 * Aligns the leading edge of text if value is set to "text"
-			 * @type {('text'|'')}
+			 * @type {'text'|''}
 			 */
 			hAlign: { type: String, reflect: true, attribute: 'h-align' },
 

--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -21,7 +21,7 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 
 			/**
 			 * Aligns the leading edge of text if value is set to "text"
-			 * @type {('text'|'')}
+			 * @type {'text'|''}
 			 */
 			hAlign: { type: String, reflect: true, attribute: 'h-align' },
 

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -12,7 +12,7 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 		return {
 			/**
 			 * Optionally align dropdown to either start or end. If not set, the dropdown will attempt be centred.
-			 * @type {('start'|'end')}
+			 * @type {'start'|'end'}
 			 */
 			align: {
 				type: String,

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -111,7 +111,7 @@ class InputText extends RtlMixin(LitElement) {
 			title: { type: String },
 			/**
 			 * The type of the text input
-			 * @type {('text'|'email'|'number'|'password'|'tel'|'url')}
+			 * @type {'text'|'email'|'number'|'password'|'tel'|'url'}
 			 */
 			type: { type: String },
 			/**

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -49,7 +49,7 @@ class InputTimeRange extends RtlMixin(LocalizeCoreElement(LitElement)) {
 			startValue: { attribute: 'start-value', reflect: true, type: String },
 			/**
 			 * Number of minutes between times shown in dropdown
-			 * @type {('five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty')}
+			 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
 			 */
 			timeInterval: { attribute: 'time-interval', reflect: true, type: String },
 		};

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -89,7 +89,7 @@ class InputTime extends LitElement {
 		return {
 			/**
 			 * Set default value of input. Valid values are times in ISO 8601 time format ("hh:mm:ss"), "startOfDay", "endOfDay".
-			 * @type {('startOfDay'|'endOfDay'|string)}
+			 * @type {'startOfDay'|'endOfDay'|string}
 			 */
 			defaultValue: { type: String, attribute: 'default-value' },
 			/**
@@ -114,7 +114,7 @@ class InputTime extends LitElement {
 			maxHeight: { type: Number, attribute: 'max-height' },
 			/**
 			 * Number of minutes between times shown in dropdown
-			 * @type {('five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty')}
+			 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
 			 */
 			timeInterval: { type: String, attribute: 'time-interval' },
 			/**

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -25,7 +25,7 @@ class List extends LitElement {
 			grid: { type: Boolean },
 			/**
 			 * Display separators. Valid values are "all" (default), "between", "none"
-			 * @type {('all'|'between'|'none')}
+			 * @type {'all'|'between'|'none'}
 			 * @default "all"
 			 */
 			separators: { type: String, reflect: true }

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -29,7 +29,7 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 
 			/**
 			 * The h-align property of the more-less button
-			 * @type {('text'|'')}
+			 * @type {'text'|''}
 			 */
 			hAlign: { type: String, attribute: 'h-align' },
 

--- a/components/status-indicator/status-indicator.js
+++ b/components/status-indicator/status-indicator.js
@@ -10,7 +10,7 @@ class StatusIndicator extends LitElement {
 		return {
 			/**
 			 * State of status indicator to display
-			 * @type {('default'|'success'|'alert'|'none')}
+			 * @type {'default'|'success'|'alert'|'none'}
 			 */
 			state: {
 				type: String,

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -88,7 +88,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		return {
 			/**
 			 * Align the tooltip with either the start or end of its target. If not set, the tooltip will attempt be centered.
-			 * @type {('start'|'end')}
+			 * @type {'start'|'end'}
 			 */
 			align: { type: String, reflect: true },
 			/**
@@ -117,7 +117,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			forceShow: { type: Boolean, attribute: 'force-show' },
 			/**
 			 * Accessibility type for the tooltip to specify whether it is the primary label for the target or a secondary descriptor.
-			 * @type {('label'|'descriptor')}
+			 * @type {'label'|'descriptor'}
 			 */
 			forType: { type: String, attribute: 'for-type' },
 			/**
@@ -126,7 +126,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			offset: { type: Number }, /* tooltipOffset */
 			/**
 			 * Force the tooltip to open in a certain direction. If no position is provided, the tooltip will open in the first position that has enough space for it in the order: bottom, top, right, left.
-			 * @type {('top'|'bottom'|'left'|'right')}
+			 * @type {'top'|'bottom'|'left'|'right'}
 			 */
 			position: { type: String },
 			/**
@@ -135,7 +135,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			showing: { type: Boolean, reflect: true },
 			/**
 			 * The style of the tooltip based on the type of information it displays
-			 * @type {('info'|'error')}
+			 * @type {'info'|'error'}
 			 */
 			state: { type: String, reflect: true },
 			_maxWidth: { type: Number },


### PR DESCRIPTION
Found this because the `lint:lit` step was yelling at me when trying to use a tooltip with `align="start"` (`Type '"start"' is not assignable to '"('start'" | "'end')"'`) so this fixes that, and I confirmed that `lint` does yell with this syntax if a value is not one of those values, and that the `|string` works for `input-time`.