### PR TITLE
Fix validation-custom connection events

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -247,13 +247,13 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 
 	_validationCustomConnected(e) {
 		e.stopPropagation();
-		const custom = e.composedPath()[0];
+		const custom = e.detail.validationCustom;
 		this.validationCustomConnected(custom);
 	}
 
 	_validationCustomDisconnected(e) {
 		e.stopPropagation();
-		const custom = e.composedPath()[0];
+		const custom = e.detail.validationCustom;
 		this.validationCustomDisconnected(custom);
 	}
 

--- a/components/validation/validation-custom-mixin.js
+++ b/components/validation/validation-custom-mixin.js
@@ -16,7 +16,18 @@ export const ValidationCustomMixin = superclass => class extends superclass {
 
 	connectedCallback() {
 		super.connectedCallback();
-		this._dispatchConnectionEvent('d2l-validation-custom-connected');
+		const connected = new CustomEvent('d2l-validation-custom-connected', { bubbles: true, composed: true, detail: { validationCustom: this } });
+		if (window.ShadyDOM) {
+			// https://github.com/Polymer/lit-element/issues/658
+			const { appendChild, removeChild } = window.ShadyDOM.nativeMethods;
+			const proxy = document.createComment('');
+
+			appendChild.call(this.parentNode, proxy);
+			proxy.dispatchEvent(connected);
+			removeChild.call(this.parentNode, proxy);
+		} else {
+			this.dispatchEvent(connected);
+		}
 	}
 
 	disconnectedCallback() {
@@ -25,7 +36,8 @@ export const ValidationCustomMixin = superclass => class extends superclass {
 			this._forElement.validationCustomDisconnected(this);
 		}
 		this._forElement = null;
-		this._dispatchConnectionEvent('d2l-validation-custom-disconnected');
+		const disconnected = new CustomEvent('d2l-validation-custom-disconnected', { bubbles: true, composed: true, detail: { validationCustom: this } });
+		this.dispatchEvent(disconnected);
 	}
 
 	updated(changedProperties) {
@@ -44,21 +56,6 @@ export const ValidationCustomMixin = superclass => class extends superclass {
 
 	async validate() {
 		throw new Error('ValidationCustomMixin requires validate to be overridden');
-	}
-
-	_dispatchConnectionEvent(type) {
-		const connected = new CustomEvent(type, { bubbles: true, composed: true, detail: { validationCustom: this } });
-		if (window.ShadyDOM) {
-			// https://github.com/Polymer/lit-element/issues/658
-			const { appendChild, removeChild } = window.ShadyDOM.nativeMethods;
-			const proxy = document.createComment('');
-
-			appendChild.call(this.parentNode, proxy);
-			proxy.dispatchEvent(connected);
-			removeChild.call(this.parentNode, proxy);
-		} else {
-			this.dispatchEvent(connected);
-		}
 	}
 
 	_updateForElement() {


### PR DESCRIPTION
## Issue
In browsers that use ShadyDOM events don't bubble correctly for slotted descendants: https://github.com/Polymer/lit-element/issues/658

## Fix
This resolves the issue by firing the events from a proxy node that bypasses ShadyDOM and adding the
element that dispatched the event to the detail.

A one off fix was used instead of creating a helper because there is some hope this might be fixed in the near future: https://github.com/webcomponents/polyfills/pull/332