### PR TITLE
input-date-time-range: remove flaky focus test

### DIFF
--- a/components/inputs/test/input-date-time-range.axe.js
+++ b/components/inputs/test/input-date-time-range.axe.js
@@ -1,5 +1,5 @@
 import '../input-date-time-range.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 
 describe('d2l-input-date-time-range', () => {
 
@@ -10,13 +10,6 @@ describe('d2l-input-date-time-range', () => {
 
 	it('disabled', async() => {
 		const elem = await fixture(html`<d2l-input-date-time-range label="label text" disabled></d2l-input-date-time-range>`);
-		await expect(elem).to.be.accessible({ignoredRules: ['color-contrast']}); // color-contrast takes a while and should be covered by axe tests in the individual components
-	});
-
-	it('focused', async() => {
-		const elem = await fixture(html`<d2l-input-date-time-range label="label text"></d2l-input-date-time-range>`);
-		setTimeout(() => elem.focus());
-		await oneEvent(elem, 'focus');
 		await expect(elem).to.be.accessible({ignoredRules: ['color-contrast']}); // color-contrast takes a while and should be covered by axe tests in the individual components
 	});
 


### PR DESCRIPTION
The testing of this behaviour should be covered in the inner component axe tests.