### PR TITLE
fix: Menu + dropdown menu: keypress to keyup and mouseup to click

### DIFF
--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -78,7 +78,7 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 		this.addEventListener('d2l-hierarchical-view-resize', this._onViewResize);
 		this.addEventListener('d2l-menu-item-visibility-change', this._onMenuItemsChanged);
 		this.addEventListener('keydown', this._onKeyDown);
-		this.addEventListener('keypress', this._onKeyPress);
+		this.addEventListener('keyup', this._onKeyUp);
 
 		this._labelChanged();
 
@@ -259,16 +259,17 @@ class Menu extends HierarchicalViewMixin(LitElement) {
 
 	}
 
-	_onKeyPress(e) {
+	_onKeyUp(e) {
 		if (this._items.indexOf(e.composedPath()[0]) === -1) return;
 
-		if (e.keyCode === keyCodes.DOWN || e.keyCode === keyCodes.UP
-			|| e.keyCode === keyCodes.SPACE || e.keyCode === keyCodes.ENTER
+		if (e.keyCode === keyCodes.SPACE || e.keyCode === keyCodes.ENTER
 			|| e.keyCode === keyCodes.ESCAPE) {
 			return;
 		}
 
 		e.stopPropagation();
+
+		if (e.keyCode === keyCodes.DOWN || e.keyCode === keyCodes.UP) return;
 
 		const startsWith = function(item, value) {
 			if (item.text && item.text.length > 0 && item.text.toLowerCase().substr(0, 1) === value) {

--- a/components/menu/test/menu.test.js
+++ b/components/menu/test/menu.test.js
@@ -112,7 +112,7 @@ describe('d2l-menu', () => {
 
 		it('sets focus to next item that starts with character pressed', () => {
 			const eventObj = document.createEvent('Events');
-			eventObj.initEvent('keypress', true, true);
+			eventObj.initEvent('keyup', true, true);
 			eventObj.charCode = 99;
 			elem.querySelector('#a1').dispatchEvent(eventObj);
 			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
@@ -120,7 +120,7 @@ describe('d2l-menu', () => {
 
 		it('sets focus to next item that starts with uppercase character pressed', () => {
 			const eventObj = document.createEvent('Events');
-			eventObj.initEvent('keypress', true, true);
+			eventObj.initEvent('keyup', true, true);
 			eventObj.charCode = 67;
 			elem.querySelector('#a1').dispatchEvent(eventObj);
 			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
@@ -128,7 +128,7 @@ describe('d2l-menu', () => {
 
 		it('sets focus by rolling over to beginning of menu when searching if necessary', () => {
 			const eventObj = document.createEvent('Events');
-			eventObj.initEvent('keypress', true, true);
+			eventObj.initEvent('keyup', true, true);
 			eventObj.charCode = 98;
 			elem.querySelector('#c1').dispatchEvent(eventObj);
 			expect(document.activeElement).to.equal(elem.querySelector('#b1'));


### PR DESCRIPTION
I ran into problems with a drop down menu in the list component. Basically, the list component does things on `keyup` which is still registered for double action on the key.

I also noticed dropdown was using `onMouseUp` and changed it to the newer `click`.

I replaced `keypress` with `keyup` since keypress is depreciated.

I don't know the risks of this change. As there could be good reasons for the choices I changed away from. If that is the case, I am happy to find another solution. 

It would be amazing if this could be a cert fix.