### PR TITLE
Fix lit analyzer errors

### DIFF
--- a/components/alert/test/alert.axe.js
+++ b/components/alert/test/alert.axe.js
@@ -10,8 +10,12 @@ describe('d2l-alert', () => {
 		'success',
 		'call-to-action',
 		'error'
-	].forEach((type) => {
-		it(`passes aXe tests for type "${type}"`, async() => {
+	].forEach((testCase) => {
+		it(`passes aXe tests for type "${testCase}"`, async() => {
+			/**
+			 * @type {'default'|'critical'|'success'|'warning'}
+			 */
+			const type = testCase;
 			const el = await fixture(html`<d2l-alert type="${type}">message</d2l-alert>`);
 			await expect(el).to.be.accessible();
 		});

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -26,7 +26,8 @@ class InputText extends RtlMixin(LitElement) {
 			 */
 			ariaInvalid: { type: String, attribute: 'aria-invalid' },
 			/**
-			 * @ignore
+			 * Specifies whether or not the screen reader should always present changes to the live region as a whole.
+			 * This only applies if live is set to polite or assertive.
 			 */
 			atomic: { type: String },
 			/**
@@ -54,7 +55,7 @@ class InputText extends RtlMixin(LitElement) {
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
 			/**
-			 * @ignore
+			 * Set the priority with which screen readers should treat updates to the input's live text region
 			 */
 			live: { type: String },
 			/**

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -103,6 +103,11 @@ class InputTimeRange extends RtlMixin(LocalizeCoreElement(LitElement)) {
 	render() {
 		const startLabel = this.startLabel ? this.startLabel : this.localize('components.input-time-range.startTime');
 		const endLabel = this.endLabel ? this.endLabel : this.localize('components.input-time-range.endTime');
+
+		/**
+		 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
+		 */
+		const timeInterval = this.timeInterval;
 		return html`
 			<d2l-input-fieldset label="${ifDefined(this.label)}" ?label-hidden="${this.labelHidden}">
 				<d2l-input-time
@@ -111,7 +116,7 @@ class InputTimeRange extends RtlMixin(LocalizeCoreElement(LitElement)) {
 					?disabled="${this.disabled}"
 					?enforce-time-intervals="${this.enforceTimeIntervals}"
 					label="${startLabel}"
-					time-interval="${ifDefined(this.timeInterval)}"
+					time-interval="${ifDefined(timeInterval)}"
 					value="${ifDefined(this.startValue)}">
 				</d2l-input-time>
 				<d2l-input-time
@@ -120,7 +125,7 @@ class InputTimeRange extends RtlMixin(LocalizeCoreElement(LitElement)) {
 					?disabled="${this.disabled}"
 					?enforce-time-intervals="${this.enforceTimeIntervals}"
 					label="${endLabel}"
-					time-interval="${ifDefined(this.timeInterval)}"
+					time-interval="${ifDefined(timeInterval)}"
 					value="${ifDefined(this.endValue)}">
 				</d2l-input-time>
 			</d2l-input-fieldset>

--- a/components/status-indicator/test/status-indicator.axe.js
+++ b/components/status-indicator/test/status-indicator.axe.js
@@ -8,8 +8,13 @@ describe('d2l-status-indicator', () => {
 		'none',
 		'alert',
 		'success'
-	].forEach((state) => {
+	].forEach((testCase) => {
 		[true, false].forEach((bold) => {
+			/**
+			 * @type {'default'|'none'|'alert'|'success'}
+			 */
+			const state = testCase;
+
 			it(`passes aXe tests for state="${state}" and bold="${bold}"`, async() => {
 				const elem = await fixture(html`<d2l-status-indicator text="test subtle" state="${state}" ?bold="${bold}"></d2l-status-indicator>`);
 				await expect(elem).to.be.accessible();


### PR DESCRIPTION
# Changes
The two culprits were `no-unknown-attribute` and `no-incompatible-type-binding`.
- `no-unknown-attribute` errored because we marked attributes as `@ignore` so they wouldn't be documented but apparently Lit Analyzer doesn't like that because it also then thinks they don't exist.
- `no-incompatible-type-binding` errored because we're passing values Lit Analyzer thinks are strings into what is effectively an enum type. Having to add comment types in these cases feels pretty bad so not sure if anyone has any thoughts on disabling this rule.
