### PR TITLE
US116586 Sticky footer for primary-secondary-template on mobile

### DIFF
--- a/templates/primary-secondary/demo/index.html
+++ b/templates/primary-secondary/demo/index.html
@@ -22,7 +22,7 @@
 				<p>I'm in the <b>secondary</b> slot of the <b>d2l-template-primary-secondary</b> component!</p>
 				Quisque justo risus, elementum quis condimentum vitae, venenatis sit amet nisl. Vivamus interdum pretium libero dictum eleifend. Donec eros tortor, facilisis eget maximus in, malesuada a magna. Nulla ac felis turpis. Donec pellentesque est in rhoncus tempus. Proin ac purus porttitor, interdum est a, venenatis mi. Maecenas nunc nulla, viverra ut ornare id, luctus eu nulla. Pellentesque massa turpis, porta ut tincidunt ut, ullamcorper vitae urna. Nam congue euismod placerat. Vestibulum aliquet, metus vitae viverra posuere, lacus urna hendrerit turpis, vel laoreet ligula odio et nisl. Mauris id lectus magna. Sed gravida tincidunt sapien quis dapibus.
 			</div>
-			<div slot="footer" style="background-color: #aaa;">I'm in the <b>footer</b> slot of the <b>d2l-template-primary-secondary</b> component!</div>
+			<div slot="footer">I'm in the <b>footer</b> slot of the <b>d2l-template-primary-secondary</b> component!</div>
 		</d2l-template-primary-secondary>
 	</body>
 </html>

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -77,7 +77,7 @@ class TemplatePrimarySecondary extends LitElement {
 				overflow-y: auto;
 			}
 			footer {
-				background-color: #fff;
+				background-color: #ffffff;
 				box-shadow: 0 -2px 4px rgba(73, 76, 78, 0.2); /* ferrite */
 				grid-area: footer;
 				padding: 0.75rem 1rem;

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -77,6 +77,7 @@ class TemplatePrimarySecondary extends LitElement {
 				overflow-y: auto;
 			}
 			footer {
+				background-color: #fff;
 				box-shadow: 0 -2px 4px rgba(73, 76, 78, 0.2); /* ferrite */
 				grid-area: footer;
 				padding: 0.75rem 1rem;
@@ -94,7 +95,6 @@ class TemplatePrimarySecondary extends LitElement {
 					grid-template-rows: auto 1px auto;
 				}
 				footer {
-					background-color: var(--d2l-color-white);
 					bottom: 0;
 					position: sticky;
 				}

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -93,6 +93,11 @@ class TemplatePrimarySecondary extends LitElement {
 					grid-template-columns: auto;
 					grid-template-rows: auto 1px auto;
 				}
+				footer {
+					background-color: var(--d2l-color-white);
+					bottom: 0;
+					position: sticky;
+				}
 			}
 		`;
 	}


### PR DESCRIPTION
On mobile when the secondary panel is repositioned below the primary panel, it can be quite a long scroll to the footer. This change makes the footer sticky on mobile devices.

Tested on Safari & Chrome on iOS, and Chrome on Android.

Demo using the FACE assignment editor:
![prim-sec-template-sticky-footer](https://user-images.githubusercontent.com/32819802/87839327-324b7900-c84f-11ea-842b-663c2affd0a9.gif)

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F391269578948