### PR TITLE
button-icon: add slot

### DIFF
--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -8,6 +8,7 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 /**
  * A button component that can be used just like the native button for instances where only an icon is displayed.
+ * @slot - Default content placed inside of the button
  */
 class ButtonIcon extends ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement))) {
 
@@ -89,8 +90,12 @@ class ButtonIcon extends ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement)
 				}
 
 				.d2l-button-icon {
+					display: none;
 					height: 0.9rem;
 					width: 0.9rem;
+				}
+				:host([icon]) .d2l-button-icon {
+					display: inline-block;
 				}
 
 				:host([translucent]) button {
@@ -154,6 +159,7 @@ class ButtonIcon extends ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement)
 				title="${ifDefined(this.text)}"
 				type="${this._getType()}">
 				<d2l-icon icon="${ifDefined(this.icon)}" class="d2l-button-icon"></d2l-icon>
+				<slot></slot>
 		</button>
 		`;
 	}


### PR DESCRIPTION
The use case for this is to be able to use `d2l-button-icon` when the button uses a legacy icon that doesn't have a d2l-icon yet. It's possible to use `d2l-button-subtle` for this, but the case I'm working on has the button icon and text switch depending on menu selection, with some options being d2l-icons and some not, so setting text causes inconsistent behaviour.