### PR TITLE
feat: add description property to d2l-dropdown-button-subtle

### DIFF
--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -83,8 +83,8 @@ dropdown.addEventListener('click', function() {
 ```
 
 **Properties:**
-- `description` (String): A description to be added to the inner `button` opener for accessibility
 - `text` (required, String): text for the button
+- `description` (String): A description to be added to the inner `button` opener for accessibility
 - `disabled` (Boolean, default: `false`): disables the dropdown opener
 - `no-auto-open` (Boolean, default: `false`): prevents the dropdown from opening automatically on or on key press
 

--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -83,9 +83,18 @@ dropdown.addEventListener('click', function() {
 ```
 
 **Properties:**
+- `description` (String): A description to be added to the inner `button` opener for accessibility
 - `text` (required, String): text for the button
 - `disabled` (Boolean, default: `false`): disables the dropdown opener
 - `no-auto-open` (Boolean, default: `false`): prevents the dropdown from opening automatically on or on key press
+
+**Accessibility:**
+
+To make your `d2l-dropdown-button-subtle` accessible, use the following properties when applicable:
+
+| Attribute | Description |
+|--|--|
+| `description` | Use when text on button does not provide enough context. |
 
 ### d2l-dropdown-context-menu
 `d2l-dropdown-context-menu` is a simple/minimal opener for dropdown content (`d2l-dropdown-content`, `d2l-dropdown-menu` or `d2l-dropdown-tabs`).

--- a/components/dropdown/dropdown-button-subtle.js
+++ b/components/dropdown/dropdown-button-subtle.js
@@ -12,6 +12,10 @@ class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
+			 * A description to be added to the opener button for accessibility when text on button does not provide enough context
+			 */
+			description: { type: String },
+			/**
 			 * REQUIRED: Text for the button
 			 */
 			text: {
@@ -26,7 +30,7 @@ class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 
 	render() {
 		return html`
-			<d2l-button-subtle text=${this.text} icon="tier1:chevron-down" icon-right ?disabled=${this.disabled}></d2l-button-subtle>
+			<d2l-button-subtle description="${this.description}" text=${this.text} icon="tier1:chevron-down" icon-right ?disabled=${this.disabled}></d2l-button-subtle>
 			<slot></slot>
 		`;
 	}


### PR DESCRIPTION
There are case(s) in Brightspace that use dropdowns with subtle button openers that also have title text, which currently we don't support other than by using a `d2l-button-subtle` + `d2l-dropdown` instead of just using `d2l-dropdown-button-subtle`.