### PR TITLE
fix: setFocusInfo shouldn't be called for those not using grid

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -117,7 +117,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 					node.nodeName === 'SLOT' && ['content'].includes(node.name)
 				);
 				// eslint-disable-next-line no-console
-				console.warning(`${slot.name} area should not have focusable items in it. Consider using href or creating a custom list-item.`);
+				console.warn(`${slot.name} area should not have focusable items in it. Consider using href or creating a custom list-item.`);
 			},
 			capture: true
 		};

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -114,31 +114,11 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 		this._preventFocus = {
 			handleEvent(event) {
-				event.preventDefault();
 				// target content slot only for now - can add others later
 				const slot = (event.path || event.composedPath()).find((node) =>
 					node.nodeName === 'SLOT' && ['content'].includes(node.name)
 				);
-				const ancestorSibling = getNextAncestorSibling(slot);
-				const next = getNextFocusable(ancestorSibling, true);
-				// related target is often on the parent
-				const related = getFirstFocusableDescendant(event.relatedTarget);
-				if (!event.relatedTarget) {
-					next.focus();
-				} else {
-					if (event.relatedTarget === next || related === next) {
-						getPreviousFocusable(slot, true).focus(); // backward tab
-					} else {
-						next.focus(); // forward tab
-					}
-				}
-			},
-			capture: true
-		};
-		this._preventClick = {
-			handleEvent(event) {
-				event.preventDefault();
-				return false;
+				console.warning(`${slot.name} area should not have focusable items in it. Consider using href or creating a custom list-item.`);
 			},
 			capture: true
 		};

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -118,6 +118,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 				const slot = (event.path || event.composedPath()).find((node) =>
 					node.nodeName === 'SLOT' && ['content'].includes(node.name)
 				);
+				// eslint-disable-next-line no-console
 				console.warning(`${slot.name} area should not have focusable items in it. Consider using href or creating a custom list-item.`);
 			},
 			capture: true
@@ -144,7 +145,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			<slot name="control" class="d2l-cell" data-cell-num="4"></slot>
 			<slot name="actions" class="d2l-cell" data-cell-num="6"></slot>
 
-			<slot name="content" @focus="${this._preventFocus}" @click="${this._preventClick}"></slot>
+			<slot name="content" @focus="${this._preventFocus}"></slot>
 		`;
 	}
 

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -4,8 +4,6 @@ import {
 	getComposedActiveElement,
 	getFirstFocusableDescendant,
 	getLastFocusableDescendant,
-	getNextFocusable,
-	getPreviousFocusable,
 	isFocusable } from '../../helpers/focus.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -432,6 +432,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 	}
 
 	_setFocusInfo(event) {
+		if (!this.gridActive) return;
 		const slot = (event.path || event.composedPath()).find(node =>
 			node.nodeName === 'SLOT' && node.classList.contains('d2l-cell'));
 		this._cellNum = parseInt(slot.getAttribute('data-cell-num'));


### PR DESCRIPTION
**Destined for 20.20.8 CERT** #741 
- Prevents a console error when people have focusable items and are not using grid
- Turns off `preventFocus` and `preventClick` on the content area. Some peeps are using content areas to do fancy things with focusable elements, such as accordions, and we don't have a good general alternative for this currently