### PR TITLE
feat: d2l-form nested validation and submission

### DIFF
--- a/components/form/demo/form-demo.js
+++ b/components/form/demo/form-demo.js
@@ -24,49 +24,54 @@ class FormDemo extends LitElement {
 		return html`
 			<d2l-form>
 				<div class="d2l-form-demo-container">
-					<label for="name">Name</label>
-					<input  class="d2l-input" type="text" id="name" name="name" required minlength="4" maxlength="8" size="10">
-				</div>
-				<div class="d2l-form-demo-container">
-					<label>Email<input class="d2l-input" name="email" type="email"></label>
-				</div>
-				<div class="d2l-form-demo-container">
-					<d2l-validation-custom for="password" @d2l-validation-custom-validate=${this._validatePassword} failure-text="Expected hunter2 or 12345" ></d2l-validation-custom>
-					<label>Password<input class="d2l-input" id="password" name="password" required type="password"></label>
-				</div>
-				<fieldset class="d2l-form-demo-container">
-					<legend>Choose your favorite monster</legend>
-					<input type="radio" id="kraken" name="monster" value="kraken">
-					<label for="kraken">Kraken</label><br />
-					<input type="radio" id="sasquatch" name="monster" value="sasquatch">
-					<label for="sasquatch">Sasquatch</label><br />
-				</fieldset>
-				<div class="d2l-form-demo-container">
-					<label for="pet-select">Favorite Pet</label><br />
-					<select class="d2l-input-select" name="pets" id="pet-select" required>
-						<option value="">--Please choose an option--</option>
-						<option value="porpoise">Porpoise</option>
-						<option value="house hippo">House Hippo</option>
-						<option value="spiker monkey">Spider Monkey</option>
-						<option value="capybara">Capybara</option>
-					</select>
-				</div>
-				<div class="d2l-form-demo-container">
-					<label for="story">Tell us your story</label>
-						<textarea class="d2l-input" minlength="20" id="story" name="story" rows="5" cols="33">It was...</textarea>
+					<label>Name
+						<input  class="d2l-input" type="text" name="name" required minlength="4" maxlength="8" size="10">
 					</label>
 				</div>
 				<div class="d2l-form-demo-container">
-					<label for="file">Super Secret File</label><br />
-					<input type="file" id="file" name="super-secret-file">
+					<label>Email
+						<input class="d2l-input" name="email" type="email">
+					</label>
 				</div>
-				<button name="action" value="save" type="submit">Save</button>
+				<div class="d2l-form-demo-container">
+					<d2l-validation-custom for="password" @d2l-validation-custom-validate=${this._validatePassword} failure-text="Expected hunter2" ></d2l-validation-custom>
+					<label>Password
+						<input class="d2l-input" id="password" name="password" required type="password">
+					</label>
+				</div>
+				<fieldset class="d2l-form-demo-container">
+					<legend>Choose your favorite monster</legend>
+					<label><input type="radio" name="monster" value="kraken">&nbsp;Kraken</label>
+					<label><input type="radio" name="monster" value="sasquatch">&nbsp;Sasquatch</label>
+				</fieldset>
+				<div class="d2l-form-demo-container">
+					<label>Favorite Pet<br/>
+						<select class="d2l-input-select" name="pets" required>
+							<option value="">--Please choose an option--</option>
+							<option value="porpoise">Porpoise</option>
+							<option value="house hippo">House Hippo</option>
+							<option value="spiker monkey">Spider Monkey</option>
+							<option value="capybara">Capybara</option>
+						</select>
+					</label>
+				</div>
+				<div class="d2l-form-demo-container">
+					<label>Tell us your story
+						<textarea class="d2l-input" minlength="20" name="story" rows="5" cols="33">It was...</textarea>
+					</label>
+				</div>
+				<div class="d2l-form-demo-container">
+					<label for="file">Super Secret File<br/>
+						<input type="file" name="super-secret-file">
+					</label>
+				</div>
+				<button name="action" value="save">Save</button>
 			</d2l-form>
 		`;
 	}
 
 	_validatePassword(e) {
-		e.detail.resolve(e.detail.forElement.value === 'hunter2' || e.detail.forElement.value === '12345');
+		e.detail.resolve(e.detail.forElement.value === 'hunter2');
 	}
 }
 customElements.define('d2l-form-demo', FormDemo);

--- a/components/form/demo/form-dialog-demo.js
+++ b/components/form/demo/form-dialog-demo.js
@@ -1,0 +1,85 @@
+
+import '../../button/button.js';
+import '../../button/floating-buttons.js';
+import '../../dialog/dialog.js';
+import '../../inputs/input-text.js';
+import '../../validation/validation-custom.js';
+import '../form.js';
+import './form-panel-demo.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { inputStyles } from '../../inputs/input-styles.js';
+import { selectStyles } from '../../inputs/input-select-styles.js';
+
+class FormDialogDemo extends LitElement {
+
+	static get styles() {
+		return [inputStyles, selectStyles, css`
+
+			.d2l-form-dialog-demo-container {
+				margin-bottom: 10px;
+			}
+		`];
+	}
+
+	render() {
+		return html`
+			<d2l-form id="dialog-main-form">
+				<div class="d2l-form-dialog-demo-container">
+					<label>Email<input class="d2l-input" name="email" type="email"></label>
+				</div>
+				<div class="d2l-form-dialog-demo-container">
+					<d2l-validation-custom for="password-dialog" @d2l-validation-custom-validate=${this._validatePassword} failure-text="Expected hunter2" ></d2l-validation-custom>
+					<label>Password<input class="d2l-input" id="password-dialog" name="password" required type="password"></label>
+				</div>
+				<d2l-dialog id="dialog" title-text="My Favorites">
+					<d2l-form id="dialog-secondary-form" async-submit no-nesting @d2l-form-submit=${this._onDialogSubmit}>
+						<fieldset class="d2l-form-dialog-demo-container">
+							<legend>Choose your favorite monster</legend>
+							<label><input type="radio" name="monster" value="kraken">&nbsp;Kraken</label>
+							<label><input type="radio" name="monster" value="sasquatch">&nbsp;Sasquatch</label>
+						</fieldset>
+						<div class="d2l-form-dialog-demo-container">
+							<label>Favorite Pet<br/>
+								<select class="d2l-input-select" name="pets" required>
+									<option value="">--Please choose an option--</option>
+									<option value="porpoise">Porpoise</option>
+									<option value="house hippo">House Hippo</option>
+									<option value="spiker monkey">Spider Monkey</option>
+									<option value="capybara">Capybara</option>
+								</select>
+							</label>
+						</div>
+					</d2l-form>
+					<d2l-button slot="footer" primary @click=${this._onDialogSubmitClicked}>Save</d2l-button>
+					<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+				</d2l-dialog>
+				<div class="d2l-form-dialog-demo-container">
+					<d2l-button @click=${this._openDialog}>Show Favorites Dialog</d2l-button>
+				</div>
+				<d2l-button primary @click=${this._onSubmitClicked}>Save</d2l-button>
+			</d2l-form>
+		`;
+	}
+
+	_onDialogSubmit() {
+		this.shadowRoot.querySelector('#dialog').opened = false;
+	}
+
+	_onDialogSubmitClicked() {
+		this.shadowRoot.querySelector('#dialog-secondary-form').submit();
+	}
+
+	_onSubmitClicked() {
+		this.shadowRoot.querySelector('#dialog-main-form').submit();
+	}
+
+	_openDialog() {
+		this.shadowRoot.querySelector('#dialog').opened = true;
+	}
+
+	_validatePassword(e) {
+		e.detail.resolve(e.detail.forElement.value === 'hunter2');
+	}
+}
+
+customElements.define('d2l-form-dialog-demo', FormDialogDemo);

--- a/components/form/demo/form-nested-demo.js
+++ b/components/form/demo/form-nested-demo.js
@@ -1,0 +1,83 @@
+
+import '../../button/button.js';
+import '../../button/floating-buttons.js';
+import '../../inputs/input-text.js';
+import '../../validation/validation-custom.js';
+import '../form.js';
+import './form-panel-demo.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { inputStyles } from '../../inputs/input-styles.js';
+import { selectStyles } from '../../inputs/input-select-styles.js';
+
+class FormNestedDemo extends LitElement {
+
+	static get styles() {
+		return [inputStyles, selectStyles, css`
+
+			.d2l-form-nested-demo-split-container {
+				display: flex;
+				margin-top: 18px;
+			}
+
+			.d2l-form-nested-demo-container {
+				margin-bottom: 10px;
+			}
+
+			.d2l-form-nested-demo-main {
+				flex-grow: 1;
+				padding: 0 20px 20px 0;
+			}
+		`];
+	}
+
+	render() {
+		return html`
+			<d2l-form id="root" @d2l-form-submit=${this._onRootSubmit}>
+				<div class="d2l-form-nested-demo-split-container">
+					<d2l-form class="d2l-form-nested-demo-main">
+						<div class="d2l-form-nested-demo-container">
+							<label>Email<input class="d2l-input" name="email" type="email"></label>
+						</div>
+						<div class="d2l-form-nested-demo-container">
+							<d2l-validation-custom for="password-nested" @d2l-validation-custom-validate=${this._validatePassword} failure-text="Expected hunter2" ></d2l-validation-custom>
+							<label>Password<input class="d2l-input" id="password-nested" name="password" required type="password"></label>
+						</div>
+						<fieldset class="d2l-form-nested-demo-container">
+							<legend>Choose your favorite monster</legend>
+							<label><input type="radio" name="monster" value="kraken">&nbsp;Kraken</label>
+							<label><input type="radio" name="monster" value="sasquatch">&nbsp;Sasquatch</label>
+						</fieldset>
+						<div class="d2l-form-nested-demo-container">
+							<label>Favorite Pet<br/>
+								<select class="d2l-input-select" name="pets" required>
+									<option value="">--Please choose an option--</option>
+									<option value="porpoise">Porpoise</option>
+									<option value="house hippo">House Hippo</option>
+									<option value="spiker monkey">Spider Monkey</option>
+									<option value="capybara">Capybara</option>
+								</select>
+							</label>
+						</div>
+					</d2l-form>
+					<d2l-form-panel-demo></d2l-form-panel-demo>
+				</div>
+				<d2l-floating-buttons always-float>
+					<d2l-button primary @click=${this._submit}>Save</d2l-button>
+				</d2l-floating-buttons>
+			</d2l-form>
+		`;
+	}
+
+	_onRootSubmit(e) {
+		e.preventDefault();
+	}
+
+	_submit() {
+		this.shadowRoot.querySelector('#root').submit();
+	}
+
+	_validatePassword(e) {
+		e.detail.resolve(e.detail.forElement.value === 'hunter2');
+	}
+}
+customElements.define('d2l-form-nested-demo', FormNestedDemo);

--- a/components/form/demo/form-panel-demo.js
+++ b/components/form/demo/form-panel-demo.js
@@ -1,0 +1,108 @@
+
+import '../../button/button-icon';
+import '../../colors/colors.js';
+import '../../expand-collapse/expand-collapse-content.js';
+import '../../inputs/input-text.js';
+import '../form.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { heading3Styles } from '../../typography/styles.js';
+import { inputStyles } from '../../inputs/input-styles.js';
+
+class FormPanelDemo extends LitElement {
+
+	static get properties() {
+		return {
+			_expanded: { type: Boolean, attribute: false }
+		};
+	}
+
+	static get styles() {
+		return [heading3Styles, inputStyles, css`
+			:host {
+				background-color: var(--d2l-color-gypsum);
+				display: block;
+				flex-basis: 35%;
+				padding: 10px;
+				width: 100%;
+			}
+
+			:host([hidden]) {
+				display: none;
+			}
+
+			.d2l-form-panel-demo-panel {
+				background-color: white;
+				border-radius: 8px;
+				padding: 20px;
+			}
+
+			.d2l-form-panel-demo-container {
+				margin-bottom: 10px;
+			}
+
+			.d2l-form-panel-demo-header {
+				align-items: top;
+				cursor: pointer;
+				display: flex;
+				justify-content: space-between;
+			}
+
+			.d2l-form-panel-demo-text {
+				align-items: center;
+				display: flex;
+				margin: 0;
+			}
+		`];
+	}
+
+	constructor() {
+		super();
+		this._expanded = false;
+	}
+
+	render() {
+		return html`
+			<div class="d2l-form-panel-demo-panel">
+				<div class="d2l-form-panel-demo-header" @click=${this._toggleExpandCollapse}>
+					<h3 class="d2l-form-panel-demo-text d2l-heading-3">Personal Information</h3>
+					<d2l-button-icon
+						aria-expanded=${this._expanded ? 'true' : 'false'}
+						icon=${this._expanded ? 'tier1:arrow-collapse-small' : 'tier1:arrow-expand-small'}
+						@click=${this._toggleExpandCollapse}>
+					</d2l-button-icon>
+				</div>
+				<hr>
+				<d2l-expand-collapse-content ?expanded=${this._expanded}>
+					<d2l-form @d2l-form-invalid=${this._onInvalid}>
+						<div class="d2l-form-panel-demo-container">
+							<label>First Name
+								<input  class="d2l-input" type="text" name="first-name" required minlength="4" maxlength="15">
+							</label>
+						</div>
+						<div class="d2l-form-panel-demo-container">
+							<label>Middle Name
+								<input  class="d2l-input" type="text" name="middle-name" minlength="4" maxlength="8">
+							</label>
+						</div>
+						<div class="d2l-form-panel-demo-container">
+							<label>Last Name
+								<input  class="d2l-input" type="text" name="last-name" required minlength="4" maxlength="15">
+							</label>
+						</div>
+					</d2l-form>
+				</d2l-expand-collapse-content>
+			</div>
+		`;
+	}
+
+	_onInvalid() {
+		this._expanded = true;
+	}
+
+	_toggleExpandCollapse(e) {
+		e.stopPropagation();
+		this._expanded = !this._expanded;
+	}
+
+}
+customElements.define('d2l-form-panel-demo', FormPanelDemo);

--- a/components/form/demo/form.html
+++ b/components/form/demo/form.html
@@ -9,6 +9,7 @@
 	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
+		import './form-dialog-demo.js';
 		import './form-nested-demo.js';
 		import './form-demo.js';
 	</script>
@@ -29,6 +30,13 @@
 		<d2l-demo-snippet>
 			<template>
 				<d2l-form-nested-demo></d2l-form-nested-demo>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Dialog</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-form-dialog-demo></d2l-form-dialog-demo>
 			</template>
 		</d2l-demo-snippet>
 

--- a/components/form/demo/form.html
+++ b/components/form/demo/form.html
@@ -9,6 +9,7 @@
 	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
+		import './form-nested-demo.js';
 		import './form-demo.js';
 	</script>
 </head>
@@ -21,6 +22,13 @@
 		<d2l-demo-snippet>
 			<template>
 				<d2l-form-demo></d2l-form-demo>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Nested</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-form-nested-demo></d2l-form-nested-demo>
 			</template>
 		</d2l-demo-snippet>
 

--- a/components/form/form-errory-summary.js
+++ b/components/form/form-errory-summary.js
@@ -53,6 +53,10 @@ class FormErrorSummary extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				margin-left: 0;
 				margin-right: 1.2rem;
 			}
+
+			d2l-alert {
+				max-width: unset;
+			}
 		`];
 	}
 

--- a/components/form/form-helper.js
+++ b/components/form/form-helper.js
@@ -23,18 +23,20 @@ export const isNativeFormElement = (node) => {
 	return !!formElements[nodeName];
 };
 
-export const findFormElements = (root) => {
+export const findFormElements = (root, isFormElementPredicate = () => false, visitChildrenPredicate = () => true) => {
 	const eles = [];
-	_findFormElementsHelper(root, eles);
+	_findFormElementsHelper(root, eles, isFormElementPredicate, visitChildrenPredicate);
 	return eles;
 };
 
-const _findFormElementsHelper = (ele, eles) => {
-	if (isNativeFormElement(ele) || isCustomFormElement(ele)) {
+const _findFormElementsHelper = (ele, eles, isFormElementPredicate, visitChildrenPredicate) => {
+	if (isNativeFormElement(ele) || isCustomFormElement(ele) || isFormElementPredicate(ele)) {
 		eles.push(ele);
 	}
-	for (const child of ele.children) {
-		_findFormElementsHelper(child, eles);
+	if (visitChildrenPredicate(ele)) {
+		for (const child of ele.children) {
+			_findFormElementsHelper(child, eles, isFormElementPredicate, visitChildrenPredicate);
+		}
 	}
 };
 
@@ -156,5 +158,21 @@ const _hasFormData = (node, submitter) => {
 		return false;
 	}
 	return true;
+};
+
+export const flattenMap = (map) => {
+
+	const flattened = new Map();
+	for (const [key, val] of map) {
+		if (val instanceof Map) {
+			const subMap = flattenMap(val);
+			for (const [nestedKey, nestedVal] of subMap) {
+				flattened.set(nestedKey, nestedVal);
+			}
+		} else {
+			flattened.set(key, val);
+		}
+	}
+	return flattened;
 };
 

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -9,15 +9,42 @@ import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { localizeFormElement } from './form-element-localize-helper.js';
 import { ValidationType } from './form-element-mixin.js';
 
+/**
+ * A component that can be used to build forms that validate and submit native and custom form elements.
+ * @slot - The native and custom form elements that participate in validation and submission
+ * @fires d2l-form-submit - Dispatched when the form is submitted
+ * @fires d2l-form-invalid - Dispatched when the form is submitted but one or more form elements failed validation
+ */
 class Form extends LocalizeCoreElement(LitElement) {
 
 	static get properties() {
 		return {
+			/**
+			 * The URL that processes the form submission
+			 */
 			action: { type: String },
+			/**
+			 * Causes the form to be submitted as an asynchronous XHR request rather than a native form submission.
+			 * If the form has nested forms then
+			 */
 			asyncSubmit: { type: Boolean, attribute: 'async-submit', reflect: true },
+			/**
+			 * The MIME type used to encode the submitted data using synchronous submit
+			 * @type {'application/x-www-form-urlencoded'|'multipart/form-data'|'text/plain'}
+			 */
 			enctype: { type: String },
+			/**
+			 * The HTTP request method to use to submit the form
+			 * @type {'POST'|'PUT'}
+			 */
 			method: { type: String },
+			/**
+			 * Prevents the form from being validated and submitted when an ancestor form is validated or submitted
+			 */
 			noNesting: { type: Boolean, attribute: 'no-nesting', reflect: true },
+			/**
+			 * Enable to warn the user about unsaved changes when navigating away
+			 */
 			trackChanges: { type: Boolean, attribute: 'track-changes', reflect: true },
 			_errors: { type: Object, attribute: false },
 			_isSubForm: { type: Boolean, attribute: false },

--- a/components/form/test/form-helper.test.js
+++ b/components/form/test/form-helper.test.js
@@ -2,7 +2,7 @@ import './form-element.js';
 import '../../status-indicator/status-indicator.js';
 import '../../tooltip/tooltip.js';
 import { expect, fixture, html } from '@open-wc/testing';
-import { findFormElements, getFormElementData, isCustomElement, isCustomFormElement, isElement, isNativeFormElement, tryGetLabelText } from '../form-helper.js';
+import { findFormElements, flattenMap, getFormElementData, isCustomElement, isCustomFormElement, isElement, isNativeFormElement, tryGetLabelText } from '../form-helper.js';
 
 const buttonFixture = html`<button type="button">Add to favorites</button>`;
 
@@ -260,10 +260,11 @@ describe('form-helper', () => {
 					</div>
 				</div>
 				<object id="ele-8" type="image/png" width="300" height="200"></object>
+				<div id="fake-form-element"></div>
 				<label>Email
 					<input id="ele-9" type="email"/>
 				</label>
-				<div>
+				<div id="secondary">
 					<h2>Secondary</h2>
 					<label for="ele-10">Tell us your story</label>
 					<textarea id="ele-10" title="my title" minlength="20" name="story">It was...</textarea>
@@ -293,6 +294,26 @@ describe('form-helper', () => {
 				id += 1;
 			}
 		});
+
+		it('should not find form elements inside elements that fail the visitChildrenPredicate', () => {
+			const secondaryEle = root.querySelector('#secondary');
+			const formElements = findFormElements(root, undefined, ele => ele !== secondaryEle);
+
+			const ele10 = root.querySelector('#ele-10');
+			const ele11 = root.querySelector('#ele-11');
+			const ele12 = root.querySelector('#ele-12');
+			const ele13 = root.querySelector('#ele-13');
+
+			expect(formElements).to.not.include.members([ele10, ele11, ele12, ele13]);
+		});
+
+		it('should find elements that pass the isFormElementPredicate', () => {
+			const fakeFormElement = root.querySelector('#fake-form-element');
+			const formElements = findFormElements(root, ele => ele === fakeFormElement);
+
+			expect(formElements).to.include.members([fakeFormElement]);
+		});
+
 	});
 
 	describe('getFormElementData', () => {
@@ -424,6 +445,47 @@ describe('form-helper', () => {
 				expect(Object.entries(actualFormData).length).to.equal(expectedEntries);
 			});
 
+		});
+
+		describe('flattenMap', () => {
+
+			it('should flatten errors', async() => {
+				const errors = new Map();
+				const pairs = [];
+
+				const set = (map, key, value) => {
+					if (!(value instanceof Map)) {
+						pairs.push([key, value]);
+					}
+					map.set(key, value);
+				};
+
+				set(errors, 'a', 1);
+
+				const subErrors1 = new Map();
+				set(subErrors1, 'ba', 'a value');
+				set(subErrors1, 'bb', { prop: 'my prop' });
+
+				const subSubErrors1 = new Map();
+				set(subSubErrors1, 'bca', 99);
+				set(subSubErrors1, 'bcb', new Map());
+				set(subErrors1, 'bc', subSubErrors1);
+
+				set(errors, 'b', subErrors1);
+
+				set(errors, 'c', [1, 2, 3, 4]);
+				set(errors, 'd', 'another val');
+
+				const subErrors2 = new Map();
+				set(subErrors2, 'ea', ['x', 'y']);
+				set(subErrors2, 'eb', 1024);
+				set(errors, 'e', subErrors2);
+
+				const flatErrors = flattenMap(errors);
+				for (const [key, value] of pairs) {
+					expect(flatErrors.get(key)).to.equal(value);
+				}
+			});
 		});
 
 	});

--- a/components/form/test/form.test.js
+++ b/components/form/test/form.test.js
@@ -1,76 +1,159 @@
 import '../../validation/validation-custom.js';
 import '../form.js';
 import './form-element.js';
+import './nested-form.js';
 import { expect, fixture } from '@open-wc/testing';
 import { html } from 'lit-element/lit-element.js';
 
-describe('form-element', () => {
+describe('d2l-form', () => {
 
 	const _validateCheckbox = e => {
 		e.detail.resolve(e.detail.forElement.checked);
 	};
 
-	const formFixture = html`
-		<d2l-form>
-			<d2l-validation-custom for="mycheck" @d2l-validation-custom-validate=${_validateCheckbox} failure-text="The checkbox failed validation" >
-			</d2l-validation-custom>
-			<input type="checkbox" id="mycheck" name="checkers" value="red-black">
-			<input type="file" name="optional-file">
-			<select aria-label="Pets" name="pets" id="pets" required>
-				<option value="">--Please choose an option--</option>
-				<option value="dog">Dog</option>
-				<option value="cat">Cat</option>
-				<option value="hamster">Hamster</option>
-				<option value="parrot">Parrot</option>
-				<option value="spider">Spider</option>
-				<option value="goldfish">Goldfish</option>
-			</select>
-			<input type="radio" id="myradio" name="optional-radio">
-			<label for="name">Name</label>
-			<d2l-test-form-element id="custom-ele"></d2l-test-form-element>
-		</d2l-form>
-	`;
+	describe('single form', () => {
 
-	let form;
+		const formFixture = html`
+			<d2l-form>
+				<d2l-validation-custom for="mycheck" @d2l-validation-custom-validate=${_validateCheckbox} failure-text="The checkbox failed validation" >
+				</d2l-validation-custom>
+				<input type="checkbox" id="mycheck" name="checkers" value="red-black">
+				<input type="file" name="optional-file">
+				<select aria-label="Pets" name="pets" id="pets" required>
+					<option value="">--Please choose an option--</option>
+					<option value="dog">Dog</option>
+					<option value="cat">Cat</option>
+					<option value="hamster">Hamster</option>
+					<option value="parrot">Parrot</option>
+					<option value="spider">Spider</option>
+					<option value="goldfish">Goldfish</option>
+				</select>
+				<input type="radio" id="myradio" name="optional-radio">
+				<d2l-test-form-element id="custom-ele"></d2l-test-form-element>
+			</d2l-form>
+		`;
 
-	beforeEach(async() => {
-		form = await fixture(formFixture);
+		let form;
+
+		beforeEach(async() => {
+			form = await fixture(formFixture);
+		});
+
+		describe('validate', () => {
+
+			it('should validate validation-customs', async() => {
+				const errors = await form.validate();
+				const ele = form.querySelector('#mycheck');
+				expect(errors.get(ele)).to.include.members(['The checkbox failed validation']);
+			});
+
+			it('should validate native form elements', async() => {
+				const errors = await form.validate();
+				const ele = form.querySelector('#pets');
+				expect(errors.get(ele)).to.include.members(['Pets is required.']);
+			});
+
+			it('should validate custom form elements', async() => {
+				const formElement = form.querySelector('#custom-ele');
+				formElement.value = 'Non-empty';
+				formElement.setValidity({ rangeOverflow: true });
+				const errors = await form.validate();
+				expect(errors.get(formElement)).to.include.members(['Test form element failed with an overridden validation message']);
+			});
+
+		});
+
+		describe('submit', () => {
+
+			it('should not submit if there are errors', async() => {
+
+				let submitted = false;
+				form.addEventListener('d2l-form-submit', () => submitted = true);
+				await form.submit();
+				expect(submitted).to.be.false;
+			});
+
+			it('should submit with form values', done => {
+
+				const mycheck = form.querySelector('#mycheck');
+				mycheck.checked = true;
+
+				const pets = form.querySelector('#pets > option:nth-child(4)');
+				pets.selected = true;
+
+				const formElement = form.querySelector('#custom-ele');
+				formElement.value = 'Non-empty';
+				formElement.formValue = {
+					'key-1': 'val-1',
+					'key-2': 'val-2'
+				};
+
+				const myradio = form.querySelector('#myradio');
+				myradio.checked = true;
+
+				form.addEventListener('d2l-form-submit', (e) => {
+					e.preventDefault();
+					const { formData } = e.detail;
+					expect(formData.checkers).to.equal('red-black');
+					expect(formData.pets).to.equal('hamster');
+					expect(formData['key-1']).to.equal('val-1');
+					expect(formData['key-2']).to.equal('val-2');
+					expect(formData['optional-file']).to.be.empty;
+					expect(formData['optional-radio']).to.equal('on');
+					done();
+				});
+				form.submit();
+			});
+
+		});
+
 	});
 
-	describe('validate', () => {
+	describe('nested form', () => {
+		const _validateStory = e => {
+			e.detail.resolve(e.detail.forElement.value === 'The PERFECT story');
+		};
 
-		it('should validate validation-customs', async() => {
-			const errors = await form.validate();
-			expect(errors).to.include.members(['The checkbox failed validation']);
+		const rootFormFixture = html`
+			<d2l-form>
+				<d2l-validation-custom for="mycheck" @d2l-validation-custom-validate=${_validateCheckbox} failure-text="The checkbox failed validation" >
+				</d2l-validation-custom>
+				<input type="checkbox" id="mycheck" name="checkers" value="red-black">
+				<div>
+					<d2l-form id="nested-form">
+						<select aria-label="Home planet" name="home-planet" id="nested-home-planet" required>
+							<option value="">--Please choose an option--</option>
+							<option value="earth">Earth</option>
+							<option value="other">Other</option>
+						</select>
+						<label>Story<input type="text" id="nested-story" name="story"></label>
+						<d2l-validation-custom for="nested-story" @d2l-validation-custom-validate=${_validateStory} failure-text="Wrong story" >
+						</d2l-validation-custom>
+						<d2l-test-form-element id="nested-custom-ele"></d2l-test-form-element>
+					</d2l-form>
+				</div>
+				<select aria-label="Pets" name="pets" id="pets" required>
+					<option value="">--Please choose an option--</option>
+					<option value="dog">Dog</option>
+					<option value="cat">Cat</option>
+					<option value="hamster">Hamster</option>
+					<option value="parrot">Parrot</option>
+					<option value="spider">Spider</option>
+					<option value="goldfish">Goldfish</option>
+				</select>
+				<d2l-test-nested-form id="composed-nested-form"></d2l-test-nested-form>
+				<input type="radio" id="myradio" name="optional-radio">
+				<d2l-test-form-element id="custom-ele"></d2l-test-form-element>
+			</d2l-form>
+		`;
+
+		let form;
+
+		beforeEach(async() => {
+			form = await fixture(rootFormFixture);
 		});
 
-		it('should validate native form elements', async() => {
-			const errors = await form.validate();
-			expect(errors).to.include.members(['Pets is required.']);
-		});
-
-		it('should validate custom form elements', async() => {
-			const formElement = form.querySelector('#custom-ele');
-			formElement.value = 'Non-empty';
-			formElement.setValidity({ rangeOverflow: true });
-			const errors = await form.validate();
-			expect(errors).to.include.members(['Test form element failed with an overridden validation message']);
-		});
-
-	});
-
-	describe('submit', () => {
-
-		it('should not submit if there are errors', async() => {
-
-			let submitted = false;
-			form.addEventListener('d2l-form-submit', () => submitted = true);
-			await form.submit();
-			expect(submitted).to.be.false;
-		});
-
-		it('should submit with form values', done => {
-
+		const fillForm = () => {
 			const mycheck = form.querySelector('#mycheck');
 			mycheck.checked = true;
 
@@ -86,21 +169,171 @@ describe('form-element', () => {
 
 			const myradio = form.querySelector('#myradio');
 			myradio.checked = true;
+		};
 
-			form.addEventListener('d2l-form-submit', (e) => {
-				e.preventDefault();
-				const { formData } = e.detail;
-				expect(formData.checkers).to.equal('red-black');
-				expect(formData.pets).to.equal('hamster');
-				expect(formData['key-1']).to.equal('val-1');
-				expect(formData['key-2']).to.equal('val-2');
-				expect(formData['optional-file']).to.be.empty;
-				expect(formData['optional-radio']).to.equal('on');
-				done();
+		const fillNestedForm = () => {
+			const nestedFormEle = form.querySelector('#nested-form');
+
+			const homePlanet = nestedFormEle.querySelector('#nested-home-planet > option:nth-child(2)');
+			homePlanet.selected = true;
+
+			const story = nestedFormEle.querySelector('#nested-story');
+			story.value = 'The PERFECT story';
+
+			const formElement = nestedFormEle.querySelector('#nested-custom-ele');
+			formElement.value = 'Non-empty';
+			formElement.formValue = {
+				'nested-key-1': 'nested-val-1',
+				'nested-key-2': 'nested-val-2'
+			};
+		};
+
+		describe('validate', () => {
+
+			[
+				{ noDirectNesting: false, noComposedNesting: false },
+				{ noDirectNesting: true, noComposedNesting: false },
+				{ noDirectNesting: false, noComposedNesting: true },
+			].forEach(({noDirectNesting, noComposedNesting}) => {
+				it(`should validate nested forms in tree order with${noDirectNesting ? ' no ' : ' '}direct nesting and${noComposedNesting ? ' no ' : ' '}composed nesting`, async() => {
+
+					const formElement = form.querySelector('#custom-ele');
+					formElement.value = 'Non-empty';
+					formElement.setValidity({ rangeOverflow: true });
+
+					const nestedFormEle = form.querySelector('#nested-form');
+					nestedFormEle.noNesting = noDirectNesting;
+
+					const composedNestedFormEle = form.querySelector('#composed-nested-form');
+					composedNestedFormEle.noNesting = noComposedNesting;
+					const expectedErrors = [
+						[form.querySelector('#mycheck'), ['The checkbox failed validation']],
+						...(nestedFormEle.noNesting ? [] : [
+							[nestedFormEle.querySelector('#nested-home-planet'), ['Home planet is required.']],
+							[nestedFormEle.querySelector('#nested-story'), ['Wrong story']],
+							[nestedFormEle.querySelector('#nested-custom-ele'), ['Test form element is required.']],
+						]),
+						[form.querySelector('#pets'), ['Pets is required.']],
+						...(composedNestedFormEle.noNesting ? [] : [
+							[composedNestedFormEle.shadowRoot.querySelector('#composed-nested-first-name'), ['First Name is required.']],
+							[composedNestedFormEle.shadowRoot.querySelector('#composed-nested-pets'), ['Expected Hamster']],
+							[composedNestedFormEle.shadowRoot.querySelector('#composed-nested-custom-ele'), ['Test form element is required.']],
+						]),
+						[formElement, ['Test form element failed with an overridden validation message']]
+					];
+					const errors = await form.validate();
+
+					const actualErrors = [...errors.entries()];
+					expect(actualErrors).to.deep.equal(expectedErrors);
+				});
 			});
-			form.submit();
+
 		});
 
+		describe('submit', () => {
+
+			[
+				{ noDirectNesting: false, noComposedNesting: false },
+				{ noDirectNesting: true, noComposedNesting: false },
+				{ noDirectNesting: false, noComposedNesting: true },
+			].forEach(({ noDirectNesting, noComposedNesting }) => {
+				it(`should not submit if there are errors in a nested form with${noDirectNesting ? ' no ' : ' '}direct nesting and${noComposedNesting ? ' no ' : ' '}composed nesting`, async() => {
+
+					fillForm();
+
+					const nestedForm = form.querySelector('#nested-form');
+					nestedForm.noNesting = noDirectNesting;
+
+					const composedNestedFormEle = form.querySelector('#composed-nested-form');
+					const composedNestedForm = composedNestedFormEle.shadowRoot.querySelector('d2l-form');
+					composedNestedForm.noNesting = noComposedNesting;
+
+					let submitted = false;
+					form.addEventListener('d2l-form-submit', () => submitted = true);
+					nestedForm.addEventListener('d2l-form-submit', () => submitted = true);
+					composedNestedForm.addEventListener('d2l-form-submit', () => submitted = true);
+					await form.submit();
+					expect(submitted).to.be.false;
+				});
+			});
+
+			[
+				{ noDirectNesting: false, noComposedNesting: false },
+				{ noDirectNesting: true, noComposedNesting: false },
+				{ noDirectNesting: false, noComposedNesting: true },
+			].forEach(({ noDirectNesting, noComposedNesting }) => {
+				it(`should submit all forms with form values with${noDirectNesting ? ' no ' : ' '}direct nesting and${noComposedNesting ? ' no ' : ' '}composed nesting`, async() => {
+
+					const nestedForm = form.querySelector('#nested-form');
+					nestedForm.noNesting = noDirectNesting;
+
+					const composedNestedFormEle = form.querySelector('#composed-nested-form');
+					const composedNestedForm = composedNestedFormEle.shadowRoot.querySelector('d2l-form');
+					composedNestedFormEle.noNesting = noComposedNesting;
+
+					if (!noDirectNesting) {
+						fillNestedForm();
+					}
+					if (!noComposedNesting) {
+						composedNestedFormEle.fill();
+					}
+					fillForm();
+
+					const formPromise = new Promise(resolve => {
+						form.addEventListener('d2l-form-submit', (e) => {
+							e.preventDefault();
+							const expectedFormData = {
+								'checkers': 'red-black',
+								'pets': 'hamster',
+								'optional-radio': 'on',
+								'key-1': 'val-1',
+								'key-2': 'val-2'
+							};
+							const { formData } = e.detail;
+							expect(formData).to.deep.equal(expectedFormData);
+							resolve();
+						});
+					});
+					const nestedFormPromise = new Promise(resolve => {
+						if (noDirectNesting) {
+							resolve();
+						}
+						nestedForm.addEventListener('d2l-form-submit', (e) => {
+							e.preventDefault();
+							const expectedFormData = {
+								'home-planet': 'earth',
+								'story': 'The PERFECT story',
+								'nested-key-1': 'nested-val-1',
+								'nested-key-2': 'nested-val-2',
+							};
+							const { formData } = e.detail;
+							expect(formData).to.deep.equal(expectedFormData);
+							resolve();
+						});
+					});
+					const composedNestedFormPromise = new Promise(resolve => {
+						if (noComposedNesting) {
+							resolve();
+						}
+						composedNestedForm.addEventListener('d2l-form-submit', (e) => {
+							e.preventDefault();
+							const expectedFormData = {
+								'first-name': 'John Doe',
+								'pets': 'hamster',
+								'composed-nested-key-1': 'val-1',
+								'composed-nested-key-2': 'val-2'
+							};
+							const { formData } = e.detail;
+							expect(formData).to.deep.equal(expectedFormData);
+							resolve();
+						});
+					});
+					form.submit();
+					await Promise.all([formPromise, nestedFormPromise, composedNestedFormPromise]);
+				});
+			});
+
+		});
 	});
 
 });

--- a/components/form/test/nested-form.js
+++ b/components/form/test/nested-form.js
@@ -1,0 +1,63 @@
+import '../../validation/validation-custom.js';
+import '../form.js';
+import './form-element.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
+
+class NestedForm extends LitElement {
+
+	static get properties() {
+		return {
+			noNesting: { type: Boolean, attribute: 'no-nesting', reflect: true },
+		};
+	}
+
+	constructor() {
+		super();
+		this.noNesting = false;
+	}
+
+	render() {
+		return html`
+			<d2l-form ?no-nesting=${this.noNesting}>
+				<label>
+					First Name
+					<input type="text" id="composed-nested-first-name" name="first-name" required minlength="4" maxlength="15">
+				</label>
+				<d2l-validation-custom for="composed-nested-pets" @d2l-validation-custom-validate=${this._validateSelect} failure-text="Expected Hamster" >
+				</d2l-validation-custom>
+				<select aria-label="Pets" name="pets" id="composed-nested-pets">
+					<option value="">--Please choose an option--</option>
+					<option value="dog">Dog</option>
+					<option value="cat">Cat</option>
+					<option value="hamster">Hamster</option>
+					<option value="parrot">Parrot</option>
+					<option value="spider">Spider</option>
+					<option value="goldfish">Goldfish</option>
+				</select>
+				<input type="radio" id="composed-nested-my-radio" name="composed-nested-optional-radio">
+				<d2l-test-form-element id="composed-nested-custom-ele"></d2l-test-form-element>
+			</d2l-form>
+		`;
+	}
+
+	fill() {
+		const firstName = this.shadowRoot.querySelector('#composed-nested-first-name');
+		firstName.value = 'John Doe';
+
+		const hamster = this.shadowRoot.querySelector('#composed-nested-pets > option:nth-child(4)');
+		hamster.selected = true;
+
+		const formElement = this.shadowRoot.querySelector('#composed-nested-custom-ele');
+		formElement.value = 'Non-empty';
+		formElement.formValue = {
+			'composed-nested-key-1': 'val-1',
+			'composed-nested-key-2': 'val-2'
+		};
+	}
+
+	_validateSelect(e) {
+		e.detail.resolve(e.detail.forElement.value === 'hamster');
+	}
+}
+
+customElements.define('d2l-test-nested-form', NestedForm);


### PR DESCRIPTION
# Changes

## Add support for nested form submission and validation:
- When a parent `d2l-form` is validated or submitted it will validate or submit all descendant `d2l-form` components; both directly nested and composed within the shadow DOM of descendant custom elements.
- All errors for nested forms are bubbled up and displayed within a single error summary in the root form.
- If all `d2l-form` components pass validation then they are submitted individually.
## Add support for `no-nesting`:
- This allows descendant forms to opt-out of being validated and submitted when an ancestor `d2l-form` is submitted or validated.
## Add support for `async-submit`:
- When the `async-submit` attribute is present the form will be submitted using XHR rather than native form submit.
- When forms are nested they can only be submitted using XHR because each `d2l-form` is submitted individually.