### PR TITLE
DE39995 - Fix event firing in consumer of the tab-panel-mixin

### DIFF
--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -69,13 +69,18 @@ export const TabPanelMixin = superclass => class extends superclass {
 			if (prop === 'selected') {
 				if (this.selected) {
 					requestAnimationFrame(() => {
-						this.dispatchEvent(new CustomEvent(
-							'd2l-tab-panel-selected', { bubbles: true, composed: true }
-						));
+						this._dispatchSelected();
 					});
 				}
 			}
 		});
+	}
+
+	// This function has been overwritten by consumers of this mixin
+	_dispatchSelected() {
+		this.dispatchEvent(new CustomEvent(
+			'd2l-tab-panel-selected', { bubbles: true, composed: true }
+		));
 	}
 
 };


### PR DESCRIPTION
In 20.20.7 I tried to cleanup this private helper method (https://github.com/BrightspaceUI/core/pull/566), but didn't realize it was being overwritten by a consumer (https://github.com/BrightspaceUI/facet-filter-sort/blob/master/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js#L188).  This means the `d2l-filter-dropdown-category-selected` event hasn't been firing since then.  From what I can tell, Portfolio is the only place currently using this event and since it's an FRA, I'll be releasing a patch fix on the version it needs (rather than making new BSI releases).

Putting everything back to get back to green ASAP, but maybe the consumer should be doing something different and less fragile.

Tests in `filter-facet-sort` would have caught this months ago, but it uses npm caches.  😒 So I'm going to turn that off.