### PR TITLE
1.49.1 - DE39995 - Fix event firing in consumer of the tab-panel-mixin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ jobs:
         - secure: hETcU1ZRPPz7ipofSeUj8fLkdM9JJda/Qg/oXU83FqZ/y/LZya6jMJjBfcHgEGsCLmVOPLw4lj2+pcyA6ZprJuujdS56elnbWPYUa4iwCbPN7ayfFQQjQx3jo3LYd7jFlCilgMT+Q+s+SnVfmV1Wa91N5WOpINpi7NzIarBRhWVeoiCQJmaabAX2pIn4G5VnBIE562SJULq+05Ucavl9zWrSFHDsMqMtcVcHG7TI6BExENJf76iutEk/YqWdaSvk5LY4xLrO29tThZBVJ7lX5wQGa3MkmlJkHZqxoONBWbGsKfrwh5I7QHExkj8PYYfvpYHQd+VugFrSkDTW3wHsoe/cmrzVe8aEbpHfUSPpO5HOkTdOqy92NVjyh4MOE7hJexmQsYRD+zjFzL4AS876hOdjrf/FS5ume843MvZseSZiCpK7uHTQWwVmitib/dNJdy8YyWoAyceWHpz46QOArrECVYOFhMKYuPrNy3gYY05kCLHCEW24pVN1ToRW2Gp6Z3Z3YblfWShjFHl3eU8riOPeCU9RaBV1k1UuP0C5POyFDPS12K8glPNIJ6dbp6GyI6KKW3iYuX/O3G4w/evO/AMy9nQPL4tUOPU5gQsPvr4Z77+bluP9VqEd3o1VBC6IBwLEcc8tzO+5EAeRbj9THU7zDmoIQH0oRHpIo+elg/8=
     - stage: deploy
       script: npm run build
-      after_success: frauci-update-version -d=skip && export TRAVIS_TAG=$(frauci-get-version)
       env:
         - REPO_NAME=core
         - OWNER_NAME=BrightspaceUI

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -55,13 +55,18 @@ export const TabPanelMixin = superclass => class extends superclass {
 			if (prop === 'selected') {
 				if (this.selected) {
 					requestAnimationFrame(() => {
-						this.dispatchEvent(new CustomEvent(
-							'd2l-tab-panel-selected', { bubbles: true, composed: true }
-						));
+						this._dispatchSelected();
 					});
 				}
 			}
 		});
+	}
+
+	// This function has been overwritten by consumers of this mixin
+	_dispatchSelected() {
+		this.dispatchEvent(new CustomEvent(
+			'd2l-tab-panel-selected', { bubbles: true, composed: true }
+		));
 	}
 
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-ui/core",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "description": "A collection of accessible, free, open-source web components for building Brightspace applications",
   "repository": "https://github.com/BrightspaceUI/core.git",
   "publishConfig": {


### PR DESCRIPTION
Same as https://github.com/BrightspaceUI/core/pull/746, but applied against the `1.49.0` version of `core`.  This is the `core` version Portfolio has in their 5.14 version.  Since this is before we setup semantic-release, going to have to release it the old fashioned way.