### PR TITLE
provide a way to give the inner input field an id

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -196,10 +196,6 @@ class InputText extends RtlMixin(LitElement) {
 		this._lastSlotWidth = 0;
 	}
 
-	_getInputId() {
-		return this.id || this._uniqueId;
-	}
-
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
@@ -307,6 +303,10 @@ class InputText extends RtlMixin(LitElement) {
 			return this.getAttribute('aria-label');
 		}
 		return undefined;
+	}
+
+	_getInputId() {
+		return this.id || this._uniqueId;
 	}
 
 	_getType() {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -18,6 +18,10 @@ class InputText extends RtlMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
+			 * To specific id of the input field. Default is to use a random id
+			 */
+			id: { type: String },
+			/**
 			 * Indicates that the input has a popup menu
 			 */
 			ariaHaspopup: { type: String, attribute: 'aria-haspopup'},
@@ -187,9 +191,13 @@ class InputText extends RtlMixin(LitElement) {
 
 		this._focused = false;
 		this._hovered = false;
-		this._inputId = getUniqueId();
+		this._uniqueId = getUniqueId();
 		this._firstSlotWidth = 0;
 		this._lastSlotWidth = 0;
+	}
+
+	_getInputId() {
+		return this.id || this._uniqueId;
 	}
 
 	firstUpdated(changedProperties) {
@@ -239,7 +247,7 @@ class InputText extends RtlMixin(LitElement) {
 					@change="${this._handleChange}"
 					class="${classMap(inputClasses)}"
 					?disabled="${this.disabled}"
-					id="${this._inputId}"
+					id="${this._getInputId()}"
 					@input="${this._handleInput}"
 					@invalid="${this._handleInvalid}"
 					@keypress="${this._handleKeypress}"
@@ -265,7 +273,7 @@ class InputText extends RtlMixin(LitElement) {
 		`;
 		if (this.label && !this.labelHidden) {
 			return html`
-				<label class="d2l-input-label" for="${this._inputId}">${this.label}</label>
+				<label class="d2l-input-label" for="${this._getInputId()}">${this.label}</label>
 				${input}`;
 		}
 		return input;


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367ud/iterationstatus?detail=%2Fuserstory%2F376732857096
https://github.com/BrightspaceHypermediaComponents/activities/blob/master/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js#L60

The story is making use of the `isFocusable` api, finding all the invalid inputs, and then put a focus on them. I need a way to ignore certain input fields. Using their id's provides just what I need and it is less intrusive. 

