### PR TITLE
Fix overflow on list containers.

### DIFF
--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -13,7 +13,7 @@ class ListItemContent extends LitElement {
 	static get styles() {
 		return [ bodySmallStyles, bodyCompactStyles, css`
 			:host {
-				overflow: hidden;
+				overflow-x: hidden;
 			}
 			.d2l-list-item-content-text {
 				color: var(--d2l-list-item-content-text-color);

--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -12,7 +12,9 @@ class ListItemContent extends LitElement {
 
 	static get styles() {
 		return [ bodySmallStyles, bodyCompactStyles, css`
-
+			:host {
+				overflow: hidden;
+			}
 			.d2l-list-item-content-text {
 				color: var(--d2l-list-item-content-text-color);
 				margin: 0;

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -65,8 +65,6 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			::slotted([slot="content"]),
 			::slotted([slot="actions"]) {
 				grid-row: 1 / 2;
-				overflow: hidden;
-				position: relative;
 			}
 			::slotted([slot="outside-control"]) {
 				grid-column: outside-control-start / outside-control-end;
@@ -80,6 +78,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 			::slotted([slot="content"]) {
 				grid-column: content-start / content-end;
+				overflow-x: hidden;
+				position: relative;
 			}
 
 			::slotted([slot="actions"]) {

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -65,6 +65,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			::slotted([slot="content"]),
 			::slotted([slot="actions"]) {
 				grid-row: 1 / 2;
+				overflow: hidden;
+				position: relative;
 			}
 			::slotted([slot="outside-control"]) {
 				grid-column: outside-control-start / outside-control-end;


### PR DESCRIPTION
There was a problem with consistent evaluation with a list item having a name that is way too long and single character. Things started to over extend to different parts grid cells. Here is the fix:
![image](https://user-images.githubusercontent.com/13232226/89074223-03063300-d34a-11ea-85d6-43d39b8740e4.png)

Picture of the problem: 
![image](https://user-images.githubusercontent.com/13232226/89074255-10bbb880-d34a-11ea-9b3f-8918db3d4a84.png)
