### PR TITLE
Lock mocha version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-sort-class-members": "^1",
     "karma-sauce-launcher": "^4.1.4",
     "lit-analyzer": "^1",
-    "mocha": "^8",
+    "mocha": "~8.0.1",
     "node-sass": "^4",
     "puppeteer": "^5",
     "semantic-release": "^17",


### PR DESCRIPTION
With the latest mocha (8.1) I'm seeing the error `TypeError: Cannot read property 'Runnable' of undefined` when running the karma tests with the problem tracing to `var Runnable = window.Mocha.Runnable;` and `window.Mocha` being undefined. Locally locking the version seems to fix it. 