### PR TITLE
Add alert-toast-close event so consumers can keep their private properties in sync.

### DIFF
--- a/components/alert/README.md
+++ b/components/alert/README.md
@@ -25,8 +25,8 @@ The `d2l-alert` component can be used to communicate important information relat
 - `type` (String, default: `'default'`): type of the alert being displayed. Can be one of  `default`, `critical`, `success` , `warning`
 
 **Events:**
-* `d2l-alert-closed`: dispatched when the alert's close button is clicked
-* `d2l-alert-button-pressed`: dispatched when the alert's action button is clicked
+* `d2l-alert-close`: dispatched when the alert's close button is clicked
+* `d2l-alert-button-press`: dispatched when the alert's action button is clicked
 
 ## d2l-alert-toast
 
@@ -53,6 +53,8 @@ a pop-up at the bottom of the screen that automatically dismisses itself by defa
 - `subtext` (optional, String) The text that is displayed below the main alert message.
 - `type` (String, default: `'default'`): type of the alert being displayed. Can be one of  `default`, `critical`, `success` , `warning`
 
+**Events:**
+* `d2l-alert-toast-close`: dispatched when the toast is closed
 
 ## Future Enhancements
 

--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -15,6 +15,7 @@ const states = {
 /**
  *  A component for communicating important information relating to the state of the system and the user's work flow, displayed as a pop-up at the bottom of the screen that automatically dismisses itself by default.
  * @slot - Default content placed inside of the component
+ * @fires d2l-alert-toast-close - Dispatched when the toast is closed
  */
 class AlertToast extends LitElement {
 
@@ -142,7 +143,7 @@ class AlertToast extends LitElement {
 				<d2l-alert
 					@blur=${this._onBlur}
 					button-text="${ifDefined(this.buttonText)}"
-					@d2l-alert-closed=${this._onCloseClicked}
+					@d2l-alert-close=${this._onCloseClicked}
 					@focus=${this._onFocus}
 					?has-close-button="${!this.hideCloseButton}"
 					@mouseenter=${this._onMouseEnter}
@@ -248,6 +249,13 @@ class AlertToast extends LitElement {
 			} else if (this._state === states.OPENING || this._state === states.OPEN) {
 				this._state = states.CLOSING;
 			}
+			this.dispatchEvent(new CustomEvent(
+				'd2l-alert-toast-close', {
+					bubbles: true,
+					composed: false,
+					detail: { action: this._action }
+				}
+			));
 		}
 	}
 

--- a/components/alert/alert.js
+++ b/components/alert/alert.js
@@ -10,8 +10,8 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
 /**
  * A component for communicating important information relating to the state of the system and the user's work flow.
  * @slot - Default content placed inside of the component
- * @fires d2l-alert-closed - Dispatched when the alert's close button is clicked
- * @fires d2l-alert-button-pressed - Dispatched when the alert's action button is clicked
+ * @fires d2l-alert-close - Dispatched when the alert's close button is clicked
+ * @fires d2l-alert-button-press - Dispatched when the alert's action button is clicked
  */
 class Alert extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
@@ -192,15 +192,22 @@ class Alert extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	close() {
-		const event = new CustomEvent('d2l-alert-closed', { bubbles: true, composed: true, cancelable: true });
-		if (this.dispatchEvent(event)) {
+		// deprecated - event names should be present tense
+		if (this.dispatchEvent(new CustomEvent('d2l-alert-closed', { bubbles: true, composed: true, cancelable: true }))) {
+			this.hidden = true;
+		}
+		if (this.dispatchEvent(new CustomEvent('d2l-alert-close', { bubbles: true, composed: true, cancelable: true }))) {
 			this.hidden = true;
 		}
 	}
 
 	_onButtonClick() {
+		// deprecated - event names should be present tense
 		this.dispatchEvent(new CustomEvent(
 			'd2l-alert-button-pressed', { bubbles: true, composed: true }
+		));
+		this.dispatchEvent(new CustomEvent(
+			'd2l-alert-button-press', { bubbles: true, composed: true }
 		));
 	}
 

--- a/components/alert/demo/alert-toast.html
+++ b/components/alert/demo/alert-toast.html
@@ -71,6 +71,10 @@
 			});
 		});
 	});
+
+	document.body.addEventListener('d2l-alert-toast-close', (e) => {
+		console.log('d2l-alert-toast-close', e);
+	});
 </script>
 
 </html>

--- a/components/alert/demo/alert.html
+++ b/components/alert/demo/alert.html
@@ -73,6 +73,14 @@
 
 	</d2l-demo-page>
 
+	<script type="module">
+		document.body.addEventListener('d2l-alert-close', (e) => {
+			console.log('d2l-alert-close', e);
+		});
+		document.body.addEventListener('d2l-alert-button-press', (e) => {
+			console.log('d2l-alert-button-press', e);
+		});
+	</script>
 </body>
 
 </html>

--- a/components/alert/test/alert-toast.test.js
+++ b/components/alert/test/alert-toast.test.js
@@ -1,5 +1,5 @@
 import '../alert-toast.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-alert-toast', () => {
@@ -13,13 +13,22 @@ describe('d2l-alert-toast', () => {
 	});
 
 	describe('close', () => {
+
 		it('should close when close button is clicked', async() => {
 			const el = await fixture(html`<d2l-alert-toast open>message</d2l-alert-toast>`);
 			const alert = el.shadowRoot.querySelector('d2l-alert');
-			alert.dispatchEvent(new CustomEvent('d2l-alert-closed'));
+			alert.dispatchEvent(new CustomEvent('d2l-alert-close'));
 			await el.updateComplete;
 			expect(el.open).to.be.false;
 		});
+
+		it('should fire "d2l-alert-toast-close" event when closed', async() => {
+			const el = await fixture(html`<d2l-alert-toast open>message</d2l-alert-toast>`);
+			setTimeout(() => el.open = false);
+			await oneEvent(el, 'd2l-alert-toast-close');
+			expect(el.open).to.be.false;
+		});
+
 	});
 
 });

--- a/components/alert/test/alert.test.js
+++ b/components/alert/test/alert.test.js
@@ -20,26 +20,26 @@ describe('d2l-alert', () => {
 
 	describe('events', () => {
 
-		it('should fire "d2l-alert-closed" event when close button is clicked', async() => {
+		it('should fire "d2l-alert-close" event when close button is clicked', async() => {
 			const alert = await fixture(alertFixture);
 			const closeButton = alert.shadowRoot.querySelector('d2l-button-icon');
 			setTimeout(() => closeButton.click());
-			await oneEvent(alert, 'd2l-alert-closed');
+			await oneEvent(alert, 'd2l-alert-close');
 			expect(alert.hasAttribute('hidden')).to.be.true;
 		});
 
-		it('should fire "d2l-alert-closed" event when close is called', async() => {
+		it('should fire "d2l-alert-close" event when close is called', async() => {
 			const alert = await fixture(alertFixture);
 			setTimeout(() => alert.close());
-			await oneEvent(alert, 'd2l-alert-closed');
+			await oneEvent(alert, 'd2l-alert-close');
 			expect(alert.hasAttribute('hidden')).to.be.true;
 		});
 
-		it('should fire "d2l-alert-button-pressed" event when action button is clicked', async() => {
+		it('should fire "d2l-alert-button-press" event when action button is clicked', async() => {
 			const alert = await fixture(alertFixture);
 			const actionButton = alert.shadowRoot.querySelector('d2l-button-subtle');
 			setTimeout(() => actionButton.click());
-			await oneEvent(alert, 'd2l-alert-button-pressed');
+			await oneEvent(alert, 'd2l-alert-button-press');
 		});
 
 	});


### PR DESCRIPTION
This fixes #759.

I've also proceeded to update the event names for the alert to be present tense.  I suspect the past-tense names were an artifact of the previous Polymer alerts.  Unfortunately this will require a little cleanup in apps.  I would have left it as it, except that I did not want `d2l-alert` and `d2l-alert-toast` following different convention, and I also didn't want to continue with the past-tense naming since there is strong precedent for present tense in dropdown, dialog, browser events, and other components.