### PR TITLE
FormElementMixin: announce errors on blur and when updated

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -1,4 +1,5 @@
 import { isCustomFormElement, tryGetLabelText } from './form-helper.js';
+import { announce } from '../../helpers/announce.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 
 export const ValidationType = {
@@ -105,6 +106,12 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		this.validationError = null;
 
 		this.shadowRoot.addEventListener('d2l-validation-custom-connected', this._validationCustomConnected);
+
+		this.addEventListener('blur', (e) => {
+			if (!this.checkValidity()) {
+				announce(`${this.localize('components.form-element.defaultError', { label: this.labelText })} ${this.validationError}`);
+			}
+		});
 	}
 
 	updated(changedProperties) {
@@ -176,6 +183,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 				break;
 			case ValidationType.UPDATE_EXISTING_ERRORS:
 				if (this.validationError && errors.length > 0) {
+					if (errors[0] !== this.validationError) announce(`${this.localize('components.form-element.defaultError', { label: this.labelText })} ${errors[0]}`);
 					this.validationError = errors[0];
 				} else {
 					this.validationError = null;

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -106,8 +106,12 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		this.validationError = null;
 
 		this.shadowRoot.addEventListener('d2l-validation-custom-connected', this._validationCustomConnected);
+	}
 
-		this.addEventListener('blur', (e) => {
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+
+		this.addEventListener('blur', () => {
 			if (!this.checkValidity()) {
 				announce(`${this.localize('components.form-element.defaultError', { label: this.labelText })} ${this.validationError}`);
 			}


### PR DESCRIPTION
Notes:
- `blur` seems to work fine when tested (mostly tested with `input-text` in order to test both change and blur, did some testing with `input-date`)
- There is some repetition with `input-text` since the tooltip is attached to the `input` (depends on the browser combination)

Results:
Does not work (announce just doesn't seem to trigger anything):
- JAWS + firefox
- NVDA + edge

Repetition
- NVDA + firefox (minor repetition - seems to state tooltip message on first blur + also states announce)
- NVDA + chrome (states both tooltip message and announcement on blur and update)
- JAWS + chrome (states both tooltip message and announcement on blur and update)
- VoiceOver + Chrome (minor repetition - tooltip announces once when focus is received and once when change happens, so not really related to this)
- VoiceOver + Safari (minor repetition - tooltip announces once when focus is received and once when change happens, so not really related to this) - Also worth noting that when typing caused an updated error, VoiceOver would interrupt the announce to state what letter had been typed