### PR TITLE
tooltip: announce inner text when used with custom elements

### DIFF
--- a/components/tooltip/README.md
+++ b/components/tooltip/README.md
@@ -77,6 +77,7 @@ In the following example to constrain the tooltip to the dashed boundary we can 
 ```
 
 **Advanced Properties:**
+* `announced` (Boolean) - announce the tooltip inner text to screen reader users when the tooltip is shown. Use with custom elements.
 * `boundary` (Object) - optionally provide boundaries to constrain where the tooltip will appear. Valid properties are `"top"`, `"bottom"`, `"left"` and `"right"`. The boundary is relative to the tooltip's [offset parent](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent).
 * `close-on-click` (Boolean, default: `false`) - causes the tooltip to close when its target is clicked
 * `disable-focus-lock` (Boolean, default: `false`) - disables focus lock so that the tooltip will automatically close when no longer hovered even if it still has focus

--- a/components/tooltip/README.md
+++ b/components/tooltip/README.md
@@ -49,7 +49,7 @@ Adding roles to custom elements that contain internal interactive elements shoul
 ```
 If you need a tooltip in a core component that does not currently support it please create a Github issue.
 
-If you are unable to add a semantically aligned ARIA role or attach the tooltip to an interactive element then accessibility may be inconsistent across different screen readers. In these scenarios, putting critical information inside the tooltip should be avoided because some users may not be able to access it.
+If you are unable to add a semantically aligned ARIA role or attach the tooltip to an interactive element then accessibility may be inconsistent across different screen readers. In these scenarios, putting critical information inside the tooltip should be avoided because some users may not be able to access it. You should use the `announced` attribute on the `d2l-tooltip` in this case, which will announce the tooltip text when the tooltip is shown and works across many browser/screen reader combinations.
 
 ### Advanced Usages
 

--- a/components/tooltip/demo/tooltip.html
+++ b/components/tooltip/demo/tooltip.html
@@ -85,6 +85,16 @@
 			</template>
 		</d2l-demo-snippet>
 
+		<h2>Tooltip (announced)</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-button id="tooltip-announced">Announced</d2l-button>
+				<d2l-tooltip for="tooltip-announced" announced>
+					Some information
+				</d2l-tooltip>
+			</template>
+		</d2l-demo-snippet>
+
 	</d2l-demo-page>
 
 </body>

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -778,7 +778,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			this.dispatchEvent(new CustomEvent(
 				'd2l-tooltip-show', { bubbles: true, composed: true }
 			));
-			if (this.announced && !this._isInteractive(this._findTarget())) announce(this.innerText);
+			if (this.announced && !this._isInteractive(this._target)) announce(this.innerText);
 		} else {
 			this.setAttribute('aria-hidden', 'true');
 			if (this._dismissibleId) {
@@ -799,14 +799,15 @@ class Tooltip extends RtlMixin(LitElement) {
 		this._removeListeners();
 		const target = this._findTarget();
 		if (target) {
+			const isInteractive = this._isInteractive(target);
 			this.id = this.id || getUniqueId();
 			this.setAttribute('role', 'tooltip');
 			if (this.forType === 'label') {
 				target.setAttribute('aria-labelledby', this.id);
-			} else {
+			} else if (!this.announced || isInteractive) {
 				target.setAttribute('aria-describedby', this.id);
 			}
-			if (logAccessibilityWarning && !this._isInteractive(target) && !this.announced) {
+			if (logAccessibilityWarning && !isInteractive && !this.announced) {
 				console.warn(
 					'd2l-tooltip may be being used in a non-accessible manner; it should be attached to interactive elements like \'a\', \'button\',' +
 					'\'input\'', '\'select\', \'textarea\' or static / custom elements if a role has been set and the element is focusable.'

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -1,5 +1,6 @@
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { announce } from '../../helpers/announce.js';
 import { bodySmallStyles } from '../typography/styles.js';
 import { getOffsetParent } from '../../helpers/dom.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
@@ -91,6 +92,10 @@ class Tooltip extends RtlMixin(LitElement) {
 			 * @type {'start'|'end'}
 			 */
 			align: { type: String, reflect: true },
+			/**
+			 * Announce the tooltip innerText when applicable (for use with custom elements)
+			 */
+			announced: { type: Boolean },
 			/**
 			 * Provide boundaries to constrain where the tooltip will appear. The boundary is relative to the tooltip's offset parent. Valid properties include a combination of "top", "bottom", "left", and "right".
 			 */
@@ -352,6 +357,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		this._onTargetTouchStart = this._onTargetTouchStart.bind(this);
 		this._onTargetTouchEnd = this._onTargetTouchEnd.bind(this);
 
+		this.announced = false;
 		this.closeOnClick = false;
 		this.delay = 0;
 		this.disableFocusLock = false;
@@ -772,6 +778,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			this.dispatchEvent(new CustomEvent(
 				'd2l-tooltip-show', { bubbles: true, composed: true }
 			));
+			if (this.announced && !this._isInteractive(this._findTarget())) announce(this.innerText);
 		} else {
 			this.setAttribute('aria-hidden', 'true');
 			if (this._dismissibleId) {
@@ -799,7 +806,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			} else {
 				target.setAttribute('aria-describedby', this.id);
 			}
-			if (logAccessibilityWarning && !this._isInteractive(target)) {
+			if (logAccessibilityWarning && !this._isInteractive(target) && !this.announced) {
 				console.warn(
 					'd2l-tooltip may be being used in a non-accessible manner; it should be attached to interactive elements like \'a\', \'button\',' +
 					'\'input\'', '\'select\', \'textarea\' or static / custom elements if a role has been set and the element is focusable.'


### PR DESCRIPTION
Added the `announced` attribute so that initially this is opt-in in order to avoid repetition when used with components that have already added their own `announce`.

`innerText` seems to work but I'm wondering if there is something else I should be using?