### PR TITLE
fix: FormElementMixin error bubbling

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -142,7 +142,8 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 
 	async requestValidate(validationType = ValidationType.SHOW_NEW_ERRORS) {
 		if (this.dispatchEvent(new CustomEvent('d2l-form-element-should-validate', { cancelable: true }))) {
-			await this.validate(validationType);
+			const errors = await this.validate(validationType);
+			this._notifyFormErrorsChanged(errors);
 		}
 	}
 
@@ -189,7 +190,6 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 				}
 				break;
 		}
-		this._notifyFormErrorsChanged(errors);
 		return errors;
 	}
 
@@ -279,7 +279,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 	}
 
 	_notifyFormErrorsChanged(errors) {
-		const detail = { bubbles: true, composed: true, detail: { errors } };
+		const detail = { bubbles: true, detail: { errors } };
 		this.dispatchEvent(new CustomEvent('d2l-form-errors-change', detail));
 	}
 

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -156,7 +156,7 @@ class InputDateRange extends FormElementMixin(RtlMixin(LocalizeCoreElement(LitEl
 			this.shadowRoot.querySelector('.d2l-input-date-range-end').validate(validationType)]
 		).then(res => res.reduce((acc, errors) => [...acc, ...errors], []));
 		const errors = await super.validate(childErrors.length > 0 ? ValidationType.SUPPRESS_ERRORS : validationType);
-		return [...errors, ...childErrors];
+		return [...childErrors, ...errors];
 	}
 
 	get validationMessageBadInput() {

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -155,7 +155,7 @@ class InputDateTimeRange extends FormElementMixin(RtlMixin(LocalizeCoreElement(L
 			this.shadowRoot.querySelector('.d2l-input-date-time-range-end').validate(validationType)]
 		).then(res => res.reduce((acc, errors) => [...acc, ...errors], []));
 		const errors = await super.validate(childErrors.length > 0 ? ValidationType.SUPPRESS_ERRORS : validationType);
-		return [...errors, ...childErrors];
+		return [...childErrors, ...errors];
 	}
 
 	get validationMessageBadInput() {


### PR DESCRIPTION
# fix: FormElementMixin error bubbling
## Issue
1. When composing multiple form elements, inner form elements were firing composed events meaning the inner form element could wipe out errors for the elements their contained within.
    - **Fix:** Change `d2l-form-errors-change` event to not be composed so its only sent from the top level custom form element and move the event to `requestValidate` so it respects `validate` being overridden.
1. When composing multiple form elements, the order errors were displayed in the tooltip and the error summary would differ if there was both an error in an inner component and an ancestor that contains it.
    - **Fix:** Change the order errors are returned when `validate` is overridden.