### PR TITLE
refactor: Simplify FormElementMixin validateMessage and label

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -1,4 +1,4 @@
-import { isCustomFormElement, tryGetLabelText } from './form-helper.js';
+import { isCustomFormElement } from './form-helper.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 
 export const ValidationType = {
@@ -131,15 +131,6 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		return true;
 	}
 
-	get labelText() {
-		const label = this.label || tryGetLabelText(this);
-		if (label) {
-			return label;
-		}
-		console.warn(this, ' is missing a label');
-		return this.localize('components.form-element.defaultFieldLabel');
-	}
-
 	async requestValidate(validationType = ValidationType.SHOW_NEW_ERRORS) {
 		if (this.dispatchEvent(new CustomEvent('d2l-form-element-should-validate', { cancelable: true }))) {
 			const errors = await this.validate(validationType);
@@ -202,76 +193,14 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 	}
 
 	get validationMessage() {
-		const validity = this.validity;
-		switch (true) {
-			case validity.valid:
-				return null;
-			case validity.customError:
-				return this._validationMessage;
-			case validity.badInput:
-				return this.validationMessageBadInput;
-			case validity.patternMismatch:
-				return this.validationMessagePatternMismatch;
-			case validity.rangeOverflow:
-				return this.validationMessageRangeOverflow;
-			case validity.rangeUnderflow:
-				return this.validationMessageRangeUnderflow;
-			case validity.stepMismatch:
-				return this.validationMessageStepMismatch;
-			case validity.tooLong:
-				return this.validationMessageTooLong;
-			case validity.tooShort:
-				return this.validationMessageTooShort;
-			case validity.typeMismatch:
-				return this.validationMessageTypeMismatch;
-			case validity.valueMissing:
-				return this.validationMessageValueMissing;
+		if (this.validity.customError) {
+			return this._validationMessage;
 		}
-		return this.localize('components.form-element.defaultError', { label: this.labelText });
-	}
-
-	get validationMessageBadInput() {
-		console.warn(this, ' is using the default validation message, override \'validationMessageBadInput\'');
-		return this.localize('components.form-element.defaultError', { label: this.labelText });
-	}
-
-	get validationMessagePatternMismatch() {
-		console.warn(this, ' is using the default validation message, override \'validationMessagePatternMismatch\'');
-		return this.localize('components.form-element.defaultError', { label: this.labelText });
-	}
-
-	get validationMessageRangeOverflow() {
-		console.warn(this, ' is using the default validation message, override \'validationMessageRangeOverflow\'');
-		return this.localize('components.form-element.defaultError', { label: this.labelText });
-	}
-
-	get validationMessageRangeUnderflow() {
-		console.warn(this, ' is using the default validation message, override \'validationMessageRangeUnderflow\'');
-		return this.localize('components.form-element.defaultError', { label: this.labelText });
-	}
-
-	get validationMessageStepMismatch() {
-		console.warn(this, ' is using the default validation message, override \'validationMessageStepMismatch\'');
-		return this.localize('components.form-element.defaultError', { label: this.labelText });
-	}
-
-	get validationMessageTooLong() {
-		console.warn(this, ' is using the default validation message, override \'validationMessageTooLong\'');
-		return this.localize('components.form-element.defaultError', { label: this.labelText });
-	}
-
-	get validationMessageTooShort() {
-		console.warn(this, ' is using the default validation message, override \'validationMessageTooShort\'');
-		return this.localize('components.form-element.defaultError', { label: this.labelText });
-	}
-
-	get validationMessageTypeMismatch() {
-		console.warn(this, ' is using the default validation message, override \'validationMessageTypeMismatch\'');
-		return this.localize('components.form-element.defaultError', { label: this.labelText });
-	}
-
-	get validationMessageValueMissing() {
-		return this.localize('components.form-element.valueMissing', { label: this.labelText });
+		const label = this.label || this.localize('components.form-element.defaultFieldLabel');
+		if (this.validity.valueMissing) {
+			return this.localize('components.form-element.valueMissing', { label });
+		}
+		return this.localize('components.form-element.defaultError', { label });
 	}
 
 	get validity() {

--- a/components/form/test/form-element.js
+++ b/components/form/test/form-element.js
@@ -33,16 +33,11 @@ class FormElement extends FormElementMixin(LitElement) {
 		return 'Test form element';
 	}
 
-	get validationMessageRangeOverflow() {
-		return `${this.labelText} failed with an overridden validation message`;
-	}
-
-	validationTooltipHide() {
-		this.tooltipMessage = null;
-	}
-
-	validationTooltipShow(message) {
-		this.tooltipMessage = message;
+	get validationMessage() {
+		if (this.validity.rangeOverflow) {
+			return `${this.label} failed with an overridden validation message`;
+		}
+		return super.validationMessage;
 	}
 
 	get validity() {

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -159,8 +159,11 @@ class InputDateRange extends FormElementMixin(RtlMixin(LocalizeCoreElement(LitEl
 		return [...childErrors, ...errors];
 	}
 
-	get validationMessageBadInput() {
-		return this.localize('components.input-date-range.errorBadInput', { startLabel: this._computedStartLabel, endLabel: this._computedEndLabel });
+	get validationMessage() {
+		if (this.validity.badInput) {
+			return this.localize('components.input-date-range.errorBadInput', { startLabel: this._computedStartLabel, endLabel: this._computedEndLabel });
+		}
+		return super.validationMessage;
 	}
 
 	get _computedEndLabel() {

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -158,8 +158,11 @@ class InputDateTimeRange extends FormElementMixin(RtlMixin(LocalizeCoreElement(L
 		return [...childErrors, ...errors];
 	}
 
-	get validationMessageBadInput() {
-		return this.localize('components.input-date-time-range.errorBadInput', { startLabel: this._computedStartLabel, endLabel: this._computedEndLabel });
+	get validationMessage() {
+		if (this.validity.badInput) {
+			return this.localize('components.input-date-time-range.errorBadInput', { startLabel: this._computedStartLabel, endLabel: this._computedEndLabel });
+		}
+		return super.validationMessage;
 	}
 
 	get _computedEndLabel() {

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -157,42 +157,19 @@ class InputDateTime extends FormElementMixin(LocalizeCoreElement(RtlMixin(LitEle
 		if (elem) elem.focus();
 	}
 
-	get validationMessageRangeOverflow() {
-		let failureText = '';
-		if (this.minValue && this.maxValue) {
-			failureText = this.localize(
-				`${this._namespace}.errorOutsideRange`, {
-					minDate: formatDateTime(getDateFromISODateTime(this.minValue), {format: 'medium'}),
-					maxDate: formatDateTime(getDateFromISODateTime(this.maxValue), {format: 'medium'})
-				}
-			);
-		} else if (this.maxValue) {
-			failureText = this.localize(
-				`${this._namespace}.errorMaxDateOnly`, {
-					maxDate: formatDateTime(getDateFromISODateTime(this.maxValue), {format: 'medium'})
-				}
-			);
+	get validationMessage() {
+		if (this.validity.rangeOverflow || this.validity.rangeUnderflow) {
+			const minDate = this.minValue ? formatDateTime(getDateFromISODateTime(this.minValue), { format: 'medium' }) : null;
+			const maxDate = this.maxValue ? formatDateTime(getDateFromISODateTime(this.maxValue), { format: 'medium' }) : null;
+			if (minDate && maxDate) {
+				return this.localize(`${this._namespace}.errorOutsideRange`, { minDate, maxDate });
+			} else if (maxDate) {
+				return this.localize(`${this._namespace}.errorMaxDateOnly`, { maxDate });
+			} else if (this.minValue) {
+				return this.localize(`${this._namespace}.errorMinDateOnly`, { minDate });
+			}
 		}
-		return failureText;
-	}
-
-	get validationMessageRangeUnderflow() {
-		let failureText = '';
-		if (this.minValue && this.maxValue) {
-			failureText = this.localize(
-				`${this._namespace}.errorOutsideRange`, {
-					minDate: formatDateTime(getDateFromISODateTime(this.minValue), {format: 'medium'}),
-					maxDate: formatDateTime(getDateFromISODateTime(this.maxValue), {format: 'medium'})
-				}
-			);
-		} else if (this.minValue) {
-			failureText = this.localize(
-				`${this._namespace}.errorMinDateOnly`, {
-					minDate: formatDateTime(getDateFromISODateTime(this.minValue), {format: 'medium'})
-				}
-			);
-		}
-		return failureText;
+		return super.validationMessage;
 	}
 
 	_dispatchChangeEvent() {

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -229,42 +229,19 @@ class InputDate extends FormElementMixin(LocalizeCoreElement(LitElement)) {
 		if (this._textInput) this._textInput.focus();
 	}
 
-	get validationMessageRangeOverflow() {
-		let failureText = '';
-		if (this.minValue && this.maxValue) {
-			failureText = this.localize(
-				`${this._namespace}.errorOutsideRange`, {
-					minDate: formatDate(getDateFromISODate(this.minValue), {format: 'medium'}),
-					maxDate: formatDate(getDateFromISODate(this.maxValue), {format: 'medium'})
-				}
-			);
-		} else if (this.maxValue) {
-			failureText = this.localize(
-				`${this._namespace}.errorMaxDateOnly`, {
-					maxDate: formatDate(getDateFromISODate(this.maxValue), {format: 'medium'})
-				}
-			);
+	get validationMessage() {
+		if (this.validity.rangeOverflow || this.validity.rangeUnderflow) {
+			const minDate = this.minValue ? formatDate(getDateFromISODate(this.minValue), { format: 'medium' }) : null;
+			const maxDate = this.maxValue ? formatDate(getDateFromISODate(this.maxValue), { format: 'medium' }) : null;
+			if (minDate && maxDate) {
+				return this.localize(`${this._namespace}.errorOutsideRange`, { minDate, maxDate });
+			} else if (maxDate) {
+				return this.localize(`${this._namespace}.errorMaxDateOnly`, { maxDate });
+			} else if (this.minValue) {
+				return this.localize(`${this._namespace}.errorMinDateOnly`, { minDate });
+			}
 		}
-		return failureText;
-	}
-
-	get validationMessageRangeUnderflow() {
-		let failureText = '';
-		if (this.minValue && this.maxValue) {
-			failureText = this.localize(
-				`${this._namespace}.errorOutsideRange`, {
-					minDate: formatDate(getDateFromISODate(this.minValue), {format: 'medium'}),
-					maxDate: formatDate(getDateFromISODate(this.maxValue), {format: 'medium'})
-				}
-			);
-		} else if (this.minValue) {
-			failureText = this.localize(
-				`${this._namespace}.errorMinDateOnly`, {
-					minDate: formatDate(getDateFromISODate(this.minValue), {format: 'medium'})
-				}
-			);
-		}
-		return failureText;
+		return super.validationMessage;
 	}
 
 	_handleBlur() {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -305,30 +305,21 @@ class InputText extends FormElementMixin(RtlMixin(LitElement)) {
 		}
 	}
 
-	get labelText() {
-		return this.label;
-	}
-
-	get validationMessageRangeOverflow() {
-		return this.localize('components.form-element.input.number.rangeOverflow', { max: formatNumber(parseFloat(this.max)) });
-	}
-
-	get validationMessageRangeUnderflow() {
-		return this.localize('components.form-element.input.number.rangeUnderflow', { min: formatNumber(parseFloat(this.min)) });
-	}
-
-	get validationMessageTooShort() {
-		return this.localize('components.form-element.input.text.tooShort', { label: this.labelText, minlength: formatNumber(this.minlength) });
-	}
-
-	get validationMessageTypeMismatch() {
-		switch (this.type) {
-			case 'email':
+	get validationMessage() {
+		if (this.validity.rangeOverflow) {
+			return this.localize('components.form-element.input.number.rangeOverflow', { max: formatNumber(parseFloat(this.max)) });
+		} else if (this.validity.rangeUnderflow) {
+			return this.localize('components.form-element.input.number.rangeUnderflow', { min: formatNumber(parseFloat(this.min)) });
+		} else if (this.validity.tooShort) {
+			return this.localize('components.form-element.input.text.tooShort', { label: this.label, minlength: formatNumber(this.minlength) });
+		} else if (this.validity.typeMismatch) {
+			if (this.type === 'email') {
 				return this.localize('components.form-element.input.email.typeMismatch');
-			case 'url':
+			} else if (this.type === 'url') {
 				return this.localize('components.form-element.input.url.typeMismatch');
+			}
 		}
-		return super.validationMessageTypeMismatch;
+		return super.validationMessage;
 	}
 
 	get validity() {

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -198,8 +198,11 @@ class InputTimeRange extends FormElementMixin(RtlMixin(LocalizeCoreElement(LitEl
 		if (input) input.focus();
 	}
 
-	get validationMessageBadInput() {
-		return this.localize('components.input-time-range.errorBadInput', { startLabel: this._computedStartLabel, endLabel: this._computedEndLabel });
+	get validationMessage() {
+		if (this.validity.badInput) {
+			return this.localize('components.input-time-range.errorBadInput', { startLabel: this._computedStartLabel, endLabel: this._computedEndLabel });
+		}
+		return super.validationMessage;
 	}
 
 	get _computedEndLabel() {


### PR DESCRIPTION
# Changes
- Remove all of the `validationMessageFlagName` overrides in favor of a single `validationMessage` method to override to make it easier to understand and use `FormElementMixin`.
- Remove `labelText` since the additional complexity of having to understand the difference between `labelText`, `label`, and where to use them wasn't worth it. Now users can provide a `label` property if they want to use the built-in default error messages or just write their own messages with their own labels as they please.