### PR TITLE
refactor: Additional FormElementMixin Simplifcations

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -126,10 +126,6 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		});
 	}
 
-	checkValidity() {
-		return this.validity.valid;
-	}
-
 	get formAssociated() {
 		return true;
 	}
@@ -156,7 +152,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		const customs = [...this._validationCustoms].filter(custom => custom.forElement === this || !isCustomFormElement(custom.forElement));
 		const results = await Promise.all(customs.map(custom => custom.validate()));
 		const errors = customs.map(custom => custom.failureText).filter((_, i) => !results[i]);
-		if (!this.checkValidity()) {
+		if (!this.validity.valid) {
 			errors.unshift(this.validationMessage);
 		}
 		switch (validationType) {

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -86,6 +86,10 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		return {
 			forceInvalid: { type: Boolean, attribute: false },
 			invalid: { type: Boolean, reflect: true },
+			/**
+			 * Name of the form control. Submitted with the form as part of a name/value pair.
+			 */
+			name: { type: String },
 			noValidate: { type: Boolean, attribute: 'novalidate' },
 			validationError: { type: String, attribute: false },
 		};

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -96,7 +96,6 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		this._validationCustomConnected = this._validationCustomConnected.bind(this);
 
 		this._validationCustoms = new Set();
-		this._validationMessage = '';
 		this._validity = new FormElementValidityState({});
 		this.forceInvalid = false;
 		this.formValue = null;
@@ -138,18 +137,12 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		}
 	}
 
-	setCustomValidity(message) {
-		this._validity = new FormElementValidityState({ customError: true });
-		this._validationMessage = message;
-	}
-
 	setFormValue(formValue) {
 		this.formValue = formValue;
 	}
 
 	setValidity(flags) {
 		this._validity = new FormElementValidityState(flags);
-		this._validationMessage = null;
 	}
 
 	async validate(validationType) {
@@ -193,9 +186,6 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 	}
 
 	get validationMessage() {
-		if (this.validity.customError) {
-			return this._validationMessage;
-		}
 		const label = this.label || this.localize('components.form-element.defaultFieldLabel');
 		if (this.validity.valueMissing) {
 			return this.localize('components.form-element.valueMissing', { label });

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -184,13 +184,6 @@ describe('form-element', () => {
 			expect(errors).to.include.members(['Test form element failed with an overridden validation message']);
 		});
 
-		it('should validate with custom validity state message', async() => {
-			formElement.value = 'Non-empty';
-			formElement.setCustomValidity('Validation failed for custom validity');
-			const errors = await formElement.validate(ValidationType.SHOW_NEW_ERRORS);
-			expect(errors).to.include.members(['Validation failed for custom validity']);
-		});
-
 		it('should pass validation when no errors', async() => {
 			formElement.value = 'Non-empty';
 			const errors = await formElement.validate(ValidationType.SHOW_NEW_ERRORS);

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -78,10 +78,6 @@ class InputText extends FormElementMixin(RtlMixin(LitElement)) {
 			 */
 			minlength: { type: Number },
 			/**
-			 * Name of the input
-			 */
-			name: { type: String },
-			/**
 			 * Regular expression pattern to validate the value
 			 */
 			pattern: { type: String },


### PR DESCRIPTION
# Changes
- Remove `FormElementMixin.setCustomValidity`
    - This is redundant with the ability to override `validationMessage` and setting `setValidity({ customError: true })` so removing it to simplify the interface.
- Add `FormElementMixin` `name` property
    - Name is used by all form elements during submission so it should be a property of all of them rather than having to add it explicitly to every single form element
- Remove `FormElementMixin.checkValidity`
    - This is redundant with `validity.valid` so removing it to simplify the interface