### PR TITLE
fix: iOS live region when changing month

### DIFF
--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -139,6 +139,10 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	static get properties() {
 		return {
 			/**
+			 * Unique label text for calendar (necessary if multiple calendars on page)
+			 */
+			label: { attribute: 'label', reflect: true, type: String },
+			/**
 			 * Maximum valid date that could be selected by a user
 			 */
 			maxValue: { attribute: 'max-value', reflect: true, type: String },
@@ -486,36 +490,38 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			'd2l-calendar-prev-updown': this._monthNav === 'prev-updown'
 		};
 		const labelId = `${this._tableInfoId}-heading`;
-		const labelledBy = this._dialog ? labelId : undefined;
 		const heading = formatDate(new Date(this._shownYear, this._shownMonth, 1), {format: 'monthYear'});
+		const regionLabel = this.label ? `${this.label}. ${heading}` : heading;
 		const role = this._dialog ? 'dialog' : undefined;
 		return html`
-			<div aria-labelledby="${ifDefined(labelledBy)}" class="${classMap(calendarClasses)}" role="${ifDefined(role)}">
-				<div role="application">
-					<div class="d2l-calendar-title">
-						<d2l-button-icon
-							@click="${this._onPrevMonthButtonClick}"
-							text="${this._computeText(getPrevMonth(this._shownMonth))}"
-							icon="tier1:chevron-left">
-						</d2l-button-icon>
-						<h2 aria-atomic="true" aria-live="polite" class="d2l-heading-4" id="${labelId}">${heading}</h2>
-						<d2l-button-icon
-							@click="${this._onNextMonthButtonClick}"
-							text="${this._computeText(getNextMonth(this._shownMonth))}"
-							icon="tier1:chevron-right">
-						</d2l-button-icon>
+			<div role="region" aria-label="${regionLabel}">
+				<div class="${classMap(calendarClasses)}" role="${ifDefined(role)}">
+					<div role="application">
+						<div class="d2l-calendar-title">
+							<d2l-button-icon
+								@click="${this._onPrevMonthButtonClick}"
+								text="${this._computeText(getPrevMonth(this._shownMonth))}"
+								icon="tier1:chevron-left">
+							</d2l-button-icon>
+							<div aria-atomic="true" aria-live="polite" class="d2l-heading-4" id="${labelId}">${heading}</div>
+							<d2l-button-icon
+								@click="${this._onNextMonthButtonClick}"
+								text="${this._computeText(getNextMonth(this._shownMonth))}"
+								icon="tier1:chevron-right">
+							</d2l-button-icon>
+						</div>
+						<table aria-labelledby="${labelId}" role="presentation">
+							${summary}
+							<thead aria-hidden="true">
+								<tr>${weekdayHeaders}</tr>
+							</thead>
+							<tbody>
+								${dayRows}
+							</tbody>
+						</table>
 					</div>
-					<table aria-labelledby="${labelId}" role="presentation">
-						${summary}
-						<thead aria-hidden="true">
-							<tr>${weekdayHeaders}</tr>
-						</thead>
-						<tbody>
-							${dayRows}
-						</tbody>
-					</table>
+					<slot></slot>
 				</div>
-				<slot></slot>
 			</div>
 		`;
 	}

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -490,8 +490,8 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			'd2l-calendar-prev-updown': this._monthNav === 'prev-updown'
 		};
 		const labelId = `${this._tableInfoId}-heading`;
-		const regionLabel = this.label ? `${this.label}. ${heading}` : heading;
 		const heading = formatDate(new Date(this._shownYear, this._shownMonth, 1), { format: 'monthYear' });
+		const regionLabel = this.label ? `${this.label}. ${heading}` : heading;
 		const role = this._dialog ? 'dialog' : undefined;
 		return html`
 			<div role="region" aria-label="${regionLabel}">

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -200,6 +200,7 @@ class InputDate extends FormElementMixin(LocalizeCoreElement(LitElement)) {
 					<d2l-focus-trap @d2l-focus-trap-enter="${this._handleFocusTrapEnter}" ?trap="${this._dropdownOpened}">
 						<d2l-calendar
 							@d2l-calendar-selected="${this._handleDateSelected}"
+							label="${ifDefined(this.label)}"
 							max-value="${ifDefined(this.maxValue)}"
 							min-value="${ifDefined(this.minValue)}"
 							selected-value="${ifDefined(this._shownValue)}">


### PR DESCRIPTION
Bug:
When an iOS user using VoiceOver changing the month (e.g., by clicking the previous or next button) VoiceOver states the month/year is the previous (e.g., if when they started navigating the calendar they were viewing September 2018, when they change months VoiceOver would still state "September 2018". VoiceOver would also state the incorrect month if the user navigates to the heading).

Solution information:
If the live region text is a `div` instead of a `h2` then it doesn't have this problem. Carin suggested using a region to wrap a calendar in this case, as removing the heading removes a way for users to navigate quickly around the page. The `label` option was added as regions should have unique names, and a scenario where they might not is when used within `input-date` if there are multiple `input-date`s on a page.

The diff is mostly indentation.