### PR TITLE
Another "Skeleton" loading approach for discussion

### DIFF
--- a/components/skeleton/demo/index.html
+++ b/components/skeleton/demo/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<meta charset="UTF-8">
+	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script type="module">
+		import '../../demo/demo-page.js';
+		import '../../button/button.js';
+		import '../../inputs/input-text.js';
+		import '../../inputs/input-date.js';
+		import './skeleton-host.js';
+	</script>
+	<style>
+		@keyframes loadingPulse {
+			0% { background-color: var(--d2l-color-sylvite); }
+			50% { background: var(--d2l-color-regolith); }
+			75% { background: var(--d2l-color-sylvite); }
+			100% { background: var(--d2l-color-sylvite); }
+		}
+
+		.skeletize::before {
+			content: "";
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			right: 0;
+			left: 0;
+			border-radius: 0.2rem;
+			animation: loadingPulse 1.8s linear infinite;
+			background-color: var(--d2l-color-sylvite);
+			z-index: 2000;
+		}
+
+		.skeletize {
+			position: relative;
+			color: transparent;
+			border: none;
+			box-shadow: none;
+		}
+
+		.flex-container {
+			display: flex;
+			flex-wrap: wrap;
+		}
+
+		.item-container {
+			margin-right: 40px;
+		}
+
+		.item-container[dir="rtl"] {
+			margin-right: 0;
+			margin-left: 40px;
+		}
+
+	</style>
+</head>
+
+<body unresolved>
+	<d2l-demo-page page-title="d2l-skeleton">
+
+		<h2>Custom Element handling skeleton behaviour internally</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-skeleton-host skeleton>
+				</d2l-skeleton-host>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Label & Date</h2>
+		<d2l-demo-snippet>
+			<template>
+				<label class="skeletize d2l-label-text">Birth date</label>
+				<d2l-input-date class="skeletize" style="display:block" label="Date" label-hidden></d2l-input-date>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Label & Text Input</h2>
+		<d2l-demo-snippet>
+			<template>
+				<label class="skeletize d2l-label-text">Hello you old skeleton you</label>
+				<d2l-input-text class="skeletize"></d2l-input-text>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Flex Items</h2>
+		<d2l-demo-snippet>
+			<template>
+			<div class="flex-container">
+				<div class="item-container">
+					<label class="skeletize d2l-label-text">Hello</label>
+					<d2l-input-text size="6" class="skeletize"></d2l-input-text>
+				</div>
+				<div class="item-container">
+					<label class="skeletize d2l-label-text">You lovely skeletal world</label>
+					<d2l-input-text size="6" class="skeletize"></d2l-input-text>
+				</div>
+			</div>
+			</template>
+		</d2l-demo-snippet>
+
+	</d2l-demo-page>
+</body>
+
+</html>

--- a/components/skeleton/demo/index.html
+++ b/components/skeleton/demo/index.html
@@ -56,6 +56,10 @@
 			margin-left: 40px;
 		}
 
+		d2l-input-text {
+			display: block;
+		}
+
 	</style>
 </head>
 
@@ -92,11 +96,11 @@
 			<div class="flex-container">
 				<div class="item-container">
 					<label class="skeletize d2l-label-text">Hello</label>
-					<d2l-input-text size="6" class="skeletize"></d2l-input-text>
+					<d2l-input-text class="skeletize"></d2l-input-text>
 				</div>
 				<div class="item-container">
 					<label class="skeletize d2l-label-text">You lovely skeletal world</label>
-					<d2l-input-text size="6" class="skeletize"></d2l-input-text>
+					<d2l-input-text class="skeletize"></d2l-input-text>
 				</div>
 			</div>
 			</template>

--- a/components/skeleton/demo/skeleton-host.js
+++ b/components/skeleton/demo/skeleton-host.js
@@ -1,0 +1,38 @@
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { skeletonStyles } from '../skeleton-styles.js';
+
+class SkeletonHost extends LitElement {
+
+	static get properties() {
+		return {
+			skeleton: { type: Boolean, reflect: true }
+		};
+	}
+
+	static get styles() {
+		return [
+			skeletonStyles,
+			css`
+				:host {
+					display: block;
+				}
+
+				:host([skeleton]) ul {
+					height: 1rem;
+				}
+			`
+		];
+	}
+
+	render() {
+		return html`
+			<label class="skeletize">I am alive</label>
+			<ul class="skeletize">
+				<li>One</li>
+				<li>Two</li>
+				<li>Three</li>
+			</ul>
+		`;
+	}
+}
+customElements.define('d2l-skeleton-host', SkeletonHost);

--- a/components/skeleton/skeleton-styles.js
+++ b/components/skeleton/skeleton-styles.js
@@ -1,0 +1,30 @@
+import { css } from 'lit-element/lit-element.js';
+
+export const skeletonStyles = css`
+	@keyframes loadingPulse {
+		0% { background-color: var(--d2l-color-sylvite); }
+		50% { background-color: var(--d2l-color-regolith); }
+		75% { background-color: var(--d2l-color-sylvite); }
+		100% { background-color: var(--d2l-color-sylvite); }
+	}
+
+	:host([skeleton]) .skeletize::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		right: 0;
+		left: 0;
+		border-radius: 0.2rem;
+		animation: loadingPulse 1.8s linear infinite;
+		background-color: var(--d2l-color-sylvite);
+		z-index: 2000;
+	}
+
+	:host([skeleton]) .skeletize {
+		position: relative;
+		color: transparent;
+		border: none;
+		box-shadow: none;
+	}
+`;

--- a/index.html
+++ b/index.html
@@ -131,6 +131,11 @@
 		<li><a href="mixins/demo/localize-mixin.html">localize-mixin</a></li>
 	</ul>
 
+	<h2 class="d2l-heading-3">Skeletons</h2>
+	<ul>
+		<li><a href="components/skeleton/demo/index.html">Skeletons</a></li>
+	</ul>
+
 	<h2 class="d2l-heading-3">Templates</h2>
 	<ul>
 		<li><a href="templates/primary-secondary/demo/index.html">Primary Secondary Template (fullscreen width)</a></li>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:lit": "lit-analyzer \"{components,directives,helpers,mixins,templates,test,tools}/**/*.js\" --strict",
     "lint:style": "stylelint \"**/*.js\"",
     "prepublishOnly": "node ./cli/verify-translations.js && npm run analyze",
-    "start": "es-dev-server --node-resolve --dedupe --watch --open",
+    "start": "es-dev-server --node-resolve --dedupe --watch --open --hostname 192.168.1.91",
     "test": "npm run lint && npm run test:headless && npm run test:axe && npm run test:diff",
     "test:axe": "karma start karma.axe.conf.js",
     "test:bs": "karma start karma.bs.conf.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:lit": "lit-analyzer \"{components,directives,helpers,mixins,templates,test,tools}/**/*.js\" --strict",
     "lint:style": "stylelint \"**/*.js\"",
     "prepublishOnly": "node ./cli/verify-translations.js && npm run analyze",
-    "start": "es-dev-server --node-resolve --dedupe --watch --open --hostname 192.168.1.91",
+    "start": "es-dev-server --node-resolve --dedupe --watch --open",
     "test": "npm run lint && npm run test:headless && npm run test:axe && npm run test:diff",
     "test:axe": "karma start karma.axe.conf.js",
     "test:bs": "karma start karma.bs.conf.js",


### PR DESCRIPTION
Just following on from some of the discussions we've had about coming up with a re-usable pattern/solution for implementing the Skeleton Page Loading effects documented on http://design.d2l/patterns/skeleton-loading/

As mentioned previously, we need a solution for FACE that will allow us to implement the design shown in the mockup linked here:
https://xd.adobe.com/view/399d5110-bf02-401d-9041-c60fcc11b1c2-6cce/

I looked at the solutions being proposed by both Maya and Chris. They are both good solutions and are not mutually exclusive to the solution shown in this PR.  However, the approach shown in this PR is one that fits quite nicely into how FACE works as it is quite lightweight and un-opinionated, and just uses a couple of CSS classes to style potentially any (OK, probably reaching there! :-) ) component.

The pattern shown in this PR boils down to styling a component with a css `::before` pseudo selector that will render a skeleton block that is absolutely positioned to cover the full dimensions of the component being skeletized. In this way the skeleton automatically adapts to the size of the component being skeletized based on that component's normal styling and so we don't have to add any other hints to `skeleton` components indicating what size they should be rendered at or conditionally render skeleton placeholder components instead of the normal components, both of which can lead to duplicated code. (see `skeleton-styles.js`)

This approach also makes it easy to skeletize more native leaf components like `label` and `d2l-text-input`

The `skeletize` class can be coupled with a `skeleton` attribute host selector such that the `skeletize` styles are only applied when the host component is rendering in `skeleton` mode.

Within FACE, we have a lot of component nesting and each sub component may be a self-contained hypermedia resource enabled component. During loading, we need each sub component to be rendered so that it can kick off it's own hypermedia API fetches. So in most cases, we can't replace a component with a dummy skeleton object as that will delay the overall fetch. Also each sub-component is in the best position to know what might be an appropriate skeleton rendering for that component. 

So in many cases it's sufficient to just apply the `skeletize` class to a sub-component (e.g. for labels, text inputs, buttons). But where the sub-component might want to take more control, it can support the `skeleton` property too, and then it can use that property to apply styling internally and potentially conditionally render certain aspects of it's own children. 

e.g. we have a `Score` component in FACE that renders both score and grade information. During loading we don't know yet whether there is just a score or score and grade, so the `Score` component only renders a skeleton view of the `score` input field, but it can do so just by adding a `skeletize` class to that input.

Anyway, let me know your thoughts. No intention for requesting this PR be merged or become part of core at this point. I do think that different scenarios might require different approaches and that for some scenarios the approaches shown by Maya and Chris might be more appropriate. But this approach seems to be a better fit for FACE and web forms, so unless you guys can see explicit red flags e.g. due to a11y issues or cross browser issues, we will most likely proceed with this approach in FACE at least for an initial implementation. I've tried the demo page included here across a number of desktop and mobile browsers and so far have not hit any major blockers.

