### PR TITLE
fix: defect de40213 rubric buttons hidden behind face footer

### DIFF
--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -61,7 +61,7 @@ class TemplatePrimarySecondary extends LitElement {
 				grid-template-columns: minmax(320px, 2fr) 1px minmax(320px, 1fr);
 				grid-template-rows: auto;
 				overflow: hidden;
-				z-index: 1;
+				z-index: auto;
 			}
 			main {
 				grid-area: primary;


### PR DESCRIPTION
fix a problem where a z-index is set on a container and constrains child elements like d2l-overlay from setting a z-index to appear on top, This is a cert fix related to pr #806