### PR TITLE
Use visual-diff oneEvent and eliminate duplicate getEvent impls.

### DIFF
--- a/components/dialog/test/dialog-helper.js
+++ b/components/dialog/test/dialog-helper.js
@@ -1,10 +1,4 @@
-const getEvent = (page, selector, name) => {
-	return page.$eval(selector, (elem, name) => {
-		return new Promise((resolve) => {
-			elem.addEventListener(name, resolve, { once: true });
-		});
-	}, name);
-};
+const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');
 
 module.exports = {
 
@@ -15,11 +9,11 @@ module.exports = {
 	},
 
 	getCloseEvent(page, selector) {
-		return getEvent(page, selector, 'd2l-dialog-close');
+		return oneEvent(page, selector, 'd2l-dialog-close');
 	},
 
 	getOpenEvent(page, selector) {
-		return getEvent(page, selector, 'd2l-dialog-open');
+		return oneEvent(page, selector, 'd2l-dialog-open');
 	},
 
 	getRect(page, selector) {

--- a/components/dropdown/test/dropdown-helper.js
+++ b/components/dropdown/test/dropdown-helper.js
@@ -1,15 +1,9 @@
-const getEvent = (page, selector, name) => {
-	return page.$eval(selector, (elem, name) => {
-		return new Promise((resolve) => {
-			elem.addEventListener(name, resolve, { once: true });
-		});
-	}, name);
-};
+const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');
 
 module.exports = {
 
 	getOpenEvent(page, selector) {
-		return getEvent(page, selector, 'd2l-dropdown-open');
+		return oneEvent(page, selector, 'd2l-dropdown-open');
 	},
 
 	async open(page, selector) {

--- a/components/tooltip/test/tooltip-helper.js
+++ b/components/tooltip/test/tooltip-helper.js
@@ -1,25 +1,15 @@
-const getEvent = (page, selector, name) => {
-	return page.$eval(selector, (elem, name) => {
-		return new Promise((resolve) => {
-			elem.addEventListener(name, resolve, { once: true });
-		});
-	}, name);
-};
+const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');
 
 module.exports = {
 
-	getShowEvent(page, selector) {
-		return getEvent(page, selector, 'd2l-tooltip-show');
-	},
-
 	async hide(page, selector) {
-		const hideEvent = getEvent(page, selector, 'd2l-tooltip-hide');
+		const hideEvent = oneEvent(page, selector, 'd2l-tooltip-hide');
 		page.$eval(`${selector} d2l-tooltip`, tooltip => tooltip.hide());
 		return hideEvent;
 	},
 
 	async show(page, selector) {
-		const openEvent = this.getShowEvent(page, selector);
+		const openEvent = oneEvent(page, selector, 'd2l-tooltip-show');
 		page.$eval(`${selector} d2l-tooltip`, tooltip => tooltip.show());
 		return openEvent;
 	}


### PR DESCRIPTION
This PR removes the duplicate getEvent implementation for visual-diff tests, in favor of new Puppeteer helper in visual-diff library.  This is the analogous of oneEvent from `@open-wc/testing`, except that it is called from the Puppeteer side.