### PR TITLE
DE39907 Fix drag focus text for screen readers

### DIFF
--- a/components/list/demo/list-demo-drag-n-drop-usage.js
+++ b/components/list/demo/list-demo-drag-n-drop-usage.js
@@ -72,6 +72,7 @@ class ListDemoDragNDropUsage extends LitElement {
 						key="${ifDefined(item.key)}"
 						draggable
 						?selectable="${this.selectable}"
+						drag-handle-text="${item.name}"
 						href="${ifDefined(this.hrefs ? item.href : undefined)}">
 						<img slot="illustration" src="${item.img}">
 						<d2l-list-item-content>

--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -122,7 +122,7 @@ class ListItemDragHandle extends LocalizeCoreElement(LitElement) {
 
 	get _defaultLabel() {
 		const namespace = 'components.list-item-drag-handle';
-		return this.localize(`${namespace}.${this._keyboardActive ? 'keyboard' : 'default'}`);
+		return this.localize(`${namespace}.${this._keyboardActive ? 'keyboard' : 'default'}`, 'name', this.text);
 	}
 
 	_dispatchAction(action) {
@@ -240,7 +240,7 @@ class ListItemDragHandle extends LocalizeCoreElement(LitElement) {
 				@focusout="${this._onFocusOut}"
 				@keyup="${this._onActiveKeyboard}"
 				@keydown="${this._onPreventDefault}"
-				aria-label="${this.text || this._defaultLabel}">
+				aria-label="${this._defaultLabel}">
 				<d2l-icon icon="tier1:arrow-toggle-up" @click="${this._dispatchActionUp}" class="d2l-button-icon"></d2l-icon>
 				<d2l-icon icon="tier1:arrow-toggle-down" @click="${this._dispatchActionDown}" class="d2l-button-icon"></d2l-icon>
 			</button>

--- a/lang/en.js
+++ b/lang/en.js
@@ -38,7 +38,7 @@ export default {
 	"components.input-time-range.endTime": "End Time",
 	"components.input-time-range.errorBadInput": "{startLabel} must be before {endLabel}",
 	"components.input-time-range.startTime": "Start Time",
-	"components.list-item-drag-handle.default": "Reorder action",
+	"components.list-item-drag-handle.default": "Reorder item action for {name}",
 	"components.list-item-drag-handle.keyboard": "Reorder items",
 	"components.menu-item-return.return": "Returns to previous menu.",
 	"components.menu-item-return.returnCurrentlyShowing": "Returns to previous menu. You are viewing {menuTitle}.",


### PR DESCRIPTION
Context:
DE39907 - https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F407158647016
Fix screen reader text when we focus on the drag handle of an item in the list. 
Went from `Reorder action` to `Reorder item action for <name>`.

Quality:
Tested locally. 