### PR TITLE
Update Semantic Release Versioning Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Releases use the [semantic-release](https://semantic-release.gitbook.io/) toolin
 
 Upon release, the version in `package.json` is updated, a tag and GitHub release is created and a new package will be deployed to NPM.
 
-Commits prefixed with `feat` will trigger a minor release, while `fix` or `perf` will trigger a patch release. A commit containing `BREAKING CHANGE` will cause a major release to occur.
+Commits prefixed with `feat` will trigger a minor release, while `fix` or `perf` will trigger a patch release. A commit containing `BREAKING CHANGE:` in the _**message body**_ will cause a major release to occur.
 
 Other useful prefixes that will not trigger a release: `build`, `ci`, `docs`, `refactor`, `style` and `test`. More details in the [Angular Contribution Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type).
 


### PR DESCRIPTION
We don't want people accidentally trigger major version bumps so clarifying that it is in the message body rather than the head like the others.