### PR TITLE
Accessibility and unit tests

### DIFF
--- a/components/form/test/form-element-localize-helper.test.js
+++ b/components/form/test/form-element-localize-helper.test.js
@@ -63,7 +63,7 @@ describe('form-element-localize-helper', () => {
 				input.value = '10';
 
 				const errorMessage = localizeFormElement(localize, input);
-				expect(errorMessage).to.equal('Number must be higher than 100');
+				expect(errorMessage).to.equal('Number must be higher than 100.');
 			});
 
 			it('should localize range overflowflow error', async() => {
@@ -71,7 +71,7 @@ describe('form-element-localize-helper', () => {
 				input.value = '100';
 
 				const errorMessage = localizeFormElement(localize, input);
-				expect(errorMessage).to.equal('Number must be lower than 9');
+				expect(errorMessage).to.equal('Number must be lower than 9.');
 			});
 
 		});

--- a/components/inputs/test/input-number.axe.js
+++ b/components/inputs/test/input-number.axe.js
@@ -1,0 +1,40 @@
+import '../input-number.js';
+import { expect, fixture, html } from '@open-wc/testing';
+
+describe('d2l-input-number', () => {
+	it('normal', async() => {
+		const elem = await fixture(html`<d2l-input-number label="label"></d2l-input-number>>`);
+		await expect(elem).to.be.accessible;
+	});
+
+	it('default value', async() => {
+		const elem = await fixture(html`<d2l-input-number label="label" value="10"></d2l-input-number>>`);
+		await expect(elem).to.be.accessible;
+	});
+
+	it('required', async() => {
+		const elem = await fixture(html`<d2l-input-number label="label" required></d2l-input-number>>`);
+		await expect(elem).to.be.accessible;
+	});
+
+	it('disabled', async() => {
+		const elem = await fixture(html`<d2l-input-number label="label" disabled></d2l-input-number>>`);
+		await expect(elem).to.be.accessible;
+	});
+
+	it('placeholder', async() => {
+		const elem = await fixture(html`<d2l-input-number label="label" placeholder="placeholder"></d2l-input-number>>`);
+		await expect(elem).to.be.accessible;
+	});
+
+	it('hidden label', async() => {
+		const elem = await fixture(html`<d2l-input-number label="label" label-hidden></d2l-input-number>>`);
+		await expect(elem).to.be.accessible;
+	});
+
+	it('focused', async() => {
+		const elem = await fixture(html`<d2l-input-number label="label"></d2l-input-number>>`);
+		elem.focus();
+		await expect(elem).to.be.accessible;
+	});
+});

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -3,7 +3,6 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-number label="label"></d2l-input-number>`;
-// const minMaxFixture = html`<d2l-input-number label="label" min="5" max="10"></d2l-input-number>`;
 
 function dispatchEvent(elem, eventType) {
 	const e = new Event(

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -1,0 +1,144 @@
+import '../input-number.js';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+const normalFixture = html`<d2l-input-number label="label"></d2l-input-number>`;
+// const minMaxFixture = html`<d2l-input-number label="label" min="5" max="10"></d2l-input-number>`;
+
+function dispatchEvent(elem, eventType) {
+	const e = new Event(
+		eventType,
+		{ bubbles: true, composed: false }
+	);
+	elem.dispatchEvent(e);
+}
+
+describe('d2l-input-number', () => {
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-input-number');
+		});
+	});
+
+	describe('default property values', () => {
+		let elem;
+		beforeEach(async() => {
+			elem = await fixture(normalFixture);
+		});
+
+		['autofocus', 'disabled', 'labelHidden', 'required'].forEach((name) => {
+			it(`should default "${name}" property to "false" when unset`, async() => {
+				expect(elem[name]).to.be.false;
+			});
+		});
+
+		['autocomplete', 'max', 'maxFractionDigits', 'min', 'minFractionDigits', 'placeholder', 'value'].forEach((name) => {
+			it(`should default "${name}" property to 'undefined' when unset`, async() => {
+				expect(elem.value).to.equal(undefined);
+			});
+		});
+
+		it('should default "formattedValue" property to empty when unset', () => {
+			expect(elem._formattedValue).to.equal('');
+		});
+	});
+
+	describe('validation', () => {
+		it('should be valid when required has value', async() => {
+			const elem = await fixture(normalFixture);
+			elem.required = true;
+			elem.value = 10;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			const errors = await elem.validate();
+			expect(errors).to.be.empty;
+		});
+
+		it('should be invalid when empty and required', async() => {
+			const elem = await fixture(normalFixture);
+			elem.required = true;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			const errors = await elem.validate();
+			expect(errors).to.contain('label is required.');
+		});
+
+		it('should be valid if number is in range', async() => {
+			const elem = await fixture(normalFixture);
+			elem.min = 5;
+			elem.max = 10;
+			elem.value = 7;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			const errors = await elem.validate();
+			expect(errors).to.be.empty;
+		});
+
+		it('should be invalid if number is out of range', async() => {
+			const elem = await fixture(normalFixture);
+			elem.min = 5;
+			elem.max = 10;
+			elem.value = 1;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			const errors = await elem.validate();
+			expect(errors).to.contain('Number must be between 5 and 10.');
+		});
+
+		it('should be valid if number is higher than min', async() => {
+			const elem = await fixture(normalFixture);
+			elem.min = 5;
+			elem.value = 10;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			const errors = await elem.validate();
+			expect(errors).to.be.empty;
+		});
+
+		it('should be invalid if number is lower than min', async() => {
+			const elem = await fixture(normalFixture);
+			elem.min = 5;
+			elem.value = 1;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			const errors = await elem.validate();
+			expect(errors).to.contain('Number must be higher than 5.');
+		});
+
+		it('should be valid if number is lower than max', async() => {
+			const elem = await fixture(normalFixture);
+			elem.max = 5;
+			elem.value = 1;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			const errors = await elem.validate();
+			expect(errors).to.be.empty;
+		});
+
+		it('should be invalid if number is higher than max', async() => {
+			const elem = await fixture(normalFixture);
+			elem.max = 5;
+			elem.value = 10;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			const errors = await elem.validate();
+			expect(errors).to.contain('Number must be lower than 5.');
+		});
+	});
+});

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -7,6 +7,7 @@ const requiredFixture = html`<d2l-input-number label="label" required></d2l-inpu
 const minMaxFixture = html`<d2l-input-number label="label" min="5" max="10"></d2l-input-number>`;
 const minFixture = html`<d2l-input-number label="label" min="5"></d2l-input-number>`;
 const maxFixture = html`<d2l-input-number label="label" max="10"></d2l-input-number>`;
+const minMaxFractionDigitsFixture = html`<d2l-input-number label="label" min-fraction-digits="2" max-fraction-digits="3"></d2l-input-number>`;
 
 function dispatchEvent(elem, eventType) {
 	const e = new Event(
@@ -43,6 +44,41 @@ describe('d2l-input-number', () => {
 
 		it('should default "formattedValue" property to empty when unset', () => {
 			expect(elem._formattedValue).to.equal('');
+		});
+	});
+
+	describe('min and max fraction digits', () => {
+		it('should automatically add zeroes to match min fraction digits', async() => {
+			const elem = await fixture(minMaxFractionDigitsFixture);
+			elem.value = 1;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			expect(elem.value).to.equal(1);
+			expect(elem._formattedValue).to.equal('1.00');
+		});
+
+		it('should automatically round up to match max fraction digits', async() => {
+			const elem = await fixture(minMaxFractionDigitsFixture);
+			elem.value = 1.2345;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			expect(elem.value).to.equal(1.235);
+			expect(elem._formattedValue).to.equal('1.235');
+		});
+
+		it('should automatically round down to match max fraction digits', async() => {
+			const elem = await fixture(minMaxFractionDigitsFixture);
+			elem.value = 1.2344;
+
+			setTimeout(() => dispatchEvent(elem, 'change'));
+			await oneEvent(elem, 'change');
+
+			expect(elem.value).to.equal(1.234);
+			expect(elem._formattedValue).to.equal('1.234');
 		});
 	});
 

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -3,6 +3,10 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-number label="label"></d2l-input-number>`;
+const requiredFixture = html`<d2l-input-number label="label" required></d2l-input-number>`;
+const minMaxFixture = html`<d2l-input-number label="label" min="5" max="10"></d2l-input-number>`;
+const minFixture = html`<d2l-input-number label="label" min="5"></d2l-input-number>`;
+const maxFixture = html`<d2l-input-number label="label" max="10"></d2l-input-number>`;
 
 function dispatchEvent(elem, eventType) {
 	const e = new Event(
@@ -44,8 +48,7 @@ describe('d2l-input-number', () => {
 
 	describe('validation', () => {
 		it('should be valid when required has value', async() => {
-			const elem = await fixture(normalFixture);
-			elem.required = true;
+			const elem = await fixture(requiredFixture);
 			elem.value = 10;
 
 			setTimeout(() => dispatchEvent(elem, 'change'));
@@ -56,8 +59,7 @@ describe('d2l-input-number', () => {
 		});
 
 		it('should be invalid when empty and required', async() => {
-			const elem = await fixture(normalFixture);
-			elem.required = true;
+			const elem = await fixture(requiredFixture);
 
 			setTimeout(() => dispatchEvent(elem, 'change'));
 			await oneEvent(elem, 'change');
@@ -67,9 +69,7 @@ describe('d2l-input-number', () => {
 		});
 
 		it('should be valid if number is in range', async() => {
-			const elem = await fixture(normalFixture);
-			elem.min = 5;
-			elem.max = 10;
+			const elem = await fixture(minMaxFixture);
 			elem.value = 7;
 
 			setTimeout(() => dispatchEvent(elem, 'change'));
@@ -80,9 +80,7 @@ describe('d2l-input-number', () => {
 		});
 
 		it('should be invalid if number is out of range', async() => {
-			const elem = await fixture(normalFixture);
-			elem.min = 5;
-			elem.max = 10;
+			const elem = await fixture(minMaxFixture);
 			elem.value = 1;
 
 			setTimeout(() => dispatchEvent(elem, 'change'));
@@ -93,8 +91,7 @@ describe('d2l-input-number', () => {
 		});
 
 		it('should be valid if number is higher than min', async() => {
-			const elem = await fixture(normalFixture);
-			elem.min = 5;
+			const elem = await fixture(minFixture);
 			elem.value = 10;
 
 			setTimeout(() => dispatchEvent(elem, 'change'));
@@ -105,8 +102,7 @@ describe('d2l-input-number', () => {
 		});
 
 		it('should be invalid if number is lower than min', async() => {
-			const elem = await fixture(normalFixture);
-			elem.min = 5;
+			const elem = await fixture(minFixture);
 			elem.value = 1;
 
 			setTimeout(() => dispatchEvent(elem, 'change'));
@@ -117,8 +113,7 @@ describe('d2l-input-number', () => {
 		});
 
 		it('should be valid if number is lower than max', async() => {
-			const elem = await fixture(normalFixture);
-			elem.max = 5;
+			const elem = await fixture(maxFixture);
 			elem.value = 1;
 
 			setTimeout(() => dispatchEvent(elem, 'change'));
@@ -129,15 +124,14 @@ describe('d2l-input-number', () => {
 		});
 
 		it('should be invalid if number is higher than max', async() => {
-			const elem = await fixture(normalFixture);
-			elem.max = 5;
-			elem.value = 10;
+			const elem = await fixture(maxFixture);
+			elem.value = 15;
 
 			setTimeout(() => dispatchEvent(elem, 'change'));
 			await oneEvent(elem, 'change');
 
 			const errors = await elem.validate();
-			expect(errors).to.contain('Number must be lower than 5.');
+			expect(errors).to.contain('Number must be lower than 10.');
 		});
 	});
 });

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -284,7 +284,7 @@ describe('d2l-input-text', () => {
 			elem.value = '9';
 
 			const errors = await elem.validate();
-			expect(errors).to.contain('Number must be higher than 10');
+			expect(errors).to.contain('Number must be higher than 10.');
 		});
 
 		it('should be invalid when value is above the max', async() => {
@@ -294,7 +294,7 @@ describe('d2l-input-text', () => {
 			elem.value = '110';
 
 			const errors = await elem.validate();
-			expect(errors).to.contain('Number must be lower than 100');
+			expect(errors).to.contain('Number must be lower than 100.');
 		});
 
 		it('should be valid when value is between min and max', async() => {


### PR DESCRIPTION
Fixed a couple unit tests that were breaking because of the lang term change in the [previous PR](https://github.com/BrightspaceUI/core/pull/819).

Added unit tests for:
~ constructor
~ default property values
~ min/max fraction digits
~ validation

Added accessibility tests for:
~ normal (only label)
~ default value
~ required
~ disabled
~ placeholder
~ hidden label
~ focused