### PR TITLE
Add more information for list item drag handle keyboard mode

### DIFF
--- a/lang/en.js
+++ b/lang/en.js
@@ -39,7 +39,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} must be before {endLabel}",
 	"components.input-time-range.startTime": "Start Time",
 	"components.list-item-drag-handle.default": "Reorder item action for {name}",
-	"components.list-item-drag-handle.keyboard": "Reorder items, current position {currentPosition} out of {size}",
+	"components.list-item-drag-handle.keyboard": "Reorder items, current position {currentPosition} out of {size}. To move this activity, press up or down arrows.",
 	"components.menu-item-return.return": "Returns to previous menu.",
 	"components.menu-item-return.returnCurrentlyShowing": "Returns to previous menu. You are viewing {menuTitle}.",
 	"components.meter-mixin.commaSeperatedAria": "{term1}, {term2}",

--- a/lang/en.js
+++ b/lang/en.js
@@ -39,7 +39,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} must be before {endLabel}",
 	"components.input-time-range.startTime": "Start Time",
 	"components.list-item-drag-handle.default": "Reorder item action for {name}",
-	"components.list-item-drag-handle.keyboard": "Reorder items, current position {currentPosition} out of {size}. To move this activity, press up or down arrows.",
+	"components.list-item-drag-handle.keyboard": "Reorder item, current position {currentPosition} out of {size}. To move this activity, press up or down arrows.",
 	"components.menu-item-return.return": "Returns to previous menu.",
 	"components.menu-item-return.returnCurrentlyShowing": "Returns to previous menu. You are viewing {menuTitle}.",
 	"components.meter-mixin.commaSeperatedAria": "{term1}, {term2}",

--- a/lang/en.js
+++ b/lang/en.js
@@ -39,7 +39,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} must be before {endLabel}",
 	"components.input-time-range.startTime": "Start Time",
 	"components.list-item-drag-handle.default": "Reorder item action for {name}",
-	"components.list-item-drag-handle.keyboard": "Reorder item, current position {currentPosition} out of {size}. To move this activity, press up or down arrows.",
+	"components.list-item-drag-handle.keyboard": "Reorder item, current position {currentPosition} out of {size}. To move this item, press up or down arrows.",
 	"components.menu-item-return.return": "Returns to previous menu.",
 	"components.menu-item-return.returnCurrentlyShowing": "Returns to previous menu. You are viewing {menuTitle}.",
 	"components.meter-mixin.commaSeperatedAria": "{term1}, {term2}",


### PR DESCRIPTION
Context:
Add more information to screen readers on drag and drop handle.

Quality: 
<img width="727" alt="Screen Shot 2020-09-16 at 2 27 08 PM" src="https://user-images.githubusercontent.com/16407009/93377996-ce7f0580-f829-11ea-8fef-f7a3d267ff46.png">
