### PR TITLE
Skeleton Paragraphs

### DIFF
--- a/components/skeleton/demo/skeleton-mixin.html
+++ b/components/skeleton/demo/skeleton-mixin.html
@@ -9,6 +9,7 @@
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../../inputs/input-text.js';
+			import './skeleton-test-paragraphs.js';
 			import './skeleton-test-typography.js';
 		</script>
 	</head>
@@ -19,6 +20,11 @@
 
 			<d2l-demo-snippet has-skeleton code-view-hidden>
 				<d2l-test-skeleton-typography></d2l-test-skeleton-typography>
+			</d2l-demo-snippet>
+
+			<h2>Paragraphs</h2>
+			<d2l-demo-snippet has-skeleton code-view-hidden>
+				<d2l-test-skeleton-paragraphs></d2l-test-skeleton-paragraphs>
 			</d2l-demo-snippet>
 
 			<h2>Text Inputs</h2>

--- a/components/skeleton/demo/skeleton-test-paragraphs.js
+++ b/components/skeleton/demo/skeleton-test-paragraphs.js
@@ -1,0 +1,40 @@
+import { bodyCompactStyles, bodySmallStyles, bodyStandardStyles } from '../../typography/styles.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { SkeletonMixin } from '../skeleton-mixin.js';
+
+export class SkeletonTestParagraphs extends SkeletonMixin(LitElement) {
+
+	static get styles() {
+		return [
+			super.styles,
+			bodyStandardStyles,
+			bodyCompactStyles,
+			bodySmallStyles,
+			css`
+				:host {
+					display: block;
+				}
+			`
+		];
+	}
+
+	render() {
+		return html`
+			<p class="d2l-body-standard d2l-skeletize-paragraph-2">Standard 2-line</p>
+			<p class="d2l-body-standard d2l-skeletize-paragraph-3">Standard 3 line</p>
+			<p class="d2l-body-standard d2l-skeletize-paragraph-5">Standard 5 line</p>
+			<hr>
+			<p class="d2l-body-compact d2l-skeletize-paragraph-2">Compact 2-line</p>
+			<p class="d2l-body-compact d2l-skeletize-paragraph-3">Compact 3 line</p>
+			<p class="d2l-body-compact d2l-skeletize-paragraph-5">Compact 5 line</p>
+			<hr>
+			<p class="d2l-body-small d2l-skeletize-paragraph-2">Small 2-line</p>
+			<br>
+			<p class="d2l-body-small d2l-skeletize-paragraph-3">Small 3 line</p>
+			<br>
+			<p class="d2l-body-small d2l-skeletize-paragraph-5">Small 5 line</p>
+		`;
+	}
+}
+
+customElements.define('d2l-test-skeleton-paragraphs', SkeletonTestParagraphs);

--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -26,6 +26,30 @@ export const skeletonStyles = css`
 		color: transparent;
 		position: relative;
 	}
+	:host([skeleton]) .d2l-skeletize-paragraph-2 {
+		background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cstyle%3E%0A%20%20%20%20%40keyframes%20loadingPulse%7B0%25%2C75%25%7Bfill%3A%23f1f5fb%7D50%25%7Bfill%3A%23f9fbff%7D%7D.skeleton%7Banimation%3AloadingPulse%201.8s%20linear%20infinite%3Bfill%3A%23f1f5fb%7D%0A%20%20%3C%2Fstyle%3E%0A%20%20%3Crect%20y%3D%2211%25%22%20width%3D%22100%25%22%20height%3D%2227%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%20%20%3Crect%20y%3D%2261%25%22%20width%3D%2290%25%22%20height%3D%2227%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%3C%2Fsvg%3E');
+		color: transparent;
+	}
+	:host([skeleton]) .d2l-skeletize-paragraph-2::before {
+		content: '\\A';
+		white-space: pre;
+	}
+	:host([skeleton]) .d2l-skeletize-paragraph-3 {
+		background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cstyle%3E%0A%20%20%20%20%40keyframes%20loadingPulse%7B0%25%2C75%25%7Bfill%3A%23f1f5fb%7D50%25%7Bfill%3A%23f9fbff%7D%7D.skeleton%7Banimation%3AloadingPulse%201.8s%20linear%20infinite%3Bfill%3A%23f1f5fb%7D%0A%20%20%3C%2Fstyle%3E%0A%20%20%3Crect%20y%3D%227%25%22%20width%3D%22100%25%22%20height%3D%2218%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%20%20%3Crect%20y%3D%2240%25%22%20width%3D%22100%25%22%20height%3D%2218%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%20%20%3Crect%20y%3D%2274%25%22%20width%3D%2290%25%22%20height%3D%2218%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%3C%2Fsvg%3E');
+		color: transparent;
+	}
+	:host([skeleton]) .d2l-skeletize-paragraph-3::before {
+		content: '\\A \\A';
+		white-space: pre;
+	}
+	:host([skeleton]) .d2l-skeletize-paragraph-5 {
+		background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cstyle%3E%0A%20%20%20%20%40keyframes%20loadingPulse%7B0%25%2C75%25%7Bfill%3A%23f1f5fb%7D50%25%7Bfill%3A%23f9fbff%7D%7D.skeleton%7Banimation%3AloadingPulse%201.8s%20linear%20infinite%3Bfill%3A%23f1f5fb%7D%0A%20%20%3C%2Fstyle%3E%0A%20%20%3Crect%20y%3D%224%25%22%20width%3D%22100%25%22%20height%3D%2211%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%20%20%3Crect%20y%3D%2224%25%22%20width%3D%22100%25%22%20height%3D%2211%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%20%20%3Crect%20y%3D%2244%25%22%20width%3D%22100%25%22%20height%3D%2211%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%20%20%3Crect%20y%3D%2264%25%22%20width%3D%22100%25%22%20height%3D%2211%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%20%20%3Crect%20y%3D%2284%25%22%20width%3D%2290%25%22%20height%3D%2211%25%22%20rx%3D%224%22%20class%3D%22skeleton%22%2F%3E%0A%3C%2Fsvg%3E');
+		color: transparent;
+	}
+	:host([skeleton]) .d2l-skeletize-paragraph-5::before {
+		content: '\\A \\A \\A \\A';
+		white-space: pre;
+	}
 	:host([skeleton]) .d2l-skeletize-95::before {
 		width: 95%;
 	}

--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -10,6 +10,15 @@ export const bodyStandardStyles = css`
 		bottom: 0.35rem;
 		top: 0.3rem;
 	}
+	:host([skeleton]) .d2l-body-standard.d2l-skeletize-paragraph-2 {
+		max-height: 2.8rem;
+	}
+	:host([skeleton]) .d2l-body-standard.d2l-skeletize-paragraph-3 {
+		max-height: 4.2rem;
+	}
+	:host([skeleton]) .d2l-body-standard.d2l-skeletize-paragraph-5 {
+		max-height: 7rem;
+	}
 	@media (max-width: 615px) {
 		.d2l-body-standard {
 			font-size: 0.8rem;
@@ -18,6 +27,15 @@ export const bodyStandardStyles = css`
 		:host([skeleton]) .d2l-body-standard.d2l-skeletize::before {
 			bottom: 0.3rem;
 			top: 0.3rem;
+		}
+		:host([skeleton]) .d2l-body-standard.d2l-skeletize-paragraph-2 {
+			max-height: 2.4rem;
+		}
+		:host([skeleton]) .d2l-body-standard.d2l-skeletize-paragraph-3 {
+			max-height: 3.6rem;
+		}
+		:host([skeleton]) .d2l-body-standard.d2l-skeletize-paragraph-5 {
+			max-height: 6rem;
 		}
 	}
 `;
@@ -31,6 +49,15 @@ export const bodyCompactStyles = css`
 	:host([skeleton]) .d2l-body-compact.d2l-skeletize::before {
 		bottom: 0.3rem;
 		top: 0.3rem;
+	}
+	:host([skeleton]) .d2l-body-compact.d2l-skeletize-paragraph-2 {
+		max-height: 2.4rem;
+	}
+	:host([skeleton]) .d2l-body-compact.d2l-skeletize-paragraph-3 {
+		max-height: 3.6rem;
+	}
+	:host([skeleton]) .d2l-body-compact.d2l-skeletize-paragraph-5 {
+		max-height: 6rem;
 	}
 `;
 
@@ -46,6 +73,15 @@ export const bodySmallStyles = css`
 		bottom: 0.25rem;
 		top: 0.2rem;
 	}
+	:host([skeleton]) .d2l-body-small.d2l-skeletize-paragraph-2 {
+		max-height: 2rem;
+	}
+	:host([skeleton]) .d2l-body-small.d2l-skeletize-paragraph-3 {
+		max-height: 3rem;
+	}
+	:host([skeleton]) .d2l-body-small.d2l-skeletize-paragraph-5 {
+		max-height: 5rem;
+	}
 	@media (max-width: 615px) {
 		.d2l-body-small {
 			font-size: 0.6rem;
@@ -54,6 +90,15 @@ export const bodySmallStyles = css`
 		:host([skeleton]) .d2l-body-small.d2l-skeletize::before {
 			bottom: 0.25rem;
 			top: 0.2rem;
+		}
+		:host([skeleton]) .d2l-body-small.d2l-skeletize-paragraph-2 {
+			max-height: 1.8rem;
+		}
+		:host([skeleton]) .d2l-body-small.d2l-skeletize-paragraph-3 {
+			max-height: 2.7rem;
+		}
+		:host([skeleton]) .d2l-body-small.d2l-skeletize-paragraph-5 {
+			max-height: 4.5rem;
 		}
 	}
 `;


### PR DESCRIPTION
This builds on the [draft skeleton mixin pull request](https://github.com/BrightspaceUI/core/pull/853), adding support for "paragraph skeletons", as defined on design.d2l:

![Screen Shot 2020-09-15 at 3 53 31 PM](https://user-images.githubusercontent.com/5491151/93616906-56d4e600-f9a3-11ea-9179-ca08923454fb.png)

### Goals

- Ability to "skeletize" blocks/paragraphs of text before we know how many lines the actual text will take up
- Consumers would choose between 2-line, 3-line and 5-line skeletons based on the expected size of the field
- Skeletons would be applied to one of our existing typography styles (standard, compact or small), and the size of the skeleton should match the font size of the style
- We'd prefer a single render path, allowing apps to apply skeleton styles to existing paragraph elements, instead of needing to render something like a `<d2l-skeleton-paragraph lines="5">` when they want skeletons to be displayed, and something else later.

### Implementation Details

This ended up being a really difficult problem to solve without something like a dedicated `<d2l-skeleton-paragraph lines="5">` component. I ended up using 3 different SVGs -- one each for the 2-line, 3-line and 5-line situations.

Since the SVGs are URL-encoded as background images, here's a sample of what the 3-line one looks like:

```xml
<svg xmlns="http://www.w3.org/2000/svg">
  <style>
    @keyframes loadingPulse{0%,75%{fill:#f1f5fb}50%{fill:#f9fbff}}
    .skeleton{animation:loadingPulse 1.8s linear infinite;fill:#f1f5fb}
  </style>
  <rect y="7%" width="100%" height="18%" rx="4" class="skeleton"/>
  <rect y="40%" width="100%" height="18%" rx="4" class="skeleton"/>
  <rect y="74%" width="90%" height="18%" rx="4" class="skeleton"/>
</svg>
```

As you can see, all Y values in the SVG are percentage-based and take the cap heights into account -- I had to do a lot of maths and am pretty proud of these! This lets us use the same SVG, stretch it horizontally and scale the height up or down to match the font size.

To get the height to be correct for 2-lines, 3-lines or 5-lines, I used this CSS:

```css
content: '\\A \\A';
white-space: pre;
```

The `\A` character is a line break, and when combined with `white-space: pre` that creates something that's the same height as 3 lines of text at the current font size.

![Screen Shot 2020-09-18 at 12 04 15 PM](https://user-images.githubusercontent.com/5491151/93619811-1a0aee00-f9a7-11ea-8b06-ba8cdf8b5dfb.png)

### Line-height Rounding Ruined My Day

So far so good, and I would have loved to be able to stop there. Except that the thing where the skeleton is being applied could also have its own height -- especially if the text inside it has already been resolved and rendered but maybe we're not quite ready to hide the skeleton yet. So even though maybe a 3-line skeleton has been chosen, there might be 10 lines of text rendered inside, and we don't want the skeleton to be 10-lines high.

To solve that, I had to apply `max-height` values for each of our typography styles that match the `line-height` multiplied by the number of lines we want. For example:

```css
:host([skeleton]) .d2l-body-standard.d2l-skeletize-paragraph-3 {
    /* line-height of "standard" is 1.4rem, multiplied by 3 is 4.2 */
    max-height: 4.2rem;
}
```

I tried to avoid having these typography-specific values, but couldn't find any other way to calculate the expected height of X lines of text based solely on the font-size (which could have been done with `calc(1em * 3)`).

This issue gets a little worse in not-Firefox, because when calculating line heights in pixels those browsers actually floor the value. So while `1.4rem` at `20px` base font size is a nice round `28px` (no flooring needed), when our users pick a `22px` (our "Large") base font size `1.4 x 22 = 30.8`, which gets floored down to `30px`, meaning our `max-height` is off by `0.8px` for every line of text -- `4px` for the 5-line variant.

That'll create a bit of height jitter when the skeleton goes away and is replaced by exactly the same number of lines of text, and only at font sizes other than our default. The worst jitter is `4px`, but typically it's 1-2. I think it's an acceptable limitation, but wanted to call it out.

### Is This Good Enough?

What I'm looking for is this: does the ability to have a single render path and simply go `<p class="d2l-body-compact d2l-skeletize-paragraph-3">` outweigh the limitations, or should we scrap this and build a dedicated `<d2l-skeleton-paragraph lines="5">` component? I feel like it does, but would love to hear from others who have already used this kind of thing.
