### PR TITLE
fix: add check for opener position to know if content is absolute wrt document

### DIFF
--- a/components/dropdown/test/dropdown-content-contained.visual-diff.html
+++ b/components/dropdown/test/dropdown-content-contained.visual-diff.html
@@ -27,13 +27,12 @@
 			position: relative;;
 			width: 300px;
 		}
-		d2l-dropdown {
-			position: absolute;
-		}
 		.top-left {
+			position: absolute;
 			top: 0;
 		}
 		.bottom-left {
+			position: absolute;
 			bottom: 0;
 		}
 	</style>
@@ -43,13 +42,15 @@
 	<div class="visual-diff">
 
 		<div id="contained-top" class="container">
-			<d2l-dropdown class="top-left">
-				<d2l-button class="d2l-dropdown-opener">Opener</d2l-button>
-				<d2l-dropdown-content>
-					<div>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</div>
-					<div>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</div>
-				</d2l-dropdown-content>
-			</d2l-dropdown>
+			<div class="top-left">
+				<d2l-dropdown>
+					<d2l-button class="d2l-dropdown-opener">Opener</d2l-button>
+					<d2l-dropdown-content>
+						<div>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</div>
+						<div>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</div>
+					</d2l-dropdown-content>
+				</d2l-dropdown>
+			</div>
 		</div>
 
 	</div>
@@ -57,13 +58,15 @@
 	<div class="visual-diff">
 
 		<div id="contained-bottom" class="container">
-			<d2l-dropdown class="bottom-left">
-				<d2l-button class="d2l-dropdown-opener">Opener</d2l-button>
-				<d2l-dropdown-content>
-					<div>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</div>
-					<div>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</div>
-				</d2l-dropdown-content>
-			</d2l-dropdown>
+			<div class="bottom-left">
+				<d2l-dropdown>
+					<d2l-button class="d2l-dropdown-opener">Opener</d2l-button>
+					<d2l-dropdown-content>
+						<div>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</div>
+						<div>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</div>
+					</d2l-dropdown-content>
+				</d2l-dropdown>
+			</div>
 		</div>
 
 	</div>


### PR DESCRIPTION
Dropdown content clipping would normally be an issue in the LMS also, except the LMS has some "special" styles that override the opener's default position from `relative` to `static`, effectively making the dropdown content positioned `absolute` with respect to the document (instead of the opener within a bounding container).  In such a case, we do not need adjust the dropdown content position and dimensions according to what would normally be the bounding container (the wrapper element within `d2l-scroll-wrapper`).