### PR TITLE
fix: OSLO remove 404 cached responses when ETag changes

### DIFF
--- a/helpers/getLocalizeResources.js
+++ b/helpers/getLocalizeResources.js
@@ -45,7 +45,7 @@ async function flushQueue() {
 
 	queue = [];
 
-	const resources = requests.map(item => `${item.resource}1`);
+	const resources = requests.map(item => item.resource);
 	const bodyObject = { resources };
 	const bodyText = JSON.stringify(bodyObject);
 

--- a/helpers/getLocalizeResources.js
+++ b/helpers/getLocalizeResources.js
@@ -45,7 +45,7 @@ async function flushQueue() {
 
 	queue = [];
 
-	const resources = requests.map(item => item.resource);
+	const resources = requests.map(item => `${item.resource}1`);
 	const bodyObject = { resources };
 	const bodyText = JSON.stringify(bodyObject);
 
@@ -194,6 +194,10 @@ async function fetchWithCaching(resource) {
 			debug && console.log(`[Oslo] cache stale: ${resource}`);
 			fetchWithQueuing(resource).then(url => URL.revokeObjectURL(url));
 		}
+	}
+
+	if (!cacheValue.ok) {
+		throw SingleFailedReason;
 	}
 
 	return await cacheValue.json();

--- a/helpers/getLocalizeResources.js
+++ b/helpers/getLocalizeResources.js
@@ -175,9 +175,6 @@ async function fetchWithCaching(resource) {
 	}
 
 	debug && console.log(`[Oslo] cache hit: ${resource}`);
-	if (!cacheValue.ok) {
-		throw SingleFailedReason;
-	}
 
 	// Check if the cache response is stale based on either the document init or
 	// any requests we've made to the LMS since init. We'll still serve stale


### PR DESCRIPTION
Related to https://github.com/Brightspace/lms/pull/1736 we want OSLO to remove cached 404 (and other possible) errors when the ETag changes (new lang terms overriden).