### PR TITLE
Update on language change

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -80,6 +80,11 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 		if (!this.label) {
 			console.warn('d2l-input-number component requires label text');
 		}
+		this.addEventListener('d2l-localize-behavior-language-changed', () => {
+			if (this._formattedValue.length > 0) {
+				this._formattedValue = formatValue(this.value, this.minFractionDigits, this.maxFractionDigits);
+			}
+		});
 	}
 
 	render() {

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -200,6 +200,12 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 			this._value = formatDateInISOTime(time);
 			this._formattedValue = formatTime(time);
 		}
+
+		this.addEventListener('d2l-localize-behavior-language-changed', () => {
+			this._formattedValue = formatTime(getDateFromISOTime(this.value));
+			INTERVALS.clear();
+		});
+
 	}
 
 	render() {

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -133,6 +133,7 @@ describe('d2l-input-number', () => {
 			const elem = await fixture(html`<d2l-input-number label="label" value="2000.3"></d2l-input-number>`);
 			setTimeout(() => documentLocaleSettings.language = 'fr');
 			await oneEvent(elem, 'd2l-localize-behavior-language-changed');
+			await elem.updateComplete;
 			expect(getInnerInputValue(elem)).to.equal('2 000,3');
 		});
 
@@ -140,6 +141,7 @@ describe('d2l-input-number', () => {
 			const elem = await fixture(html`<d2l-input-number label="label"></d2l-input-number>`);
 			setTimeout(() => documentLocaleSettings.language = 'fr');
 			await oneEvent(elem, 'd2l-localize-behavior-language-changed');
+			await elem.updateComplete;
 			expect(getInnerInputValue(elem)).to.equal('');
 		});
 	});

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -1,5 +1,6 @@
 import '../input-number.js';
 import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-number label="label"></d2l-input-number>`;
@@ -24,6 +25,12 @@ function getInnerInputValue(elem) {
 }
 
 describe('d2l-input-number', () => {
+
+	const documentLocaleSettings = getDocumentLocaleSettings();
+	afterEach(() => {
+		documentLocaleSettings.reset();
+	});
+
 	describe('constructor', () => {
 		it('should construct', () => {
 			runConstructor('d2l-input-number');
@@ -120,6 +127,20 @@ describe('d2l-input-number', () => {
 			await elem.updateComplete;
 			expect(elem.value).to.equal(123);
 			expect(getInnerInputValue(elem)).to.equal('123');
+		});
+
+		it('should update value when language changes', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="2000.3"></d2l-input-number>`);
+			setTimeout(() => documentLocaleSettings.language = 'fr');
+			await oneEvent(elem, 'd2l-localize-behavior-language-changed');
+			expect(getInnerInputValue(elem)).to.equal('2 000,3');
+		});
+
+		it('should not update empty value when language changes', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label"></d2l-input-number>`);
+			setTimeout(() => documentLocaleSettings.language = 'fr');
+			await oneEvent(elem, 'd2l-localize-behavior-language-changed');
+			expect(getInnerInputValue(elem)).to.equal('');
 		});
 	});
 

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -1,5 +1,6 @@
 import '../input-time.js';
 import { aTimeout, expect, fixture, oneEvent } from '@open-wc/testing';
+import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = '<d2l-input-time label="label text"></d2l-input-time>';
@@ -27,6 +28,11 @@ function getNumberOfIntervals(elem) {
 }
 
 describe('d2l-input-time', () => {
+
+	const documentLocaleSettings = getDocumentLocaleSettings();
+	afterEach(() => {
+		documentLocaleSettings.reset();
+	});
 
 	describe('constructor', () => {
 
@@ -154,6 +160,21 @@ describe('d2l-input-time', () => {
 			await elem.updateComplete;
 			expect(getInput(elem).value).to.equal('12:00 AM');
 		});
+
+		it('should update value when document language changes', async() => {
+			const elem = await fixture(fixtureWithValue);
+			setTimeout(() => documentLocaleSettings.language = 'fr');
+			await oneEvent(elem, 'd2l-localize-behavior-language-changed');
+			expect(getInput(elem).value).to.equal('11 h 22');
+		});
+
+		it('should update intervals when document language changes', async() => {
+			const elem = await fixture(fixtureWithValue);
+			setTimeout(() => documentLocaleSettings.language = 'fr');
+			await oneEvent(elem, 'd2l-localize-behavior-language-changed');
+			expect(getFirstOption(elem).text).to.equal('00 h 00');
+		});
+
 	});
 
 	describe('intervals', () => {

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -165,6 +165,7 @@ describe('d2l-input-time', () => {
 			const elem = await fixture(fixtureWithValue);
 			setTimeout(() => documentLocaleSettings.language = 'fr');
 			await oneEvent(elem, 'd2l-localize-behavior-language-changed');
+			await elem.updateComplete;
 			expect(getInput(elem).value).to.equal('11 h 22');
 		});
 
@@ -172,6 +173,7 @@ describe('d2l-input-time', () => {
 			const elem = await fixture(fixtureWithValue);
 			setTimeout(() => documentLocaleSettings.language = 'fr');
 			await oneEvent(elem, 'd2l-localize-behavior-language-changed');
+			await elem.updateComplete;
 			expect(getFirstOption(elem).text).to.equal('00 h 00');
 		});
 


### PR DESCRIPTION
Fixing a couple bugs with time and numeric input that I discovered building the demo for the meeting today. When the language on the document changes, we want all the UI controls to re-render in that language.