### PR TITLE
adding an entrypoint for all the form documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ npm install @brightspace-ui/core
   * [Dropdowns](components/dropdown/): dropdown openers and content containers
   * [Expand Collapse](components/expand-collapse): component to create expandable and collapsible content
   * [Focus Trap](components/focus-trap/): generic container that traps focus
-  * Forms
-	* [Forms](components/form/docs/form.md): Forms that aggregate data so the user can control how it is submitted
-	* [Native Forms](components/form/docs/form-native.md): Forms that emulate native HTML forms with support for custom form elements
-	* [FormElementMixin](components/form/docs/form-element-mixin.md): allow custom elements to participate in form submission and validation
+  * [Forms](components/form/): aggregate data for submission and validation
   * [Icons](components/icons/): iconography SVGs and web components
   * [Inputs](components/inputs/):
     * [Checkbox](components/inputs/docs/input-checkbox.md): checkbox components and styles
@@ -59,9 +56,11 @@ npm install @brightspace-ui/core
 * Mixins
   * [ArrowKeysMixin](mixins/arrow-keys-mixin.md): manage focus with arrow keys
   * [AsyncContainerMixin](mixins/async-container/): manage collective async state
+  * [FormElementMixin](components/form/docs/form-element-mixin.md): allow components to participate in forms and validation
   * [LocalizeMixin](mixins/localize-mixin.md): localize text in your components
   * [ProviderMixin](mixins/provider-mixin.md): provide and consume data across elements in a DI-like fashion
   * [RtlMixin](mixins/rtl-mixin.md): enable components to define RTL styles
+  * [SkeletonMixin](components/skeleton/): make components skeleton-aware
   * [VisibleOnAncestorMixin](mixins/visible-on-ancestor-mixin.md): display element on-hover of an ancestor
 * Templates
   * [PrimarySecondaryTemplate](templates/primary-secondary): Two Panel (primary and secondary) page template with header and optional footer

--- a/components/form/README.md
+++ b/components/form/README.md
@@ -1,0 +1,18 @@
+# Forms
+
+There are several components and mixins available to help make working with forms easier.
+
+## Validating and Submitting Forms Using `<d2l-form>` and `<d2l-form-native>`
+
+These two components behave much like a native `<form>` element, grouping nested form elements together and controlling how their data is validated and submitted. Unlike native `<form>`s, they support our custom form elements.
+
+- [d2l-form](docs/form.md): supports aggregation of nested forms for validation and submission
+- [d2l-form-native](docs/form-native.md): emulates how a native `<form>` submits, but supports our custom form elements
+
+## Custom Elements in Forms
+
+To allow custom elements to participate in `<d2l-form>` and `<d2l-form-native>` submission and validation, use the [FormElementMixin](docs/form-element-mixin.md).
+
+If your custom element uses other nested *custom* form elements internally, read about [form element nesting](docs/form-element-nesting.md).
+
+On the other hand, if your custom element uses other nested *native* form elements internally, read about [form element wrapping](docs/form-element-wrapping.md).


### PR DESCRIPTION
I think having a single place we can send people (and link to in other places) to learn about forms would be nice. Also this makes browsing the source on GitHub nicer.