### PR TITLE
only requesting an update if something changed

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -192,11 +192,14 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		e.stopPropagation();
 		const errors = e.detail.errors;
 		if (errors.length === 0) {
-			this.childErrors.delete(e.target);
+			if (this.childErrors.has(e.target)) {
+				this.childErrors.delete(e.target);
+				this.requestUpdate('childErrors');
+			}
 		} else {
 			this.childErrors.set(e.target, errors);
+			this.requestUpdate('childErrors');
 		}
-		this.requestUpdate('childErrors');
 	}
 
 	_validationCustomConnected(e) {


### PR DESCRIPTION
While investigating some performance slowness, I noticed that the date input (and likely others but didn't look) was rendering 3 times initially. One of those times was being caused by this `requestUpdate`, but there still weren't any actual errors.

This change makes things so that only if an error is actually removed or added that wasn't there before does it cause a re-render.