### PR TITLE
Add request instance helper.

### DIFF
--- a/mixins/provider-mixin.js
+++ b/mixins/provider-mixin.js
@@ -24,7 +24,7 @@ export function requestInstance(node, key) {
 	});
 	node.dispatchEvent(event);
 	return event.detail.instance;
-};
+}
 
 export const RequesterMixin = superclass => class extends superclass {
 	requestInstance(key) {

--- a/mixins/provider-mixin.js
+++ b/mixins/provider-mixin.js
@@ -15,16 +15,19 @@ export const ProviderMixin = superclass => class extends superclass {
 	}
 };
 
+export function requestInstance(node, key) {
+	const event = new CustomEvent('d2l-request-instance', {
+		detail: { key },
+		bubbles: true,
+		composed: true,
+		cancelable: true
+	});
+	node.dispatchEvent(event);
+	return event.detail.instance;
+};
+
 export const RequesterMixin = superclass => class extends superclass {
 	requestInstance(key) {
-		const event = new CustomEvent('d2l-request-instance', {
-			detail: { key },
-			bubbles: true,
-			composed: true,
-			cancelable: true
-		});
-
-		this.dispatchEvent(event);
-		return event.detail.instance;
+		return requestInstance(this, key);
 	}
 };

--- a/mixins/provider-mixin.js
+++ b/mixins/provider-mixin.js
@@ -1,17 +1,19 @@
-export const ProviderMixin = superclass => class extends superclass {
-	constructor() {
-		super();
-		this._instances = new Map();
-		this.addEventListener('d2l-request-instance', e => {
-			if (this._instances.has(e.detail.key)) {
-				e.detail.instance = this._instances.get(e.detail.key);
+export function provideInstance(node, key, obj) {
+	if (!node._providerInstances) {
+		node._providerInstances = new Map();
+		node.addEventListener('d2l-request-instance', e => {
+			if (node._providerInstances.has(e.detail.key)) {
+				e.detail.instance = node._providerInstances.get(e.detail.key);
 				e.stopPropagation();
 			}
 		});
 	}
+	node._providerInstances.set(key, obj);
+}
 
+export const ProviderMixin = superclass => class extends superclass {
 	provideInstance(key, obj) {
-		this._instances.set(key, obj);
+		provideInstance(this, key, obj);
 	}
 };
 

--- a/mixins/provider-mixin.md
+++ b/mixins/provider-mixin.md
@@ -51,3 +51,13 @@ class InterestingFactUI extends RequesterMixin(LitElement) {
 	}
 }
 ```
+
+In the absence of a component context, the `requestInstance` helper may be used by providing the `node` context and the `key` for the instance.
+
+```js
+import { requestInstance } from '@brightspace-ui/core/mixins/provider-mixin.js'
+
+const factString = requestInstance(node, 'd2l-interesting-fact-string');
+const factObjectString = requestInstance(node, 'd2l-interesting-fact-object').fact;
+const factFunctionString = requestInstance(node, 'd2l-interesting-fact-function')('Olives');
+```


### PR DESCRIPTION
This PR factors the `requestInstance` logic out into a helper that can be used outside the context of a web component.  I've run into a case where I need the ability to request an instance from a custom tinyMCE plugin.