### PR TITLE
Fix defect where tooltips would incorrectly start open

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -804,15 +804,15 @@ class Tooltip extends RtlMixin(LitElement) {
 
 	_updateTarget() {
 		this._removeListeners();
-		const target = this._findTarget();
-		if (target) {
-			const isInteractive = this._isInteractive(target);
+		this._target = this._findTarget();
+		if (this._target) {
+			const isInteractive = this._isInteractive(this._target);
 			this.id = this.id || getUniqueId();
 			this.setAttribute('role', 'tooltip');
 			if (this.forType === 'label') {
-				target.setAttribute('aria-labelledby', this.id);
+				this._target.setAttribute('aria-labelledby', this.id);
 			} else if (!this.announced || isInteractive) {
-				target.setAttribute('aria-describedby', this.id);
+				this._target.setAttribute('aria-describedby', this.id);
 			}
 			if (logAccessibilityWarning && !isInteractive && !this.announced) {
 				console.warn(
@@ -821,15 +821,13 @@ class Tooltip extends RtlMixin(LitElement) {
 				);
 				logAccessibilityWarning = false;
 			}
+			if (this.showing) {
+				this.updatePosition();
+			} else if (this.getRootNode().activeElement === this._target) {
+				this._onTargetFocus();
+			}
 		}
-		this._target = target;
 		this._addListeners();
-
-		if (this.showing) {
-			this.updatePosition();
-		} else if (this.getRootNode().activeElement === target) {
-			this._onTargetFocus();
-		}
 	}
 }
 customElements.define('d2l-tooltip', Tooltip);


### PR DESCRIPTION
## Issue
- A race condition in `d2l-tooltip` can cause it to start open when the page loads. This could happen anywhere but has only been reproduced with site tabs.

## Cause

- When tooltips are connected to the page they check to see if their target has focus to determine if they should start open or closed. On initial load this code can be triggered with a `null` target which causes the tooltip to start open if the `activeElement` is also `null`. In most cases `updated` is run afterwards which properly sets the `_isFocused` value to `false`. Some pages have load timing that changes the order these run in causing the tooltips to start open.

## Fix
- Fix the initial load check to also check if the target is non-null so we never initially show the tooltip unless it has an actual target with focus.