### PR TITLE
fix more-less component is throwing null exception in some unit test cases

### DIFF
--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -110,7 +110,7 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 			this.__mutationObserver = null;
 		}
 
-		this.__content.removeEventListener('load', this.__bound_reactToChanges, true);
+		this.__content && this.__content.removeEventListener('load', this.__bound_reactToChanges, true);
 		this.__bound_reactToChanges = null;
 		this.__bound_reactToMutationChanges = null;
 


### PR DESCRIPTION
chrome 74                Tests failed: Error thrown outside of test function: Cannot read property 'removeEventListener' of null
  HTMLElement.disconnectedCallback at /components/@brightspace-ui/core/components/more-less/more-less.js:132
           HTMLElement.<anonymous> at /components/@polymer/test-fixture/test-fixture.js:256
           HTMLElement.forElements at /components/@polymer/test-fixture/test-fixture.js:260
        HTMLElement.removeElements at /components/@polymer/test-fixture/test-fixture.js:255
               HTMLElement.restore at /components/@polymer/test-fixture/test-fixture.js:214
               Context.<anonymous> at /components/wct-browser-legacy/browser.js:1827

For some reason, on the ci linux side, it also needs Line 113 to be null checked. 