### PR TITLE
fix: more-less.js

### DIFF
--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -110,7 +110,7 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 			this.__mutationObserver = null;
 		}
 
-		this.__content.removeEventListener('load', this.__bound_reactToChanges, true);
+		this.__content && this.__content.removeEventListener('load', this.__bound_reactToChanges, true);
 		this.__bound_reactToChanges = null;
 		this.__bound_reactToMutationChanges = null;
 


### PR DESCRIPTION
adding the `semantic-release` commit message formatting that I missed last time.  Sorry for the back and forth PRs. 