### PR TITLE
fix: do not render href if null

### DIFF
--- a/components/card/card.js
+++ b/components/card/card.js
@@ -260,7 +260,7 @@ class Card extends RtlMixin(LitElement) {
 				<a @blur="${this._onLinkBlur}"
 					?download="${this.download}"
 					@focus="${this._onLinkFocus}"
-					href="${ifDefined(this.href)}"
+					href="${ifDefined(this.href ? this.href : undefined)}"
 					hreflang="${ifDefined(this.hreflang)}"
 					@mouseenter="${this._onLinkMouseEnter}"
 					@mouseleave="${this._onLinkMouseLeave}"

--- a/components/card/test/card.test.js
+++ b/components/card/test/card.test.js
@@ -1,10 +1,19 @@
 import '../card.js';
+import { expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-card', () => {
 
 	it('should construct', () => {
 		runConstructor('d2l-card');
+	});
+
+	it('should not set href attribute if null', async() => {
+		const elem = await fixture(html`<d2l-card></d2l-card>`);
+		elem.href = null;
+		await elem.updateComplete;
+		const anchorElem = elem.shadowRoot.querySelector('a');
+		expect(anchorElem.hasAttribute('href')).to.be.false;
 	});
 
 });


### PR DESCRIPTION
The enrollment card Polymer element is binding the card's `href` to a `null` value. Back when this was Polymer, that resulted in no `href` being set, but that's not the case in Lit so we need to handle it specially.