### PR TITLE
fix: extra check to make sure polyfill is really there

### DIFF
--- a/mixins/focus-visible-polyfill-mixin.js
+++ b/mixins/focus-visible-polyfill-mixin.js
@@ -14,7 +14,10 @@ export const FocusVisiblePolyfillMixin = superclass => class extends superclass 
 		}
 
 		window.addEventListener('focus-visible-polyfill-ready', () => {
-			window.applyFocusVisiblePolyfill(this.shadowRoot);
+			// somehow it's occasionally still not available
+			if (this.shadowRoot && window.applyFocusVisiblePolyfill) {
+				window.applyFocusVisiblePolyfill(this.shadowRoot);
+			}
 		}, { once: true });
 
 		if (!polyfillLoading) {


### PR DESCRIPTION
I noticed the following JS error in Kibana from Spark since this was introduced:

> TypeError: window.applyFocusVisiblePolyfill is not a function
    at shadowRoot.window.applyFocusVisiblePolyfill.window.addEventListener.once (https://s.brightspace.com/lib/bsi/20.20.12-83/unbundled/button-styles.js:1:310)

So somehow, despite the event [not being fired until after the global is introduced](https://github.com/WICG/focus-visible/blob/master/src/focus-visible.js#L297), it's still not there when this code runs. Very confusing, but 🤷 