### PR TITLE
Close drop-dropdown menu on link select

### DIFF
--- a/components/dropdown/demo/dropdown-menu.html
+++ b/components/dropdown/demo/dropdown-menu.html
@@ -11,6 +11,7 @@
 		import '../../demo/demo-page.js';
 		import '../../menu/menu.js';
 		import '../../menu/menu-item.js';
+		import '../../menu/menu-item-link.js';
 		import '../../menu/menu-item-radio.js';
 		import '../dropdown.js';
 		import '../dropdown-menu.js';
@@ -148,6 +149,22 @@
 							<d2l-menu-item-radio text="Chapter 8" value=8></d2l-menu-item-radio>
 							<d2l-menu-item-radio text="Chapter 9" value=9></d2l-menu-item-radio>
 							<d2l-menu-item-radio text="Chapter 10" value=10></d2l-menu-item-radio>
+						</d2l-menu>
+					</d2l-dropdown-menu>
+				</d2l-dropdown>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>With Links</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-dropdown>
+					<button class="d2l-dropdown-opener">Open it!</button>
+					<d2l-dropdown-menu no-padding-footer>
+						<div slot="header" style="font-weight: bold; width: 100%; text-align: center;">Helpful Links</div>
+						<d2l-menu>
+							<d2l-menu-item-link text="menu.js (View)" href="../../menu/menu.js"></d2l-menu-item-link>
+							<d2l-menu-item-link text="menu.js (Download)" href="../../menu/menu.js" target="_blank" download></d2l-menu-item-link>
 						</d2l-menu>
 					</d2l-dropdown-menu>
 				</d2l-dropdown>

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -102,7 +102,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 	}
 
 	_onSelect(e) {
-		if (e.target.tagName !== 'D2L-MENU-ITEM') {
+		if (['D2L-MENU-ITEM', 'D2L-MENU-ITEM-LINK'].indexOf(e.target.tagName) < 0) {
 			return;
 		}
 		this.close();

--- a/components/dropdown/test/dropdown-menu.test.js
+++ b/components/dropdown/test/dropdown-menu.test.js
@@ -2,6 +2,7 @@ import '../dropdown.js';
 import '../dropdown-menu.js';
 import '../../menu/menu.js';
 import '../../menu/menu-item.js';
+import '../../menu/menu-item-link.js';
 import '../../menu/menu-item-radio';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
@@ -15,6 +16,19 @@ const itemFixture = html`
 					<d2l-menu-item text="Introduction" id="first-item"></d2l-menu-item>
 					<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
 					<d2l-menu-item text="The Universe"></d2l-menu-item>
+				</d2l-menu>
+			</d2l-dropdown-menu>
+		</d2l-dropdown>
+	</div>
+`;
+
+const linkFixture = html`
+	<div>
+		<d2l-dropdown>
+			<button class="d2l-dropdown-opener">Open it!</button>
+			<d2l-dropdown-menu id="dropdown">
+				<d2l-menu label="Helpful Links">
+					<d2l-menu-item-link text="menu.js (View)" href="../../menu/menu.js" id="first-item"></d2l-menu-item-link>
 				</d2l-menu>
 			</d2l-dropdown-menu>
 		</d2l-dropdown>
@@ -42,6 +56,7 @@ describe('d2l-dropdown-menu', () => {
 
 		[
 			{ name: 'should close when menu item is selected', fixture: itemFixture },
+			{ name: 'should close when menu link item is selected', fixture: linkFixture },
 			{ name: 'should close when menu radio item is changed', fixture: radioFixture },
 		].forEach((testCase) => {
 			it(testCase.name, async() => {

--- a/components/dropdown/test/dropdown-menu.test.js
+++ b/components/dropdown/test/dropdown-menu.test.js
@@ -28,7 +28,7 @@ const linkFixture = html`
 			<button class="d2l-dropdown-opener">Open it!</button>
 			<d2l-dropdown-menu id="dropdown">
 				<d2l-menu label="Helpful Links">
-					<d2l-menu-item-link text="menu.js (View)" href="../../menu/menu.js" id="first-item"></d2l-menu-item-link>
+					<d2l-menu-item-link text="menu.js (View)" href="#" id="first-item"></d2l-menu-item-link>
 				</d2l-menu>
 			</d2l-dropdown-menu>
 		</d2l-dropdown>

--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -105,6 +105,7 @@ The link menu item, `d2l-menu-item-link`, is used for navigating.
 
 | Property | Type | Description |
 |--|--|--|
+| `download` | String | If the attribute is provided, it will prompt the user to download the resource instead of navigating to it. Additionally, if the attribute is provided with a value, that value will be used for the filename. |
 | `href` | String, required | The URL the menu item link navigates to |
 | `text` | String, required | Text displayed by the menu item |
 | `disabled` | Boolean | Disables the menu item |

--- a/components/menu/demo/menu.html
+++ b/components/menu/demo/menu.html
@@ -158,6 +158,9 @@
 						<d2l-menu-item-link text="Dwarf Planets (link)" href="https://en.wikipedia.org/wiki/Dwarf_planet">
 							<span slot="supporting">39+ AU</span>
 						</d2l-menu-item-link>
+						<d2l-menu-item-link text="Dwarf Planets (link to download)" href="../menu.js" target="_blank" download>
+							<span slot="supporting">Something</span>
+						</d2l-menu-item-link>
 					</d2l-menu>
 				</template>
 			</d2l-demo-snippet>

--- a/components/menu/menu-item-link.js
+++ b/components/menu/menu-item-link.js
@@ -14,6 +14,10 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
+			 * Name to use for download
+			 */
+			download: { type: String },
+			/**
 			 * The url the menu item link navigates to
 			 */
 			href: { type: String },
@@ -57,7 +61,7 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 	render() {
 		const rel = this.target ? 'noreferrer noopener' : undefined;
 		return html`
-			<a href="${ifDefined(this.href)}" rel="${ifDefined(rel)}" target="${ifDefined(this.target)}" tabindex="-1">
+			<a download="${ifDefined(this.download)}" href="${ifDefined(this.href)}" rel="${ifDefined(rel)}" target="${ifDefined(this.target)}" tabindex="-1">
 				<div class="d2l-menu-item-text">${this.text}</div>
 				<div class="d2l-menu-item-supporting"><slot name="supporting"></slot></div>
 			</a>

--- a/components/menu/menu-item-link.js
+++ b/components/menu/menu-item-link.js
@@ -14,7 +14,9 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * Name to use for download
+			 * Prompts the user to save the linked URL instead of navigating to it.
+			 * Must be to a resource on the same origin.
+			 * Can be used with or without a value, when set the value becomes the filename.
 			 */
 			download: { type: String },
 			/**


### PR DESCRIPTION
Selecting a menu item did not previously close menus,
because they were expected to navigate to another page.
If the target is a new tab, the original page would remain
intact, with the drop-down menu still open.

This change will close drop-down menus whenever a menu
item link is selected. Also, passes `download` attribute through to anchor.

![example-video](https://user-images.githubusercontent.com/24978103/98115407-c845f680-1e74-11eb-833d-43d14e806906.gif)