### PR TITLE
fix: making form elements block

### DIFF
--- a/components/form/docs/form-native.md
+++ b/components/form/docs/form-native.md
@@ -14,7 +14,7 @@ If you're looking to submit form data via your own API calls or nest multiple fo
 
 ```html
 <script type="module">
-  import '@brightspace-ui/core/components/form/d2l-form-native.js';
+  import '@brightspace-ui/core/components/form/form-native.js';
 </script>
 <d2l-form-native>
   <d2l-input-text required label="Email" name="email" type="email"></d2l-input-text>

--- a/components/form/docs/form.md
+++ b/components/form/docs/form.md
@@ -15,7 +15,7 @@ If you're looking to emulate native form element submission, [`d2l-form-native`]
 
 ```html
 <script type="module">
-  import '@brightspace-ui/core/components/form/d2l-form.js';
+  import '@brightspace-ui/core/components/form/form.js';
 </script>
 <d2l-form>
   <d2l-input-text required label="Email" name="email" type="email"></d2l-input-text>
@@ -66,7 +66,7 @@ Form nesting will only consider descendants relative to the `d2l-form` that `sub
 
 ```html
 <script type="module">
-  import '@brightspace-ui/core/components/form/d2l-form.js';
+  import '@brightspace-ui/core/components/form/form.js';
 </script>
 <d2l-form id="root">
 	<div>

--- a/components/form/form-native.js
+++ b/components/form/form-native.js
@@ -1,5 +1,5 @@
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { findFormElements, getFormElementData, isCustomFormElement, isNativeFormElement } from './form-helper.js';
-import { html, LitElement } from 'lit-element/lit-element.js';
 import { FormMixin } from './form-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 
@@ -34,6 +34,17 @@ class FormNative extends FormMixin(LitElement) {
 			 */
 			target: { type: String },
 		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`;
 	}
 
 	constructor() {

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -1,5 +1,5 @@
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { findFormElements, flattenMap, getFormElementData, isCustomFormElement, isNativeFormElement } from './form-helper.js';
-import { html, LitElement } from 'lit-element/lit-element.js';
 import { FormMixin } from './form-mixin.js';
 
 /**
@@ -17,6 +17,17 @@ class Form extends FormMixin(LitElement) {
 			 */
 			noNesting: { type: Boolean, attribute: 'no-nesting', reflect: true },
 		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`;
 	}
 
 	constructor() {

--- a/mixins/test/localize-mixin.test.js
+++ b/mixins/test/localize-mixin.test.js
@@ -212,7 +212,7 @@ describe('LocalizeMixin', () => {
 				setTimeout(() => {
 					expect(renderCount).to.equal(1);
 					done();
-				}, 300);
+				}, 500); // larger timeout for legacy-Edge
 			});
 		});
 


### PR DESCRIPTION
The native `<form>` element is block by default, so ours should be too.

Fixed some file locations in the READMEs while I was in here.