### PR TITLE
fix: do not throw if the key (e.g. icon) changes while still pending

### DIFF
--- a/directives/run-async.js
+++ b/directives/run-async.js
@@ -50,9 +50,6 @@ export const runAsync = directive((key, task, templates, options) => (part) => {
 			if (currentRunState.abortController !== undefined) {
 				currentRunState.abortController.abort();
 			}
-			// TODO(justinfagnani): This should be an AbortError, but it's not
-			// implemented yet
-			currentRunState.rejectPending(new Error());
 		}
 		const abortController = hasAbortController ? new AbortController() : undefined;
 		const abortSignal = hasAbortController ? abortController.signal : undefined;


### PR DESCRIPTION
This ends up throwing an exception if for example a `<d2l-icon>`'s icon property changes (which acts as the `runAsync` key) while the original task is still pending. Seems safe to just abort and not throw here.