### PR TITLE
Toggle dropdown opener on spacebar

### DIFF
--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -113,7 +113,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	}
 
 	__onKeyPress(e) {
-		if (![13, 32].includes(e.keyCode)) return;
+		if (e.keyCode !== 13 && e.keyCode !== 32) return;
 		if (this.noAutoOpen) return;
 		this.toggleOpen(true);
 	}

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -113,7 +113,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	}
 
 	__onKeyPress(e) {
-		if (e.keyCode !== 13) return;
+		if (![13, 32].includes(e.keyCode)) return;
 		if (this.noAutoOpen) return;
 		this.toggleOpen(true);
 	}


### PR DESCRIPTION
While testing `@brightspace-ui-labs/media-player`, we found that the `<d2l-button-icon>`'s were clickable with mouse, enter, or spacebar. The settings menu has a `<d2l-button-icon class="dropdown-opener">` to toggle it, but the toggling is only handled by mouse or enter.

This change would allow the dropdown menu to be toggled with spacebar as well.