### PR TITLE
safety check around removing event listener

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -212,8 +212,11 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		window.removeEventListener('resize', this.__onResize);
-		document.body.removeEventListener('focus', this.__onAutoCloseFocus, true);
-		document.body.removeEventListener('click', this.__onAutoCloseClick, true);
+		if (document.body) {
+			// DE41322: document.body can be null in some scenarios
+			document.body.removeEventListener('focus', this.__onAutoCloseFocus, true);
+			document.body.removeEventListener('click', this.__onAutoCloseClick, true);
+		}
 		clearDismissible(this.__dismissibleId);
 		this.__dismissibleId = null;
 	}


### PR DESCRIPTION
Seeing a frequent JavaScript error originating from here in production.
> Uncaught TypeError: Cannot read property 'removeEventListener' of null

Call stack:
> TypeError: Cannot read property 'removeEventListener' of null
    at HTMLElement.disconnectedCallback (https://s.brightspace.com/lib/bsi/20.20.11-110/unbundled/dropdown-content-styles.js:1:2605)

And occasionally the call stack includes information from Cypress (test automation software):

> TypeError: The following error originated from your application code, not from Cypress.
> 
> Cannot read property 'removeEventListener' of null
> 
> When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
> 
> This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.
>     at HTMLElement.disconnectedCallback (https://s.brightspace.com/lib/bsi/20.20.11-110/unbundled/dropdown-content-styles.js:1:2605)

I can't reproduce this on my own, so I think it's only being triggered from test automation. Still, it's good to fix this and get it out of our logs.