### PR TITLE
Fix secondary panel height

### DIFF
--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -560,7 +560,7 @@ class TemplatePrimarySecondary extends FocusVisiblePolyfillMixin(RtlMixin(LitEle
 				display: none;
 			}
 			aside {
-				max-height: 100%;
+				height: 100%;
 				min-width: ${desktopMinSize}px;
 				-webkit-overflow-scrolling: touch;
 				overflow-y: auto;


### PR DESCRIPTION
I didn't update the header and footer z-index because [the other z-index change](https://github.com/BrightspaceUI/core/pull/944) was enough to fix the consistent eval issues and I don't want to make unnecessary changes this close to branching.

## Issue
If dropdowns or tooltips open in the secondary panel they may get cut off. This
happens because the aside inside the secondary panel only takes up the height of its
content, not the height of its panel.

## Fix
This is fixed by forcing the aside to always be the height of the panel