### PR TITLE
Adding absolute positioning to hidden MathML

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -218,6 +218,9 @@ class HtmlBlock extends LitElement {
 				outline-width: 0;
 				text-decoration: underline;
 			}
+			mjx-assistive-mml math {
+				position: absolute;
+			}
 			:host([dir="rtl"]) {
 				text-align: right;
 			}


### PR DESCRIPTION
MathJax creates (or passes on) some hidden `MathML` for screen readers. However, if the containing `MathML` is large enough (ex: contains `semantics` tags), it can push the width of its container (which might make some unnecessary horizontal scrollbars).

Adding a `position: absolute` to take it out of the visual flow of the document (since you can't see it anyway) so it doesn't add any width. Shouldn't affect screen reading either (tested with JAWS and NVDA w/MathPlayer just in case).

[Before](https://user-images.githubusercontent.com/52549862/99118385-0ea9fc80-25bd-11eb-80b2-906b85ad6a3b.png) and [after](https://user-images.githubusercontent.com/52549862/99118278-db676d80-25bc-11eb-99a7-0556bdff6b1a.png).
