### PR TITLE
input ranges: fire change event when endValue updates due to autoShiftDates

### DIFF
--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -200,6 +200,10 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			if (prop === 'startValue' || prop === 'endValue') {
 				if (!this.invalid && this.autoShiftDates && prop === 'startValue' && this.endValue && oldVal) {
 					this.endValue = getShiftedEndDate(this.startValue, this.endValue, oldVal, this.inclusiveDateRange);
+					this.dispatchEvent(new CustomEvent(
+						'change',
+						{ bubbles: true, composed: false }
+					));
 				}
 
 				this.setFormValue({

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -238,6 +238,10 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 			if (prop === 'startValue' || prop === 'endValue') {
 				if (!this.invalid && this.autoShiftDates && prop === 'startValue' && this.endValue && oldVal) {
 					this.endValue = getShiftedEndDateTime(this.startValue, this.endValue, oldVal, this.inclusiveDateRange, this.localized);
+					this.dispatchEvent(new CustomEvent(
+						'change',
+						{ bubbles: true, composed: false }
+					));
 				}
 
 				this.setFormValue({

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -253,6 +253,10 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			if (prop === 'startValue' || prop === 'endValue') {
 				if (!this.invalid && this.autoShiftTimes && prop === 'startValue' && this.endValue && oldVal) {
 					this.endValue = getShiftedEndTime(this.startValue, this.endValue, oldVal, this.inclusiveTimeRange);
+					this.dispatchEvent(new CustomEvent(
+						'change',
+						{ bubbles: true, composed: false }
+					));
 				}
 
 				this.setFormValue({


### PR DESCRIPTION
Use case: in the LMS adding the range components in the hidden input nodes need to update when a change occurs.