### PR TITLE
fix: Allow skeleton Mixin to be apart of a Mixin chain

### DIFF
--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -139,7 +139,7 @@ export const SkeletonMixin = superclass => class extends superclass {
 	}
 
 	static get styles() {
-		const styles = skeletonStyles;
+		const styles = [ skeletonStyles ];
 		super.styles && styles.unshift(super.styles);
 		return styles;
 	}

--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -139,7 +139,9 @@ export const SkeletonMixin = superclass => class extends superclass {
 	}
 
 	static get styles() {
-		return skeletonStyles;
+		const styles = skeletonStyles;
+		super.styles && styles.unshift(super.styles);
+		return styles;
 	}
 
 	constructor() {


### PR DESCRIPTION
Basically, using `skeletonMixin(ListItemMixin(...))` will remove the ListItemMixin styles without this fix.