### PR TITLE
fix: Remove input-width from input-number and input-text

### DIFF
--- a/components/inputs/demo/input-number.html
+++ b/components/inputs/demo/input-number.html
@@ -82,7 +82,7 @@
 			<h2>Custom Input Width</h2>
 			<d2l-demo-snippet>
 				<template>
-					<d2l-input-number label="Custom Width" input-width="10rem"></d2l-input-number>
+					<d2l-input-number label="Custom Width" style="width: 10rem;"></d2l-input-number>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/inputs/demo/input-text.html
+++ b/components/inputs/demo/input-text.html
@@ -120,7 +120,7 @@
 			<h2>Custom Width</h2>
 			<d2l-demo-snippet>
 				<template>
-					<d2l-input-text label="Name" input-width="400px"></d2l-input-text>
+					<d2l-input-text label="Name" style="width: 400px;"></d2l-input-text>
 				</template>
 			</d2l-demo-snippet>
 		</d2l-demo-page>

--- a/components/inputs/docs/input-number.md
+++ b/components/inputs/docs/input-number.md
@@ -19,7 +19,6 @@ The `<d2l-input-number>` element is similar to `<d2l-input-text>`, except it's i
 | `autocomplete` | String | Specifies which types of values [can be autofilled](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) by the browser. |
 | `autofocus` | Boolean, default: `false` | When set, will automatically place focus on the input. |
 | `disabled` | Boolean, default: `false` | Disables the input. |
-| `input-width` | String, default: `4rem` | Restricts the maximum width of the input box without impacting the width of the label. |
 | `label-hidden` | Boolean, default: `false` | Hides the label visually (moves it to the input's `aria-label` attribute). |
 | `max` | Number | Maximum value allowed. |
 | `max-exclusive` | Boolean, default: `false` | Indicates whether the max value is exclusive. |

--- a/components/inputs/docs/input-text.md
+++ b/components/inputs/docs/input-text.md
@@ -25,7 +25,6 @@ The `<d2l-input-text>` element is a simple wrapper around the native `<input typ
 | `autofocus` | Boolean | When set, will automatically place focus on the input |
 | `description` | String | A description to be added to the `input` for accessibility |
 | `disabled` | Boolean | Disables the input |
-| `input-width` | String, default: `100%` | Restricts the maximum width of the input box without impacting the width of the label |
 | `label-hidden` | Boolean | Hides the label visually (moves it to the input's `aria-label` attribute) |
 | `max` | String | For number inputs, maximum value |
 | `maxlength` | Number | Imposes an upper character limit |

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -22,7 +22,6 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 			autocomplete: { type: String },
 			autofocus: { type: Boolean },
 			disabled: { type: Boolean },
-			inputWidth: { attribute: 'input-width', type: String },
 			label: { type: String },
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
 			max: { type: Number },
@@ -58,7 +57,6 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 		super();
 		this.autofocus = false;
 		this.disabled = false;
-		this.inputWidth = '4rem';
 		this.labelHidden = false;
 		this.maxExclusive = false;
 		this.minExclusive = false;
@@ -105,7 +103,6 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 				?disabled="${this.disabled}"
 				.forceInvalid="${this.invalid}"
 				id="${this._inputId}"
-				input-width="${this.inputWidth}"
 				label="${ifDefined(this.label)}"
 				?label-hidden="${this.labelHidden}"
 				name="${ifDefined(this.name)}"

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -57,10 +57,6 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 			 */
 			hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
 			/**
-			 * Restricts the maximum width of the input box without impacting the width of the label.
-			 */
-			inputWidth: { attribute: 'input-width', type: String },
-			/**
 			 * REQUIRED: Label for the input
 			 */
 			label: { type: String },
@@ -259,10 +255,6 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 			inputStyles.paddingRight = isFocusedOrHovered ? `${this._lastSlotWidth - 1}px` : `${this._lastSlotWidth}px`;
 		}
 
-		const inputContainerStyles = {
-			maxWidth: this.inputWidth
-		};
-
 		const firstSlotName = (this.dir === 'rtl') ? 'right' : 'left';
 		const lastSlotName = (this.dir === 'rtl') ? 'left' : 'right';
 
@@ -274,7 +266,7 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		};
 		const input = html`
 			<div class="d2l-input-container">
-				<div class="d2l-input-text-container d2l-skeletize" style="${styleMap(inputContainerStyles)}">
+				<div class="d2l-input-text-container d2l-skeletize">
 					<input aria-atomic="${ifDefined(this.atomic)}"
 						aria-describedby="${ifDefined(this.description ? this._descriptionId : undefined)}"
 						aria-haspopup="${ifDefined(this.ariaHaspopup)}"

--- a/components/inputs/test/input-number.visual-diff.html
+++ b/components/inputs/test/input-number.visual-diff.html
@@ -40,7 +40,7 @@
 				</d2l-input-number>
 			</div>
 			<div class="visual-diff">
-				<d2l-input-number id="custom-width" label="Number" value="10" input-width="10rem"></d2l-input-number>
+				<d2l-input-number id="custom-width" label="Number" value="10" style="width: 10rem;"></d2l-input-number>
 			</div>
 		</div>
 	</body>

--- a/components/inputs/test/input-text.visual-diff.html
+++ b/components/inputs/test/input-text.visual-diff.html
@@ -144,7 +144,7 @@
 				</d2l-input-text>
 			</div>
 			<div class="visual-diff">
-				<d2l-input-text id="wc-custom-width" label="Custom Width Longer Than Input" input-width="100px"></d2l-input-text>
+				<d2l-input-text id="wc-custom-width" label="Custom Width Longer Than Input" style="width: 100px;"></d2l-input-text>
 			</div>
 			<div class="visual-diff">
 				<input id="sass-basic" class="d2l-test-input-text" type="text" value="text">


### PR DESCRIPTION
## Summary
~ Removed `input-width` from `input-number` and `input-text` components