### PR TITLE
Fix RTL label causing an `overflow-x` which creates horizontal scrollbar

### DIFF
--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -566,6 +566,7 @@ class TemplatePrimarySecondary extends FocusVisiblePolyfillMixin(RtlMixin(LitEle
 				height: 100%;
 				min-width: ${desktopMinSize}px;
 				-webkit-overflow-scrolling: touch;
+				overflow-x: hidden;
 				overflow-y: scroll;
 				position: relative;
 			}


### PR DESCRIPTION
### FACE Assignments

Fixes: https://trello.com/c/DwgFvfRz/262-rtl-new-picker-causes-horizontal-scroll-in-rhp

**Cause:**
By setting the `time` field with the new date picker a horizontal scrollbar appears in the secondary panel.

**Initial investigation:**
`label` for the `time` fields triggers an overflow in the x-axis and so a horizontal scrollbar appears as the `label` is set to render at `left: -10000px`. Setting it to `right: -10000px` maintains functionality and has no overflow/horizontal scrollbar, not sure if the RTL mixin needs a fix to get this to happen.

**Before:**
![image](https://user-images.githubusercontent.com/15062048/102978632-a7d00b00-44b9-11eb-8052-554a66aa3f75.png)

**After:**
![image](https://user-images.githubusercontent.com/15062048/102980269-2fb71480-44bc-11eb-8c7f-58ed7167108c.png)