### PR TITLE
announce: remove duplication of messages

### DIFF
--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -1,5 +1,6 @@
 let timeoutId = null;
 let container = null;
+let messages = {};
 
 export function announce(message) {
 	if (!message) return;
@@ -25,8 +26,16 @@ export function announce(message) {
 	treat the change as an update. Firefox sometimes ignores changes if the region
 	and update are made too quickly in succession. RequestAnimationFrame is not
 	sufficient here. */
+	let child;
+	if (Object.keys(message).length === 0 || !Object.keys(messages).includes(message)) {
+		child = document.createTextNode(message);
+		messages[message] = child;
+	} else {
+		child = messages[message];
+		child.parentNode.removeChild(child);
+	}
 	setTimeout(() => {
-		container.appendChild(document.createTextNode(message));
+		container.appendChild(child);
 	}, 100);
 
 	/* Need to purge old messages so that they are not discovered by screen readers
@@ -36,6 +45,7 @@ export function announce(message) {
 		container.parentNode.removeChild(container);
 		container = null;
 		timeoutId = null;
+		messages = {};
 	}, 10000);
 
 }

--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -29,7 +29,7 @@ export function announce(message) {
 	if (elem) elem.parentNode.removeChild(elem);
 	setTimeout(() => {
 		container.appendChild(document.createTextNode(message));
-	}, 100);
+	}, 200);
 
 	/* Need to purge old messages so that they are not discovered by screen readers
 	using virtual cursor, but we need to give the browser ample time to hand off

--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -1,6 +1,5 @@
 let timeoutId = null;
 let container = null;
-let messages = {};
 
 export function announce(message) {
 	if (!message) return;
@@ -26,16 +25,10 @@ export function announce(message) {
 	treat the change as an update. Firefox sometimes ignores changes if the region
 	and update are made too quickly in succession. RequestAnimationFrame is not
 	sufficient here. */
-	let child;
-	if (Object.keys(message).length === 0 || !Object.keys(messages).includes(message)) {
-		child = document.createTextNode(message);
-		messages[message] = child;
-	} else {
-		child = messages[message];
-		child.parentNode.removeChild(child);
-	}
+	const elem = [...container.childNodes].find((c) => c.textContent === message);
+	if (elem) elem.parentNode.removeChild(elem);
 	setTimeout(() => {
-		container.appendChild(child);
+		container.appendChild(document.createTextNode(message));
 	}, 100);
 
 	/* Need to purge old messages so that they are not discovered by screen readers
@@ -45,7 +38,6 @@ export function announce(message) {
 		container.parentNode.removeChild(container);
 		container = null;
 		timeoutId = null;
-		messages = {};
 	}, 10000);
 
 }


### PR DESCRIPTION
Fixes https://github.com/BrightspaceUI/core/issues/526

This fix checks if a message has already been added to the aria-live container. If not, it performs as before. If it has, it removes then re-adds it (otherwise it might not actually get read). 

This was tested with the `input-time-range` component validation which can end up adding the text of multiple "Start time must be before end time" tooltips to the announcement if the user is quickly tabbing around.

This assumes that there isn't a scenario where there should be duplicate messages that are repeated in succession. A different fix will need to be made if that is the case.