### PR TITLE
fix: Verify cache storage is available before trying to use batch route

### DIFF
--- a/helpers/getLocalizeResources.js
+++ b/helpers/getLocalizeResources.js
@@ -281,10 +281,10 @@ function getVersion() {
 	return documentLocaleSettings.oslo.version;
 }
 
-function shouldFetchOverrides() {
+async function shouldFetchOverrides() {
 
 	const isOsloAvailable =
-		shouldUseBatchFetch() ||
+		await shouldUseBatchFetch() ||
 		shouldUseCollectionFetch();
 
 	return isOsloAvailable;
@@ -349,7 +349,7 @@ export async function getLocalizeOverrideResources(
 
 	promises.push(translations);
 
-	if (shouldFetchOverrides()) {
+	if (await shouldFetchOverrides()) {
 		const overrides = await fetchOverride(formatFunc);
 		promises.push(overrides);
 	}
@@ -372,7 +372,7 @@ export async function getLocalizeResources(
 	const promises = [];
 	let supportedLanguage;
 
-	if (shouldFetchOverrides()) {
+	if (await shouldFetchOverrides()) {
 
 		const overrides = await fetchOverride(formatFunc, fetchFunc);
 		promises.push(overrides);

--- a/helpers/test/getLocalizeResources.test.js
+++ b/helpers/test/getLocalizeResources.test.js
@@ -208,7 +208,8 @@ describe('getLocalizeResources', () => {
 
 		expect(formatFuncSpy).to.have.been.callCount(1); // 1 lms
 		expect(formatFuncSpy).to.have.been.calledWithExactly();
-		expect(openSpy).to.have.been.calledOnceWithExactly('d2l-oslo');
+		expect(openSpy).to.always.have.been.calledWithExactly('d2l-oslo');
+		expect(openSpy).to.have.callCount(3);
 		expect(matchSpy).to.have.been.callCount(1);
 		expect(matchSpy).to.have.been.calledWithMatch(new Request(UrlOverrides));
 		expect(fetchStub).to.have.been.calledOnceWithExactly(UrlBatch, {
@@ -239,7 +240,8 @@ describe('getLocalizeResources', () => {
 
 		expect(formatFuncSpy).to.have.been.callCount(1); // 1 cache key
 		expect(formatFuncSpy).to.have.been.calledWithExactly();
-		expect(openSpy).to.have.not.been.called; // in the window cache
+		expect(openSpy).to.always.have.been.calledWithExactly('d2l-oslo'); // in the window cache
+		expect(openSpy).to.have.callCount(2);
 		expect(matchSpy).to.have.not.been.called;
 		expect(fetchStub).to.have.not.been.called;
 		expect(putSpy).to.have.not.been.called;
@@ -262,7 +264,8 @@ describe('getLocalizeResources', () => {
 
 		expect(formatFuncSpy).to.have.been.callCount(1); // 1 cache key
 		expect(formatFuncSpy).to.have.been.calledWithExactly();
-		expect(openSpy).to.have.been.calledOnceWithExactly('d2l-oslo');
+		expect(openSpy).to.have.been.calledWithExactly('d2l-oslo');
+		expect(openSpy).to.have.callCount(3);
 		expect(matchSpy).to.have.been.callCount(1);
 		expect(matchSpy).to.have.been.calledWithMatch(new Request(UrlOverrides));
 		expect(fetchStub).to.have.not.been.called; // worker updated version with NextVersion


### PR DESCRIPTION
[DE41794](https://rally1.rallydev.com/#/110294864140d/dashboard?detail=%2Fdefect%2F466890048628)

This fixes an issue where Firefox private browsers could not use OSLO (and so not get overrides) because they would try to use the batch call but then fail when trying to open CacheStorage because it is not available in private mode.

**More info:**
https://bugzilla.mozilla.org/show_bug.cgi?id=1320796
https://bugzilla.mozilla.org/show_bug.cgi?id=1112134