### PR TITLE
fix: increase skeleton z-index

### DIFF
--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -18,7 +18,7 @@ export const skeletonStyles = css`
 		position: absolute;
 		right: 0;
 		top: 0;
-		z-index: 1;
+		z-index: 2;
 	}
 	@media (prefers-reduced-motion: reduce) {
 		:host([skeleton]) .d2l-skeletize::before {


### PR DESCRIPTION
The new html editor has a z-index = 1 on the toolbar, so the skeleton doesn't overlap it.

![image](https://user-images.githubusercontent.com/1471557/104494844-dbb7c100-558b-11eb-8fca-dc92c1c0ed2a.png)
