### PR TITLE
Remove code owners for the visual-diff goldens

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 *       @dbatiste @dlockhart @margaree @svanherk
 helpers/getLocalizeResources.js @BrightspaceUI/team-usa-devs @BrightspaceUI/team-usa-senior-devs
+golden/	no_one


### PR DESCRIPTION
This won't do a lot if you're watching the whole `core` repo anyways, but I think it would result in one less email.  If you aren't watching it, then you'd no longer get notified about the visual-diff PRs unless you caused the commit that opened it.  For whatever reason, I couldn't do `screenshots/ci/golden/`, I had to pick just one level.

Thoughts?