### PR TITLE
Fix CODEOWNERS for visual-diff goldens

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 *       @dbatiste @dlockhart @margaree @svanherk
 helpers/getLocalizeResources.js @BrightspaceUI/team-usa-devs @BrightspaceUI/team-usa-senior-devs
-golden/	no_one
+golden/


### PR DESCRIPTION
Actually, I think this is what we want.  The other canceled everything out for some reason.