### PR TITLE
Revert "fix: Verify cache storage is available before trying to use batch route"

### DIFF
--- a/helpers/getLocalizeResources.js
+++ b/helpers/getLocalizeResources.js
@@ -214,7 +214,7 @@ function fetchWithPooling(resource) {
 	return promise;
 }
 
-async function shouldUseBatchFetch() {
+function shouldUseBatchFetch() {
 
 	if (documentLocaleSettings === undefined) {
 		documentLocaleSettings = getDocumentLocaleSettings();
@@ -224,19 +224,10 @@ async function shouldUseBatchFetch() {
 		return false;
 	}
 
-	try {
+	// Only batch if we can do client-side caching, otherwise it's worse on each
+	// subsequent page navigation.
 
-		// try opening CacheStorage, if the session is in a private browser in firefox this throws an exception
-		await caches.open(CacheName);
-
-		// Only batch if we can do client-side caching, otherwise it's worse on each
-		// subsequent page navigation.
-
-		return Boolean(documentLocaleSettings.oslo.batch) && 'CacheStorage' in window;
-	} catch (err) {
-		return false;
-	}
-
+	return Boolean(documentLocaleSettings.oslo.batch) && 'CacheStorage' in window;
 }
 
 function shouldUseCollectionFetch() {
@@ -281,20 +272,20 @@ function getVersion() {
 	return documentLocaleSettings.oslo.version;
 }
 
-async function shouldFetchOverrides() {
+function shouldFetchOverrides() {
 
 	const isOsloAvailable =
-		await shouldUseBatchFetch() ||
+		shouldUseBatchFetch() ||
 		shouldUseCollectionFetch();
 
 	return isOsloAvailable;
 }
 
-async function fetchOverride(formatFunc) {
+function fetchOverride(formatFunc) {
 
 	let resource, res, requestURL;
 
-	if (await shouldUseBatchFetch()) {
+	if (shouldUseBatchFetch()) {
 
 		// If batching is available, pool requests together.
 
@@ -349,8 +340,8 @@ export async function getLocalizeOverrideResources(
 
 	promises.push(translations);
 
-	if (await shouldFetchOverrides()) {
-		const overrides = await fetchOverride(formatFunc);
+	if (shouldFetchOverrides()) {
+		const overrides = fetchOverride(formatFunc);
 		promises.push(overrides);
 	}
 
@@ -372,9 +363,9 @@ export async function getLocalizeResources(
 	const promises = [];
 	let supportedLanguage;
 
-	if (await shouldFetchOverrides()) {
+	if (shouldFetchOverrides()) {
 
-		const overrides = await fetchOverride(formatFunc, fetchFunc);
+		const overrides = fetchOverride(formatFunc, fetchFunc);
 		promises.push(overrides);
 	}
 

--- a/helpers/test/getLocalizeResources.test.js
+++ b/helpers/test/getLocalizeResources.test.js
@@ -208,8 +208,7 @@ describe('getLocalizeResources', () => {
 
 		expect(formatFuncSpy).to.have.been.callCount(1); // 1 lms
 		expect(formatFuncSpy).to.have.been.calledWithExactly();
-		expect(openSpy).to.always.have.been.calledWithExactly('d2l-oslo');
-		expect(openSpy).to.have.callCount(3);
+		expect(openSpy).to.have.been.calledOnceWithExactly('d2l-oslo');
 		expect(matchSpy).to.have.been.callCount(1);
 		expect(matchSpy).to.have.been.calledWithMatch(new Request(UrlOverrides));
 		expect(fetchStub).to.have.been.calledOnceWithExactly(UrlBatch, {
@@ -240,8 +239,7 @@ describe('getLocalizeResources', () => {
 
 		expect(formatFuncSpy).to.have.been.callCount(1); // 1 cache key
 		expect(formatFuncSpy).to.have.been.calledWithExactly();
-		expect(openSpy).to.always.have.been.calledWithExactly('d2l-oslo'); // in the window cache
-		expect(openSpy).to.have.callCount(2);
+		expect(openSpy).to.have.not.been.called; // in the window cache
 		expect(matchSpy).to.have.not.been.called;
 		expect(fetchStub).to.have.not.been.called;
 		expect(putSpy).to.have.not.been.called;
@@ -264,8 +262,7 @@ describe('getLocalizeResources', () => {
 
 		expect(formatFuncSpy).to.have.been.callCount(1); // 1 cache key
 		expect(formatFuncSpy).to.have.been.calledWithExactly();
-		expect(openSpy).to.have.been.calledWithExactly('d2l-oslo');
-		expect(openSpy).to.have.callCount(3);
+		expect(openSpy).to.have.been.calledOnceWithExactly('d2l-oslo');
 		expect(matchSpy).to.have.been.callCount(1);
 		expect(matchSpy).to.have.been.calledWithMatch(new Request(UrlOverrides));
 		expect(fetchStub).to.have.not.been.called; // worker updated version with NextVersion


### PR DESCRIPTION
Reverts BrightspaceUI/core#1036

Seems like OSLO is having issues on quad with one of the activity editor collections being a 404 (check cache storage for status codes), and this seems like the only recent change to OSLO. Not sure why it would cause the issue but gonna try a rollback just incase because I am off tomorrow.

![image](https://user-images.githubusercontent.com/2337524/104650945-f9b51c80-5684-11eb-8939-f9c24cccdcd7.png)
