### PR TITLE
calendar: reduce renders

### DIFF
--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -415,6 +415,8 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		);
 		if (dropdownContent) this._dialog = true;
 
+		this.addEventListener('blur', () => this._isInitialFocusDate = true);
+
 		this.addEventListener('d2l-localize-behavior-language-changed', () => {
 			calendarData = null;
 			getCalendarData(true);
@@ -795,8 +797,6 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		} else {
 			this._focusDateAddFocus();
 		}
-		await this.updateComplete;
-		this._isInitialFocusDate = true;
 	}
 
 	_triggerMonthChangeAnimations(increase, keyboardTriggered, transitionUpDown) {
@@ -811,7 +811,12 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	async _updateFocusDate(possibleFocusDate, latestPossibleFocusDate, allowDisabled) {
-		await this.updateComplete;
+		if (!this.minValue && !this.maxValue) {
+			this._focusDate = possibleFocusDate;
+			return true;
+		}
+
+		await this.updateComplete; // for case of keyboard navigation where second month contains no enabled dates
 		if (isDateInRange(possibleFocusDate, getDateFromISODate(this.minValue), getDateFromISODate(this.maxValue)) || allowDisabled) {
 			this._focusDate = possibleFocusDate;
 			return true;

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -557,7 +557,6 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		else date = getDateFromISODate(getClosestValidDate(this.minValue, this.maxValue, false));
 		this._shownMonth = date.getMonth();
 		this._shownYear = date.getFullYear();
-		await this.updateComplete;
 		await this._updateFocusDate(date, false, allowDisabled);
 	}
 
@@ -597,6 +596,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		const date = selectedDate.getAttribute('data-date');
 
 		this.selectedValue = formatDateInISO({ year: year, month: (parseInt(month) + 1), date: date });
+		this._dateSelected = true;
 
 		const eventDetails = {
 			bubbles: true,
@@ -604,8 +604,6 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			detail: { date: this.selectedValue }
 		};
 		this.dispatchEvent(new CustomEvent('d2l-calendar-selected', eventDetails));
-		await this._updateFocusDateOnChange();
-		this._focusDateAddFocus();
 	}
 
 	async _onKeyDown(e) {
@@ -838,6 +836,11 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		const selectedValueDate = this.selectedValue ? getDateFromISODate(this.selectedValue) : null;
 		const dateElem = selectedValueDate ? await this._getDateElement(selectedValueDate) : null;
 		await this._updateFocusDate(dateElem ? selectedValueDate : new Date(this._shownYear, this._shownMonth, 1));
+
+		if (this._dateSelected) {
+			this._focusDateAddFocus();
+			this._dateSelected = false;
+		}
 	}
 
 }

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -535,6 +535,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			if (prop === '_shownMonth' && this._keyboardTriggeredMonthChange) {
 				this._focusDateAddFocus();
 			} else if (prop === 'selectedValue' && this.selectedValue) {
+				await this.updateComplete;
 				await this._updateFocusDateOnChange();
 			}
 		});
@@ -834,7 +835,6 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	async _updateFocusDateOnChange() {
-		await this.updateComplete;
 		const selectedValueDate = this.selectedValue ? getDateFromISODate(this.selectedValue) : null;
 		const dateElem = selectedValueDate ? await this._getDateElement(selectedValueDate) : null;
 		await this._updateFocusDate(dateElem ? selectedValueDate : new Date(this._shownYear, this._shownMonth, 1));

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -424,7 +424,9 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		});
 
 		this._today = getDateFromDateObj(getToday());
-		this._getInitialFocusDate();
+		if (this.selectedValue) this._getInitialFocusDate();
+		else this.reset();
+
 	}
 
 	render() {

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -537,7 +537,8 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			if (prop === '_shownMonth' && this._keyboardTriggeredMonthChange) {
 				this._focusDateAddFocus();
 			} else if (prop === 'selectedValue' && this.selectedValue) {
-				if (!this._focusDate || !checkIfDatesEqual(this._focusDate, getDateFromISODate(this.selectedValue))) {
+				const selectedDate = getDateFromISODate(this.selectedValue);
+				if (!this._focusDate || !checkIfDatesEqual(this._focusDate, selectedDate)) {
 					await this.updateComplete;
 					await this._updateFocusDateOnChange();
 				}
@@ -820,9 +821,8 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	async _updateFocusDate(possibleFocusDate, latestPossibleFocusDate, allowDisabled) {
-		if ((!this.minValue && !this.maxValue)
-			|| (isDateInRange(possibleFocusDate, getDateFromISODate(this.minValue), getDateFromISODate(this.maxValue)) || allowDisabled)
-		) {
+		const possibleFocusDateInRange = isDateInRange(possibleFocusDate, getDateFromISODate(this.minValue), getDateFromISODate(this.maxValue));
+		if ((!this.minValue && !this.maxValue) || possibleFocusDateInRange || allowDisabled) {
 			this._focusDate = possibleFocusDate;
 			return true;
 		}

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -424,7 +424,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		});
 
 		this._today = getDateFromDateObj(getToday());
-		this.reset();
+		this._getInitialFocusDate();
 	}
 
 	render() {
@@ -552,11 +552,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	async reset(allowDisabled) {
-		let date;
-		if (this.selectedValue) date = getDateFromISODate(this.selectedValue);
-		else date = getDateFromISODate(getClosestValidDate(this.minValue, this.maxValue, false));
-		this._shownMonth = date.getMonth();
-		this._shownYear = date.getFullYear();
+		const date = this._getInitialFocusDate();
 		await this._updateFocusDate(date, false, allowDisabled);
 	}
 
@@ -576,6 +572,15 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	async _getDateElement(date) {
 		await this.updateComplete;
 		return this.shadowRoot.querySelector(`td[data-date="${date.getDate()}"][data-month="${date.getMonth()}"][data-year="${date.getFullYear()}"]`);
+	}
+
+	_getInitialFocusDate() {
+		let date;
+		if (this.selectedValue) date = getDateFromISODate(this.selectedValue);
+		else date = getDateFromISODate(getClosestValidDate(this.minValue, this.maxValue, false));
+		this._shownMonth = date.getMonth();
+		this._shownYear = date.getFullYear();
+		return date;
 	}
 
 	_monthDecrease() {


### PR DESCRIPTION
The biggest culprits were:
- `_focusDate` which sometimes was being set to the same value multiple times, so work was done to minimize that.
- Unnecessary `await this.updateComplete`