### PR TITLE
fix: suppressing iOS's rounded corners on search inputs

### DIFF
--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -61,7 +61,7 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 					display: none;
 				}
 				.d2l-input {
-					-webkit-appearance: textfield;
+					-webkit-appearance: none;
 					overflow: hidden;
 					padding-right: 2.2rem;
 					text-overflow: ellipsis;


### PR DESCRIPTION
`-webkit-appearance: none` seems to be [the way to fix this](https://css-tricks.com/almanac/properties/a/appearance/).

Before:
![Screen Shot 2021-01-21 at 6 30 26 PM](https://user-images.githubusercontent.com/5491151/105425129-c3dcde80-5c16-11eb-88b2-ec96adc46f88.png)

After:
![Screen Shot 2021-01-21 at 6 30 12 PM](https://user-images.githubusercontent.com/5491151/105425149-cccdb000-5c16-11eb-8dfa-45c81116ff59.png)
