### PR TITLE
Temporarily adding this method to facilitate transition.

### DIFF
--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -231,6 +231,11 @@ class InputTextArea extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))
 		}
 	}
 
+	get textarea() {
+		// temporary until consumers are updated
+		return this.shadowRoot.querySelector('textarea');
+	}
+
 	get validationMessage() {
 		if (this.validity.tooShort) {
 			return this.localize('components.form-element.input.text.tooShort', { label: this.label, minlength: formatNumber(this.minlength) });


### PR DESCRIPTION
Adding this property temporarily so that we can switch consumers to use this component.  This will be removed once consumers are updated to stop accessing the textarea directly.