### PR TITLE
input-date: use resizeobserver for getting hiddenContentWidth

### DIFF
--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -134,7 +134,6 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		this._dropdownOpened = false;
 		this._dropdownFirstOpened = false;
 		this._formattedValue = '';
-		this._hiddenContentResizeObserver = null;
 		this._hiddenContentWidth = '8rem';
 		this._inputId = getUniqueId();
 		this._inputTextFocusMouseup = false;
@@ -144,15 +143,6 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		this._shownValue = '';
 
 		this._dateTimeDescriptor = getDateTimeDescriptorShared();
-	}
-
-	disconnectedCallback() {
-		super.disconnectedCallback();
-
-		if (this._hiddenContentResizeObserver) {
-			this._hiddenContentResizeObserver.disconnect();
-			this._hiddenContentResizeObserver = null;
-		}
 	}
 
 	async firstUpdated(changedProperties) {

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -13,6 +13,7 @@ import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
+import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
@@ -133,6 +134,7 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		this._dropdownOpened = false;
 		this._dropdownFirstOpened = false;
 		this._formattedValue = '';
+		this._hiddenContentResizeObserver = null;
 		this._hiddenContentWidth = '8rem';
 		this._inputId = getUniqueId();
 		this._inputTextFocusMouseup = false;
@@ -142,6 +144,15 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		this._shownValue = '';
 
 		this._dateTimeDescriptor = getDateTimeDescriptorShared();
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+
+		if (this._hiddenContentResizeObserver) {
+			this._hiddenContentResizeObserver.disconnect();
+			this._hiddenContentResizeObserver = null;
+		}
 	}
 
 	async firstUpdated(changedProperties) {
@@ -165,8 +176,14 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		this._formattedValue = this.emptyText ? this.emptyText : '';
 
 		await (document.fonts ? document.fonts.ready : Promise.resolve());
-		const width = Math.ceil(parseFloat(getComputedStyle(this.shadowRoot.querySelector('.d2l-input-date-hidden-content')).getPropertyValue('width')));
-		this._hiddenContentWidth = `${width}px`;
+
+		const hiddenContent = this.shadowRoot.querySelector('.d2l-input-date-hidden-content');
+		this._hiddenContentResizeObserver = this._hiddenContentResizeObserver || new ResizeObserver(() => {
+			const width = Math.ceil(parseFloat(getComputedStyle(hiddenContent).getPropertyValue('width')));
+			this._hiddenContentWidth = `${width}px`;
+		});
+		this._hiddenContentResizeObserver.disconnect();
+		this._hiddenContentResizeObserver.observe(hiddenContent);
 	}
 
 	render() {
@@ -180,7 +197,7 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 			? html`<d2l-icon icon="tier1:alert" slot="left" style="${styleMap({ color: 'var(--d2l-color-cinnabar)' })}"></d2l-icon>`
 			: html`<d2l-icon icon="tier1:calendar" slot="left"></d2l-icon>`;
 		const errorTooltip = (this.validationError && !this._dropdownOpened && this.childErrors.size === 0) ? html`<d2l-tooltip align="start" announced for="${this._inputId}" state="error">${this.validationError}</d2l-tooltip>` : null;
-		const infoTooltip = (this._showInfoTooltip && !errorTooltip && !this.invalid && this.childErrors.size === 0 && !this.skeleton && this._inputTextFocusShowTooltip) ? html`<d2l-tooltip align="start" announced delay="1000" for="${this._inputId}">${this.localize(`${this._namespace}.openInstructions`, { format: shortDateFormat })}</d2l-tooltip>` : null;
+		const infoTooltip = (this._showInfoTooltip && !errorTooltip && !this.invalid && !this.disabled && this.childErrors.size === 0 && !this.skeleton && this._inputTextFocusShowTooltip) ? html`<d2l-tooltip align="start" announced delay="1000" for="${this._inputId}">${this.localize(`${this._namespace}.openInstructions`, { format: shortDateFormat })}</d2l-tooltip>` : null;
 
 		const dropdownContent = this._dropdownFirstOpened ? html`
 			<d2l-dropdown-content

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -178,11 +178,10 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		await (document.fonts ? document.fonts.ready : Promise.resolve());
 
 		const hiddenContent = this.shadowRoot.querySelector('.d2l-input-date-hidden-content');
-		this._hiddenContentResizeObserver = this._hiddenContentResizeObserver || new ResizeObserver(() => {
+		this._hiddenContentResizeObserver = new ResizeObserver(() => {
 			const width = Math.ceil(parseFloat(getComputedStyle(hiddenContent).getPropertyValue('width')));
 			this._hiddenContentWidth = `${width}px`;
 		});
-		this._hiddenContentResizeObserver.disconnect();
 		this._hiddenContentResizeObserver.observe(hiddenContent);
 	}
 


### PR DESCRIPTION
This was noticed in activities where the input-date was unnecessarily wide. The input is initially hidden and so the hidden divs here that are used to calculate the maxWidth don't actually have widths themselves when `firstUpdated` is run. I moved this calculation into a ResizeObserver which seems to solve this issue.

In fixing this I also noticed that the info tooltip was showing up when the input-date was disabled so I hid that.