### PR TITLE
change top position for d2l-dialog on mobile

### DIFF
--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -68,9 +68,9 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
 
 				.d2l-dialog-outer {
-					height: calc(100vh - 42px) !important;
+					height: calc(100vh - var(--d2l-dialog-mobile-top, 42px)) !important;
 					margin: 0 !important;
-					top: 42px;
+					top: var(--d2l-dialog-mobile-top, 42px);
 					width: 100vw !important;
 				}
 

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -68,10 +68,10 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
 
 				.d2l-dialog-outer {
-					height: calc(100vh - var(--d2l-dialog-mobile-top, 42px)) !important;
-					margin: 0 !important;
-					top: var(--d2l-dialog-mobile-top, 42px);
+					top: 0;
+					height: 100vh !important;
 					width: 100vw !important;
+					margin: 0 !important;
 				}
 
 				div[nested].d2l-dialog-outer {


### PR DESCRIPTION
On mobile devices the d2l-dialog has default top offset of 42px. 
In some cases the bottom of the dialog is cutoff by device borders.
Suggested: use custom css property to pass top value. ( or use by default `top:0px`)
 See  screenshot and  rally DE42182   
![Cutoff+Browse+AcivityLibrary+on+Android](https://user-images.githubusercontent.com/14826663/106044040-346b7b80-60ad-11eb-9f2d-d0bbb091e1ef.jpeg)


Here is screenshot for suggested change: 
![image](https://user-images.githubusercontent.com/14826663/106155199-684aad80-614e-11eb-894f-5acc65746350.png)
