### PR TITLE
fix: using window's inner height/width instead of vh/vw units

### DIFF
--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -1,5 +1,6 @@
 import '../button/button-icon.js';
 import '../loading-spinner/loading-spinner.js';
+import '../../helpers/viewport-size.js';
 import { AsyncContainerMixin, asyncStates } from '../../mixins/async-container/async-container-mixin.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
@@ -68,10 +69,10 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
 
 				.d2l-dialog-outer {
-					height: calc(100vh - 42px) !important;
 					margin: 0 !important;
+					min-height: calc(var(--d2l-vh, 1vh) * 100 - 42px);
+					min-width: calc(var(--d2l-vw, 1vw) * 100);
 					top: 42px;
-					width: 100vw !important;
 				}
 
 				div[nested].d2l-dialog-outer {

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -173,3 +173,23 @@ import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 // gets a unique indexed id (for lifetime of page)
 getUniqueId();
 ```
+
+## Viewport Size
+
+Background: the `vh` (viewport height) and `vw` (viewport width) CSS units will often reflect a mobile device's full screen size, instead of the browser window size. Device chrome (like the browser URL bar or device-specific toolbars) takes up space within that viewport, which often causes elements sized using `vh` or `vw` to be sized or positioned incorrectly.
+
+This helper provides CSS custom properties `--d2l-vh` and `--d2l-vw` for use in place of `vh` and `vw` units. They will equal `1%` of the value of `window.innerHeight` and `window.innerWidth` respectively.
+
+Including the helper will set up the variables and add an event listener to update them when the browser resizes:
+
+```javascript
+import '@brightspace-ui/core/helpers/viewport-size.js';
+```
+
+```css
+.full-screen-elem {
+    min-height: calc(var(--d2l-vh, 1vh) * 100);
+    min-width: calc(var(--d2l-vw, 1vw) * 100);
+}
+```
+

--- a/helpers/viewport-size.js
+++ b/helpers/viewport-size.js
@@ -1,0 +1,28 @@
+let vh, vw;
+let ticking = false;
+
+function requestTick() {
+	if (!ticking) {
+		requestAnimationFrame(update);
+	}
+	ticking = true;
+}
+
+function update() {
+	ticking = false;
+	document.documentElement.style.setProperty('--d2l-vh', `${vh}px`);
+	document.documentElement.style.setProperty('--d2l-vw', `${vw}px`);
+}
+
+function onResize() {
+	vh = window.innerHeight * 0.01;
+	vw = window.innerWidth * 0.01;
+	requestTick();
+}
+
+let installed = false;
+if (!installed) {
+	installed = true;
+	window.addEventListener('resize', onResize);
+}
+onResize();


### PR DESCRIPTION
This is an alternate solution to #1074 -- thank you @AKobets for bringing this to our attention!

This bug was introduced back in November when we [switched from % units to viewport units](#966). That solved a bunch of problems, but also introduced a new one. Mobile devices use the full device size for `vh` and `vw`, _including_ any browser/device chrome above or below the actual browser viewport. Sometimes that chrome slides away when the user scrolls, which is why [they made this choice](https://bugs.webkit.org/show_bug.cgi?id=141832).

The solution I'm going with here is the one [discussed in this blog post](https://bugs.webkit.org/show_bug.cgi?id=141832). It uses JavaScript to expose the `window.innerHeight` and `window.innerWidth` as CSS custom properties. Then our CSS can use those custom properties instead of the `vh`/`vw` units.

To make this reusable  and to centralize the `resize` event handler registration, I've put this into a helper. The helper also throttles the update using `requestAnimationFrame`, a technique described in the [related post](https://css-tricks.com/debouncing-throttling-explained-examples/).