### PR TITLE
fix: let width of confirmation dialog be specified.

### DIFF
--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -115,6 +115,7 @@ document.querySelector('#open').addEventListener('click', () => {
 | `text` | String, required | The required text content for the confirmation dialog |
 | `opened` | Boolean | Whether or not the dialog is open |
 | `title-text` | String | The optional title for the confirmation dialog |
+| `width` | Number, default: `420` | The preferred width (unit-less) for the dialog |
 
 **Events:**
 

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -11,6 +11,9 @@ import { heading3Styles } from '../typography/styles.js';
  * @fires d2l-dialog-open - Dispatched when the dialog is opened
  * @fires d2l-dialog-close - Dispatched with the action value when the dialog is closed for any reason
  */
+
+const defaultWidth = 420;
+
 class DialogConfirm extends DialogMixin(LitElement) {
 
 	static get properties() {
@@ -18,16 +21,17 @@ class DialogConfirm extends DialogMixin(LitElement) {
 			/**
 			 * REQUIRED: The text content for the confirmation dialog
 			 */
-			text: { type: String }
+			text: { type: String },
+
+			/**
+			 * The optional width for the dialog
+			 */
+			width: { type: Number },
 		};
 	}
 
 	static get styles() {
 		return [ dialogStyles, heading3Styles, css`
-
-			.d2l-dialog-outer {
-				max-width: 420px;
-			}
 
 			.d2l-dialog-content > div {
 				padding-top: 30px;
@@ -95,7 +99,11 @@ class DialogConfirm extends DialogMixin(LitElement) {
 	}
 
 	_getWidth() {
-		/* override default width measurement and just use max-width */
+		if (this.width) {
+			return this.width;
+		} else {
+			return defaultWidth;
+		}
 	}
 
 }


### PR DESCRIPTION
I want to make the confirm dialog wider. Let me know if there was a reason why we had the max width/some reason why I shouldn't make this change!