### PR TITLE
fix: list-item-link gap caused by border

### DIFF
--- a/components/list/list-item-link-mixin.js
+++ b/components/list/list-item-link-mixin.js
@@ -26,7 +26,9 @@ export const ListItemLinkMixin = superclass => class extends ListItemMixin(super
 			a[href] {
 				display: block;
 				height: 100%;
+				margin-top: -1px;
 				outline: none;
+				padding: 1px 0;
 				width: 100%;
 			}
 			:host([skeleton]) a[href] {


### PR DESCRIPTION
The list-item border causes links not to cover the entire element, leaving 1px at the top where the element can be hovered/clicked without engaging the link.

![list-item-link-coverage-2](https://user-images.githubusercontent.com/1289042/106472264-7fe8a580-6470-11eb-961e-dbc45464b99b.gif)
