### PR TITLE
fix: list-item-link gap caused by border

### DIFF
--- a/components/list/list-item-link-mixin.js
+++ b/components/list/list-item-link-mixin.js
@@ -19,16 +19,14 @@ export const ListItemLinkMixin = superclass => class extends ListItemMixin(super
 			:host([action-href]:not([action-href=""])) {
 				--d2l-list-item-content-text-color: var(--d2l-color-celestine);
 			}
-			:host([action-href]:not([action-href=""]):not([skeleton])) d2l-list-item-generic-layout.d2l-focusing,
-			:host([action-href]:not([action-href=""]):not([skeleton])) d2l-list-item-generic-layout.d2l-hovering {
+			:host([action-href]:not([action-href=""]):not([skeleton])) [slot="content"].d2l-focusing,
+			:host([action-href]:not([action-href=""]):not([skeleton])) [slot="content"].d2l-hovering {
 				background-color: var(--d2l-color-regolith);
 			}
 			a[href] {
 				display: block;
 				height: 100%;
-				margin-top: -1px;
 				outline: none;
-				padding: 1px 0;
 				width: 100%;
 			}
 			:host([skeleton]) a {

--- a/components/list/list-item-link-mixin.js
+++ b/components/list/list-item-link-mixin.js
@@ -26,7 +26,9 @@ export const ListItemLinkMixin = superclass => class extends ListItemMixin(super
 			a[href] {
 				display: block;
 				height: 100%;
+				margin-top: -1px;
 				outline: none;
+				padding: 1px 0;
 				width: 100%;
 			}
 			:host([skeleton]) a {


### PR DESCRIPTION
The list-item border causes links not to cover the entire element, leaving 1px at the top where the element can be hovered/clicked without engaging the link.

![list-item-link-coverage-2](https://user-images.githubusercontent.com/1289042/106473522-de625380-6471-11eb-9adc-4b6a65a66199.gif)
