### PR TITLE
dropdown: use opener's parent for running getBoundingAncestor

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -472,7 +472,7 @@ export const DropdownContentMixin = superclass => class extends RtlMixin(supercl
 		this._width = null;
 
 		const openerPosition = window.getComputedStyle(opener, null).getPropertyValue('position');
-		const boundingContainer = getBoundingAncestor(target);
+		const boundingContainer = getBoundingAncestor(target.parentNode);
 		const boundingContainerRect = boundingContainer.getBoundingClientRect();
 		const scrollHeight = boundingContainer.scrollHeight;
 


### PR DESCRIPTION
This is to fix the case with html editor where the dropdowns are opening in the incorrect direction. I found that the values used in the left position calculation here https://github.com/BrightspaceUI/core/blob/master/components/dropdown/dropdown-content-mixin.js#L591 seemed really off (e.g., target width was 44, space around was -20) and that if I set bounded to false then things were fine. I also noticed that `getBoundingAncestor` for these cases was just returning the opener (`d2l-button-subtle`) since it was going into this case https://github.com/BrightspaceUI/core/blob/master/helpers/dom.js#L17. This is one of those fixes where it fixes the case at hand and the visual diffs locally were fine but I don't know if it was like this for a reason.