### PR TITLE
Add d2l-list-item-link-click event so consumers can use (ex. telemetry).

### DIFF
--- a/components/list/README.md
+++ b/components/list/README.md
@@ -84,6 +84,10 @@ The `d2l-list-item` provides the appropriate `listitem` semantics for children w
 |--|--|--|
 | `href` | String | Address of item link if navigable |
 
+**Events**
+
+- `d2l-list-item-link-click`: dispatched when the item's primary link action is clicked
+
 ## d2l-list-item-button
 
 The `d2l-list-item-button` provides the same functionality as `d2l-list-item` except with button semantics for its primary action. It extends `ListItemButtonMixin` and `ListItemMixin` and has all the same use cases as the mixin.

--- a/components/list/demo/list-item-actions.html
+++ b/components/list/demo/list-item-actions.html
@@ -44,7 +44,7 @@
 
 			<h2>Navigation (href) Primary Action</h2>
 
-			<d2l-demo-snippet>
+			<d2l-demo-snippet id="link-demo">
 				<template>
 					<d2l-list>
 						<d2l-list>
@@ -59,6 +59,11 @@
 							</d2l-list-item>
 						</d2l-list>
 					</d2l-list>
+					<script>
+						document.querySelector('#link-demo').addEventListener('d2l-list-item-link-click', (e) => {
+							console.log('d2l-list-item-link clicked!', e);
+						});
+					</script>
 				</template>
 			</d2l-demo-snippet>
 
@@ -159,7 +164,7 @@
 
 			<h2>Selection & Navigation (href) Primary Action</h2>
 
-			<d2l-demo-snippet>
+			<d2l-demo-snippet id="selection-link-demo">
 				<template>
 					<d2l-list>
 						<d2l-list-item href="http://www.d2l.com" selectable key="1">
@@ -172,6 +177,11 @@
 							<d2l-list-item-content>Geomorphology and GIS</d2l-list-item-content>
 						</d2l-list-item>
 					</d2l-list>
+					<script>
+						document.querySelector('#selection-link-demo').addEventListener('d2l-list-item-link-click', (e) => {
+							console.log('d2l-list-item-link clicked!', e);
+						});
+					</script>
 				</template>
 			</d2l-demo-snippet>
 
@@ -200,7 +210,7 @@
 
 			<h2>Grid Actions with Navigation (href) Primary Action</h2>
 
-			<d2l-demo-snippet>
+			<d2l-demo-snippet id="grid-link-demo">
 				<template>
 					<d2l-list grid>
 						<d2l-list-item href="http://www.d2l.com" selectable key="1">
@@ -222,6 +232,11 @@
 							</div>
 						</d2l-list-item>
 					</d2l-list>
+					<script>
+						document.querySelector('#grid-link-demo').addEventListener('d2l-list-item-link-click', (e) => {
+							console.log('d2l-list-item-link clicked!', e);
+						});
+					</script>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/list/list-item-link-mixin.js
+++ b/components/list/list-item-link-mixin.js
@@ -43,9 +43,13 @@ export const ListItemLinkMixin = superclass => class extends ListItemMixin(super
 		this.actionHref = null;
 	}
 
+	_handleLinkClick() {
+		this.dispatchEvent(new CustomEvent('d2l-list-item-link-click', { bubbles: true }));
+	}
+
 	_renderPrimaryAction(labelledBy) {
 		if (!this.actionHref) return;
-		return html`<a aria-labelledby="${labelledBy}" href="${this.actionHref}"></a>`;
+		return html`<a aria-labelledby="${labelledBy}" href="${this.actionHref}" @click="${this._handleLinkClick}"></a>`;
 	}
 
 };

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -41,6 +41,12 @@ describe('d2l-list-item-button', () => {
 
 	describe('events', () => {
 
+		it('dispatches d2l-list-item-link-click event when clicked', async() => {
+			const el = await fixture(html`<d2l-list-item action-href="javascript:void(0)"></d2l-list-item>`);
+			setTimeout(() => el.shadowRoot.querySelector('a').click());
+			await oneEvent(el, 'd2l-list-item-link-click');
+		});
+
 		it('dispatches d2l-list-item-button-click event when clicked', async() => {
 			const el = await fixture(html`<d2l-list-item-button></d2l-list-item-button>`);
 			setTimeout(() => el.shadowRoot.querySelector('button').click());


### PR DESCRIPTION
This PR surfaces a custom event for the primary navigation action on list items, so that consumers can wire-up for things like telemetry.  Without this, consumers are forced to wire-up click and key handlers on the list-item, which doesn't always translate to navigation when there are other things the user can interact with, such as selection, drag & drop, secondary actions, etc.