### PR TITLE
fix: list-item hover gap caused by border

### DIFF
--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -596,7 +596,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 
 	_renderDragTarget(templateMethod) {
 		templateMethod = templateMethod || (dragTarget => dragTarget);
-		return this.draggable && !this._keyboardActive ? templateMethod(html`
+		return this.draggable && !this._keyboardActive ? templateMethod.call(this, html`
 			<div
 				class="d2l-list-item-drag-area"
 				draggable="true"

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -330,8 +330,6 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 	}
 
 	firstUpdated(changedProperties) {
-		this.addEventListener('mouseenter', this._onMouseEnter.bind(this));
-		this.addEventListener('mouseleave', this._onMouseLeave.bind(this));
 		this.addEventListener('dragenter', this._onHostDragEnter.bind(this));
 		super.firstUpdated(changedProperties);
 	}
@@ -494,14 +492,6 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		dragState.addDropTarget(this);
 		this._draggingOver = true;
 		e.dataTransfer.dropEffect = 'move';
-	}
-
-	_onMouseEnter() {
-		this._hovering = true;
-	}
-
-	_onMouseLeave() {
-		this._hovering = false;
 	}
 
 	_onTouchCancel() {

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -368,7 +368,7 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 	}
 
 	_renderOutsideControlAction(dragTarget) {
-		return html`<div slot="outside-control-action">${dragTarget}</div>`;
+		return html`<div slot="outside-control-action" @mouseenter="${this._onMouseEnter}" @mouseleave="${this._onMouseLeave}">${dragTarget}</div>`;
 	}
 
 };

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -179,9 +179,8 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 				margin-left: 0.9rem;
 				margin-right: 0;
 			}
-			:host([selectable]:not([disabled]):not([draggable]):not([skeleton]):hover) d2l-list-item-generic-layout,
 			:host([selectable]:not([disabled]):not([skeleton])) d2l-list-item-generic-layout.d2l-focusing,
-			:host([selectable][draggable]:not([disabled]):not([skeleton])) d2l-list-item-generic-layout.d2l-hovering {
+			:host([selectable]:not([disabled]):not([skeleton])) d2l-list-item-generic-layout.d2l-hovering {
 				background-color: var(--d2l-color-regolith);
 			}
 			:host([selected]:not([disabled])) d2l-list-item-generic-layout {
@@ -273,6 +272,7 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 
 	_onFocusInPrimaryAction() {
 		this._focusingPrimaryAction = true;
+		this._focusing = true;
 	}
 
 	_onFocusOut() {
@@ -281,14 +281,25 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 
 	_onFocusOutPrimaryAction() {
 		this._focusingPrimaryAction = false;
+		this._focusing = false;
+	}
+
+	_onMouseEnter() {
+		this._hovering = true;
 	}
 
 	_onMouseEnterPrimaryAction() {
 		this._hoveringPrimaryAction = true;
+		this._hovering = true;
+	}
+
+	_onMouseLeave() {
+		this._hovering = false;
 	}
 
 	_onMouseLeavePrimaryAction() {
 		this._hoveringPrimaryAction = false;
+		this._hovering = false;
 	}
 
 	_renderListItem({ illustration, content, actions } = {}) {
@@ -321,7 +332,11 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 					${this._renderDragTarget(this._renderOutsideControlAction)}
 					${this.selectable ? html`
 					<div slot="control">${ this._renderCheckbox() }</div>
-					<div slot="control-action">${ this._renderCheckboxAction('', this._contentId) }</div>` : nothing }
+					<div slot="control-action"
+						@mouseenter="${this._onMouseEnter}"
+						@mouseleave="${this._onMouseLeave}">
+							${ this._renderCheckboxAction('', this._contentId) }
+					</div>` : nothing }
 					${primaryAction ? html`
 					<div slot="content-action"
 						@focusin="${this._onFocusInPrimaryAction}"
@@ -336,7 +351,10 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 						<slot name="illustration" class="d2l-list-item-illustration">${illustration}</slot>
 						<slot>${content}</slot>
 					</div>
-					<div class="d2l-list-item-actions-container" slot="actions">
+					<div slot="actions"
+						@mouseenter="${this._onMouseEnter}"
+						@mouseleave="${this._onMouseLeave}"
+						class="d2l-list-item-actions-container">
 						<slot name="actions" class="d2l-list-item-actions">${actions}</slot>
 					</div>
 				</d2l-list-item-generic-layout>

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -272,7 +272,6 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 
 	_onFocusInPrimaryAction() {
 		this._focusingPrimaryAction = true;
-		this._focusing = true;
 	}
 
 	_onFocusOut() {
@@ -281,7 +280,6 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 
 	_onFocusOutPrimaryAction() {
 		this._focusingPrimaryAction = false;
-		this._focusing = false;
 	}
 
 	_onMouseEnter() {


### PR DESCRIPTION
All hover effects should _not_ be triggered by hovering `d2l-list-item-generic-layout` itself, but by hovering its child elements (inside its 1px borders).

This prevents the background color from changing before any actionable child elements are hovered.

Fix is for all action, button, and selectable list-items.

(green background color is just for GIF contrast)
![hover-gap](https://user-images.githubusercontent.com/1289042/106612028-a244f680-6536-11eb-8049-4869943aeadb.gif)
