### PR TITLE
input-date-time-range: attempt to fix flaky tests

### DIFF
--- a/components/inputs/test/input-date-time-range.test.js
+++ b/components/inputs/test/input-date-time-range.test.js
@@ -39,11 +39,12 @@ describe('d2l-input-date-time-range', () => {
 
 			describe(`getShiftedEndDateTime in ${timezone}`, () => {
 
-				beforeEach(() => {
+				before(async() => {
 					documentLocaleSettings.timezone.identifier = timezone;
+					await aTimeout(5); // Fixes flaky tests likely caused by timezone not yet being set
 				});
 
-				afterEach(() => {
+				after(() => {
 					documentLocaleSettings.timezone.identifier = 'America/Toronto';
 				});
 

--- a/components/inputs/test/input-date-time-range.test.js
+++ b/components/inputs/test/input-date-time-range.test.js
@@ -41,7 +41,7 @@ describe('d2l-input-date-time-range', () => {
 
 				before(async() => {
 					documentLocaleSettings.timezone.identifier = timezone;
-					await aTimeout(5); // Fixes flaky tests likely caused by timezone not yet being set
+					await aTimeout(10); // Fixes flaky tests likely caused by timezone not yet being set
 				});
 
 				after(() => {


### PR DESCRIPTION
Opening as draft in order to rerun the tests several times.

Should fix https://github.com/BrightspaceUI/core/issues/1083.

This is likely cause by the same problem as https://github.com/BrightspaceUI/core/pull/1101, which is the timezone not yet being set, and there isn't an event to listen to that I'm aware of so a timeout should help with this.

