### PR TITLE
Add support for dynamically imported translation resources

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,9 @@
 {
   "extends": "brightspace/lit-config",
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+			"requireConfigFile": false
+  },
   "globals": {
     "Prism": false
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "extends": "brightspace/lit-config",
   "parser": "@babel/eslint-parser",
   "parserOptions": {
-			"requireConfigFile": false
+    "requireConfigFile": false
   },
   "globals": {
     "Prism": false

--- a/mixins/localize-dynamic-mixin.js
+++ b/mixins/localize-dynamic-mixin.js
@@ -1,7 +1,9 @@
 import { getLocalizeOverrideResources } from '../helpers/getLocalizeResources.js';
 import { LocalizeMixin } from './localize-mixin.js';
 
+/*** WARNING! ¡ATENCIÓN! ACHTUNG! Adding to defaultLangs MUST be a BREAKING change with a MAJOR version bump! ***/
 const defaultLangs = ['ar', 'cy-gb', 'cy', 'da', 'de', 'en', 'es-es', 'es', 'fr-ca', 'fr', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh-tw', 'zh'];
+/****************************************************************************************************************/
 const fallbackLang = 'en';
 const defaultExportName = 'default';
 
@@ -17,8 +19,8 @@ export const LocalizeDynamicMixin = superclass => class extends LocalizeMixin(su
 		for (const lang of [...langs, fallbackLang]) {
 
 			if (supportedLangs.includes(lang)) {
-				const mod = await importFunc(lang);
-				const resources = mod[exportName];
+				const mod = await importFunc(lang).catch(() => {});
+				const resources = mod && mod[exportName];
 
 				if (resources) {
 

--- a/mixins/localize-dynamic-mixin.js
+++ b/mixins/localize-dynamic-mixin.js
@@ -1,0 +1,41 @@
+import { getLocalizeOverrideResources } from '../helpers/getLocalizeResources.js';
+import { LocalizeMixin } from './localize-mixin.js';
+
+const defaultLangs = ['ar', 'cy-gb', 'cy', 'da', 'de', 'en', 'es-es', 'es', 'fr-ca', 'fr', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh-tw', 'zh'];
+const fallbackLang = 'en';
+const defaultExportName = 'default';
+
+export const LocalizeDynamicMixin = superclass => class extends LocalizeMixin(superclass) {
+
+	static get config() {
+		return {};
+	}
+
+	static async getLocalizeResources(langs, config) {
+		const { importFunc, osloCollection, supportedLangs = defaultLangs, exportName = defaultExportName } = config;
+
+		for (const lang of [...langs, fallbackLang]) {
+
+			if (supportedLangs.includes(lang)) {
+				const mod = await importFunc(lang);
+				const resources = mod[exportName];
+
+				if (resources) {
+
+					if (osloCollection) {
+						return await getLocalizeOverrideResources(
+							lang,
+							resources,
+							() => osloCollection
+						);
+					}
+
+					return {
+						language: lang,
+						resources
+					};
+				}
+			}
+		}
+	}
+};

--- a/mixins/localize-dynamic-mixin.js
+++ b/mixins/localize-dynamic-mixin.js
@@ -2,36 +2,26 @@ import { getLocalizeOverrideResources } from '../helpers/getLocalizeResources.js
 import { LocalizeMixin } from './localize-mixin.js';
 
 const fallbackLang = 'en';
-const defaultExportName = 'default';
 
 function warnMissingFiles(failures, resolvedLang) {
-	const { path } = failures[0].err.message.match(/(?:https?:\/\/.*?\/)(?<path>.*)\/.*\./).groups;
+	const { path } = failures[0].err.message.match(/https?:\/\/.*?\/(?<path>.*)\/.*\./).groups;
 	const langs = failures.map(f => f.lang).join('","');
-	console.warn(
-		'WARNING: Unacceptable in production. Consider Manually Retrieved Resources method.\n\n' +
-		`Failed to load translation resources for languages "${langs}" from ${path}.`,
-		`Falling back to "${resolvedLang}". `);
+	console.warn(`Failed to load translation resources for languages "${langs}" from ${path}. Falling back to "${resolvedLang}".`);
 }
 
 export const LocalizeDynamicMixin = superclass => class extends LocalizeMixin(superclass) {
 
-	static get config() {
-		return {};
-	}
-
-	static async getLocalizeResources(langs, config) {
-		const { importFunc, osloCollection, exportName = defaultExportName } = config;
+	static async getLocalizeResources(langs, { importFunc, osloCollection }) {
 		const missingFiles = [];
 
 		for (const lang of [...langs, fallbackLang]) {
 
-			const mod = await importFunc(lang).catch(err => {
+			const resources = await importFunc(lang).catch(err => {
 				// TypeErrors are unsupported languages that fail to be imported (404). Report them.
 				// Errors are unsupported languages that are never imported and fall through. Supress them.
-				// in either case fallback languages are used (e.g. gd-ie -> gd -> en)
+				// In either case fallback languages are used (e.g. gd-ie -> gd -> en)
 				if (err.constructor === TypeError) missingFiles.push({ lang, err });
 			});
-			const resources = mod && mod[exportName];
 
 			if (resources) {
 
@@ -54,4 +44,9 @@ export const LocalizeDynamicMixin = superclass => class extends LocalizeMixin(su
 			}
 		}
 	}
+
+	static get localizeConfig() {
+		return {};
+	}
+
 };

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -152,7 +152,7 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 		return Array.from(langs);
 	}
 
-	static _getAllLocalizeResources(possibleLanguages, config = this.config) {
+	static _getAllLocalizeResources(possibleLanguages, config = this.localizeConfig) {
 		let resourcesLoadedPromises;
 		const superCtor = Object.getPrototypeOf(this);
 		if ('_getAllLocalizeResources' in superCtor) {

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -152,17 +152,17 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 		return Array.from(langs);
 	}
 
-	static _getAllLocalizeResources(possibleLanguages) {
+	static _getAllLocalizeResources(possibleLanguages, config = this.config) {
 		let resourcesLoadedPromises;
 		const superCtor = Object.getPrototypeOf(this);
 		if ('_getAllLocalizeResources' in superCtor) {
-			resourcesLoadedPromises = superCtor._getAllLocalizeResources(possibleLanguages);
+			resourcesLoadedPromises = superCtor._getAllLocalizeResources(possibleLanguages, config);
 		} else {
 			resourcesLoadedPromises = [];
 		}
 		// eslint-disable-next-line no-prototype-builtins
 		if (this.hasOwnProperty('getLocalizeResources') || this.hasOwnProperty('resources')) {
-			const res = this.getLocalizeResources([...possibleLanguages]);
+			const res = this.getLocalizeResources([...possibleLanguages], config);
 			resourcesLoadedPromises.push(res);
 		}
 		return resourcesLoadedPromises;

--- a/mixins/localize-mixin.md
+++ b/mixins/localize-mixin.md
@@ -31,7 +31,7 @@ Always provide language resources for base languages (e.g. `en`, `fr`, `pt`, etc
 
 ### Static vs. Async Resources
 
-For components with local resources, use the `LocalizeStaticMixin` and implement a `static` `resources` getter that returns the local resources. To get resources asynchronously, use the `LocalizeMixin` and implement `getLocalizedResources` as an `async` method.
+For components with local resources, use the `LocalizeStaticMixin` and implement a `static` `resources` getter that returns the local resources. To get resources asynchronously, use the `LocalizeMixin` and implement `getLocalizeResources` as an `async` method.
 
 #### Example 1: Static Resources
 

--- a/mixins/localize-mixin.md
+++ b/mixins/localize-mixin.md
@@ -33,7 +33,7 @@ Always provide language resources for base languages (e.g. `en`, `fr`, `pt`, etc
 
 For components with local resources, use the `LocalizeStaticMixin` and implement a `static` `resources` getter that returns the local resources synchronously. To get resources asynchronously, use the `LocalizeDynamicMixin` and implement a `static` `config` getter that returns details about where to find your resources.
 
-It is also possible to implement your own `getLocalizeResources` method to get your resources manually. However, this method is outdated and discouraged.
+It is also possible to implement your own `getLocalizeResources` method to get your resources manually if absolutely necessary.
 
 #### Example 1: Static Resources
 
@@ -92,14 +92,13 @@ Or with additional optional properties in the `config` object:
 return {
   ...,
   osloCollection: 'my-project\\myComponent', // To enable OSLO
-  supportedLangs: ['en', 'fr', ...], // For incomplete language support
   exportName: 'resources' // If your resource files use named exports
 }
 ```
 
 #### Example 3: Manually Retrieved Resources
 
-This approach is outdated and discouraged.
+It is highly recommended that you try to use the dynamic approach whenever possible, but if your builds _can't_ handle variable dynamic imports, you may be best served by writing your own `getLocalizeResources` method to retrieve your resources manually.
 
 Manually retrieve your resources:
 ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,35 @@
         "semver": "^6.3.0"
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.12.17.tgz",
+      "integrity": "sha512-CoetDyQRwtkUlOtbkCmYFpneXD78oANblFGUMX4DKLYj/mHzuS3rPt7zWzaDf0lB4uEB3C7C+hQAS/QgxqjdXQ==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "5.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.12.17",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.17.tgz",


### PR DESCRIPTION
Adds a proper `localize-dynamic` mixin to simplify individual component complexity. Docs have been updated with example usage.

Dependent upon:
~https://github.com/Brightspace/brightspace-integration/pull/3350~
~https://github.com/Brightspace/eslint-config-brightspace/pull/39~