### PR TITLE
input-date-time-range: change test to no longer flake

### DIFF
--- a/components/inputs/test/input-date-time-range.test.js
+++ b/components/inputs/test/input-date-time-range.test.js
@@ -49,10 +49,10 @@ describe('d2l-input-date-time-range', () => {
 				});
 
 				it('should return correctly forward shifted end date when localized without Z', () => {
-					const prevStartValue = '2020-10-25T04:00:00.000';
-					const prevEnd = '2020-10-27T04:00:00.000';
-					const start = '2020-10-26T04:00:00.000';
-					const newEndValue = '2020-10-28T04:00:00.000';
+					const prevStartValue = '2020-10-15T04:00:00.000';
+					const prevEnd = '2020-10-17T04:00:00.000';
+					const start = '2020-10-16T04:00:00.000';
+					const newEndValue = '2020-10-18T04:00:00.000';
 					expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, true)).to.equal(newEndValue);
 				});
 
@@ -60,15 +60,15 @@ describe('d2l-input-date-time-range', () => {
 					let prevStartValue, start, prevEnd, newEndValue;
 
 					if (timezone === 'America/Toronto') {
-						prevStartValue = '2020-10-24T12:00:00.000Z';
-						prevEnd = '2020-10-25T02:00:00.000Z';
-						start = '2020-10-24T08:00:00.000Z';
-						newEndValue = '2020-10-24T22:00:00.000Z';
+						prevStartValue = '2020-10-14T12:00:00.000Z';
+						prevEnd = '2020-10-15T02:00:00.000Z';
+						start = '2020-10-14T08:00:00.000Z';
+						newEndValue = '2020-10-14T22:00:00.000Z';
 					} else {
-						prevStartValue = '2020-10-23T22:00:00.000Z';
-						prevEnd = '2020-10-24T12:00:00.000Z';
-						start = '2020-10-23T18:00:00.000Z';
-						newEndValue = '2020-10-24T08:00:00.000Z';
+						prevStartValue = '2020-10-13T22:00:00.000Z';
+						prevEnd = '2020-10-14T12:00:00.000Z';
+						start = '2020-10-13T18:00:00.000Z';
+						newEndValue = '2020-10-14T08:00:00.000Z';
 					}
 					expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, false)).to.equal(newEndValue);
 				});
@@ -92,7 +92,6 @@ describe('d2l-input-date-time-range', () => {
 
 					beforeEach(async() => {
 						documentLocaleSettings.timezone.identifier = timezone;
-						await aTimeout(20); // Fixes flaky tests likely caused by timezone not yet being set
 					});
 
 					afterEach(() => {
@@ -101,18 +100,18 @@ describe('d2l-input-date-time-range', () => {
 
 					describe('date change', () => {
 						it('should return correctly forward shifted end date', () => {
-							const prevStartValue = '2020-10-25T04:00:00.000Z';
-							const prevEnd = '2020-10-27T04:00:00.000Z';
-							const start = '2020-10-26T04:00:00.000Z';
-							const newEndValue = `2020-10-28T04:00:00.000${localized ? '' : 'Z'}`;
+							const prevStartValue = '2020-10-15T04:00:00.000Z';
+							const prevEnd = '2020-10-17T04:00:00.000Z';
+							const start = '2020-10-16T04:00:00.000Z';
+							const newEndValue = `2020-10-18T04:00:00.000${localized ? '' : 'Z'}`;
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, localized)).to.equal(newEndValue);
 						});
 
 						it.skip('should return correctly backward shifted end date', () => {
-							const prevStartValue = '2020-10-25T04:00:00.000Z';
-							const prevEnd = '2020-10-27T04:00:00.000Z';
-							const start = '2020-10-24T04:00:00.000Z';
-							const newEndValue = `2020-10-26T04:00:00.000${localized ? '' : 'Z'}`;
+							const prevStartValue = '2020-10-15T04:00:00.000Z';
+							const prevEnd = '2020-10-17T04:00:00.000Z';
+							const start = '2020-10-14T04:00:00.000Z';
+							const newEndValue = `2020-10-16T04:00:00.000${localized ? '' : 'Z'}`;
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, localized)).to.equal(newEndValue);
 						});
 
@@ -125,78 +124,78 @@ describe('d2l-input-date-time-range', () => {
 						});
 
 						it('should return initial end date if prev start value was after end date', () => {
-							const prevStartValue = '2020-10-25T04:00:00.000Z';
-							const prevEnd = '2020-10-22T04:00:00.000Z';
-							const start = '2020-10-21T04:00:00.000Z';
+							const prevStartValue = '2020-10-15T04:00:00.000Z';
+							const prevEnd = '2020-10-12T04:00:00.000Z';
+							const start = '2020-10-11T04:00:00.000Z';
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, localized)).to.equal(prevEnd);
 						});
 
 						it('should return initial end date if not inclusive and prev start value was equal to end date', () => {
-							const prevStartValue = '2020-10-25T04:00:00.000Z';
-							const prevEnd = '2020-10-25T04:00:00.000Z';
-							const start = '2020-10-20T04:00:00.000Z';
+							const prevStartValue = '2020-10-15T04:00:00.000Z';
+							const prevEnd = '2020-10-15T04:00:00.000Z';
+							const start = '2020-10-10T04:00:00.000Z';
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, localized)).to.equal(prevEnd);
 						});
 
 						it('should return correctly shifted end date if inclusive and prev start value was equal to end date', () => {
-							const prevStartValue = '2020-10-25T04:00:00.000Z';
-							const prevEnd = '2020-10-25T04:00:00.000Z';
-							const start = `2020-10-20T04:00:00.000${localized ? '' : 'Z'}`;
+							const prevStartValue = '2020-10-15T04:00:00.000Z';
+							const prevEnd = '2020-10-15T04:00:00.000Z';
+							const start = `2020-10-10T04:00:00.000${localized ? '' : 'Z'}`;
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, true, localized)).to.equal(start);
 						});
 					});
 
 					describe('time change', () => {
 						it('should not shift if start and end dates are different', () => {
-							const prevStartValue = '2020-10-20T06:00:00.000Z';
-							const prevEnd = '2020-10-25T06:00:00.000Z';
-							const start = '2020-10-20T08:00:00.000Z';
+							const prevStartValue = '2020-10-10T06:00:00.000Z';
+							const prevEnd = '2020-10-15T06:00:00.000Z';
+							const start = '2020-10-10T08:00:00.000Z';
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, localized)).to.equal(prevEnd);
 						});
 
 						it('should shift forward as expected when times are different but dates the same', () => {
-							const prevStartValue = '2020-10-25T06:00:00.000Z';
-							const prevEnd = '2020-10-25T07:00:00.000Z';
-							const start = '2020-10-25T08:00:00.000Z';
-							const newEndValue = `2020-10-25T09:00:00.000${localized ? '' : 'Z'}`;
+							const prevStartValue = '2020-10-15T06:00:00.000Z';
+							const prevEnd = '2020-10-15T07:00:00.000Z';
+							const start = '2020-10-15T08:00:00.000Z';
+							const newEndValue = `2020-10-15T09:00:00.000${localized ? '' : 'Z'}`;
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, localized)).to.equal(newEndValue);
 						});
 
 						it('should shift backward as expected when times are different but dates the same', () => {
-							const prevStartValue = '2020-10-25T06:00:00.000Z';
-							const prevEnd = '2020-10-25T07:00:00.000Z';
-							const start = '2020-10-25T04:00:00.000Z';
-							const newEndValue = `2020-10-25T05:00:00.000${localized ? '' : 'Z'}`;
+							const prevStartValue = '2020-10-15T06:00:00.000Z';
+							const prevEnd = '2020-10-15T07:00:00.000Z';
+							const start = '2020-10-15T04:00:00.000Z';
+							const newEndValue = `2020-10-15T05:00:00.000${localized ? '' : 'Z'}`;
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, localized)).to.equal(newEndValue);
 						});
 
 						it('should not shift when previously same and not inclusive', () => {
-							const prevStartValue = '2020-10-25T04:00:00.000Z';
-							const prevEnd = '2020-10-25T04:00:00.000Z';
-							const start = '2020-10-25T08:00:00.000Z';
+							const prevStartValue = '2020-10-15T04:00:00.000Z';
+							const prevEnd = '2020-10-15T04:00:00.000Z';
+							const start = '2020-10-15T08:00:00.000Z';
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, false, localized)).to.equal(prevEnd);
 						});
 
 						it('should shift as expected when previously same and inclusive', () => {
-							const prevStartValue = '2020-10-25T06:00:00.000Z';
-							const prevEnd = '2020-10-25T06:00:00.000Z';
-							const start = '2020-10-25T08:00:00.000Z';
-							const newEndValue = `2020-10-25T08:00:00.000${localized ? '' : 'Z'}`;
+							const prevStartValue = '2020-10-15T06:00:00.000Z';
+							const prevEnd = '2020-10-15T06:00:00.000Z';
+							const start = '2020-10-15T08:00:00.000Z';
+							const newEndValue = `2020-10-15T08:00:00.000${localized ? '' : 'Z'}`;
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, true, localized)).to.equal(newEndValue);
 						});
 
 						it('should only shift at latest to 11:59 PM', () => {
 							let prevStartValue, prevEnd, start, newEndValue;
 							if (timezone === 'America/Toronto') {
-								prevStartValue = '2020-10-25T06:00:00.000Z';
-								prevEnd = '2020-10-25T20:00:00.000Z';
-								start = '2020-10-25T14:00:00.000Z';
-								newEndValue = localized ? '2020-10-25T23:59:00.000' : '2020-10-26T03:59:00.000Z';
+								prevStartValue = '2020-10-15T06:00:00.000Z';
+								prevEnd = '2020-10-15T20:00:00.000Z';
+								start = '2020-10-15T14:00:00.000Z';
+								newEndValue = localized ? '2020-10-15T23:59:00.000' : '2020-10-16T03:59:00.000Z';
 							} else {
-								prevStartValue = '2020-10-25T17:00:00.000Z';
-								prevEnd = '2020-10-25T23:00:00.000Z';
-								start = localized ? '2020-10-25T20:00:00.000Z' : '2020-10-26T10:15:00.000Z';
-								newEndValue = localized ? '2020-10-25T23:59:00.000' : '2020-10-26T15:14:00.000Z';
+								prevStartValue = '2020-10-15T17:00:00.000Z';
+								prevEnd = '2020-10-15T23:00:00.000Z';
+								start = localized ? '2020-10-15T20:00:00.000Z' : '2020-10-16T10:15:00.000Z';
+								newEndValue = localized ? '2020-10-15T23:59:00.000' : '2020-10-16T15:14:00.000Z';
 							}
 
 							expect(getShiftedEndDateTime(start, prevEnd, prevStartValue, inclusive, localized)).to.equal(newEndValue);


### PR DESCRIPTION
Problem:
Between 5 - 6 pm some of the tests end up being run on a machine that has its timezone set to Central Europe Time. In 2020, CET had Daylight Savings time end on Oct 25. Since our difference calculation for shifting dates is done using `Date`, because of the time change it becomes off by 1 hour (https://github.com/BrightspaceUI/core/blob/master/components/inputs/input-date-time-range.js#L34).

"Solution":
I shifted all the tests to be further from that time shift.

What does this mean:
This is how our old date picker behaved as well and is not new. How it normally exhibits itself is that when a user picks a date that moves start to one side of daylight savings and end to the other side, the end time shifts by an hour. This usually should seem fine to a user since they would in theory have their system set to the same timezone as their LMS. This does bring up the interesting case where if the system timezone is different than the LMS timezone then they would see that weird shifting on a different date than potentially expected. In practice I don't think this would cause any user error as the user is likely to change the time anyways.