### PR TITLE
fix: don't show invalid tooltip when disabled

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -94,7 +94,7 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 	}
 
 	render() {
-		const tooltip = this.validationError && this.childErrors.size === 0 ? html`<d2l-tooltip announced for="${this._inputId}" state="error" align="start">${this.validationError}</d2l-tooltip>` : null;
+		const tooltip = !this.disabled && this.validationError && this.childErrors.size === 0 ? html`<d2l-tooltip announced for="${this._inputId}" state="error" align="start">${this.validationError}</d2l-tooltip>` : null;
 		return html`
 			<d2l-input-text
 				autocomplete="${ifDefined(this.autocomplete)}"


### PR DESCRIPTION
Numeric inputs were incorrectly showing the invalid tooltip on-hover when they were in a disabled state:

![Screen Shot 2021-02-25 at 11 51 20 AM](https://user-images.githubusercontent.com/5491151/109187353-d4c1c800-775f-11eb-9421-ed31bd25b85e.png)

As you can see, internally `d2l-input-text` was already suppressing the red outline and the invalid icon when it's disabled.