### PR TITLE
US125413 - Allow support for LaTeX rendering in our MathJax implementation

### DIFF
--- a/components/html-block/README.md
+++ b/components/html-block/README.md
@@ -39,12 +39,6 @@ class SomeComponent extends LitElement {
 customElements.define('d2l-some-component', SomeComponent);
 ```
 
-**Properties:**
-
-| Property | Type | Description |
-|--|--|--|
-| `math-jax-config` | Object, default: `'{}'` | Configuration options for MathJax |
-
 ## Future Enhancements
 
 Looking for an enhancement not listed here? Create a GitHub issue!

--- a/components/html-block/README.md
+++ b/components/html-block/README.md
@@ -39,6 +39,12 @@ class SomeComponent extends LitElement {
 customElements.define('d2l-some-component', SomeComponent);
 ```
 
+**Properties:**
+
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Property&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description |
+|--|--|--|
+| `math-jax-config` | Object, default: `'{}'` | Configuration options for MathJax |
+
 ## Future Enhancements
 
 Looking for an enhancement not listed here? Create a GitHub issue!

--- a/components/html-block/README.md
+++ b/components/html-block/README.md
@@ -41,7 +41,7 @@ customElements.define('d2l-some-component', SomeComponent);
 
 **Properties:**
 
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Property&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description |
+| Property | Type | Description |
 |--|--|--|
 | `math-jax-config` | Object, default: `'{}'` | Configuration options for MathJax |
 

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -10,6 +10,17 @@
 			import '../../demo/demo-page.js';
 			import '../html-block.js';
 		</script>
+		<script>
+			if (window.location.search.indexOf('latex=true') !== -1) {
+				D2L = {};
+				D2L.LP = {};
+				D2L.LP.Web = {};
+				D2L.LP.Web.UI = {};
+				D2L.LP.Web.UI.Flags = {
+					Flag: (flagName, defaultValue) => { return true; }
+				}
+			}
+		</script>
 	</head>
 	<body unresolved>
 
@@ -41,6 +52,7 @@
 								<li>ordered item 2</li>
 							</ol>
 							<div><a href="https://d2l.com">anchor</a></div>
+							<div style="display: none">\( )\</div>
 						</template>
 					</d2l-html-block>
 				</template>
@@ -255,6 +267,33 @@
 										<mo>)</mo>
 									</mrow>
 								</math> and other symbols.
+							</div>
+						</template>
+					</d2l-html-block>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>HTML Block (LaTeX math)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-html-block>
+						<template>
+							<div>$$ f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x $$ $$ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} $$</div>
+						</template>
+					</d2l-html-block>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>HTML Block (LaTeX inline math)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-html-block>
+						<template>
+							<div>An equation rendered using LaTeX...
+								\( f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x \)
+								... and some text!
 							</div>
 						</template>
 					</d2l-html-block>

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -11,6 +11,7 @@
 			import '../html-block.js';
 		</script>
 		<script>
+			// mock flag for us125413-mathjax-render-latex
 			if (window.location.search.indexOf('latex=true') !== -1) {
 				window.D2L = {};
 				D2L.LP = {};

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -11,14 +11,16 @@
 			import '../html-block.js';
 		</script>
 		<script>
-			// mock flag for us125413-mathjax-render-latex
 			if (window.location.search.indexOf('latex=true') !== -1) {
 				window.D2L = {};
 				D2L.LP = {};
 				D2L.LP.Web = {};
 				D2L.LP.Web.UI = {};
 				D2L.LP.Web.UI.Flags = {
-					Flag: () => { return true; }
+					Flag: (feature, defaultValue) => {
+						if (feature === 'us125413-mathjax-render-latex') return true;
+						else return defaultValue;
+					}
 				};
 			}
 		</script>

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -19,7 +19,7 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-html-block math-jax-config='{ "renderLatex": true }'>
+					<d2l-html-block>
 						<template>
 							<h1>heading 1</h1>
 							<h2>heading 2</h2>
@@ -50,7 +50,7 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-html-block math-jax-config='{ "renderLatex": true }''>
+					<d2l-html-block>
 						<template>
 							<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
 								<mi>x</mi>
@@ -162,7 +162,7 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-html-block math-jax-config='{ "renderLatex": true }'>
+					<d2l-html-block>
 						<template>
 							<div>An equation...
 								<math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -255,33 +255,6 @@
 										<mo>)</mo>
 									</mrow>
 								</math> and other symbols.
-							</div>
-						</template>
-					</d2l-html-block>
-				</template>
-			</d2l-demo-snippet>
-
-			<h2>HTML Block (LaTeX math)</h2>
-
-			<d2l-demo-snippet>
-				<template>
-					<d2l-html-block math-jax-config='{ "renderLatex": true }'>
-						<template>
-							<div>$$ f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x $$ $$ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} $$</div>
-						</template>
-					</d2l-html-block>
-				</template>
-			</d2l-demo-snippet>
-
-			<h2>HTML Block (LaTeX inline math)</h2>
-
-			<d2l-demo-snippet>
-				<template>
-					<d2l-html-block math-jax-config='{ "renderLatex": true }'>
-						<template>
-							<div>An equation rendered using LaTeX...
-								\( f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x \)
-								... and some text!
 							</div>
 						</template>
 					</d2l-html-block>

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -12,8 +12,7 @@
 		</script>
 		<script>
 			if (window.location.search.indexOf('latex=true') !== -1) {
-				/* eslint-disable-next-line no-global-assign */
-				D2L = {};
+				window.D2L = {};
 				D2L.LP = {};
 				D2L.LP.Web = {};
 				D2L.LP.Web.UI = {};
@@ -53,7 +52,6 @@
 								<li>ordered item 2</li>
 							</ol>
 							<div><a href="https://d2l.com">anchor</a></div>
-							<div style="display: none">\( )\</div>
 						</template>
 					</d2l-html-block>
 				</template>

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -12,13 +12,14 @@
 		</script>
 		<script>
 			if (window.location.search.indexOf('latex=true') !== -1) {
+				/* eslint-disable-next-line no-global-assign */
 				D2L = {};
 				D2L.LP = {};
 				D2L.LP.Web = {};
 				D2L.LP.Web.UI = {};
 				D2L.LP.Web.UI.Flags = {
-					Flag: (flagName, defaultValue) => { return true; }
-				}
+					Flag: () => { return true; }
+				};
 			}
 		</script>
 	</head>

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -19,7 +19,7 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-html-block>
+					<d2l-html-block math-jax-config='{ "renderLatex": true }'>
 						<template>
 							<h1>heading 1</h1>
 							<h2>heading 2</h2>
@@ -50,7 +50,7 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-html-block>
+					<d2l-html-block math-jax-config='{ "renderLatex": true }''>
 						<template>
 							<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
 								<mi>x</mi>
@@ -162,7 +162,7 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-html-block>
+					<d2l-html-block math-jax-config='{ "renderLatex": true }'>
 						<template>
 							<div>An equation...
 								<math xmlns="http://www.w3.org/1998/Math/MathML">
@@ -255,6 +255,33 @@
 										<mo>)</mo>
 									</mrow>
 								</math> and other symbols.
+							</div>
+						</template>
+					</d2l-html-block>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>HTML Block (LaTeX math)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-html-block math-jax-config='{ "renderLatex": true }'>
+						<template>
+							<div>$$ f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x $$ $$ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} $$</div>
+						</template>
+					</d2l-html-block>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>HTML Block (LaTeX inline math)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-html-block math-jax-config='{ "renderLatex": true }'>
+						<template>
+							<div>An equation rendered using LaTeX...
+								\( f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x \)
+								... and some text!
 							</div>
 						</template>
 					</d2l-html-block>

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -135,7 +135,7 @@ class HtmlBlock extends LitElement {
 				temp.appendChild(fragment);
 				const fragmentHTML = temp.innerHTML;
 
-				const isLatexSupported = D2L.LP && D2L.LP.Web.UI.Flags.Flag('us125413-mathjax-render-latex', true);
+				const isLatexSupported = D2L && D2L.LP && D2L.LP.Web.UI.Flags.Flag('us125413-mathjax-render-latex', true);
 				if (hasMathML || (isLatexSupported && /\$\$|\\\(/.test(fragmentHTML))) {
 					const mathJaxConfig = { renderLatex: isLatexSupported };
 					await loadMathJax(mathJaxConfig);

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -7,6 +7,12 @@ import { loadMathJax } from '../../helpers/mathjax.js';
  */
 class HtmlBlock extends LitElement {
 
+	static get properties() {
+		return {
+			mathJaxConfig: { type: Object, attribute: 'math-jax-config' }
+		};
+	}
+
 	static get styles() {
 		return css`
 			:host {
@@ -113,6 +119,11 @@ class HtmlBlock extends LitElement {
 		`;
 	}
 
+	constructor() {
+		super();
+		this.mathJaxConfig = {};
+	}
+
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		if (this._templateObserver) this._templateObserver.disconnect();
@@ -129,14 +140,16 @@ class HtmlBlock extends LitElement {
 			const fragment = template ? document.importNode(template.content, true) : null;
 			if (fragment) {
 
-				const hasMath = !!fragment.querySelector('math');
+				const hasMathML = !!fragment.querySelector('math');
 
 				const temp = document.createElement('div');
 				temp.appendChild(fragment);
 				const fragmentHTML = temp.innerHTML;
 
-				if (hasMath) {
-					await loadMathJax();
+				const hasLatex = /\$\$|\\\(/.test(fragmentHTML);
+
+				if (hasMathML || hasLatex) {
+					await loadMathJax(this.mathJaxConfig);
 					this._renderContainer.innerHTML = `<mjx-doc><mjx-head></mjx-head><mjx-body>${fragmentHTML}</mjx-body></mjx-doc>`;
 					window.MathJax.typesetShadow(this.shadowRoot);
 				} else {

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -7,12 +7,6 @@ import { loadMathJax } from '../../helpers/mathjax.js';
  */
 class HtmlBlock extends LitElement {
 
-	static get properties() {
-		return {
-			mathJaxConfig: { type: Object, attribute: 'math-jax-config' }
-		};
-	}
-
 	static get styles() {
 		return css`
 			:host {
@@ -119,11 +113,6 @@ class HtmlBlock extends LitElement {
 		`;
 	}
 
-	constructor() {
-		super();
-		this.mathJaxConfig = {};
-	}
-
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		if (this._templateObserver) this._templateObserver.disconnect();
@@ -146,8 +135,12 @@ class HtmlBlock extends LitElement {
 				temp.appendChild(fragment);
 				const fragmentHTML = temp.innerHTML;
 
-				if (hasMathML || /\$\$|\\\(/.test(fragmentHTML)) {
-					await loadMathJax(this.mathJaxConfig);
+				const hasLatex = D2L.LP && D2L.LP.Web.UI.Flags.Flag('us125413-mathjax-render-latex', true) && /\$\$|\\\(/.test(fragmentHTML);
+
+				if (hasMathML || hasLatex) {
+					const mathJaxConfig = { renderLatex: hasLatex }
+					await loadMathJax(mathJaxConfig);
+
 					this._renderContainer.innerHTML = `<mjx-doc><mjx-head></mjx-head><mjx-body>${fragmentHTML}</mjx-body></mjx-doc>`;
 					window.MathJax.typesetShadow(this.shadowRoot);
 				} else {

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -138,7 +138,7 @@ class HtmlBlock extends LitElement {
 				const hasLatex = D2L.LP && D2L.LP.Web.UI.Flags.Flag('us125413-mathjax-render-latex', true) && /\$\$|\\\(/.test(fragmentHTML);
 
 				if (hasMathML || hasLatex) {
-					const mathJaxConfig = { renderLatex: hasLatex }
+					const mathJaxConfig = { renderLatex: hasLatex };
 					await loadMathJax(mathJaxConfig);
 
 					this._renderContainer.innerHTML = `<mjx-doc><mjx-head></mjx-head><mjx-body>${fragmentHTML}</mjx-body></mjx-doc>`;

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -135,10 +135,9 @@ class HtmlBlock extends LitElement {
 				temp.appendChild(fragment);
 				const fragmentHTML = temp.innerHTML;
 
-				const hasLatex = D2L.LP && D2L.LP.Web.UI.Flags.Flag('us125413-mathjax-render-latex', true) && /\$\$|\\\(/.test(fragmentHTML);
-
-				if (hasMathML || hasLatex) {
-					const mathJaxConfig = { renderLatex: hasLatex };
+				const isLatexSupported = D2L.LP && D2L.LP.Web.UI.Flags.Flag('us125413-mathjax-render-latex', true);
+				if (hasMathML || (isLatexSupported && /\$\$|\\\(/.test(fragmentHTML))) {
+					const mathJaxConfig = { renderLatex: isLatexSupported };
 					await loadMathJax(mathJaxConfig);
 
 					this._renderContainer.innerHTML = `<mjx-doc><mjx-head></mjx-head><mjx-body>${fragmentHTML}</mjx-body></mjx-doc>`;

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -146,9 +146,7 @@ class HtmlBlock extends LitElement {
 				temp.appendChild(fragment);
 				const fragmentHTML = temp.innerHTML;
 
-				const hasLatex = /\$\$|\\\(/.test(fragmentHTML);
-
-				if (hasMathML || hasLatex) {
+				if (hasMathML || /\$\$|\\\(/.test(fragmentHTML)) {
 					await loadMathJax(this.mathJaxConfig);
 					this._renderContainer.innerHTML = `<mjx-doc><mjx-head></mjx-head><mjx-body>${fragmentHTML}</mjx-body></mjx-doc>`;
 					window.MathJax.typesetShadow(this.shadowRoot);

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -135,7 +135,7 @@ class HtmlBlock extends LitElement {
 				temp.appendChild(fragment);
 				const fragmentHTML = temp.innerHTML;
 
-				const isLatexSupported = D2L && D2L.LP && D2L.LP.Web.UI.Flags.Flag('us125413-mathjax-render-latex', true);
+				const isLatexSupported = window.D2L && window.D2L.LP && window.D2L.LP.Web.UI.Flags.Flag('us125413-mathjax-render-latex', true);
 				if (hasMathML || (isLatexSupported && /\$\$|\\\(/.test(fragmentHTML))) {
 					const mathJaxConfig = { renderLatex: isLatexSupported };
 					await loadMathJax(mathJaxConfig);

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -1,6 +1,6 @@
 let mathJaxLoaded;
 
-export function loadMathJax() {
+export function loadMathJax(mathJaxConfig) {
 
 	if (mathJaxLoaded) return mathJaxLoaded;
 
@@ -110,7 +110,12 @@ export function loadMathJax() {
 		const script = document.createElement('script');
 		script.async = 'async';
 		script.onload = resolve;
-		script.src = 'https://s.brightspace.com/lib/mathjax/3.1.2/mml-chtml.js';
+
+		const component = mathJaxConfig && mathJaxConfig.renderLatex
+			? 'tex-mml-chtml'
+			: 'mml-chtml';
+
+		script.src = `https://s.brightspace.com/lib/mathjax/3.1.2/${component}.js`;
 		document.head.appendChild(script);
 	});
 

--- a/index.html
+++ b/index.html
@@ -76,7 +76,13 @@
 			</ul>
 		</li>
 		<li><a href="components/hierarchical-view/demo/hierarchical-view.html">d2l-hierarchical-view</a></li>
-		<li><a href="components/html-block/demo/html-block.html">d2l-html-block</a></li>
+		<li>
+			HtmlBlock
+			<ul>
+				<li><a href="components/html-block/demo/html-block.html">d2l-html-block</a></li>
+				<li><a href="components/html-block/demo/html-block.html?latex=true">d2l-html-block (with LaTeX rendering)</a></li>
+			</ul>
+		</li>
 		<li><a href="components/icons/demo/icon.html">d2l-icon</a></li>
 		<li>
 			Inputs


### PR DESCRIPTION
This PR allows consumers to specify an optional MathJax config object when using an HTML block. Right now this is used to enable (or disable) LaTeX rendering within MathJax.