### PR TITLE
Remove missing file warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,5 @@
 {
   "extends": "brightspace/lit-config",
-  "parser": "@babel/eslint-parser",
-  "parserOptions": {
-    "requireConfigFile": false
-  },
   "globals": {
     "Prism": false
   },

--- a/mixins/localize-dynamic-mixin.js
+++ b/mixins/localize-dynamic-mixin.js
@@ -3,31 +3,15 @@ import { LocalizeMixin } from './localize-mixin.js';
 
 const fallbackLang = 'en';
 
-function warnMissingFiles(failures, resolvedLang) {
-	const { path } = failures[0].err.message.match(/https?:\/\/.*?\/(?<path>.*)\/.*\./).groups;
-	const langs = failures.map(f => f.lang).join('","');
-	console.warn(`Failed to load translation resources for languages "${langs}" from ${path}. Falling back to "${resolvedLang}".`);
-}
-
 export const LocalizeDynamicMixin = superclass => class extends LocalizeMixin(superclass) {
 
 	static async getLocalizeResources(langs, { importFunc, osloCollection }) {
-		const missingFiles = [];
 
 		for (const lang of [...langs, fallbackLang]) {
 
-			const resources = await importFunc(lang).catch(err => {
-				// TypeErrors are unsupported languages that fail to be imported (404). Report them.
-				// Errors are unsupported languages that are never imported and fall through. Supress them.
-				// In either case fallback languages are used (e.g. gd-ie -> gd -> en)
-				if (err.constructor === TypeError) missingFiles.push({ lang, err });
-			});
+			const resources = await importFunc(lang).catch(() => {});
 
 			if (resources) {
-
-				if (missingFiles.length) {
-					warnMissingFiles(missingFiles, lang);
-				}
 
 				if (osloCollection) {
 					return await getLocalizeOverrideResources(


### PR DESCRIPTION
Remove the missing file warning to decrease confusion and noise, and fix Firefox.