### PR TITLE
Bump up z-index for skeleton to provide room for low-level stacking.

### DIFF
--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -20,7 +20,7 @@ export const skeletonStyles = css`
 		position: absolute;
 		right: 0;
 		top: 0;
-		z-index: 1;
+		z-index: 4;
 	}
 	@media (prefers-reduced-motion: reduce) {
 		:host([skeleton]) .d2l-skeletize::before {


### PR DESCRIPTION
Some components use low-level z-index for their own purposes, and sometimes the value can be slightly higher than the skeleton z-index.  In order to provide some room for components to do their stacking, while still ensuring the skeleton stacks on top, this PR increases the z-index slightly.