### PR TITLE
Allow slot inception for dropdown openers.

### DIFF
--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -100,7 +100,8 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	}
 
 	__getContentElement() {
-		return this.shadowRoot.querySelector('slot').assignedNodes().filter(node => node.hasAttribute && node.hasAttribute('dropdown-content'))[0];
+		return this.shadowRoot.querySelector('slot').assignedNodes({ flatten: true })
+			.filter(node => node.hasAttribute && node.hasAttribute('dropdown-content'))[0];
 	}
 
 	__onClosed() {


### PR DESCRIPTION
This PR allows the contents of a dropdown to be distributed from nested slots.  For example:

```html
<special-dropdown>
  --shadowDOM
    <d2l-dropdown>
      --shadowDOM
        <slot></slot>
      <button class="d2l-dropdown-opener">cool stuff</button>
      <slot></slot>
    </d2l-dropdown>
  <d2l-dropdown-menu>...</<d2l-dropdown-menu> or <d2l-dropdown-content>
</special-dropdown>
```

This is needed for the HtmlEditor.