### PR TITLE
Add getContentSlot method that mixin consumer can override.

### DIFF
--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -79,6 +79,10 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		opener.focus();
 	}
 
+	getContentSlot() {
+		return this.shadowRoot.querySelector('slot');
+	}
+
 	getOpener() {
 		return this;
 	}
@@ -100,7 +104,8 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	}
 
 	__getContentElement() {
-		return this.shadowRoot.querySelector('slot').assignedNodes().filter(node => node.hasAttribute && node.hasAttribute('dropdown-content'))[0];
+		return this.getContentSlot().assignedNodes()
+			.filter(node => node.hasAttribute && node.hasAttribute('dropdown-content'))[0];
 	}
 
 	__onClosed() {

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -79,6 +79,10 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		opener.focus();
 	}
 
+	/**
+	 * Gets the slot where dropdown content will be distributed. May be overridden by mixin consumers.
+	 * @return {HTMLElement}
+	 */
 	getContentSlot() {
 		return this.shadowRoot.querySelector('slot');
 	}
@@ -87,6 +91,10 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		return this;
 	}
 
+	/**
+	 * Gets the actual oepener element (ex. button). Typically overridden by mixin consumers.
+	 * @return {HTMLElement}
+	 */
 	getOpenerElement() {
 		return this;
 	}


### PR DESCRIPTION
Consumers of the mixin that have more than one slot need the ability to resolve the slot containing the dropdown content for the opener.  Otherwise, the opener-mixin may try to use the wrong slot, and the dropdown will not open as expected.

In the same way the consumer can override the default for resolving the opener element, they can provide an override to get the slot.

This is alternate solution to this other PR: https://github.com/BrightspaceUI/core/pull/1218
