### PR TITLE
fix: sprouting aria-label

### DIFF
--- a/components/menu/menu-item-link.js
+++ b/components/menu/menu-item-link.js
@@ -70,6 +70,14 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 		`;
 	}
 
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (changedProperties.has('text')) {
+			// Voiceover + iOS can't find label inside <a>
+			this.setAttribute('aria-label', this.text);
+		}
+	}
+
 	_getTarget() {
 		if (this.target && this.target !== '') {
 			return this.target;

--- a/components/menu/test/menu-item-link.test.js
+++ b/components/menu/test/menu-item-link.test.js
@@ -1,4 +1,5 @@
 import '../menu-item-link.js';
+import { expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-menu-item-link', () => {
@@ -7,6 +8,12 @@ describe('d2l-menu-item-link', () => {
 
 		it('should construct', () => {
 			runConstructor('d2l-menu-item-link');
+		});
+
+		it('should sprout "aria-label"', async() => {
+			// without explicit aria-label, Voiceover on iOS cannot find nested label inside <a> element
+			const elem = await fixture(html`<d2l-menu-item-link text="link text"></d2l-menu-item-link>`);
+			expect(elem.getAttribute('aria-label')).to.equal('link text');
 		});
 
 	});


### PR DESCRIPTION
This is the cert version of [this fix](https://github.com/BrightspaceUI/core/pull/1226), which will go into `20.21.4`.