### PR TITLE
Attempt to fix overflow test flakiness 

### DIFF
--- a/components/overflow-group/test/overflow-group.visual-diff.js
+++ b/components/overflow-group/test/overflow-group.visual-diff.js
@@ -11,7 +11,7 @@ describe('d2l-overflow-group', () => {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await visualDiff.createPage(browser);
-		await page.goto(`${visualDiff.getBaseUrl()}/components/overflow-group/test/overflow-group.visual-diff.html`, { 
+		await page.goto(`${visualDiff.getBaseUrl()}/components/overflow-group/test/overflow-group.visual-diff.html`, {
 			waitUntil: ['networkidle0', 'load'],
 			timeout: 1000
 		});

--- a/components/overflow-group/test/overflow-group.visual-diff.js
+++ b/components/overflow-group/test/overflow-group.visual-diff.js
@@ -11,7 +11,10 @@ describe('d2l-overflow-group', () => {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await visualDiff.createPage(browser);
-		await page.goto(`${visualDiff.getBaseUrl()}/components/overflow-group/test/overflow-group.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
+		await page.goto(`${visualDiff.getBaseUrl()}/components/overflow-group/test/overflow-group.visual-diff.html`, { 
+			waitUntil: ['networkidle0', 'load'],
+			timeout: 1000
+		});
 		await page.bringToFront();
 	});
 


### PR DESCRIPTION
I was able to see this happening through the chrome performance profiling tools where for a couple frames the icons don't exist on dropdown buttons. But it seems like the icons are loading in later than the dropdown menu (reproducible in the dropdown-openers tests as well).


There may be some more logical fix we can put in here to avoid this being an issue but I couldn't figure out exactly what that should be. I think the reason we are seeing these tests being flaky and not the dropdown-openers ones as well is because the dropdown menu gets rendered later (once we determine its necessary for the overflow group to have it) .



