### PR TITLE
Fix overflow group test flakiness, use waitForTimeout to delay test execution

### DIFF
--- a/components/overflow-group/test/overflow-group.visual-diff.js
+++ b/components/overflow-group/test/overflow-group.visual-diff.js
@@ -12,6 +12,8 @@ describe('d2l-overflow-group', () => {
 		browser = await puppeteer.launch();
 		page = await visualDiff.createPage(browser);
 		await page.goto(`${visualDiff.getBaseUrl()}/components/overflow-group/test/overflow-group.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
+		// some tests were being excecuted before icons had time to load asnycronously causing
+		// the tests to be flaky, the 500ms delay ensures they have loaded before any tests begin execution
 		await page.waitForTimeout(500);
 		await page.bringToFront();
 	});

--- a/components/overflow-group/test/overflow-group.visual-diff.js
+++ b/components/overflow-group/test/overflow-group.visual-diff.js
@@ -12,6 +12,7 @@ describe('d2l-overflow-group', () => {
 		browser = await puppeteer.launch();
 		page = await visualDiff.createPage(browser);
 		await page.goto(`${visualDiff.getBaseUrl()}/components/overflow-group/test/overflow-group.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
+		await page.waitForTimeout(500);
 		await page.bringToFront();
 	});
 


### PR DESCRIPTION
This just delays the test by a few hundred milliseconds so that the icons will definitely have time to load in before we start taking screen shots. 

There is probably a better fix we can put in here to avoid this being an issue with icons in general. I think the reason we are seeing these tests being flaky and not the dropdown-openers ones as well is because the dropdown menu gets rendered later (once we determine its necessary for the overflow group to have it).
