### PR TITLE
Minor fixes for overflow group

### DIFF
--- a/components/overflow-group/demo/overflow-group.html
+++ b/components/overflow-group/demo/overflow-group.html
@@ -57,7 +57,7 @@
 						</d2l-dropdown>
 						<d2l-button>Copy</d2l-button>
 						<d2l-button>Import</d2l-button>
-						<d2l-button class="d2l-overflow-group-no-show">Delete</d2l-button>
+						<d2l-button class="d2l-button-group-no-show">Delete</d2l-button>
 						<d2l-link href="http://www.desire2learn.com">D2L</d2l-link>
 					</d2l-overflow-group>
 				</template>

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -34,6 +34,7 @@ function createMenuItem(node) {
 	const childText = node.text || node.firstChild && (node.firstChild.label || node.firstChild.text || node.firstChild.textContent.trim());
 	const disabled = node.disabled;
 	return html`<d2l-menu-item 
+		@click=${node.onclick}
 		?disabled=${disabled}
 		text="${childText}">
 	</d2l-menu-item>`;

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -33,9 +33,13 @@ const OPENER_STYLE = {
 function createMenuItem(node) {
 	const childText = node.text || node.firstChild && (node.firstChild.label || node.firstChild.text || node.firstChild.textContent.trim());
 	const disabled = node.disabled;
-	return html`<d2l-menu-item 
-		@click=${node.onclick}
+	const handleItemSelect = () => {
+		node.dispatchEvent(new CustomEvent('d2l-button-ghost-click'));
+		node.click();
+	};
+	return html`<d2l-menu-item
 		?disabled=${disabled}
+		@d2l-menu-item-select=${handleItemSelect}
 		text="${childText}">
 	</d2l-menu-item>`;
 }

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -15,7 +15,7 @@ import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
-import { throttle } from 'lodash-es';
+import throttle from 'lodash-es/throttle';
 
 const AUTO_SHOW_CLASS = 'd2l-button-group-show';
 const AUTO_NO_SHOW_CLASS = 'd2l-button-group-no-show';


### PR DESCRIPTION
Changes: 
- Pass click handlers through so menu-items fire their respective buttons click handlers through the dropdown menu.
- change the way throttle is being imported to prevent other packages loading 
- changes incorrect class name in the demo page