### PR TITLE
feat: adding a position override for text inputs

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -46,7 +46,7 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 			css`
 				:host {
 					display: inline-block;
-					position: relative;
+					position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
 					width: 100%;
 				}
 				:host([hidden]) {

--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -19,7 +19,7 @@ export const inputStyles = css`
 		margin: 0;
 		min-height: calc(2rem + 2px);
 		min-width: calc(2rem + 1em);
-		position: relative;
+		position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
 		text-align: var(--d2l-input-text-align, start);
 		vertical-align: middle;
 		width: 100%;

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -161,7 +161,7 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 				}
 				.d2l-input-text-container {
 					flex: 1 1 auto;
-					position: relative;
+					position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
 				}
 				.d2l-input {
 					-webkit-appearance: textfield;


### PR DESCRIPTION
See the [PR in table](https://github.com/BrightspaceUI/table/pull/235) for the full description of why this is needed. I'm hoping this is temporary until a better solution can be devised as part of the Lit migration of table sticky headers.

There is [a PR into the LMS](https://github.com/Brightspace/lms/pull/8475) to set this variable from the grades page.