### PR TITLE
Overflow group causing warnings when running tests in other d2l repositories

### DIFF
--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -226,7 +226,7 @@ class OverflowGroup extends RtlMixin(LocalizeCoreElement(LitElement)) {
 		super();
 		this._handleResize = this._handleResize.bind(this);
 
-		this._throttledResize = throttle(this._handleResize, 15);
+		this._throttledResize = (entries) => requestAnimationFrame(this._handleResize(entries));
 
 		this._overflowHidden = false;
 		this.autoShow = false;
@@ -249,8 +249,8 @@ class OverflowGroup extends RtlMixin(LocalizeCoreElement(LitElement)) {
 
 		this._getItems();
 
-		this.resizeObserver = new ResizeObserver(this._throttledResize);
-		this.resizeObserver.observe(this._container);
+		this._resizeObserver = new ResizeObserver(this._throttledResize);
+		this._resizeObserver.observe(this._container);
 	}
 	render() {
 		const overflowMenu = this._getOverflowMenu();
@@ -449,7 +449,7 @@ class OverflowGroup extends RtlMixin(LocalizeCoreElement(LitElement)) {
 		return filteredNodes;
 	}
 	_handleResize(entries) {
-
+		console.log(true)
 		this._availableWidth = Math.ceil(entries[0].contentRect.width);
 
 		this._chomp();

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -15,7 +15,6 @@ import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
-import throttle from 'lodash-es/throttle';
 
 const AUTO_SHOW_CLASS = 'd2l-button-group-show';
 const AUTO_NO_SHOW_CLASS = 'd2l-button-group-no-show';

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -448,7 +448,7 @@ class OverflowGroup extends RtlMixin(LocalizeCoreElement(LitElement)) {
 		return filteredNodes;
 	}
 	_handleResize(entries) {
-		console.log(true)
+
 		this._availableWidth = Math.ceil(entries[0].contentRect.width);
 
 		this._chomp();


### PR DESCRIPTION
When running unit tests in other repos occasionally the tests would fail with the error: 
`Error: ResizeObserver loop limit exceeded (http://localhost:9876/context.html?v=home%2C0&cvhf=0%2C1&caf=&undefined=&cgf=20%2C40&daf=7&tcgf=bottomRight#:0)`

The error essentially means that the ResizeObserver was not able to deliver all of its observations within the same animation frame. This is a non-fatal error but would cause the tests to fail, I did a bit of investigating and it seems like replacing throttle with requestAnimationFrame is suitable in this scenario. They should have a very similar effect in this case since rAF targets 60fps which is about 16ms (very similar to the throttle value). 

There is another option of ignoring the errors within the tests but I thought it would be bothersome to have to do that for every repo we started seeing this in. 