### PR TITLE
Awang/animation directive fixes

### DIFF
--- a/directives/animate/animate.js
+++ b/directives/animate/animate.js
@@ -4,8 +4,8 @@ import { isComposedAncestor } from '../../helpers/dom.js';
 
 const stateMap = new WeakMap();
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
-const showTransitionDuration = 3000;
-const hideTransitionDuration = 2000;
+const showTransitionDuration = 300;
+const hideTransitionDuration = 200;
 const moveYValue = 20;
 
 class AnimationState {

--- a/directives/animate/animate.js
+++ b/directives/animate/animate.js
@@ -118,7 +118,7 @@ class AnimationState {
 		if (paddingTopOriginal) {
 			this.elem.style.paddingTop = `${paddingTopOriginal}px`;
 		} else {
-			this.elem.style.removeProperty('padding-top')
+			this.elem.style.removeProperty('padding-top');
 		}
 
 		const paddingBottomOriginal = (parseInt(this.elem.style.paddingBottom) || 0);
@@ -129,7 +129,7 @@ class AnimationState {
 		if (paddingBottomOriginal) {
 			this.elem.style.paddingBottom = `${paddingBottomOriginal}px`;
 		} else {
-			this.elem.style.removeProperty('padding-bottom')
+			this.elem.style.removeProperty('padding-bottom');
 		}
 
 		const marginsV = marginT + marginB;

--- a/directives/animate/animate.js
+++ b/directives/animate/animate.js
@@ -4,8 +4,8 @@ import { isComposedAncestor } from '../../helpers/dom.js';
 
 const stateMap = new WeakMap();
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
-const showTransitionDuration = 300;
-const hideTransitionDuration = 200;
+const showTransitionDuration = 3000;
+const hideTransitionDuration = 2000;
 const moveYValue = 20;
 
 class AnimationState {
@@ -88,8 +88,6 @@ class AnimationState {
 		const styleAttr = this.elem.getAttribute('style');
 
 		const rect = this.elem.getBoundingClientRect();
-		const top = this.elem.offsetTop - (this.elem.scrollTop || 0);
-		const left = this.elem.offsetLeft - (this.elem.scrollLeft || 0);
 		const marginsH = (parseInt(style.marginLeft) || 0) + (parseInt(style.marginRight) || 0);
 		const originalHeight = rect.height;
 
@@ -121,6 +119,9 @@ class AnimationState {
 		this.elem.style.paddingBottom = `0px`;
 
 		const marginsV = marginT + marginB;
+
+		const top = this.elem.offsetTop - (this.elem.scrollTop || 0) - marginT;
+		const left = this.elem.offsetLeft - (this.elem.scrollLeft || 0);
 
 		let cloneHeight = 0;
 		if (this.clone !== null) {

--- a/directives/animate/animate.js
+++ b/directives/animate/animate.js
@@ -66,6 +66,18 @@ class AnimationState {
 
 	}
 
+	calculateCollapsedMargin(marginParent, marginChild) {
+		let margin;
+		if (marginParent < 0 && marginChild < 0) {
+			margin = Math.min(marginParent, marginChild);
+		} else if (marginParent < 0 || marginChild < 0) {
+			margin = marginParent + marginChild;
+		} else {
+			margin = Math.max(marginParent, marginChild);
+		}
+		return margin;
+	}
+
 	dispatchEvent(timeout = 0) {
 		// need a timeout as when motion is reduced
 		// event fires too quickly to listen for
@@ -98,37 +110,22 @@ class AnimationState {
 
 		const paddingTemp = 1;
 
-		const paddingTopOriginal = parseInt(this.elem.style.paddingTop || 0);
+		const paddingTopOriginal = (parseInt(this.elem.style.paddingTop) || 0);
 		const marginTParent = (parseInt(style.marginTop) || 0);
-		this.elem.style.paddingTop = `${paddingTemp}px`; // forces top margin to NOT collapse between parent and topmost child!
+		this.elem.style.paddingTop = `${paddingTemp}px`; // forces top margin to NOT collapse between parent and top-most child
 		const marginTChild = (this.elem.getBoundingClientRect().height - paddingTemp + paddingTopOriginal - originalHeight || 0);
-		let marginT;
-		if (marginTParent < 0 && marginTChild < 0) {
-			marginT = Math.min(marginTParent, marginTChild);
-		} else if (marginTParent < 0 || marginTChild < 0) {
-			marginT = marginTParent + marginTChild;
-		} else {
-			marginT = Math.max(marginTParent, marginTChild);
-		}
+		const marginT = this.calculateCollapsedMargin(marginTParent, marginTChild);
 		if (paddingTopOriginal) {
-			console.log(paddingTopOriginal)
 			this.elem.style.paddingTop = `${paddingTopOriginal}px`;
 		} else {
 			this.elem.style.removeProperty('padding-top')
 		}
 
-		const paddingBottomOriginal = parseInt(this.elem.style.paddingBottom || 0);
+		const paddingBottomOriginal = (parseInt(this.elem.style.paddingBottom) || 0);
 		const marginBParent = (parseInt(style.marginBottom) || 0);
-		this.elem.style.paddingBottom = `${paddingTemp}px`; // forces bottom margin to NOT collapse between parent and bottommost child!
+		this.elem.style.paddingBottom = `${paddingTemp}px`; // forces bottom margin to NOT collapse between parent and bottom-most child!
 		const marginBChild = (this.elem.getBoundingClientRect().height - paddingTemp + paddingBottomOriginal - originalHeight || 0);
-		let marginB;
-		if (marginBParent < 0 && marginBChild < 0) {
-			marginB = Math.min(marginBParent, marginBChild);
-		} else if (marginBParent < 0 || marginBChild < 0) {
-			marginB = marginBParent + marginBChild;
-		} else {
-			marginB = Math.max(marginBParent, marginBChild);
-		}
+		const marginB = this.calculateCollapsedMargin(marginBParent, marginBChild);
 		if (paddingBottomOriginal) {
 			this.elem.style.paddingBottom = `${paddingBottomOriginal}px`;
 		} else {

--- a/directives/animate/animate.js
+++ b/directives/animate/animate.js
@@ -92,9 +92,11 @@ class AnimationState {
 		const originalHeight = rect.height;
 
 		const paddingTemp = 1;
+
+		const paddingTopOriginal = parseInt(this.elem.style.paddingTop || 0);
 		const marginTParent = (parseInt(style.marginTop) || 0);
 		this.elem.style.paddingTop = `${paddingTemp}px`; // forces top margin to NOT collapse between parent and topmost child!
-		const marginTChild = (this.elem.getBoundingClientRect().height - paddingTemp - originalHeight || 0);
+		const marginTChild = (this.elem.getBoundingClientRect().height - paddingTemp + paddingTopOriginal - originalHeight || 0);
 		let marginT;
 		if (marginTParent < 0 && marginTChild < 0) {
 			marginT = Math.min(marginTParent, marginTChild);
@@ -103,11 +105,17 @@ class AnimationState {
 		} else {
 			marginT = Math.max(marginTParent, marginTChild);
 		}
-		this.elem.style.paddingTop = `0px`;
+		if (paddingTopOriginal) {
+			console.log(paddingTopOriginal)
+			this.elem.style.paddingTop = `${paddingTopOriginal}px`;
+		} else {
+			this.elem.style.removeProperty('padding-top')
+		}
 
+		const paddingBottomOriginal = parseInt(this.elem.style.paddingBottom || 0);
 		const marginBParent = (parseInt(style.marginBottom) || 0);
 		this.elem.style.paddingBottom = `${paddingTemp}px`; // forces bottom margin to NOT collapse between parent and bottommost child!
-		const marginBChild = (this.elem.getBoundingClientRect().height - paddingTemp - originalHeight || 0);
+		const marginBChild = (this.elem.getBoundingClientRect().height - paddingTemp + paddingBottomOriginal - originalHeight || 0);
 		let marginB;
 		if (marginBParent < 0 && marginBChild < 0) {
 			marginB = Math.min(marginBParent, marginBChild);
@@ -116,7 +124,11 @@ class AnimationState {
 		} else {
 			marginB = Math.max(marginBParent, marginBChild);
 		}
-		this.elem.style.paddingBottom = `0px`;
+		if (paddingBottomOriginal) {
+			this.elem.style.paddingBottom = `${paddingBottomOriginal}px`;
+		} else {
+			this.elem.style.removeProperty('padding-bottom')
+		}
 
 		const marginsV = marginT + marginB;
 

--- a/directives/animate/animate.js
+++ b/directives/animate/animate.js
@@ -86,23 +86,47 @@ class AnimationState {
 		const style = window.getComputedStyle(this.elem);
 
 		const styleAttr = this.elem.getAttribute('style');
-		if (style.display !== 'flex') {
-			this.elem.style.display = 'grid'; // forces margins to collapse during size calculation
-		}
 
 		const rect = this.elem.getBoundingClientRect();
 		const top = this.elem.offsetTop - (this.elem.scrollTop || 0);
 		const left = this.elem.offsetLeft - (this.elem.scrollLeft || 0);
 		const marginsH = (parseInt(style.marginLeft) || 0) + (parseInt(style.marginRight) || 0);
-		const marginsV = (parseInt(style.marginTop) || 0) + (parseInt(style.marginBottom) || 0);
+		const originalHeight = rect.height;
+
+		const paddingTemp = 1;
+		const marginTParent = (parseInt(style.marginTop) || 0);
+		this.elem.style.paddingTop = `${paddingTemp}px`; // forces top margin to NOT collapse between parent and topmost child!
+		const marginTChild = (this.elem.getBoundingClientRect().height - paddingTemp - originalHeight || 0);
+		let marginT;
+		if (marginTParent < 0 && marginTChild < 0) {
+			marginT = Math.min(marginTParent, marginTChild);
+		} else if (marginTParent < 0 || marginTChild < 0) {
+			marginT = marginTParent + marginTChild;
+		} else {
+			marginT = Math.max(marginTParent, marginTChild);
+		}
+		this.elem.style.paddingTop = `0px`;
+
+		const marginBParent = (parseInt(style.marginBottom) || 0);
+		this.elem.style.paddingBottom = `${paddingTemp}px`; // forces bottom margin to NOT collapse between parent and bottommost child!
+		const marginBChild = (this.elem.getBoundingClientRect().height - paddingTemp - originalHeight || 0);
+		let marginB;
+		if (marginBParent < 0 && marginBChild < 0) {
+			marginB = Math.min(marginBParent, marginBChild);
+		} else if (marginBParent < 0 || marginBChild < 0) {
+			marginB = marginBParent + marginBChild;
+		} else {
+			marginB = Math.max(marginBParent, marginBChild);
+		}
+		this.elem.style.paddingBottom = `0px`;
+
+		const marginsV = marginT + marginB;
 
 		let cloneHeight = 0;
 		if (this.clone !== null) {
 			const cloneRect = this.clone.getBoundingClientRect();
 			cloneHeight = cloneRect.height;
 		}
-
-		this.elem.style.removeProperty('display');
 
 		return {
 			clone: {

--- a/directives/animate/animate.js
+++ b/directives/animate/animate.js
@@ -87,6 +87,11 @@ class AnimationState {
 
 		const styleAttr = this.elem.getAttribute('style');
 
+		const hasHiddenAttr = this.elem.getAttribute('hidden') !== null ? true : false;
+		if (hasHiddenAttr) {
+			this.elem.removeAttribute('hidden');
+		}
+
 		const rect = this.elem.getBoundingClientRect();
 		const marginsH = (parseInt(style.marginLeft) || 0) + (parseInt(style.marginRight) || 0);
 		const originalHeight = rect.height;
@@ -139,6 +144,10 @@ class AnimationState {
 		if (this.clone !== null) {
 			const cloneRect = this.clone.getBoundingClientRect();
 			cloneHeight = cloneRect.height;
+		}
+
+		if (hasHiddenAttr) {
+			this.elem.setAttribute('hidden', '');
 		}
 
 		return {


### PR DESCRIPTION
This PR aims to fix some issues that I noticed [while trying to use this directive with Discover's rule picker](https://github.com/BrightspaceHypermediaComponents/foundation-components/commits/awang/us126118-animation-directive-rule-picker), as well as some other issues that I found.

- At the end of the show transition, the "Add Condition" button would snap back. This was because the absolute positioned elem used a `top` value of `elem.offsetTop`, but  `offsetTop` is the distance to the border, whereas `top` position refers to the top of the margin. Subtracted additional `marginTop` from `top` to fix this 
- I removed the use of `display: grid` for calculating the clone's height. I found that in certain situations, this was actually causing an issue. For example, this forces children (i.e. grid items) to have un-collapsed margins, despite being originally collapsed. This caused improper calculations in height. This has been been replaced with using temporary padding on the elem to force margins to but un-collapsed, and then calculating the top and bottom margins individually from there, and applying that to the clone's height. This solution avoids changing the display style, so that we know exactly what will happen to the margins/padding when calculating clone height.
- In the rule picker, it was possible to add a condition, and exit the dialog fast enough such that the `transitionend` event won't fire. This PR adds a 'transitioncancel' event to handle that scenario.
- `styleAttr` would act very weirdly if we hide -> show while still in hide transition. The elem would still have inline styling from the hide animation, so show's styleAttr would be based on that. Handled this case.


With these out of the way, the rule picker looks mostly great. An issue I noticed but wasn't able to fix (and might not affect the rule picker, but would possibly affect other things):
- If there is margin collapse between sibling elements (for example, in the demo's case, if there is `margin-bottom` on the checkbox, and `margin-top` on the list), snapping still occurs. Setting the `margin-bottom` to 0 on the checkbox, and letting the list have any value for `margin-top` seems to avoid snapping, so I suspect that sibling margin-collapse is the issue here.