### PR TITLE
fix: properly handle min/max fraction digits

### DIFF
--- a/components/inputs/demo/input-number.html
+++ b/components/inputs/demo/input-number.html
@@ -66,7 +66,7 @@
 			<h2>Min and Max Fraction Digits</h2>
 			<d2l-demo-snippet>
 				<template>
-					<d2l-input-number label="Points" value="1.23" min-fraction-digits="1" max-fraction-digits="2"></d2l-input-number>
+					<d2l-input-number label="Points" value="1.23456" min-fraction-digits="1" max-fraction-digits="2"></d2l-input-number>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/inputs/docs/input-number.md
+++ b/components/inputs/docs/input-number.md
@@ -23,10 +23,10 @@ The `<d2l-input-number>` element is similar to `<d2l-input-text>`, except it's i
 | `label-hidden` | Boolean, default: `false` | Hides the label visually (moves it to the input's `aria-label` attribute). |
 | `max` | Number | Maximum value allowed. |
 | `max-exclusive` | Boolean, default: `false` | Indicates whether the max value is exclusive. |
-| `max-fraction-digits` | Number | Maximum number of digits allowed after the decimal place. |
+| `max-fraction-digits` | Number, default: Greater of `minFractionDigits` or `3` | Maximum number of digits allowed after the decimal place. Must be between 0 and 20 and greater than or equal to `minFractionDigits` |
 | `min` | Number | Minimum value allowed. |
 | `min-exclusive` | Boolean, default: `false` | Indicates whether the min value is exclusive. |
-| `min-fraction-digits` | Number | Minimum number of digits allowed after the decimal place. |
+| `min-fraction-digits` | Number, default: `0` | Minimum number of digits allowed after the decimal place. Must be between 0 and 20 and less than or equal to `maxFractionDigits` |
 | `placeholder` | String | Placeholder text. |
 | `required` | Boolean, default: `false` | Indicates that a value is required. |
 | `title` | String | Text for additional screen reader and mouseover context. |

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -40,6 +40,15 @@ function countDecimalDigits(value, useLocaleDecimal) {
 
 }
 
+// from: https://medium.com/swlh/how-to-round-to-a-certain-number-of-decimal-places-in-javascript-ed74c471c1b8
+function roundPrecisely(val, maxFractionDigits) {
+	const isNegative = val < 0;
+	const positiveValue = Math.abs(val);
+	// eslint-disable-next-line prefer-template
+	const roundedValue = Number(Math.round(positiveValue + `e${maxFractionDigits}`) + `e-${maxFractionDigits}`);
+	return isNegative ? -Math.abs(roundedValue) : roundedValue;
+}
+
 class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))) {
 
 	static get properties() {
@@ -63,7 +72,7 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 			trailingZeroes: { type: Boolean, attribute: 'trailing-zeroes' },
 			unit: { type: String },
 			value: { type: Number },
-			valueTrailingZeroes: { String, attribute: 'value-trailing-zeroes' },
+			valueTrailingZeroes: { type: String, attribute: 'value-trailing-zeroes' },
 			_formattedValue: { type: String }
 		};
 	}
@@ -100,6 +109,7 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 	}
 
 	get maxFractionDigits() {
+		// emulate Intl's default maxFractionDigits behaviour
 		return this._maxFractionDigits ?? Math.max(this.minFractionDigits, 3);
 	}
 	set maxFractionDigits(val) {
@@ -129,8 +139,7 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 
 	get value() {
 		if (this._value === undefined) return undefined;
-		const precision = Math.pow(10, this.maxFractionDigits);
-		return Math.round((this._value + Number.EPSILON) * precision) / precision;
+		return roundPrecisely(this._value, this.maxFractionDigits);
 	}
 	set value(val) {
 		const oldValue = this.value;

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -40,13 +40,16 @@ function countDecimalDigits(value, useLocaleDecimal) {
 
 }
 
-// from: https://medium.com/swlh/how-to-round-to-a-certain-number-of-decimal-places-in-javascript-ed74c471c1b8
 function roundPrecisely(val, maxFractionDigits) {
-	const isNegative = val < 0;
-	const positiveValue = Math.abs(val);
-	// eslint-disable-next-line prefer-template
-	const roundedValue = Number(Math.round(positiveValue + `e${maxFractionDigits}`) + `e-${maxFractionDigits}`);
-	return isNegative ? -Math.abs(roundedValue) : roundedValue;
+	const strValue = new Intl.NumberFormat(
+		'en-US',
+		{
+			maximumFractionDigits: maxFractionDigits,
+			minimumFractionDigits: 0,
+			useGrouping: false
+		}
+	).format(val);
+	return parseFloat(strValue);
 }
 
 class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))) {

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -173,6 +173,12 @@ describe('d2l-input-number', () => {
 			expect(elem._formattedValue).to.equal('1.000000');
 		});
 
+		it('should round negative numbers properly', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="-0.55" max-fraction-digits="1"></d2l-input-number>`);
+			expect(elem.value).to.equal(-0.6);
+			expect(elem._formattedValue).to.equal('-0.6');
+		});
+
 	});
 
 	describe('invalid values', () => {
@@ -450,6 +456,19 @@ describe('d2l-input-number', () => {
 			expect(elem.value).to.equal(2001);
 			expect(elem.valueTrailingZeroes).to.equal('2001.00');
 			expect(elem._formattedValue).to.equal('2 001,00');
+		});
+
+		[
+			'12', '12.1', '12.10', '12.0', '12.00000',
+			'1', '1.1', '1.10', '1.0', '1.00000',
+			'-1', '-1.1', '-1.10', '-1.0', '-1.00000'
+		].forEach((val) => {
+			it(`should preserve ${val} when set initially`, async() => {
+				const elem = await fixture(html`<d2l-input-number label="label" trailing-zeroes value-trailing-zeroes="${val}" max-fraction-digits="16"></d2l-input-number>`);
+				expect(elem.value).to.equal(parseFloat(val));
+				expect(elem.valueTrailingZeroes).to.equal(val);
+				expect(elem._formattedValue).to.equal(val);
+			});
 		});
 
 	});

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -179,6 +179,14 @@ describe('d2l-input-number', () => {
 			expect(elem._formattedValue).to.equal('-0.6');
 		});
 
+		it('should handle large numbers with large precision', async() => {
+			// Safari won't format numbers with more than 15 significant digits
+			// Other browsers can handle no more than 17
+			const elem = await fixture(html`<d2l-input-number label="label" value="1234567890.12345" max-fraction-digits="16"></d2l-input-number>`);
+			expect(elem.value).to.equal(1234567890.12345);
+			expect(elem._formattedValue).to.equal('1,234,567,890.12345');
+		});
+
 	});
 
 	describe('invalid values', () => {

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -12,8 +12,6 @@ const minFixture = html`<d2l-input-number label="label" min="5"></d2l-input-numb
 const minExclusiveFixture = html`<d2l-input-number label="label" min="5" min-exclusive></d2l-input-number>`;
 const maxFixture = html`<d2l-input-number label="label" max="10"></d2l-input-number>`;
 const maxExclusiveFixture = html`<d2l-input-number label="label" max="10" max-exclusive></d2l-input-number>`;
-const minMaxFractionDigitsFixture = html`<d2l-input-number label="label" min-fraction-digits="2" max-fraction-digits="3"></d2l-input-number>`;
-const integerFixture = html`<d2l-input-number label="label" max-fraction-digits="0"></d2l-input-number>`;
 
 function dispatchEvent(elem, eventType) {
 	const e = new Event(
@@ -58,90 +56,142 @@ describe('d2l-input-number', () => {
 			});
 		});
 
-		['autocomplete', 'max', 'maxFractionDigits', 'min', 'minFractionDigits', 'placeholder', 'title', 'value'].forEach((name) => {
+		['autocomplete', 'max', 'min', 'placeholder', 'title', 'value'].forEach((name) => {
 			it(`should default "${name}" property to 'undefined' when unset`, async() => {
-				expect(elem.value).to.equal(undefined);
+				expect(elem[name]).to.equal(undefined);
 			});
 		});
 
 		it('should default "formattedValue" property to empty when unset', () => {
 			expect(elem._formattedValue).to.equal('');
 		});
+
 	});
 
 	describe('min and max fraction digits', () => {
-		[
-			{
-				name: 'should round down to the nearest integer',
-				fixture: integerFixture,
-				value: 15.2345,
-				expectedValue: 15,
-				expectInnerValue: '15'
-			},
-			{
-				name: 'should round up to the nearest integer',
-				fixture: integerFixture,
-				value: 15.6345,
-				expectedValue: 16,
-				expectInnerValue: '16'
-			},
-			{
-				name: 'should automatically add zeroes to match min fraction digits',
-				fixture: minMaxFractionDigitsFixture,
-				value: 1,
-				expectedValue: 1,
-				expectInnerValue: '1.00'
-			},
-			{
-				name: 'should automatically round up to match max fraction digits',
-				fixture: minMaxFractionDigitsFixture,
-				value: 1.2345,
-				expectedValue: 1.235,
-				expectInnerValue: '1.235'
-			},
-			{
-				name: 'should automatically round down to match max fraction digits',
-				fixture: minMaxFractionDigitsFixture,
-				value: 1.2344,
-				expectedValue: 1.234,
-				expectInnerValue: '1.234'
-			}
-		].forEach((test) => {
-			it(test.name, async() => {
-				const elem = await fixture(test.fixture);
-				elem.value = test.value;
+
+		it('should default "maxFractionDigits" to 3', async() => {
+			const elem = await fixture(normalFixture);
+			expect(elem.maxFractionDigits).to.equal(3);
+		});
+
+		it('should default "maxFractionDigits" to "minFractionDigits" if set', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" min-fraction-digits="5"></d2l-input-number>`);
+			expect(elem.maxFractionDigits).to.equal(5);
+		});
+
+		it('should update "maxFractionDigits" to "minFractionDigits" if changed', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label"></d2l-input-number>`);
+			elem.minFractionDigits = 6;
+			expect(elem.maxFractionDigits).to.equal(6);
+		});
+
+		it('should default "minFractionDigits" to 0', async() => {
+			const elem = await fixture(normalFixture);
+			expect(elem.minFractionDigits).to.equal(0);
+		});
+
+		it('should throw if minFractionDigits is less than zero', async() => {
+			const elem = await fixture(normalFixture);
+			expect(() => elem.minFractionDigits = -1).to.throw(RangeError);
+		});
+
+		it('should throw if minFractionDigits is greater than 20', async() => {
+			const elem = await fixture(normalFixture);
+			expect(() => elem.minFractionDigits = 21).to.throw(RangeError);
+		});
+
+		it('should throw if maxFractionDigits is less than zero', async() => {
+			const elem = await fixture(normalFixture);
+			expect(() => elem.maxFractionDigits = -1).to.throw(RangeError);
+		});
+
+		it('should throw if maxFractionDigits is greater than 20', async() => {
+			const elem = await fixture(normalFixture);
+			expect(() => elem.maxFractionDigits = 21).to.throw(RangeError);
+		});
+
+		it('should throw if maxFractionDigits is less than minFractionDigits', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" min-fraction-digits="6"></d2l-input-number>`);
+			expect(() => elem.maxFractionDigits = 5).to.throw(RangeError);
+		});
+
+		it('should round to 3 fraction digits by default', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="0.555555"></d2l-input-number>`);
+			expect(elem.value).to.equal(0.556);
+			expect(getInnerInputValue(elem)).to.equal('0.556');
+		});
+
+		it('should round to specified max fraction digits', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="0.555555" max-fraction-digits="4"></d2l-input-number>`);
+			expect(elem.value).to.equal(0.5556);
+			expect(getInnerInputValue(elem)).to.equal('0.5556');
+		});
+
+		it('should round down to the nearest integer', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="15.2345" max-fraction-digits="0"></d2l-input-number>`);
+			expect(elem.value).to.equal(15);
+			expect(getInnerInputValue(elem)).to.equal('15');
+		});
+
+		it('should round up to the nearest integer', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="15.512" max-fraction-digits="0"></d2l-input-number>`);
+			expect(elem.value).to.equal(16);
+			expect(getInnerInputValue(elem)).to.equal('16');
+		});
+
+		it('should preserve precision when max fraction digits increases', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="0.555555" max-fraction-digits="4"></d2l-input-number>`);
+			elem.maxFractionDigits = 5;
+			expect(elem.value).to.equal(0.55556);
+			expect(elem._formattedValue).to.equal('0.55556');
+		});
+
+		it('should round further when max fraction digits decreases', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="0.555555" max-fraction-digits="4"></d2l-input-number>`);
+			elem.maxFractionDigits = 2;
+			expect(elem.value).to.equal(0.56);
+			expect(elem._formattedValue).to.equal('0.56');
+		});
+
+		it('should have no minimum fraction digits by default', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="1.00"></d2l-input-number>`);
+			expect(elem.value).to.equal(1);
+			expect(getInnerInputValue(elem)).to.equal('1');
+		});
+
+		it('should add minimum fraction digits when set', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="1" min-fraction-digits="5"></d2l-input-number>`);
+			expect(elem.value).to.equal(1);
+			expect(getInnerInputValue(elem)).to.equal('1.00000');
+		});
+
+		it('should add fraction digits when min fraction digits changes', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="1" min-fraction-digits="5"></d2l-input-number>`);
+			elem.minFractionDigits = 6;
+			expect(elem.value).to.equal(1);
+			expect(elem._formattedValue).to.equal('1.000000');
+		});
+
+	});
+
+	describe('invalid values', () => {
+		[undefined, null, NaN, 'helloworld123'].forEach((val) => {
+			it(`should reset "${val} to undefined`, async() => {
+				const elem = await fixture(normalFixture);
+				elem.value = val;
 				await elem.updateComplete;
-				expect(elem.value).to.equal(test.expectedValue);
-				expect(getInnerInputValue(elem)).to.equal(test.expectInnerValue);
+				expect(elem.value).to.equal(undefined);
+				expect(getInnerInputValue(elem)).to.equal('');
 			});
 		});
 	});
 
-	describe('invalid values', () => {
-		it('should reset value', async() => {
-			const elem = await fixture(normalFixture);
-			elem.value = 'helloworld123';
-			await elem.updateComplete;
-			expect(elem.value).to.equal(undefined);
-			expect(getInnerInputValue(elem)).to.equal('');
-		});
-	});
-
-	describe('re-formatting values', () => {
-		it('should add a comma for numbers in thousands using Intl library', async() => {
-			const elem = await fixture(normalFixture);
-			elem.value = 1000;
-			await elem.updateComplete;
+	describe('formatted value', () => {
+		it('should add a comma for numbers in thousands', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value="1000"></d2l-input-number>`);
 			expect(elem.value).to.equal(1000);
 			expect(getInnerInputValue(elem)).to.equal('1,000');
-		});
-
-		it('should format/parse values that start with numbers using Intl library', async() => {
-			const elem = await fixture(normalFixture);
-			elem.value = '123abc';
-			await elem.updateComplete;
-			expect(elem.value).to.equal(123);
-			expect(getInnerInputValue(elem)).to.equal('123');
 		});
 	});
 
@@ -271,57 +321,135 @@ describe('d2l-input-number', () => {
 
 	describe('trailing zeroes', () => {
 
-		const trailingZeroesFixture = html`<d2l-input-number label="label" value-trailing-zeroes="1.00" trailing-zeroes></d2l-input-number>`;
+		const trailingZeroesFixture = html`<d2l-input-number label="label" value-trailing-zeroes="2001.00" trailing-zeroes></d2l-input-number>`;
+
+		it('should default to empty', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" trailing-zeroes></d2l-input-number>`);
+			expect(elem.value).to.be.undefined;
+			expect(elem.valueTrailingZeroes).to.equal('');
+			expect(getInnerInputValue(elem)).to.equal('');
+		});
+
+		it('should become empty when set to empty string', async() => {
+			const elem = await fixture(trailingZeroesFixture);
+			elem.valueTrailingZeroes = '';
+			expect(elem.value).to.be.undefined;
+			expect(elem.valueTrailingZeroes).to.equal('');
+			await elem.updateComplete;
+			expect(getInnerInputValue(elem)).to.equal('');
+		});
 
 		it('should preserve initial trailing zeroes', async() => {
 			const elem = await fixture(trailingZeroesFixture);
-			expect(elem.value).to.equal(1);
-			expect(elem._formattedValue).to.equal('1.00');
+			expect(elem.value).to.equal(2001);
+			expect(elem.valueTrailingZeroes).to.equal('2001.00');
+			expect(getInnerInputValue(elem)).to.equal('2,001.00');
+		});
+
+		it('should cap initial trailing zeroes at default max-fraction-digits (3)', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value-trailing-zeroes="2001.00000" trailing-zeroes></d2l-input-number>`);
+			expect(elem.value).to.equal(2001);
+			expect(elem.valueTrailingZeroes).to.equal('2001.000');
+			expect(getInnerInputValue(elem)).to.equal('2,001.000');
 		});
 
 		it('should cap initial trailing zeroes at max-fraction-digits', async() => {
-			const elem = await fixture(html`<d2l-input-number label="label" value-trailing-zeroes="1.00000" trailing-zeroes max-fraction-digits="4"></d2l-input-number>`);
-			expect(elem.value).to.equal(1);
-			expect(elem._formattedValue).to.equal('1.0000');
+			const elem = await fixture(html`<d2l-input-number label="label" value-trailing-zeroes="2001.00000" trailing-zeroes max-fraction-digits="4"></d2l-input-number>`);
+			expect(elem.value).to.equal(2001);
+			expect(elem.valueTrailingZeroes).to.equal('2001.0000');
+			expect(getInnerInputValue(elem)).to.equal('2,001.0000');
 		});
 
-		it('should have no cap if max-fraction-digits is not set', async() => {
-			const elem = await fixture(html`<d2l-input-number label="label" value-trailing-zeroes="-5.0000000" trailing-zeroes></d2l-input-number>`);
-			expect(elem.value).to.equal(-5);
-			expect(elem._formattedValue).to.equal('-5.0000000');
+		it('should only add extra trailing zeroes to formatted value', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" value-trailing-zeroes="2001.00" trailing-zeroes min-fraction-digits="4"></d2l-input-number>`);
+			expect(elem.value).to.equal(2001);
+			expect(elem.valueTrailingZeroes).to.equal('2001.00');
+			expect(getInnerInputValue(elem)).to.equal('2,001.0000');
 		});
 
 		it('should preserve trailing zeroes after user interaction', async() => {
 			const elem = await fixture(trailingZeroesFixture);
-			setInnerInputValue(elem, '2.00');
+			setInnerInputValue(elem, '3002.000');
 			await oneEvent(elem, 'change');
-			expect(elem.value).to.equal(2);
-			expect(elem._formattedValue).to.equal('2.00');
+			expect(elem.value).to.equal(3002);
+			expect(elem.valueTrailingZeroes).to.equal('3002.000');
+			expect(elem._formattedValue).to.equal('3,002.000');
 		});
 
 		it('should preserve trailing zeroes after user interaction with no initial value', async() => {
 			const elem = await fixture(html`<d2l-input-number label="label" trailing-zeroes></d2l-input-number>`);
-			expect(elem.value).to.be.undefined;
-			expect(elem._formattedValue).to.equal('');
-			setInnerInputValue(elem, '2.00');
+			setInnerInputValue(elem, '1234.00');
 			await oneEvent(elem, 'change');
-			expect(elem.value).to.equal(2);
-			expect(elem._formattedValue).to.equal('2.00');
+			expect(elem.value).to.equal(1234);
+			expect(elem.valueTrailingZeroes).to.equal('1234.00');
+			expect(elem._formattedValue).to.equal('1,234.00');
 		});
 
 		it('should preserve trailing zeroes after setAttribute', async() => {
 			const elem = await fixture(trailingZeroesFixture);
-			elem.setAttribute('value-trailing-zeroes', '1234.29000');
-			await elem.updateComplete;
+			elem.setAttribute('value-trailing-zeroes', '1234.2900');
 			expect(elem.value).to.equal(1234.29);
-			expect(elem._formattedValue).to.equal('1,234.29000');
+			expect(elem.valueTrailingZeroes).to.equal('1234.290');
+			await elem.updateComplete;
+			expect(getInnerInputValue(elem)).to.equal('1,234.290');
 		});
 
-		it('should forget trailing zeroes when value is set directly', async() => {
+		it('should preserve trailing zeroes after property setter', async() => {
 			const elem = await fixture(trailingZeroesFixture);
-			elem.value = 2;
+			elem.valueTrailingZeroes = '1234.2900';
+			expect(elem.value).to.equal(1234.29);
+			expect(elem.valueTrailingZeroes).to.equal('1234.290');
 			await elem.updateComplete;
-			expect(elem._formattedValue).to.equal('2');
+			expect(getInnerInputValue(elem)).to.equal('1,234.290');
+		});
+
+		it('should preserve trailing zeroes after property setter to negative value', async() => {
+			const elem = await fixture(trailingZeroesFixture);
+			elem.valueTrailingZeroes = '-1234.2900';
+			expect(elem.value).to.equal(-1234.29);
+			expect(elem.valueTrailingZeroes).to.equal('-1234.290');
+			await elem.updateComplete;
+			expect(getInnerInputValue(elem)).to.equal('-1,234.290');
+		});
+
+		it('should handle no decimals trailing zeroes', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" trailing-zeroes value-trailing-zeroes="-9.000"></d2l-input-number>`);
+			expect(elem.value).to.equal(-9);
+			expect(elem.valueTrailingZeroes).to.equal('-9.000');
+			expect(getInnerInputValue(elem)).to.equal('-9.000');
+		});
+
+		it('should handle some decimals trailing zeroes', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" trailing-zeroes value-trailing-zeroes="-9.100"></d2l-input-number>`);
+			expect(elem.value).to.equal(-9.1);
+			expect(elem.valueTrailingZeroes).to.equal('-9.100');
+			expect(getInnerInputValue(elem)).to.equal('-9.100');
+		});
+
+		it('should fire "change" event when only decimals change', async() => {
+			const elem = await fixture(trailingZeroesFixture);
+			setInnerInputValue(elem, '2001.000');
+			await oneEvent(elem, 'change');
+			expect(elem.value).to.equal(2001);
+			expect(elem.valueTrailingZeroes).to.equal('2001.000');
+			expect(elem._formattedValue).to.equal('2,001.000');
+		});
+
+		it('should handle changing to a negative value', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" trailing-zeroes value-trailing-zeroes="3.140"></d2l-input-number>`);
+			setInnerInputValue(elem, '-3.290');
+			await oneEvent(elem, 'change');
+			expect(elem.value).to.equal(-3.29);
+			expect(elem.valueTrailingZeroes).to.equal('-3.290');
+			expect(getInnerInputValue(elem)).to.equal('-3.290');
+		});
+
+		it('should handle different locales', async() => {
+			documentLocaleSettings.language = 'fr-CA';
+			const elem = await fixture(trailingZeroesFixture);
+			expect(elem.value).to.equal(2001);
+			expect(elem.valueTrailingZeroes).to.equal('2001.00');
+			expect(elem._formattedValue).to.equal('2 001,00');
 		});
 
 	});

--- a/components/inputs/test/input-percent.test.js
+++ b/components/inputs/test/input-percent.test.js
@@ -59,7 +59,7 @@ describe('d2l-input-percent', () => {
 
 			const inputNumberElement = elem.shadowRoot.querySelector('d2l-input-number');
 			setTimeout(() => {
-				inputNumberElement.value = '80';
+				inputNumberElement.setAttribute('value', 80);
 				dispatchEvent(inputNumberElement, 'change');
 			});
 			await aTimeout(1);


### PR DESCRIPTION
Lots of tricky stuff at play here, so would definitely appreciate feedback.

This fixes some major issues with how `value` (and `valueTrailingZeroes`), `minFractionDigits` and `maxFractionDigits` work together. These were problems before the trailing-zeroes stuff, but we just weren't testing/looking for it.

The problem is this: while the element is initializing, property setters get called out of order. So initially, the constructor sets default values -- which may be `undefined`. Then one by one, if an attribute is set, the property setter will get called with that attribute. But if you have properties that are interdependent on each other -- like is the case here where value gets rounded based on `maxFractionDigits`, this is problem.

As an example, I noticed that `<d2l-input-number value="1.23456" max-fraction-digits="10">` would cause the value to immediately get trimmed to `1.235` since the default `maxFractionDigits` is `3`. Then `maxFractionDigits` would get set to `10` but it would be too late -- we've already rounded `value` and lost the original precision and can't get it back.

To fix this, `_value` (and `_valueTrailingZeroes` if that crazy setup is being used) will always store the full precision. It's only in the getter that we do the rounding. And then in the setters for max/min fraction digits we just have to update the formatted value.

I tried several iterations of this fix, including storing separate `_value` and `_valuePrecise` and this is the one I landed on. But definitely open to other ideas!