### PR TITLE
accidentally was running only input-number tests

### DIFF
--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -33,7 +33,7 @@ async function setInnerInputValue(elem, value) {
 	setTimeout(() => dispatchEvent(inputTextElement, 'change'));
 }
 
-describe.only('d2l-input-number', () => {
+describe('d2l-input-number', () => {
 
 	const documentLocaleSettings = getDocumentLocaleSettings();
 	afterEach(() => {


### PR DESCRIPTION
Probably good to get this fix in [separate from the input number changes](#1260).