### PR TITLE
hierarchical view fixes for better custom view support

### DIFF
--- a/components/dropdown/demo/dropdown-menu.html
+++ b/components/dropdown/demo/dropdown-menu.html
@@ -106,7 +106,7 @@
 					<button class="d2l-dropdown-opener">Open it!</button>
 					<d2l-dropdown-menu id="dropdown" no-padding-footer>
 						<div slot="header" style="font-weight: bold; width: 100%; text-align: center;">Physics Topics</div>
-						<d2l-menu>
+						<d2l-menu label="Physics Topics">
 							<d2l-menu-item text="Introduction"></d2l-menu-item>
 							<d2l-menu-item text="Matter"></d2l-menu-item>
 							<d2l-menu-item text="Speed"></d2l-menu-item>
@@ -137,7 +137,7 @@
 					<button class="d2l-dropdown-opener">Open it!</button>
 					<d2l-dropdown-menu id="dropdown" no-padding-footer>
 						<div slot="header" style="font-weight: bold; width: 100%; text-align: center;">Study Guide</div>
-						<d2l-menu>
+						<d2l-menu label="Study Guide">
 							<d2l-menu-item-radio text="Introduction" value=0></d2l-menu-item-radio>
 							<d2l-menu-item-radio text="Chapter 1" value=1></d2l-menu-item-radio>
 							<d2l-menu-item-radio text="Chapter 2" value=2></d2l-menu-item-radio>
@@ -162,7 +162,7 @@
 					<button class="d2l-dropdown-opener">Open it!</button>
 					<d2l-dropdown-menu no-padding-footer>
 						<div slot="header" style="font-weight: bold; width: 100%; text-align: center;">Helpful Links</div>
-						<d2l-menu>
+						<d2l-menu label="Helpful Links">
 							<d2l-menu-item-link text="menu.js (View)" href="../../menu/menu.js"></d2l-menu-item-link>
 							<d2l-menu-item-link text="menu.js (Download)" href="../../menu/menu.js" target="_blank" download></d2l-menu-item-link>
 						</d2l-menu>

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -303,9 +303,9 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 		/* The purpose of this logic is to direct focus to the correct element, so that user
 		is never focused in a view that is not visible. It works based on the premise that all
-		elements are "display: none" except for the elements between the root view and the active
-		view, and the elements within the active view. Also worth noting, only the root view
-		captures focus with this handler. */
+		elements within the hierarchy are "display: none" except for the elements between the
+		root view and the active view, and the elements within the active view. Also worth noting,
+		only the root view captures focus with this handler. */
 
 		const parentView = this.__getParentViewFromEvent(e);
 

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -300,8 +300,16 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__focusCapture(e) {
+
+		/* The purpose of this logic is to direct focus to the correct element, so that user
+		is never focused in a view that is not visible to the user. It works based on the premise
+		that all elements are "display: none" except for the elements between the root of the
+		hierarchy and the active view, and the elements within the active view. Also worth noting,
+		only the root-view captures focus with this handler. */
+
 		const parentView = this.__getParentViewFromEvent(e);
 
+		// the parent view of the element receiving focus is active, so nothing special to do
 		if (parentView.isActive()) return;
 
 		const relatedTarget = e.relatedTarget;
@@ -318,8 +326,10 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 		if (relatedTarget) {
 			if (!isComposedAncestor(this, relatedTarget)) {
+				// user MUST be tabbing forwards from outside hierarchy so move focus to active view
 				focusableElement = getNextFocusableLocal();
 			} else {
+				// user MUST be tabbing backwards out of the active view so move focus before the hierarchy
 				focusableElement = getPreviousFocusable(this);
 			}
 		} else {

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -522,11 +522,11 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__updateFocusablesHide(view) {
-		this.__updateFocusables(view, 'd2l-hierarchical-view-tabindex', 'tabindex');
+		this.__updateFocusables(view, 'data-d2l-hierarchical-view-tabindex', 'tabindex');
 	}
 
 	__updateFocusablesShow(view) {
-		this.__updateFocusables(view, 'tabindex', 'd2l-hierarchical-view-tabindex');
+		this.__updateFocusables(view, 'tabindex', 'data-d2l-hierarchical-view-tabindex');
 	}
 
 };

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -391,7 +391,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 	__onHideStart(e) {
 		// re-enable focusable ancestor
-		this.__updateFocusablesHide(e.detail.sourceView);
+		this.__resetAncestorTabIndicies(e.detail.sourceView);
 
 		const rootTarget = e.composedPath()[0];
 		if (rootTarget === this || !rootTarget.hierarchicalView) return;
@@ -406,7 +406,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 				rootTarget.shown = false;
 				requestAnimationFrame(() => {
 					// disable focusable ancestors of new active view so they can't steal focus from custom views
-					this.__updateFocusablesShow(this.getActiveView());
+					this.__removeAncestorTabIndicies(this.getActiveView());
 
 					rootTarget.__dispatchHideComplete(data);
 				});
@@ -450,7 +450,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 	__onShowStart(e) {
 		// disable focusable ancestors so they can't steal focus from custom views
-		this.__updateFocusablesShow(e.detail.sourceView);
+		this.__removeAncestorTabIndicies(e.detail.sourceView);
 
 		const rootTarget = e.composedPath()[0];
 		if (rootTarget === this || !rootTarget.hierarchicalView) return;
@@ -498,6 +498,14 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		}
 	}
 
+	__removeAncestorTabIndicies(view) {
+		this.__updateAncestorTabIndicies(view, 'tabindex', 'data-d2l-hierarchical-view-tabindex');
+	}
+
+	__resetAncestorTabIndicies(view) {
+		this.__updateAncestorTabIndicies(view, 'data-d2l-hierarchical-view-tabindex', 'tabindex');
+	}
+
 	__startResizeObserver() {
 		const content = this.shadowRoot.querySelector('.d2l-hierarchical-view-content');
 		this.__bound_dispatchViewResize = this.__bound_dispatchViewResize || this.__dispatchViewResize.bind(this);
@@ -506,7 +514,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.__resizeObserver.observe(content);
 	}
 
-	__updateFocusables(view, sourceAttribute, targetAttribute) {
+	__updateAncestorTabIndicies(view, sourceAttribute, targetAttribute) {
 		const rootView = this.getRootView();
 		let node = getComposedParent(view);
 		while (node && node !== rootView) {
@@ -519,14 +527,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 			}
 			node = getComposedParent(node);
 		}
-	}
-
-	__updateFocusablesHide(view) {
-		this.__updateFocusables(view, 'data-d2l-hierarchical-view-tabindex', 'tabindex');
-	}
-
-	__updateFocusablesShow(view) {
-		this.__updateFocusables(view, 'tabindex', 'data-d2l-hierarchical-view-tabindex');
 	}
 
 };

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -137,6 +137,13 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.addEventListener('d2l-hierarchical-view-show-start', this.__onShowStart);
 		this.addEventListener('d2l-hierarchical-view-resize', this.__onViewResize);
 
+		// prevent these events from bubbling up from custom views
+		this.addEventListener('beforeinput', e => e.stopPropagation());
+		this.addEventListener('click', e => e.stopPropagation());
+		this.addEventListener('keydown', e => e.stopPropagation());
+		this.addEventListener('keyup', e => e.stopPropagation());
+		this.addEventListener('keypress', e => e.stopPropagation());
+
 		this.__isChildView();
 	}
 

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -302,10 +302,10 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	__focusCapture(e) {
 
 		/* The purpose of this logic is to direct focus to the correct element, so that user
-		is never focused in a view that is not visible to the user. It works based on the premise
-		that all elements are "display: none" except for the elements between the root of the
-		hierarchy and the active view, and the elements within the active view. Also worth noting,
-		only the root-view captures focus with this handler. */
+		is never focused in a view that is not visible. It works based on the premise that all
+		elements are "display: none" except for the elements between the root view and the active
+		view, and the elements within the active view. Also worth noting, only the root view
+		captures focus with this handler. */
 
 		const parentView = this.__getParentViewFromEvent(e);
 

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -137,12 +137,18 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.addEventListener('d2l-hierarchical-view-show-start', this.__onShowStart);
 		this.addEventListener('d2l-hierarchical-view-resize', this.__onViewResize);
 
+		const stopPropagation = e => {
+			// only stop for child views, so that Esc from root view can close dropdown
+			if (!this.childView) return;
+			e.stopPropagation();
+		};
+
 		// prevent these events from bubbling up from custom views
-		this.addEventListener('beforeinput', e => e.stopPropagation());
-		this.addEventListener('click', e => e.stopPropagation());
-		this.addEventListener('keydown', e => e.stopPropagation());
-		this.addEventListener('keyup', e => e.stopPropagation());
-		this.addEventListener('keypress', e => e.stopPropagation());
+		this.addEventListener('beforeinput', stopPropagation);
+		this.addEventListener('click', stopPropagation);
+		this.addEventListener('keydown', stopPropagation);
+		this.addEventListener('keyup', stopPropagation);
+		this.addEventListener('keypress', stopPropagation);
 
 		this.__isChildView();
 	}


### PR DESCRIPTION
This PR addresses two issues:

* ancestor views stealing focus away from nested custom views
* click and key events propagating outside the custom view

To prevent ancestor views from stealing focus, we temporarily remove `tabindex` from composed ancestors when drilled into custom views, and we restore them when drilling out.  Focusable items nested within other focusable items is kinda of a recipe for disaster.

For the click & key events, we simply call `stopPropagation` as they bubble to the custom view container.

I added some comments to the focus-capture code in effort to save some headaches of others that may read this code later, since it cost us both some time to figure it out.