### PR TITLE
fix: treat setting value to empty string the same as clearing it

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -146,7 +146,7 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 	}
 	set value(val) {
 		const oldValue = this.value;
-		if (val === null || isNaN(val)) {
+		if (val === null || val === '' || isNaN(val)) {
 			val = undefined;
 		}
 		this._value = val;

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -190,8 +190,8 @@ describe('d2l-input-number', () => {
 	});
 
 	describe('invalid values', () => {
-		[undefined, null, NaN, 'helloworld123'].forEach((val) => {
-			it(`should reset "${val} to undefined`, async() => {
+		[undefined, null, '', NaN, 'helloworld123'].forEach((val) => {
+			it(`should reset "${val}" to undefined`, async() => {
 				const elem = await fixture(normalFixture);
 				elem.value = val;
 				await elem.updateComplete;


### PR DESCRIPTION
Slight regression caused by #1260. Previously setting the value to empty string -- which [the monolith does](https://search.d2l.dev/xref/lms/lp/framework/web/D2L.Web/ui/Edit/JavaScript/EditNumber.js?r=dae941fe#32) to "clear" the input -- would result in an `undefined` value. After the recent changes, value would become `0`.

🎩  to @Dan-DeAraujo and the UI automation for catching this!