### PR TITLE
Refactor html-block rendering for math and @mentions.

### DIFF
--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -9,6 +9,60 @@
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../html-block.js';
+			import { provideInstance } from '../../../mixins/provider-mixin.js';
+
+			let profileCardAccess;
+			const hasProfileCardAccess = () => {
+				if (profileCardAccess) return profileCardAccess;
+
+				profileCardAccess = new Promise(resolve => {
+
+					resolve(true); // temp
+
+					if (!D2L.LP) {
+						resolve(false);
+						return;
+					}
+
+					D2L.LP.Web.UI.Rpc.Connect(
+						D2L.LP.Web.UI.Rpc.Verbs.GET,
+						new D2L.LP.Web.Http.UrlLocation('/d2l/lp/profilecardsaccess/AccessCheck'),
+						null,
+						{ success: response => resolve(response) }
+					);
+				});
+
+				return profileCardAccess;
+			};
+
+			provideInstance(document, 'html-block-renderers', [{
+				prepare: async() => {
+					return hasProfileCardAccess();
+				},
+				render: elem => {
+
+					const mentions = elem.querySelectorAll('[data-mentions-id]');
+					if (mentions.length === 0) return elem;
+
+					mentions.forEach(mention => {
+
+						const userId = mention.getAttribute('data-mentions-id');
+						if (!userId) return;
+
+						const anchor = document.createElement('a');
+						anchor.href = `/d2l/lp/profilecardsaccess/UserProfile?userId=${parseInt(userId)}`;
+						anchor.target = '_blank';
+						anchor.innerText = mention.innerText;
+
+						mention.innerText = '';
+						mention.appendChild(anchor);
+
+					});
+
+					return elem;
+				}
+			}]);
+
 		</script>
 		<script>
 			if (window.location.search.indexOf('latex=true') !== -1) {
@@ -440,6 +494,7 @@
 							</math> and other symbols.
 						</div>`,
 						'The wizard quickly jinxed the gnomes before they vaporized.',
+						'The wizard (<span data-mentions-id="0">Elmer Fudd</span>) quickly jinxed the gnomes before they vaporized.',
 						'A quick movement of the enemy will jeopardize six gunboats.',
 						'Grumpy wizards make a toxic brew for the jovial queen.',
 						'Painful zombies quickly watch a jinxed graveyard.',

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -1,5 +1,26 @@
 let mathJaxLoaded;
 
+export const htmlBlockMathRenderer = {
+	prepare: async elem => {
+		const isLatexSupported = window.D2L && window.D2L.LP && window.D2L.LP.Web.UI.Flags.Flag('us125413-mathjax-render-latex', true);
+
+		if (!elem.querySelector('math') && !(isLatexSupported && /\$\$|\\\(/.test(elem.innerHTML))) return false;
+
+		const mathJaxConfig = { renderLatex: isLatexSupported };
+		await loadMathJax(mathJaxConfig);
+
+		return true;
+	},
+	render: elem => {
+		const temp = document.createElement('div');
+		temp.attachShadow({ mode: 'open' });
+		temp.shadowRoot.innerHTML = `<div><mjx-doc><mjx-head></mjx-head><mjx-body>${elem.innerHTML}</mjx-body></mjx-doc></div>`;
+
+		window.MathJax.typesetShadow(temp.shadowRoot);
+		return temp.shadowRoot.firstChild;
+	}
+};
+
 export function loadMathJax(mathJaxConfig) {
 
 	if (mathJaxLoaded) return mathJaxLoaded;


### PR DESCRIPTION
Putting this PR to get feedback on this approach to making `d2l-html-block` rendering extensible. Currently, `d2l-html-block` contains rendering logic specific to MathJax, and we will need to extend it further to support `@mentions`, and likely also `prismjs` for code samples, et.al..

The general idea is to define a common interface for renderer implementations to replace parts of the user-authored HTML.  The `d2l-html-block` component may know of renderers built into core, but would be able to request additional domain-specific renderers using `requestInstance`.

The interface is simple - an asynchronous `prepare` method for loading dependencies or performing checks; and a synchronous `render` method for doing the actual replacement.