### PR TITLE
build: switching to use ESM for visual-diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,16 @@ If you'd like to run the tests locally to help troubleshoot or develop new tests
 
 ```shell
 # Install dependencies locally
-npm i mocha -g
-npm i @brightspace-ui/visual-diff puppeteer --no-save
+npm install esm mocha puppeteer @brightspace-ui/visual-diff --no-save
 
 # run visual-diff tests
-mocha './**/*.visual-diff.js' -t 10000
+mocha './**/*.visual-diff.js' -t 10000 --require esm
 
 # subset of visual-diff tests:
-mocha './**/*.visual-diff.js' -t 10000 -g some-pattern
+mocha './**/*.visual-diff.js' -t 10000 --require esm -g some-pattern
 
 # update visual-diff goldens
-mocha './**/*.visual-diff.js' -t 10000 --golden
+mocha './**/*.visual-diff.js' -t 10000 --require esm --golden
 ```
 
 ## Versioning & Releasing

--- a/components/alert/test/alert-toast-helper.js
+++ b/components/alert/test/alert-toast-helper.js
@@ -1,26 +1,21 @@
-
-module.exports = {
-
-	async getRect(page, selector) {
-		const rect = await page.$eval(selector, (toast) => {
-			const elem = toast.shadowRoot.querySelector('.d2l-alert-toast-container');
-			return {
-				x: elem.offe,
-				y: elem.offsetTop,
-				width: elem.offsetwidth,
-				height: elem.offsetHeight
-			};
-		});
+export async function getRect(page, selector) {
+	const rect = await page.$eval(selector, (toast) => {
+		const elem = toast.shadowRoot.querySelector('.d2l-alert-toast-container');
 		return {
-			x: 0,
-			y: rect.y - 10,
-			width: page.viewport().width,
-			height: page.viewport().height - rect.y + 10
+			x: elem.offe,
+			y: elem.offsetTop,
+			width: elem.offsetwidth,
+			height: elem.offsetHeight
 		};
-	},
+	});
+	return {
+		x: 0,
+		y: rect.y - 10,
+		width: page.viewport().width,
+		height: page.viewport().height - rect.y + 10
+	};
+}
 
-	async open(page, selector) {
-		return page.$eval(selector, (toast) => toast.open = true);
-	},
-
-};
+export async function open(page, selector) {
+	return page.$eval(selector, (toast) => toast.open = true);
+}

--- a/components/alert/test/alert-toast-helper.js
+++ b/components/alert/test/alert-toast-helper.js
@@ -1,18 +1,13 @@
 export async function getRect(page, selector) {
-	const rect = await page.$eval(selector, (toast) => {
+	const offsetTop = await page.$eval(selector, (toast) => {
 		const elem = toast.shadowRoot.querySelector('.d2l-alert-toast-container');
-		return {
-			x: elem.offe,
-			y: elem.offsetTop,
-			width: elem.offsetwidth,
-			height: elem.offsetHeight
-		};
+		return elem.offsetTop;
 	});
 	return {
 		x: 0,
-		y: rect.y - 10,
+		y: offsetTop - 10,
 		width: page.viewport().width,
-		height: page.viewport().height - rect.y + 10
+		height: page.viewport().height - offsetTop + 10
 	};
 }
 

--- a/components/alert/test/alert-toast.visual-diff.js
+++ b/components/alert/test/alert-toast.visual-diff.js
@@ -1,6 +1,6 @@
-const helper = require('./alert-toast-helper.js');
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import { getRect, open } from './alert-toast-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-alert-toast', () => {
 
@@ -29,8 +29,8 @@ describe('d2l-alert-toast', () => {
 	].forEach((testName) => {
 		it(testName, async function() {
 			const selector = `#${testName}`;
-			await helper.open(page, selector);
-			const rect = await helper.getRect(page, selector);
+			await open(page, selector);
+			const rect = await getRect(page, selector);
 
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
@@ -38,7 +38,7 @@ describe('d2l-alert-toast', () => {
 
 	describe('responsive-position', () => {
 		it('wide', async function() {
-			await helper.open(page, '#subtext-button-close');
+			await open(page, '#subtext-button-close');
 
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 		});
@@ -47,7 +47,7 @@ describe('d2l-alert-toast', () => {
 			page = await visualDiff.createPage(browser, { viewport: { width: 400, height: 400 } });
 			await page.goto(`${visualDiff.getBaseUrl()}/components/alert/test/alert-toast.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 			await page.bringToFront();
-			await helper.open(page, '#subtext-button-close');
+			await open(page, '#subtext-button-close');
 
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 		});

--- a/components/alert/test/alert.visual-diff.js
+++ b/components/alert/test/alert.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-alert', () => {
 

--- a/components/backdrop/test/backdrop.visual-diff.js
+++ b/components/backdrop/test/backdrop.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-backdrop', () => {
 

--- a/components/breadcrumbs/test/breadcrumbs.visual-diff.js
+++ b/components/breadcrumbs/test/breadcrumbs.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-breadcrumbs', () => {
 

--- a/components/button/test/button-icon.visual-diff.js
+++ b/components/button/test/button-icon.visual-diff.js
@@ -1,6 +1,6 @@
 /*global forceFocusVisible */
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-button-icon', () => {
 

--- a/components/button/test/button-subtle.visual-diff.js
+++ b/components/button/test/button-subtle.visual-diff.js
@@ -1,6 +1,6 @@
 /*global forceFocusVisible */
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-button-subtle', () => {
 

--- a/components/button/test/button.visual-diff.js
+++ b/components/button/test/button.visual-diff.js
@@ -1,6 +1,6 @@
 /*global forceFocusVisible */
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-button', () => {
 

--- a/components/button/test/floating-buttons.visual-diff.js
+++ b/components/button/test/floating-buttons.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-floating-buttons', () => {
 

--- a/components/calendar/test/calendar.visual-diff.js
+++ b/components/calendar/test/calendar.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-calendar', () => {
 

--- a/components/card/test/card-content-meta.visual-diff.js
+++ b/components/card/test/card-content-meta.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-card-content-meta', () => {
 

--- a/components/card/test/card-content-title.visual-diff.js
+++ b/components/card/test/card-content-title.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-card-content-title', () => {
 

--- a/components/card/test/card-footer-link.visual-diff.js
+++ b/components/card/test/card-footer-link.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-card-footer-link', () => {
 

--- a/components/card/test/card.visual-diff.js
+++ b/components/card/test/card.visual-diff.js
@@ -1,7 +1,7 @@
 /*global forceFocusVisible */
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const dropdownHelper = require('../../dropdown/test/dropdown-helper.js');
+import { open } from '../../dropdown/test/dropdown-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-card', () => {
 
@@ -37,9 +37,9 @@ describe('d2l-card', () => {
 		{ name: 'link-actions-focus', selector: '#link', action: (selector) => page.$eval(`${selector} > d2l-button-icon`, (elem) => forceFocusVisible(elem)) },
 		{ name: 'link-footer-focus', selector: '#link', action: (selector) => page.$eval(`${selector} > d2l-button`, (elem) => forceFocusVisible(elem)) },
 		{ name: 'with-dropdown', selector: '#with-dropdown', margin: 20 },
-		{ name: 'with-dropdown-open', selector: '#with-dropdown', margin: 20, action: (selector) => dropdownHelper.open(page, `${selector} d2l-dropdown-more`) },
+		{ name: 'with-dropdown-open', selector: '#with-dropdown', margin: 20, action: (selector) => open(page, `${selector} d2l-dropdown-more`) },
 		{ name: 'with-dropdown-adjacent-hover', selector: '#with-dropdown-adjacent-hover', margin: 20, action: async(selector) => {
-			await dropdownHelper.open(page, `${selector} d2l-dropdown-more`);
+			await open(page, `${selector} d2l-dropdown-more`);
 			return page.hover(`${selector} #hover-target`);
 		} },
 		{ name: 'with-tooltip', selector: '#with-tooltip', margin: 20 },

--- a/components/colors/test/colors.visual-diff.js
+++ b/components/colors/test/colors.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('colors', () => {
 

--- a/components/dialog/test/dialog-confirm.visual-diff.js
+++ b/components/dialog/test/dialog-confirm.visual-diff.js
@@ -1,6 +1,6 @@
-const helper = require('./dialog-helper.js');
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import { getRect, open, reset } from './dialog-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-dialog-confirm', () => {
 
@@ -26,11 +26,11 @@ describe('d2l-dialog-confirm', () => {
 			});
 
 			beforeEach(async() => {
-				await helper.reset(page, '#confirm');
-				await helper.reset(page, '#confirmLongTitle');
-				await helper.reset(page, '#confirmNoTitle');
-				await helper.reset(page, '#confirmLongText');
-				await helper.reset(page, '#confirmRtl');
+				await reset(page, '#confirm');
+				await reset(page, '#confirmLongTitle');
+				await reset(page, '#confirmNoTitle');
+				await reset(page, '#confirmLongText');
+				await reset(page, '#confirmRtl');
 			});
 
 			[
@@ -45,12 +45,12 @@ describe('d2l-dialog-confirm', () => {
 					});
 
 					it('opened', async function() {
-						await helper.open(page, '#confirm');
+						await open(page, '#confirm');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
 					it('rtl', async function() {
-						await helper.open(page, '#confirmRtl');
+						await open(page, '#confirmRtl');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
@@ -73,8 +73,8 @@ describe('d2l-dialog-confirm', () => {
 				].forEach((info) => {
 
 					it(info.name, async function() {
-						await helper.open(page, info.selector);
-						const rect = await helper.getRect(page, info.selector);
+						await open(page, info.selector);
+						const rect = await getRect(page, info.selector);
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 

--- a/components/dialog/test/dialog-fullscreen.visual-diff.js
+++ b/components/dialog/test/dialog-fullscreen.visual-diff.js
@@ -1,6 +1,6 @@
-const helper = require('./dialog-helper.js');
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import { open, reset } from './dialog-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-dialog-fullscreen', () => {
 
@@ -26,10 +26,10 @@ describe('d2l-dialog-fullscreen', () => {
 			});
 
 			beforeEach(async() => {
-				await helper.reset(page, '#dialog');
-				await helper.reset(page, '#dialogLong');
-				await helper.reset(page, '#dialogRtl');
-				await helper.reset(page, '#dialogNoFooterContent');
+				await reset(page, '#dialog');
+				await reset(page, '#dialogLong');
+				await reset(page, '#dialogRtl');
+				await reset(page, '#dialogNoFooterContent');
 			});
 
 			[
@@ -44,12 +44,12 @@ describe('d2l-dialog-fullscreen', () => {
 					});
 
 					it('opened', async function() {
-						await helper.open(page, '#dialog');
+						await open(page, '#dialog');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
 					it('rtl', async function() {
-						await helper.open(page, '#dialogRtl');
+						await open(page, '#dialogRtl');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
@@ -64,12 +64,12 @@ describe('d2l-dialog-fullscreen', () => {
 				});
 
 				it('no footer content', async function() {
-					await helper.open(page, '#dialogNoFooterContent');
+					await open(page, '#dialogNoFooterContent');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 				});
 
 				it('scroll bottom shadow', async function() {
-					await helper.open(page, '#dialogLong');
+					await open(page, '#dialogLong');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 				});
 
@@ -79,7 +79,7 @@ describe('d2l-dialog-fullscreen', () => {
 							await elem.$eval('#bottom', (bottom) => bottom.scrollIntoView());
 						});
 
-					await helper.open(page, '#dialogLong');
+					await open(page, '#dialogLong');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 				});
 

--- a/components/dialog/test/dialog-helper.js
+++ b/components/dialog/test/dialog-helper.js
@@ -1,53 +1,49 @@
-const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');
+import oneEvent from '@brightspace-ui/visual-diff/helpers/oneEvent.js';
 
-module.exports = {
+export async function close(page, selector) {
+	const closeEvent = getCloseEvent(page, selector);
+	await page.$eval(selector, (dialog) => dialog.opened = false);
+	return closeEvent;
+}
 
-	async close(page, selector) {
-		const closeEvent = this.getCloseEvent(page, selector);
-		await page.$eval(selector, (dialog) => dialog.opened = false);
-		return closeEvent;
-	},
+export function getCloseEvent(page, selector) {
+	return oneEvent(page, selector, 'd2l-dialog-close');
+}
 
-	getCloseEvent(page, selector) {
-		return oneEvent(page, selector, 'd2l-dialog-close');
-	},
+export function getOpenEvent(page, selector) {
+	return oneEvent(page, selector, 'd2l-dialog-open');
+}
 
-	getOpenEvent(page, selector) {
-		return oneEvent(page, selector, 'd2l-dialog-open');
-	},
+export function getRect(page, selector) {
+	return page.$eval(selector, (dialog) => {
+		const elem = dialog.shadowRoot.querySelector('.d2l-dialog-outer');
+		return {
+			x: elem.offsetLeft - 10,
+			y: elem.offsetTop - 10,
+			width: elem.offsetWidth + 20,
+			height: elem.offsetHeight + 20
+		};
+	});
+}
 
-	getRect(page, selector) {
-		return page.$eval(selector, (dialog) => {
-			const elem = dialog.shadowRoot.querySelector('.d2l-dialog-outer');
-			return {
-				x: elem.offsetLeft - 10,
-				y: elem.offsetTop - 10,
-				width: elem.offsetWidth + 20,
-				height: elem.offsetHeight + 20
-			};
+export async function open(page, selector) {
+	const openEvent = getOpenEvent(page, selector);
+	await page.$eval(selector, (dialog) => dialog.opened = true);
+	return openEvent;
+}
+
+export async function reset(page, selector) {
+	await page.$eval(selector, (dialog) => {
+		return new Promise((resolve) => {
+			dialog._fullscreenWithin = 0;
+			dialog.shadowRoot.querySelector('.d2l-dialog-content').scrollTo(0, 0);
+			if (dialog._state) {
+				dialog.addEventListener('d2l-dialog-close', () => resolve(), { once: true });
+				dialog.opened = false;
+			} else {
+				resolve();
+			}
 		});
-	},
-
-	async open(page, selector) {
-		const openEvent = this.getOpenEvent(page, selector);
-		await page.$eval(selector, (dialog) => dialog.opened = true);
-		return openEvent;
-	},
-
-	async reset(page, selector) {
-		await page.$eval(selector, (dialog) => {
-			return new Promise((resolve) => {
-				dialog._fullscreenWithin = 0;
-				dialog.shadowRoot.querySelector('.d2l-dialog-content').scrollTo(0, 0);
-				if (dialog._state) {
-					dialog.addEventListener('d2l-dialog-close', () => resolve(), { once: true });
-					dialog.opened = false;
-				} else {
-					resolve();
-				}
-			});
-		});
-		return page.click('#open');
-	}
-
-};
+	});
+	return page.click('#open');
+}

--- a/components/dialog/test/dialog-ifrau.visual-diff.js
+++ b/components/dialog/test/dialog-ifrau.visual-diff.js
@@ -1,6 +1,6 @@
-const helper = require('./dialog-helper.js');
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import { open, reset } from './dialog-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-dialog-ifrau', () => {
 
@@ -27,7 +27,7 @@ describe('d2l-dialog-ifrau', () => {
 			});
 
 			beforeEach(async() => {
-				await helper.reset(page, '#ifrau-dialog');
+				await reset(page, '#ifrau-dialog');
 			});
 
 			[
@@ -41,7 +41,7 @@ describe('d2l-dialog-ifrau', () => {
 						window.ifrauAvailableHeight = info.ifrau.availableHeight;
 						window.ifrauTop = info.ifrau.top;
 					}, info);
-					await helper.open(page, '#ifrau-dialog');
+					await open(page, '#ifrau-dialog');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 				});
 			});

--- a/components/dialog/test/dialog-mixin.visual-diff.js
+++ b/components/dialog/test/dialog-mixin.visual-diff.js
@@ -1,6 +1,6 @@
-const helper = require('./dialog-helper.js');
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import { close, getCloseEvent, open, reset } from './dialog-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-dialog-mixin', () => {
 
@@ -26,7 +26,7 @@ describe('d2l-dialog-mixin', () => {
 			});
 
 			beforeEach(async() => {
-				await helper.reset(page, '#dialog');
+				await reset(page, '#dialog');
 			});
 
 			describe('generic', () => {
@@ -40,14 +40,14 @@ describe('d2l-dialog-mixin', () => {
 				});
 
 				it('closed', async function() {
-					await helper.open(page, '#dialog');
-					await helper.close(page, '#dialog');
+					await open(page, '#dialog');
+					await close(page, '#dialog');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 				});
 
 				it('abort', async function() {
-					await helper.open(page, '#dialog');
-					const closeEvent = helper.getCloseEvent(page, '#dialog');
+					await open(page, '#dialog');
+					const closeEvent = getCloseEvent(page, '#dialog');
 					await page.$eval('#dialog', (dialog) => {
 						dialog.shadowRoot.querySelector('d2l-button-icon').click();
 					});
@@ -56,8 +56,8 @@ describe('d2l-dialog-mixin', () => {
 				});
 
 				it('escape', async function() {
-					await helper.open(page, '#dialog');
-					const closeEvent = helper.getCloseEvent(page, '#dialog');
+					await open(page, '#dialog');
+					const closeEvent = getCloseEvent(page, '#dialog');
 
 					/* test handler for dialog's custom close event strangely does not get
 					invoked when using puppeteer's keyboard api for the escape key for the

--- a/components/dialog/test/dialog.visual-diff.js
+++ b/components/dialog/test/dialog.visual-diff.js
@@ -1,6 +1,6 @@
-const helper = require('./dialog-helper.js');
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import { open, reset } from './dialog-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-dialog', () => {
 
@@ -26,11 +26,11 @@ describe('d2l-dialog', () => {
 			});
 
 			beforeEach(async() => {
-				await helper.reset(page, '#dialog');
-				await helper.reset(page, '#dialogLong');
-				await helper.reset(page, '#dialogRtl');
-				await helper.reset(page, '#dialogResize');
-				await helper.reset(page, '#dialogNoFooterContent');
+				await reset(page, '#dialog');
+				await reset(page, '#dialogLong');
+				await reset(page, '#dialogRtl');
+				await reset(page, '#dialogResize');
+				await reset(page, '#dialogNoFooterContent');
 			});
 
 			[
@@ -47,24 +47,24 @@ describe('d2l-dialog', () => {
 					});
 
 					it('opened', async function() {
-						await helper.open(page, '#dialog');
+						await open(page, '#dialog');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
 					it('opened-wide', async function() {
 						await page.$eval('#wideContainer', wideContainer => wideContainer.style.width = '1500px');
-						await helper.open(page, '#dialog');
+						await open(page, '#dialog');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 						await page.$eval('#wideContainer', wideContainer => wideContainer.style.width = 'auto');
 					});
 
 					it('rtl', async function() {
-						await helper.open(page, '#dialogRtl');
+						await open(page, '#dialogRtl');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 					});
 
 					it('resize', async function() {
-						await helper.open(page, '#dialogResize');
+						await open(page, '#dialogResize');
 						await page.$eval('#dialogResize', (dialog) => {
 							dialog.querySelector('div').style.height = '60px';
 							dialog.width = 500;
@@ -84,12 +84,12 @@ describe('d2l-dialog', () => {
 				});
 
 				it('no footer content', async function() {
-					await helper.open(page, '#dialogNoFooterContent');
+					await open(page, '#dialogNoFooterContent');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 				});
 
 				it('scroll bottom shadow', async function() {
-					await helper.open(page, '#dialogLong');
+					await open(page, '#dialogLong');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 				});
 
@@ -99,12 +99,12 @@ describe('d2l-dialog', () => {
 							await elem.$eval('#bottom', (bottom) => bottom.scrollIntoView());
 						});
 
-					await helper.open(page, '#dialogLong');
+					await open(page, '#dialogLong');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 				});
 
 				it('fullscreen-within-on', async function() {
-					await helper.open(page, '#dialog');
+					await open(page, '#dialog');
 					page.$eval('#top', childElem => {
 						childElem.dispatchEvent(new CustomEvent(
 							'd2l-fullscreen-within', {
@@ -118,7 +118,7 @@ describe('d2l-dialog', () => {
 				});
 
 				it('fullscreen-within-off', async function() {
-					await helper.open(page, '#dialog');
+					await open(page, '#dialog');
 					page.$eval('#top', childElem => {
 						childElem.dispatchEvent(new CustomEvent(
 							'd2l-fullscreen-within', {

--- a/components/dropdown/test/dropdown-content-contained.visual-diff.js
+++ b/components/dropdown/test/dropdown-content-contained.visual-diff.js
@@ -1,6 +1,6 @@
-const helper = require('./dropdown-helper.js');
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import { open } from './dropdown-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-dropdown-content-contained', () => {
 
@@ -24,7 +24,7 @@ describe('d2l-dropdown-content-contained', () => {
 		it(testName, async function() {
 			const rect = await visualDiff.getRect(page, `#${testName}`);
 			const selector = `#${testName} d2l-dropdown`;
-			await helper.open(page, selector);
+			await open(page, selector);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 	});

--- a/components/dropdown/test/dropdown-content.visual-diff.js
+++ b/components/dropdown/test/dropdown-content.visual-diff.js
@@ -1,6 +1,6 @@
-const helper = require('./dropdown-helper.js');
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import { open } from './dropdown-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-dropdown-content', () => {
 
@@ -51,7 +51,7 @@ describe('d2l-dropdown-content', () => {
 	].forEach((testName) => {
 		it(testName, async function() {
 			const selector = `#${testName}`;
-			await helper.open(page, selector);
+			await open(page, selector);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 		});
 	});
@@ -69,7 +69,7 @@ describe('d2l-dropdown-content', () => {
 					});
 				});
 			});
-		await helper.open(page, selector);
+		await open(page, selector);
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 	});
 

--- a/components/dropdown/test/dropdown-helper.js
+++ b/components/dropdown/test/dropdown-helper.js
@@ -1,48 +1,45 @@
-const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');
+import oneEvent from '@brightspace-ui/visual-diff/helpers/oneEvent.js';
 
-module.exports = {
+export function getOpenEvent(page, selector) {
+	return oneEvent(page, selector, 'd2l-dropdown-open');
+}
 
-	getOpenEvent(page, selector) {
-		return oneEvent(page, selector, 'd2l-dropdown-open');
-	},
+export async function open(page, selector) {
+	const openEvent = getOpenEvent(page, selector);
+	await page.$eval(selector, dropdown => dropdown.toggleOpen());
+	return openEvent;
+}
 
-	async open(page, selector) {
-		const openEvent = this.getOpenEvent(page, selector);
-		await page.$eval(selector, dropdown => dropdown.toggleOpen());
-		return openEvent;
-	},
-
-	async reset(page, selector) {
-		await page.$eval(selector, (dropdown) => {
-			return new Promise((resolve) => {
-				const content = dropdown.querySelector('[dropdown-content]');
-				content.scrollTo(0);
-				if (content.opened) {
-					content.addEventListener('d2l-dropdown-close', () => resolve(), { once: true });
-					content.opened = false;
-				} else {
-					resolve();
-				}
-			});
+export async function reset(page, selector) {
+	await page.$eval(selector, (dropdown) => {
+		return new Promise((resolve) => {
+			const content = dropdown.querySelector('[dropdown-content]');
+			content.scrollTo(0);
+			if (content.opened) {
+				content.addEventListener('d2l-dropdown-close', () => resolve(), { once: true });
+				content.opened = false;
+			} else {
+				resolve();
+			}
 		});
-	},
+	});
+}
 
-	getRect(page, selector) {
-		return page.$eval(`${selector} > [dropdown-content]`, (content) => {
-			const opener = content.__getOpener();
-			const contentWidth = content.shadowRoot.querySelector('.d2l-dropdown-content-width');
-			const openerRect = opener.getBoundingClientRect();
-			const contentRect = contentWidth.getBoundingClientRect();
-			const x = Math.min(openerRect.x, contentRect.x);
-			const y = Math.min(openerRect.y, contentRect.y);
-			const width = Math.max(openerRect.right, contentRect.right) - x;
-			const height = Math.max(openerRect.bottom, contentRect.bottom) - y;
-			return {
-				x: x - 10,
-				y: y - 10,
-				width: width + 20,
-				height: height + 20
-			};
-		});
-	},
-};
+export function getRect(page, selector) {
+	return page.$eval(`${selector} > [dropdown-content]`, (content) => {
+		const opener = content.__getOpener();
+		const contentWidth = content.shadowRoot.querySelector('.d2l-dropdown-content-width');
+		const openerRect = opener.getBoundingClientRect();
+		const contentRect = contentWidth.getBoundingClientRect();
+		const x = Math.min(openerRect.x, contentRect.x);
+		const y = Math.min(openerRect.y, contentRect.y);
+		const width = Math.max(openerRect.right, contentRect.right) - x;
+		const height = Math.max(openerRect.bottom, contentRect.bottom) - y;
+		return {
+			x: x - 10,
+			y: y - 10,
+			width: width + 20,
+			height: height + 20
+		};
+	});
+}

--- a/components/dropdown/test/dropdown-menu.visual-diff.js
+++ b/components/dropdown/test/dropdown-menu.visual-diff.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const helper = require('./dropdown-helper.js');
+import { getRect, open, reset } from './dropdown-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-dropdown-menu', () => {
 
@@ -16,41 +16,41 @@ describe('d2l-dropdown-menu', () => {
 	});
 
 	beforeEach(async() => {
-		await helper.reset(page, '#dropdown-menu');
+		await reset(page, '#dropdown-menu');
 	});
 
 	after(async() => await browser.close());
 
 	it('first-page', async function() {
-		await helper.open(page, '#dropdown-menu');
-		const rect = await helper.getRect(page, '#dropdown-menu');
+		await open(page, '#dropdown-menu');
+		const rect = await getRect(page, '#dropdown-menu');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	/* Prevent regression to DE37329: reopening caused etra bottom spacing */
 	it('closed-reopened', async function() {
-		await helper.open(page, '#dropdown-menu');
-		await helper.reset(page, '#dropdown-menu');
-		await helper.open(page, '#dropdown-menu');
-		const rect = await helper.getRect(page, '#dropdown-menu');
+		await open(page, '#dropdown-menu');
+		await reset(page, '#dropdown-menu');
+		await open(page, '#dropdown-menu');
+		const rect = await getRect(page, '#dropdown-menu');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('with-header-footer', async function() {
-		await helper.open(page, '#dropdown-menu-header-footer');
-		const rect = await helper.getRect(page, '#dropdown-menu-header-footer');
+		await open(page, '#dropdown-menu-header-footer');
+		const rect = await getRect(page, '#dropdown-menu-header-footer');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('with-nopadding-header-footer', async function() {
-		await helper.open(page, '#dropdown-menu-header-footer-nopadding');
-		const rect = await helper.getRect(page, '#dropdown-menu-header-footer-nopadding');
+		await open(page, '#dropdown-menu-header-footer-nopadding');
+		const rect = await getRect(page, '#dropdown-menu-header-footer-nopadding');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('dark theme', async function() {
-		await helper.open(page, '#dark');
-		const rect = await helper.getRect(page, '#dark');
+		await open(page, '#dark');
+		const rect = await getRect(page, '#dark');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 });

--- a/components/dropdown/test/dropdown-openers.visual-diff.js
+++ b/components/dropdown/test/dropdown-openers.visual-diff.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const helper = require('./dropdown-helper.js');
+import { getRect, open } from './dropdown-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-dropdown-openers', () => {
 
@@ -36,8 +36,8 @@ describe('d2l-dropdown-openers', () => {
 	].forEach((testName) => {
 		it(testName, async function() {
 			const selector = `#${testName}`;
-			await helper.open(page, selector);
-			const rect = await helper.getRect(page, selector);
+			await open(page, selector);
+			const rect = await getRect(page, selector);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 	});

--- a/components/expand-collapse/test/expand-collapse-content.visual-diff.js
+++ b/components/expand-collapse/test/expand-collapse-content.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-expand-collapse-content', () => {
 

--- a/components/form/test/form-error-summary.visual-diff.js
+++ b/components/form/test/form-error-summary.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-form-error-summary', () => {
 

--- a/components/html-block/test/html-block.visual-diff.js
+++ b/components/html-block/test/html-block.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-html-block', () => {
 

--- a/components/icons/test/icon-custom.visual-diff.js
+++ b/components/icons/test/icon-custom.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-icon-custom', () => {
 

--- a/components/icons/test/icon.visual-diff.js
+++ b/components/icons/test/icon.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-icon', () => {
 

--- a/components/inputs/test/input-checkbox.visual-diff.js
+++ b/components/inputs/test/input-checkbox.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-checkbox', () => {
 

--- a/components/inputs/test/input-date-range.visual-diff.js
+++ b/components/inputs/test/input-date-range.visual-diff.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const helper = require('./input-helper.js');
+import { getRectTooltip } from './input-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-date-range', () => {
 
@@ -211,13 +211,13 @@ describe('d2l-input-date-range', () => {
 
 					it('focus start', async function() {
 						await focusOnInput(page, '#min-max', startDateSelector);
-						const rect = await helper.getRectTooltip(page, '#min-max');
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
 					it('focus end', async function() {
 						await focusOnInput(page, '#min-max', endDateSelector);
-						const rect = await helper.getRectTooltip(page, '#min-max', 1);
+						const rect = await getRectTooltip(page, '#min-max', 1);
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});

--- a/components/inputs/test/input-date-time-range.visual-diff.js
+++ b/components/inputs/test/input-date-time-range.visual-diff.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const helper = require('./input-helper.js');
+import { getRectTooltip } from './input-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-date-time-range', () => {
 
@@ -240,13 +240,13 @@ describe('d2l-input-date-time-range', () => {
 
 					it('focus start', async function() {
 						await focusOnInput(page, '#min-max', startDateSelector);
-						const rect = await helper.getRectTooltip(page, '#min-max');
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
 					it('focus end', async function() {
 						await focusOnInput(page, '#min-max', endDateSelector);
-						const rect = await helper.getRectTooltip(page, '#min-max', 1);
+						const rect = await getRectTooltip(page, '#min-max', 1);
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});

--- a/components/inputs/test/input-date-time.visual-diff.js
+++ b/components/inputs/test/input-date-time.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-date-time', () => {
 

--- a/components/inputs/test/input-date.visual-diff.js
+++ b/components/inputs/test/input-date.visual-diff.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const helper = require('./input-helper.js');
+import { getRect, getRectTooltip, open, reset } from './input-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-date', () => {
 
@@ -37,7 +37,7 @@ describe('d2l-input-date', () => {
 			elem.focus();
 			elem._inputTextFocusShowTooltip = true;
 		});
-		const rect = await helper.getRectTooltip(page, '#value');
+		const rect = await getRectTooltip(page, '#value');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
@@ -102,18 +102,18 @@ describe('d2l-input-date', () => {
 				);
 				input.dispatchEvent(e);
 			});
-			const rect = await helper.getRect(page, '#disabled');
+			const rect = await getRect(page, '#disabled');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 
 		describe('with min and max', () => {
 			afterEach(async() => {
-				await helper.reset(page, '#min-max');
+				await reset(page, '#min-max');
 			});
 
 			it('open', async function() {
-				await helper.open(page, '#min-max');
-				const rect = await helper.getRect(page, '#min-max');
+				await open(page, '#min-max');
+				const rect = await getRect(page, '#min-max');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -126,7 +126,7 @@ describe('d2l-input-date', () => {
 					input.dispatchEvent(eventObj);
 				});
 
-				const rect = await helper.getRect(page, '#min-max');
+				const rect = await getRect(page, '#min-max');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -152,7 +152,7 @@ describe('d2l-input-date', () => {
 					});
 
 					afterEach(async() => {
-						await helper.reset(page, '#min-max');
+						await reset(page, '#min-max');
 					});
 
 					it('focus', async function() {
@@ -160,7 +160,7 @@ describe('d2l-input-date', () => {
 							const input = elem.shadowRoot.querySelector('d2l-input-text');
 							input.focus();
 						});
-						const rect = await helper.getRectTooltip(page, '#min-max');
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
@@ -173,7 +173,7 @@ describe('d2l-input-date', () => {
 							);
 							input.dispatchEvent(e);
 						});
-						const rect = await helper.getRect(page, '#min-max');
+						const rect = await getRect(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
@@ -185,7 +185,7 @@ describe('d2l-input-date', () => {
 							eventObj.keyCode = 13;
 							input.dispatchEvent(eventObj);
 						});
-						const rect = await helper.getRect(page, '#min-max');
+						const rect = await getRect(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
@@ -200,7 +200,7 @@ describe('d2l-input-date', () => {
 						});
 						await page.waitForTimeout(100);
 						await page.keyboard.press('Tab');
-						const rect = await helper.getRect(page, '#min-max');
+						const rect = await getRect(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});
@@ -216,7 +216,7 @@ describe('d2l-input-date', () => {
 								input.dispatchEvent(eventObj);
 							});
 							await page.keyboard.press('ArrowLeft');
-							const rect = await helper.getRect(page, '#min-max');
+							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 						});
 
@@ -229,7 +229,7 @@ describe('d2l-input-date', () => {
 								input.dispatchEvent(eventObj);
 							});
 							await page.keyboard.press('ArrowRight');
-							const rect = await helper.getRect(page, '#min-max');
+							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 						});
 					});
@@ -251,7 +251,7 @@ describe('d2l-input-date', () => {
 								input.dispatchEvent(eventObj);
 							});
 							await page.keyboard.press('ArrowLeft');
-							const rect = await helper.getRect(page, '#min-max');
+							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 						});
 
@@ -264,7 +264,7 @@ describe('d2l-input-date', () => {
 								input.dispatchEvent(eventObj);
 							});
 							await page.keyboard.press('ArrowRight');
-							const rect = await helper.getRect(page, '#min-max');
+							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 						});
 					});
@@ -292,7 +292,7 @@ describe('d2l-input-date', () => {
 								input.dispatchEvent(eventObj);
 							});
 							await page.keyboard.press('ArrowLeft');
-							const rect = await helper.getRect(page, '#min-max');
+							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 
 						});
@@ -306,7 +306,7 @@ describe('d2l-input-date', () => {
 								input.dispatchEvent(eventObj);
 							});
 							await page.keyboard.press('ArrowRight');
-							const rect = await helper.getRect(page, '#min-max');
+							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 						});
 					});
@@ -317,12 +317,12 @@ describe('d2l-input-date', () => {
 
 		describe('with placeholder', () => {
 			afterEach(async() => {
-				await helper.reset(page, '#placeholder');
+				await reset(page, '#placeholder');
 			});
 
 			it('open', async function() {
-				await helper.open(page, '#placeholder');
-				const rect = await helper.getRect(page, '#placeholder');
+				await open(page, '#placeholder');
+				const rect = await getRect(page, '#placeholder');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -335,7 +335,7 @@ describe('d2l-input-date', () => {
 					input.dispatchEvent(eventObj);
 				});
 
-				const rect = await helper.getRect(page, '#placeholder');
+				const rect = await getRect(page, '#placeholder');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 		});
@@ -346,24 +346,24 @@ describe('d2l-input-date', () => {
 			});
 
 			afterEach(async() => {
-				await helper.reset(page, '#value');
+				await reset(page, '#value');
 			});
 
 			it('open', async function() {
-				await helper.open(page, '#value');
-				const rect = await helper.getRect(page, '#value');
+				await open(page, '#value');
+				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('tab on open', async function() {
-				await helper.open(page, '#value');
+				await open(page, '#value');
 				await page.keyboard.press('Tab');
-				const rect = await helper.getRect(page, '#value');
+				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('click date', async function() {
-				await helper.open(page, '#value');
+				await open(page, '#value');
 				await page.$eval('#value', (elem) => {
 					const calendar = elem.shadowRoot.querySelector('d2l-calendar');
 					const date = calendar.shadowRoot.querySelector('td[data-date="8"] button');
@@ -393,7 +393,7 @@ describe('d2l-input-date', () => {
 
 			it('opens then changes month then closes then reopens', async function() {
 				// open
-				await helper.open(page, '#value');
+				await open(page, '#value');
 
 				// change month
 				await page.$eval('#value', (elem) => {
@@ -403,12 +403,12 @@ describe('d2l-input-date', () => {
 				});
 
 				// close
-				await helper.reset(page, '#value');
+				await reset(page, '#value');
 
 				// re-open
-				await helper.open(page, '#value');
+				await open(page, '#value');
 
-				const rect = await helper.getRect(page, '#value');
+				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -422,7 +422,7 @@ describe('d2l-input-date', () => {
 					);
 					input.dispatchEvent(e);
 				});
-				const rect = await helper.getRect(page, '#value');
+				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -436,7 +436,7 @@ describe('d2l-input-date', () => {
 					);
 					input.dispatchEvent(e);
 				});
-				const rect = await helper.getRect(page, '#value');
+				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -449,7 +449,7 @@ describe('d2l-input-date', () => {
 					eventObj.keyCode = 13;
 					input.dispatchEvent(eventObj);
 				});
-				const rect = await helper.getRect(page, '#value');
+				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -462,7 +462,7 @@ describe('d2l-input-date', () => {
 					eventObj.keyCode = 13;
 					input.dispatchEvent(eventObj);
 				});
-				const rect = await helper.getRect(page, '#value');
+				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -475,7 +475,7 @@ describe('d2l-input-date', () => {
 					eventObj.keyCode = 40;
 					input.dispatchEvent(eventObj);
 				});
-				const rect = await helper.getRect(page, '#value');
+				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -488,7 +488,7 @@ describe('d2l-input-date', () => {
 					eventObj.keyCode = 40;
 					input.dispatchEvent(eventObj);
 				});
-				const rect = await helper.getRect(page, '#value');
+				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
@@ -518,7 +518,7 @@ describe('d2l-input-date', () => {
 			});
 
 			afterEach(async() => {
-				await helper.reset(page, '#required');
+				await reset(page, '#required');
 			});
 
 			it('required focus then blur', async function() {
@@ -552,9 +552,9 @@ describe('d2l-input-date', () => {
 					eventObj.keyCode = 13;
 					input.dispatchEvent(eventObj);
 				});
-				const rect = await helper.getRect(page, '#required-value');
+				const rect = await getRect(page, '#required-value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
-				await helper.reset(page, '#required-value');
+				await reset(page, '#required-value');
 			});
 		});
 	});

--- a/components/inputs/test/input-helper.js
+++ b/components/inputs/test/input-helper.js
@@ -1,70 +1,69 @@
-module.exports = {
-	async open(page, selector) {
-		const openEvent = page.$eval(selector, (elem) => {
-			return new Promise((resolve) => {
-				elem.shadowRoot.querySelector('d2l-dropdown').addEventListener('d2l-dropdown-open', resolve, { once: true });
-			});
-		});
 
-		await page.$eval(selector, (elem) => {
-			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
-			dropdown.toggleOpen();
+export async function open(page, selector) {
+	const openEvent = page.$eval(selector, (elem) => {
+		return new Promise((resolve) => {
+			elem.shadowRoot.querySelector('d2l-dropdown').addEventListener('d2l-dropdown-open', resolve, { once: true });
 		});
-		return openEvent;
-	},
+	});
 
-	async reset(page, selector) {
-		await page.$eval(selector, (elem) => {
-			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
-			return new Promise((resolve) => {
-				const content = dropdown.querySelector('[dropdown-content]');
-				content.scrollTo(0);
-				if (content.opened) {
-					content.addEventListener('d2l-dropdown-close', () => resolve(), { once: true });
-					content.opened = false;
-				} else {
-					resolve();
-				}
-			});
+	await page.$eval(selector, (elem) => {
+		const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
+		dropdown.toggleOpen();
+	});
+	return openEvent;
+}
+
+export async function reset(page, selector) {
+	await page.$eval(selector, (elem) => {
+		const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
+		return new Promise((resolve) => {
+			const content = dropdown.querySelector('[dropdown-content]');
+			content.scrollTo(0);
+			if (content.opened) {
+				content.addEventListener('d2l-dropdown-close', () => resolve(), { once: true });
+				content.opened = false;
+			} else {
+				resolve();
+			}
 		});
-	},
+	});
+}
 
-	getRect(page, selector) {
-		return page.$eval(selector, (elem) => {
-			const content = elem.shadowRoot.querySelector('[dropdown-content]');
-			const opener = content.__getOpener();
-			const contentWidth = content.shadowRoot.querySelector('.d2l-dropdown-content-width');
-			const openerRect = opener.getBoundingClientRect();
-			const contentRect = contentWidth.getBoundingClientRect();
-			const x = Math.min(openerRect.x, contentRect.x);
-			const y = Math.min(openerRect.y, contentRect.y);
-			const width = Math.max(openerRect.right, contentRect.right) - x;
-			const height = Math.max(openerRect.bottom, contentRect.bottom) - y;
-			return {
-				x: x - 10,
-				y: y - 10,
-				width: width + 20,
-				height: height + 20
-			};
-		});
-	},
+export function getRect(page, selector) {
+	return page.$eval(selector, (elem) => {
+		const content = elem.shadowRoot.querySelector('[dropdown-content]');
+		const opener = content.__getOpener();
+		const contentWidth = content.shadowRoot.querySelector('.d2l-dropdown-content-width');
+		const openerRect = opener.getBoundingClientRect();
+		const contentRect = contentWidth.getBoundingClientRect();
+		const x = Math.min(openerRect.x, contentRect.x);
+		const y = Math.min(openerRect.y, contentRect.y);
+		const width = Math.max(openerRect.right, contentRect.right) - x;
+		const height = Math.max(openerRect.bottom, contentRect.bottom) - y;
+		return {
+			x: x - 10,
+			y: y - 10,
+			width: width + 20,
+			height: height + 20
+		};
+	});
+}
 
-	getRectTooltip(page, selector, tooltipIndex) {
-		return page.$eval(selector, (elem, tooltipIndex) => {
-			const content = elem.shadowRoot.querySelectorAll('d2l-tooltip')[tooltipIndex ? tooltipIndex : 0];
-			const contentWidth = content.shadowRoot.querySelector('.d2l-tooltip-content');
-			const openerRect = elem.getBoundingClientRect();
-			const contentRect = contentWidth.getBoundingClientRect();
-			const x = Math.min(openerRect.x, contentRect.x);
-			const y = Math.min(openerRect.y, contentRect.y);
-			const width = Math.max(openerRect.right, contentRect.right) - x;
-			const height = Math.max(openerRect.bottom, contentRect.bottom) - y;
-			return {
-				x: x - 10,
-				y: y - 10,
-				width: width + 20,
-				height: height + 20
-			};
-		}, tooltipIndex);
-	}
-};
+export function getRectTooltip(page, selector, tooltipIndex) {
+	return page.$eval(selector, (elem, tooltipIndex) => {
+		const content = elem.shadowRoot.querySelectorAll('d2l-tooltip')[tooltipIndex ? tooltipIndex : 0];
+		const contentWidth = content.shadowRoot.querySelector('.d2l-tooltip-content');
+		const openerRect = elem.getBoundingClientRect();
+		const contentRect = contentWidth.getBoundingClientRect();
+		const x = Math.min(openerRect.x, contentRect.x);
+		const y = Math.min(openerRect.y, contentRect.y);
+		const width = Math.max(openerRect.right, contentRect.right) - x;
+		const height = Math.max(openerRect.bottom, contentRect.bottom) - y;
+		return {
+			x: x - 10,
+			y: y - 10,
+			width: width + 20,
+			height: height + 20
+		};
+	}, tooltipIndex);
+}

--- a/components/inputs/test/input-label.visual-diff.js
+++ b/components/inputs/test/input-label.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-label', () => {
 

--- a/components/inputs/test/input-number.visual-diff.js
+++ b/components/inputs/test/input-number.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-number', () => {
 	const visualDiff = new VisualDiff('input-number', __dirname);

--- a/components/inputs/test/input-percent.visual-diff.js
+++ b/components/inputs/test/input-percent.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-percent', () => {
 	const visualDiff = new VisualDiff('input-percent', __dirname);

--- a/components/inputs/test/input-radio.visual-diff.js
+++ b/components/inputs/test/input-radio.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-radio', () => {
 

--- a/components/inputs/test/input-search.visual-diff.js
+++ b/components/inputs/test/input-search.visual-diff.js
@@ -1,6 +1,6 @@
 /*global forceFocusVisible */
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-search', () => {
 

--- a/components/inputs/test/input-select.visual-diff.js
+++ b/components/inputs/test/input-select.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-select', () => {
 

--- a/components/inputs/test/input-text.visual-diff.js
+++ b/components/inputs/test/input-text.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-text', () => {
 

--- a/components/inputs/test/input-textarea.visual-diff.js
+++ b/components/inputs/test/input-textarea.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-textarea', () => {
 

--- a/components/inputs/test/input-time-range.visual-diff.js
+++ b/components/inputs/test/input-time-range.visual-diff.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const helper = require('./input-helper.js');
+import { getRectTooltip } from './input-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-time-range', () => {
 
@@ -180,13 +180,13 @@ describe('d2l-input-time-range', () => {
 
 					it('focus start', async function() {
 						await focusOnInput(page, '#basic', startTimeSelector);
-						const rect = await helper.getRectTooltip(page, '#basic');
+						const rect = await getRectTooltip(page, '#basic');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
 					it('focus end', async function() {
 						await focusOnInput(page, '#basic', endTimeSelector);
-						const rect = await helper.getRectTooltip(page, '#basic', 1);
+						const rect = await getRectTooltip(page, '#basic', 1);
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});

--- a/components/inputs/test/input-time.visual-diff.js
+++ b/components/inputs/test/input-time.visual-diff.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const helper = require('./input-helper.js');
+import { getRect, open, reset } from './input-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-time', () => {
 
@@ -82,12 +82,12 @@ describe('d2l-input-time', () => {
 	describe('open behavior', () => {
 
 		afterEach(async() => {
-			await helper.reset(page, '#dropdown');
+			await reset(page, '#dropdown');
 		});
 
 		it('dropdown open top', async function() {
-			await helper.open(page, '#dropdown');
-			const rect = await helper.getRect(page, '#dropdown');
+			await open(page, '#dropdown');
+			const rect = await getRect(page, '#dropdown');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 
@@ -99,16 +99,16 @@ describe('d2l-input-time', () => {
 				eventObj.keyCode = 13;
 				input.dispatchEvent(eventObj);
 			});
-			const rect = await helper.getRect(page, '#dropdown');
+			const rect = await getRect(page, '#dropdown');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 
 		it('dropdown open enforce-time-intervals', async function() {
 			await page.$eval('#enforce', (elem) => elem.skeleton = false);
-			await helper.open(page, '#enforce');
-			const rect = await helper.getRect(page, '#enforce');
+			await open(page, '#enforce');
+			const rect = await getRect(page, '#enforce');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
-			await helper.reset(page, '#enforce'); // Make sure the dropdown is closed before the next test
+			await reset(page, '#enforce'); // Make sure the dropdown is closed before the next test
 		});
 
 	});
@@ -117,7 +117,7 @@ describe('d2l-input-time', () => {
 		await page.$eval('#basic', (elem) => elem.focus());
 		const rect = await visualDiff.getRect(page, '#basic');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
-		await helper.reset(page, '#basic');
+		await reset(page, '#basic');
 	});
 
 });

--- a/components/link/test/link.visual-diff.js
+++ b/components/link/test/link.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-link', () => {
 

--- a/components/list/test/list-item-drag-handle.visual-diff.js
+++ b/components/list/test/list-item-drag-handle.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-list-item-drag-handle', () => {
 

--- a/components/list/test/list-item-placement-marker.visual-diff.js
+++ b/components/list/test/list-item-placement-marker.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-list-item-placement-marker', () => {
 

--- a/components/list/test/list.visual-diff.js
+++ b/components/list/test/list.visual-diff.js
@@ -1,7 +1,7 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const dropdownHelper = require('../../dropdown/test/dropdown-helper.js');
-const tooltipHelper = require('../../tooltip/test/tooltip-helper.js');
+import { hide, show } from '../../tooltip/test/tooltip-helper.js';
+import { open, reset } from '../../dropdown/test/dropdown-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-list', () => {
 
@@ -10,7 +10,7 @@ describe('d2l-list', () => {
 	let browser, page;
 
 	const closeDropdown = (selector) => {
-		return dropdownHelper.reset(page, selector);
+		return reset(page, selector);
 	};
 
 	const focusMethod = (selector) => {
@@ -38,7 +38,7 @@ describe('d2l-list', () => {
 	};
 
 	const hideTooltip = (selector) => {
-		return tooltipHelper.hide(page, selector);
+		return hide(page, selector);
 	};
 
 	const hover = (selector) => {
@@ -46,11 +46,11 @@ describe('d2l-list', () => {
 	};
 
 	const openDropdown = (selector) => {
-		return dropdownHelper.open(page, selector);
+		return open(page, selector);
 	};
 
 	const showTooltip = (selector) => {
-		return tooltipHelper.show(page, selector);
+		return show(page, selector);
 	};
 
 	before(async() => {

--- a/components/menu/test/menu-checkbox.visual-diff.js
+++ b/components/menu/test/menu-checkbox.visual-diff.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');
+import oneEvent from '@brightspace-ui/visual-diff/helpers/oneEvent.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-menu checkbox', () => {
 

--- a/components/menu/test/menu-radio.visual-diff.js
+++ b/components/menu/test/menu-radio.visual-diff.js
@@ -1,6 +1,6 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
-const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');
+import oneEvent from '@brightspace-ui/visual-diff/helpers/oneEvent.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-menu radio', () => {
 

--- a/components/menu/test/menu-rtl.visual-diff.js
+++ b/components/menu/test/menu-rtl.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-menu rtl', () => {
 

--- a/components/menu/test/menu.visual-diff.js
+++ b/components/menu/test/menu.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-menu', () => {
 

--- a/components/meter/test/meter-circle.visual-diff.js
+++ b/components/meter/test/meter-circle.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-meter-circle', () => {
 

--- a/components/meter/test/meter-linear.visual-diff.js
+++ b/components/meter/test/meter-linear.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-meter-linear', () => {
 

--- a/components/meter/test/meter-radial.visual-diff.js
+++ b/components/meter/test/meter-radial.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-meter-radial', () => {
 

--- a/components/more-less/test/more-less.visual-diff.js
+++ b/components/more-less/test/more-less.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-more-less', () => {
 

--- a/components/offscreen/test/offscreen.visual-diff.js
+++ b/components/offscreen/test/offscreen.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-offscreen', () => {
 

--- a/components/overflow-group/test/overflow-group.visual-diff.js
+++ b/components/overflow-group/test/overflow-group.visual-diff.js
@@ -1,6 +1,6 @@
 
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-overflow-group', () => {
 

--- a/components/skeleton/test/skeleton.visual-diff.js
+++ b/components/skeleton/test/skeleton.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-skeleton', () => {
 

--- a/components/status-indicator/test/status-indicator.visual-diff.js
+++ b/components/status-indicator/test/status-indicator.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-status-indicator', () => {
 

--- a/components/switch/test/switch-visibility.visual-diff.js
+++ b/components/switch/test/switch-visibility.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-switch-visibility', () => {
 

--- a/components/switch/test/switch.visual-diff.js
+++ b/components/switch/test/switch.visual-diff.js
@@ -1,6 +1,6 @@
 /*global forceFocusVisible */
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-switch', () => {
 

--- a/components/tabs/test/tabs.visual-diff.js
+++ b/components/tabs/test/tabs.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-tabs', () => {
 

--- a/components/tooltip/test/tooltip-helper.js
+++ b/components/tooltip/test/tooltip-helper.js
@@ -1,17 +1,13 @@
-const { oneEvent } = require('@brightspace-ui/visual-diff/helpers');
+import { oneEvent } from '@brightspace-ui/visual-diff/helpers';
 
-module.exports = {
+export async function hide(page, selector) {
+	const hideEvent = oneEvent(page, selector, 'd2l-tooltip-hide');
+	page.$eval(`${selector} d2l-tooltip`, tooltip => tooltip.hide());
+	return hideEvent;
+}
 
-	async hide(page, selector) {
-		const hideEvent = oneEvent(page, selector, 'd2l-tooltip-hide');
-		page.$eval(`${selector} d2l-tooltip`, tooltip => tooltip.hide());
-		return hideEvent;
-	},
-
-	async show(page, selector) {
-		const openEvent = oneEvent(page, selector, 'd2l-tooltip-show');
-		page.$eval(`${selector} d2l-tooltip`, tooltip => tooltip.show());
-		return openEvent;
-	}
-
-};
+export async function show(page, selector) {
+	const openEvent = oneEvent(page, selector, 'd2l-tooltip-show');
+	page.$eval(`${selector} d2l-tooltip`, tooltip => tooltip.show());
+	return openEvent;
+}

--- a/components/tooltip/test/tooltip.visual-diff.js
+++ b/components/tooltip/test/tooltip.visual-diff.js
@@ -1,6 +1,6 @@
-const helper = require('./tooltip-helper.js');
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import { show } from './tooltip-helper.js';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-tooltip', () => {
 
@@ -55,7 +55,7 @@ describe('d2l-tooltip', () => {
 
 		it(testName, async function() {
 			const selector = `#${testName}`;
-			await helper.show(page, selector);
+			await show(page, selector);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 		});
 

--- a/components/typography/test/typography.visual-diff.js
+++ b/components/typography/test/typography.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-typography', function() {
 

--- a/mixins/async-container/test/async-container-mixin.visual-diff.js
+++ b/mixins/async-container/test/async-container-mixin.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-async-container-mixin', function() {
 

--- a/templates/primary-secondary/test/primary-secondary.visual-diff.js
+++ b/templates/primary-secondary/test/primary-secondary.visual-diff.js
@@ -1,5 +1,5 @@
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-template-primary-secondary', () => {
 	const visualDiff = new VisualDiff('primary-secondary', __dirname);


### PR DESCRIPTION
Converts core to use ES modules for our visual diff tests. Mostly straightforward... the helpers obviously needed to be converted over to modules.

The one remaining ugly part is for tests that use `forceFocusVisible`, they still need to import that into the HTML file and expose it as a global. Since it's a function, it can't be imported into the JS file and serialized and passed into an `eval` call. Maybe we could port it over into the visual diff helpers such that it could take an `ElementHandle` or a CSS query, but that'll be a separate change regardless.