### PR TITLE
Wire-up for pending-state in render for d2l-dialog and d2l-dialog-fullscreen.

### DIFF
--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -97,6 +97,10 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 		this._hasFooterContent = false;
 	}
 
+	get asyncContainerCustom() {
+		return true;
+	}
+
 	render() {
 
 		let loading = null;
@@ -129,7 +133,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 						<d2l-button-icon icon="tier1:close-small" text="${this.localize('components.dialog.close')}" @click="${this._abort}"></d2l-button-icon>
 					</div>
 				</div>
-				<div class="d2l-dialog-content">${content}</div>
+				<div class="d2l-dialog-content" @pending-state="${this._handleAsyncItemState}">${content}</div>
 				<div class="${classMap(footerClasses)}">
 					<slot name="footer" @slotchange="${this._handleFooterSlotChange}"></slot>
 				</div>
@@ -148,10 +152,6 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 			// while the dialog itself will not change size, we need to update overflow
 			this.resize();
 		}
-	}
-
-	asyncContainer() {
-		return this.shadowRoot.querySelector('.d2l-dialog-content');
 	}
 
 	_abort() {

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -99,6 +99,10 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		this.width = 600;
 	}
 
+	get asyncContainerCustom() {
+		return true;
+	}
+
 	render() {
 
 		let loading = null;
@@ -131,7 +135,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 						<d2l-button-icon icon="tier1:close-small" text="${this.localize('components.dialog.close')}" @click="${this._abort}"></d2l-button-icon>
 					</div>
 				</div>
-				<div class="d2l-dialog-content">${content}</div>
+				<div class="d2l-dialog-content" @pending-state="${this._handleAsyncItemState}">${content}</div>
 				<div class="${classMap(footerClasses)}">
 					<slot name="footer" @slotchange="${this._handleFooterSlotChange}"></slot>
 				</div>
@@ -149,10 +153,6 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		if (this.asyncState === asyncStates.complete) {
 			this.resize();
 		}
-	}
-
-	asyncContainer() {
-		return this.shadowRoot.querySelector('.d2l-dialog-content');
 	}
 
 	_abort() {

--- a/mixins/async-container/async-container-mixin.js
+++ b/mixins/async-container/async-container-mixin.js
@@ -24,17 +24,14 @@ export const AsyncContainerMixin = superclass => class extends superclass {
 		super();
 		this._initializeAsyncState();
 		this.asyncPendingDelay = 0;
-		if (!this.asyncContainer) {
-			this.addEventListener('pending-state', this._handleAsyncItemState.bind(this));
+		this._handleAsyncItemState = this._handleAsyncItemState.bind(this);
+		if (!this.asyncContainerCustom) {
+			this.addEventListener('pending-state', this._handleAsyncItemState);
 		}
 	}
 
-	firstUpdated() {
-		if (!this.asyncContainer) return;
-		const container = this.asyncContainer();
-		if (container) {
-			container.addEventListener('pending-state', this._handleAsyncItemState.bind(this));
-		}
+	get asyncContainerCustom() {
+		return false;
 	}
 
 	resetAsyncState() {


### PR DESCRIPTION
This PR fixes and issue where async dialogs could remain in their initial loading state forever if the dialog's local DOM is re-rendered.  In such a case, the async container would no longer have a handler for the `pending-state` event because it was previously being wired up in the `AsyncContainerMixin` `firstUpdated` method, which only runs once. The fix is to wire up for `pending-state` in `render`.