### PR TITLE
fix: NVDA reads buttons instead of dialog text

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -315,10 +315,21 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		// native dialog backdrop does not prevent body scrolling
 		this._bodyScrollKey = preventBodyScroll();
 
+		// focus first focusable child prior to auto resize (fixes screen reader hiccups)
+		this._focusInitial();
+
 		requestAnimationFrame(async() => {
 			await this._updateSize();
 			this._state = 'showing';
-			this._focusInitial();
+
+			// edge case: no children were focused, try again after one redraw
+			const activeElement = getComposedActiveElement();
+			if (!activeElement
+			|| !isComposedAncestor(dialog, activeElement)
+			|| !activeElement.classList.contains('focus-visible')) {
+				this._focusInitial();
+			}
+
 			if (!reduceMotion) await animPromise;
 			this.dispatchEvent(new CustomEvent(
 				'd2l-dialog-open', { bubbles: true, composed: true }


### PR DESCRIPTION
Rally: [US125198](https://rally1.rallydev.com/#/57732444928d/dashboard?detail=%2Fuserstory%2F502279656304)

EDIT - Using `autofocus` is unnecessary here, culprit appears to be a RAF that occurs prior to initial focus

~~Overrides~~ Addresses an accessibility defect with the `dialog-confirm` component where NVDA will occasionally read off the one element focused by `_focusFirst` instead of the actual dialog text. This issue is present in all dialogs that use the dialog mixin.

~~The native `<button>` autofocus attribute (accessible through d2l-button) appears to perform the same functionality while avoiding DOM traversal and retaining screen reader compatibility.~~