### PR TITLE
[Fix] Overflow Group - Add aria labels to overflowing menu items

### DIFF
--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -11,6 +11,7 @@ import '../menu/menu-item.js';
 import '../menu/menu-item-separator.js';
 import '../menu/menu-item-link.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
@@ -39,7 +40,8 @@ function createMenuItem(node) {
 	return html`<d2l-menu-item
 		?disabled=${disabled}
 		@d2l-menu-item-select=${handleItemSelect}
-		text="${childText}">
+		text="${childText}"
+		aria-label="${ifDefined(node.description || node.ariaLabel)}">
 	</d2l-menu-item>`;
 }
 

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -41,7 +41,7 @@ function createMenuItem(node) {
 		?disabled=${disabled}
 		@d2l-menu-item-select=${handleItemSelect}
 		text="${childText}"
-		aria-label="${ifDefined(node.description || node.ariaLabel)}">
+		aria-label="${ifDefined(node.description || node.ariaLabel || childText)}">
 	</d2l-menu-item>`;
 }
 


### PR DESCRIPTION
Screen readers were not properly calling out some menu items, this explicitly adds aria labels to the menu items and prioritizes the descriptions (like button/button subtle do).

Tested with NVDA and voiceover 