### PR TITLE
DE43639 Cert 21.06: Check for null in focus-trap focus() method

### DIFF
--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -48,7 +48,8 @@ class FocusTrap extends LitElement {
 	}
 
 	focus() {
-		this.shadowRoot.querySelector('.d2l-focus-trap-start').focus();
+		const focusable = this.shadowRoot.querySelector('.d2l-focus-trap-start');
+		if (focusable) focusable.focus();
 	}
 
 	_focusFirst() {


### PR DESCRIPTION
Cert for #1351, porting only the actual fix and excluding the test and package-lock updates.