### PR TITLE
fix: setting border-collapse to override reset stylesheets

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -5,6 +5,7 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 export const tableStyles = css`
 	.d2l-table {
+		border-collapse: separate; /* needed to override reset stylesheets */
 		border-spacing: 0;
 		font-size: 0.8rem;
 		font-weight: 400;


### PR DESCRIPTION
When integrating this into the LMS I noticed the corners weren't rounding. It's because in MVC we include a reset stylesheet that sets the border-collapse on all tables to "collapse"... even though the default user agent style is now "separate". So need to explicitly set this here.