### PR TITLE
Created focus helper to traverse up the tree to find focusable ancestor 

### DIFF
--- a/components/dialog/demo/dialog-fullscreen.html
+++ b/components/dialog/demo/dialog-fullscreen.html
@@ -14,6 +14,11 @@
 			import '../../button/button.js';
 			import '../dialog-fullscreen.js';
 			import './dialog-async-content.js';
+			import '../../dropdown/dropdown.js';
+			import '../../dropdown/dropdown-more.js';
+			import '../../dropdown/dropdown-menu.js';
+			import '../../menu/menu.js';
+			import '../../menu/menu-item.js';
 		</script>
 		<style>
 			.d2l-typography p:first-child { margin-top: 0; }
@@ -29,6 +34,13 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-button id="open">Show Dialog</d2l-button>
+					<d2l-dropdown-more text="Open!">
+						<d2l-dropdown-menu>
+							<d2l-menu label="Dialog">
+								<d2l-menu-item id="dropdown" text="See dialog"></d2l-menu-item>
+							</d2l-menu>
+						</d2l-dropdown-menu>
+					</d2l-dropdown-more>
 					<d2l-dialog-fullscreen id="dialogFullscreen" title-text="Fullscreen Title">
 						<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
 						<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
@@ -47,6 +59,9 @@
 					</d2l-dialog-fullscreen>
 					<script>
 						document.querySelector('#open').addEventListener('click', () => {
+							document.querySelector('#dialogFullscreen').opened = true;
+						});
+						document.querySelector('#dropdown').addEventListener('click', () => {
 							document.querySelector('#dialogFullscreen').opened = true;
 						});
 						document.querySelector('#dialogFullscreen').addEventListener('d2l-dialog-close', (e) => {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -2,7 +2,7 @@ import '../focus-trap/focus-trap.js';
 import { allowBodyScroll, preventBodyScroll } from '../backdrop/backdrop.js';
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
-import { forceFocusVisible, getComposedActiveElement, getNextFocusable } from '../../helpers/focus.js';
+import { forceFocusVisible, getComposedActiveElement, getLastFocusableDescendant, getNextFocusable, tryApplyFocus } from '../../helpers/focus.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit-element/lit-element.js';
@@ -78,7 +78,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		if (this._useNative) {
 			window.addEventListener('d2l-mvc-dialog-open', this._handleMvcDialogOpen);
 		}
-
 		if (!window.ifrauclient) return;
 		const ifrauClient = await window.ifrauclient().connect();
 		this._ifrauDialogService = await ifrauClient.getService('dialogWC', '0.1');
@@ -175,7 +174,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		if (this._opener && this._opener.focus) {
 			// wait for inactive focus trap
 			requestAnimationFrame(() => {
-				forceFocusVisible(this._opener);
+				tryApplyFocus(this._opener);
 				this._opener = null;
 			});
 		}
@@ -436,5 +435,4 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			});
 		});
 	}
-
 };

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -2,7 +2,7 @@ import '../focus-trap/focus-trap.js';
 import { allowBodyScroll, preventBodyScroll } from '../backdrop/backdrop.js';
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
-import { forceFocusVisible, getComposedActiveElement, getLastFocusableDescendant, getNextFocusable, tryApplyFocus } from '../../helpers/focus.js';
+import { forceFocusVisible, getComposedActiveElement, getNextFocusable, tryApplyFocus } from '../../helpers/focus.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit-element/lit-element.js';

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -114,6 +114,10 @@ getPreviousFocusableAncestor(node, includeHidden, includeTabbablesOnly)
 
 // returns true/false whether the element is focusable
 isFocusable(node, includeHidden, includeTabbablesOnly, includeDisabled)
+
+// returns true and focuses on node or its nearest focusable ancestor;
+// or false if node and its ancestors are not focusable
+tryApplyFocus(node)
 ```
 
 ## Gesture - Swipe

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -181,6 +181,10 @@ export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDi
 }
 
 export function tryApplyFocus(elem) {
+	if (isFocusable(elem)) {
+		forceFocusVisible(elem);
+		return true;
+	}
 	const focusable = findComposedAncestor(elem, (node) => (isFocusable(node) || getFirstFocusableDescendant(node) !== null));
 	if (focusable) {
 		forceFocusVisible(focusable);

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -183,7 +183,7 @@ export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDi
 export function tryApplyFocus(elem) {
 	const focusable = findComposedAncestor(elem, (node) => (isFocusable(node) || getFirstFocusableDescendant(node) !== null));
 	if (focusable) {
-		forceFocusVisible(getComposedParent(focusable));
+		forceFocusVisible(focusable);
 		return true;
 	}
 	return false;

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -1,4 +1,4 @@
-import { getComposedChildren, getComposedParent, getNextAncestorSibling, getPreviousAncestorSibling } from './dom.js';
+import { findComposedAncestor, getComposedChildren, getComposedParent, getNextAncestorSibling, getPreviousAncestorSibling } from './dom.js';
 
 const focusableElements = {
 	a: true,
@@ -178,4 +178,13 @@ export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDi
 
 	return _isFocusable;
 
+}
+
+export function tryApplyFocus(elem) {
+	const focusable = findComposedAncestor(elem, (node) => isFocusable(node));
+	if (focusable) {
+		forceFocusVisible(getComposedParent(focusable));
+		return true;
+	}
+	return false;
 }

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -181,7 +181,7 @@ export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDi
 }
 
 export function tryApplyFocus(elem) {
-	const focusable = findComposedAncestor(elem, (node) => isFocusable(node));
+	const focusable = findComposedAncestor(elem, (node) => (isFocusable(node) || getFirstFocusableDescendant(node) !== null));
 	if (focusable) {
 		forceFocusVisible(getComposedParent(focusable));
 		return true;

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -6,7 +6,8 @@ import {
 	getNextFocusable,
 	getPreviousFocusable,
 	getPreviousFocusableAncestor,
-	isFocusable
+	isFocusable,
+	tryApplyFocus
 } from '../focus.js';
 import { LitElement } from 'lit-element/lit-element.js';
 
@@ -70,6 +71,23 @@ const focusableFixture = html`
 			<button></button>
 			some text node
 			<!-- some comment node -->
+		</div>
+	</div>
+`;
+const focusableAncestorFixture = html`
+	<a>
+		<div>
+			<button disabled></button>
+		</div>
+	</a>
+`;
+const parentSiblingFocusableAncestorFixture = html`
+	<div>
+		<div>
+			<iframe></iframe>
+			<div>
+				<button disabled></button>
+			</div>
 		</div>
 	</div>
 `;
@@ -356,6 +374,34 @@ describe('focus', () => {
 			expect(isFocusable(commentNode)).to.be.false;
 		});
 
+	});
+
+	describe('tryApplyFocus', () => {
+
+		it('returns true on single focusable element', async() => {
+			const elem = await fixture(focusableFixture);
+			expect(tryApplyFocus(elem.querySelector('button'))).to.be.true;
+		});
+
+		it('returns false on non-existent element', async() => {
+			const elem = await fixture(focusableFixture);
+			expect(tryApplyFocus(elem.querySelector('#nonExistentDiv'))).to.be.false;
+		});
+
+		it('returns true on element with focusable parent', async() => {
+			const elem = await fixture(focusableAncestorFixture);
+			expect(tryApplyFocus(elem.querySelector('div'))).to.be.true;
+		});
+
+		it('returns true on element with focusable grandparent', async() => {
+			const elem = await fixture(focusableAncestorFixture);
+			expect(tryApplyFocus(elem.querySelector('button'))).to.be.true;
+		});
+
+		it('returns true on element with focusable sibling of parent', async() => {
+			const elem = await fixture(parentSiblingFocusableAncestorFixture);
+			expect(tryApplyFocus(elem.querySelector('button'))).to.be.true;
+		});
 	});
 
 });


### PR DESCRIPTION
Traversing up the tree will allow us to restore focus to the first visible element when the original opening element is hidden, as in the case of a dropdown. Currently, if the original opener is hidden, the focus is lost 😢 