### PR TITLE
Only add event listener if method exists (prevents issues on safari)

### DIFF
--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -192,11 +192,11 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 	connectedCallback() {
 		super.connectedCallback();
-		mediaQueryList.addEventListener('change', this._handleResize);
+		if (mediaQueryList.addEventListener) mediaQueryList.addEventListener('change', this._handleResize);
 	}
 
 	disconnectedCallback() {
-		mediaQueryList.removeEventListener('change', this._handleResize);
+		if (mediaQueryList.removeEventListener) mediaQueryList.removeEventListener('change', this._handleResize);
 		super.disconnectedCallback();
 	}
 


### PR DESCRIPTION
Safari 13 does not have the addEventListener method, specifically it can not listen for the 'change' event. An alternative is to use addListener, but it is a deprecated API. Instead, if the browser does not support addEventListener, no listener will be added at all. The typography will stay the same from when it was loaded (ie. a mobile page will stay mobile-styled).