### PR TITLE
fix: use IntersectionObserver to apply classes

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -261,7 +261,9 @@ export class TableWrapper extends RtlMixin(LitElement) {
 		}
 	}
 
-	async _applyClassNames(table) {
+	async _applyClassNames(table, count) {
+
+		if (count === 10) return;
 
 		await new Promise((resolve) => requestAnimationFrame(resolve));
 
@@ -274,6 +276,10 @@ export class TableWrapper extends RtlMixin(LitElement) {
 			firstRow = firstRow || r;
 			lastRow = r;
 		});
+		if (rows.length > 0 && firstRow === null) {
+			setTimeout(() => this._applyClassNames(table, ++count), 300);
+			return;
+		}
 
 		const topHeader = table.querySelector('tr.d2l-table-header:first-child th:not([rowspan]), tr[header]:first-child th:not([rowspan]), thead tr:first-child th:not([rowspan])');
 		const topHeaderHeight = topHeader ? topHeader.clientHeight : -1;
@@ -328,14 +334,14 @@ export class TableWrapper extends RtlMixin(LitElement) {
 
 		// observes mutations to <table>'s direct children and also
 		// its subtree (rows or cells added/removed to any descendant)
-		this._tableObserver = new MutationObserver(() => this._applyClassNames(table));
+		this._tableObserver = new MutationObserver(() => this._applyClassNames(table, 0));
 		this._tableObserver.observe(table, {
 			attributes: true, /* required for legacy-Edge, otherwise attributeFilter throws a syntax error */
 			attributeFilter: ['selected'],
 			childList: true,
 			subtree: true
 		});
-		this._applyClassNames(table);
+		this._applyClassNames(table, 0);
 
 	}
 

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -237,12 +237,6 @@ export class TableWrapper extends RtlMixin(LitElement) {
 		this._tableMutationObserver = null;
 	}
 
-	disconnectedCallback() {
-		super.disconnectedCallback();
-		if (this._tableIntersectionObserver) this._tableIntersectionObserver.disconnect();
-		if (this._tableMutationObserver) this._tableMutationObserver.disconnect();
-	}
-
 	render() {
 		const slot = html`<slot @slotchange="${this._handleSlotChange}"></slot>`;
 		if (this.stickyHeaders) {

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -353,9 +353,8 @@ export class TableWrapper extends RtlMixin(LitElement) {
 				this._tableIntersectionObserver.disconnect();
 			}
 			this._tableIntersectionObserver.observe(table);
-		} else {
-			requestAnimationFrame(() => this._applyClassNames(table));
 		}
+		requestAnimationFrame(() => this._applyClassNames(table));
 
 	}
 


### PR DESCRIPTION
Now that extra 👀  are on tables, it was noticed that in a few places in the LMS when the code to apply the first/last row and cell CSS classes runs, the rows aren't visible yet so nothing gets applied. This results in missing borders and no rounded corners:

![image (2)](https://user-images.githubusercontent.com/5491151/120032385-1add3080-bfc8-11eb-849d-b5558ff0809f.png)

This actually isn't a new problem -- I went back to the May release and the old Polymer tables had the same issue. In this instance it's a timing issue -- the table is in our legacy tabs and there's an HTML editor on the page and things just take a while to load up. But in theory the table could be legitimately hidden (maybe in a dialog that isn't open yet or an inactive tab) and that would result in the same broken behaviour.

The fix is to use an `IntersectionObserver` to detect when the table enters the viewport for the first time. ~This has the added benefit of deferring the paint/reflows to when the table is actually about to be rendered.~ Nope, that causes an initial jitter as you scroll them into view and broke the visual diff tests.

🎩 -tip to @Dan-DeAraujo for finding this!