### PR TITLE
Add LabelMixin and LabelledMixin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ npm install @brightspace-ui/core
   * [AsyncContainerMixin](mixins/async-container/): manage collective async state
   * [FocusVisiblePolyfillMixin](mixins/focus-visible-polyfill-mixin.md): components can use the `:focus-visible` pseudo-class polyfill
   * [FormElementMixin](components/form/docs/form-element-mixin.md): allow components to participate in forms and validation
+  * [LabelledMixin](mixins/labelled-mixin.md): label custom elements by referencing elements across DOM scopes
   * [LocalizeMixin](mixins/localize-mixin.md): localize text in your components
   * [ProviderMixin](mixins/provider-mixin.md): provide and consume data across elements in a DI-like fashion
   * [RtlMixin](mixins/rtl-mixin.md): enable components to define RTL styles

--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
 	<h2 class="d2l-heading-3">Mixins</h2>
 	<ul>
 		<li><a href="mixins/async-container/demo/async-container.html">async-container-mixin</a></li>
+		<li><a href="mixins/demo/labelled-mixin.html">labelled-mixin</a></li>
 		<li><a href="mixins/demo/localize-mixin.html">localize-mixin</a></li>
 		<li><a href="components/skeleton/demo/skeleton-mixin.html">skeleton-mixin</a></li>
 	</ul>

--- a/mixins/demo/labelled-mixin.html
+++ b/mixins/demo/labelled-mixin.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '../../components/demo/demo-page.js';
+			import '../../components/inputs/input-checkbox.js';
+			import { css, html, LitElement } from 'lit-element/lit-element.js';
+			import { LabelledMixin, LabelMixin } from '../labelled-mixin.js';
+			import { ifDefined } from 'lit-html/directives/if-defined.js';
+
+			class DemoInput extends LabelledMixin(LitElement) {
+				static get styles() {
+					return css`
+						:host {
+							disply: inline-block;
+						}
+						d2l-input-checkbox {
+							margin-bottom: 0;
+						}
+					`;
+				}
+				render() {
+					return html`
+						<d2l-input-checkbox aria-label="${ifDefined(this.label)}"></d2l-input-checkbox>
+					`;
+				}
+			}
+			customElements.define('d2l-demo-input', DemoInput);
+
+			class DemoText extends LabelMixin(LitElement) {
+				static get properties() {
+					return {
+						text: { type: String }
+					};
+				}
+				static get styles() {
+					return css`
+						:host {
+							disply: inline-block;
+						}
+					`;
+				}
+				constructor() {
+					super();
+					this.text = '';
+				}
+				render() {
+					return html`
+						<span>${this.text}</span>
+					`;
+				}
+				updated(changedProperties) {
+					super.updated(changedProperties);
+					this._label = this.text;
+				}
+			}
+			customElements.define('d2l-demo-text', DemoText);
+
+		</script>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+	</head>
+	<body unresolved>
+		<d2l-demo-page page-title="LabelledMixin">
+
+			<h2>Default</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<table>
+						<tr>
+							<td><d2l-demo-input labelled-by="topping-1"></d2l-demo-input></td>
+							<td><span id="topping-1" class="d2l-label-text">Caramel</span></td>
+						</tr>
+						<tr>
+							<td><d2l-demo-input label="Sprinkles"></d2l-demo-input></td>
+							<td><span class="d2l-label-text">Sprinkles</span></td>
+						</tr>
+						<tr>
+							<td><d2l-demo-input labelled-by="topping-3"></d2l-demo-input></td>
+							<td><d2l-demo-text id="topping-3" class="d2l-label-text" text="Hard Chocolate Coating"></d2l-demo-text></td>
+						</tr>
+					</table>
+				</template>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+	</body>
+</html>

--- a/mixins/demo/labelled-mixin.html
+++ b/mixins/demo/labelled-mixin.html
@@ -64,7 +64,7 @@
 		<meta charset="UTF-8">
 	</head>
 	<body unresolved>
-		<d2l-demo-page page-title="LabelledMixin">
+		<d2l-demo-page page-title="LabelMixin & LabelledMixin">
 
 			<h2>Default</h2>
 

--- a/mixins/demo/labelled-mixin.html
+++ b/mixins/demo/labelled-mixin.html
@@ -53,7 +53,7 @@
 				}
 				updated(changedProperties) {
 					super.updated(changedProperties);
-					this._label = this.text;
+					this.updateLabel(this.text);
 				}
 			}
 			customElements.define('d2l-demo-text', DemoText);

--- a/mixins/labelled-mixin.js
+++ b/mixins/labelled-mixin.js
@@ -1,0 +1,87 @@
+
+export const LabelMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			_label: { type: String, reflect: true }
+		};
+	}
+
+};
+
+export const LabelledMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			labelledBy: { type: String, reflect: true, attribute: 'labelled-by' },
+			label: { type: String }
+		};
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		if (!changedProperties.has('labelledBy')) return;
+
+		if (this._labelObserver) this._labelObserver.disconnect();
+
+		if (this.labelledBy) {
+
+			let labelElem = this.getRootNode().querySelector(`#${this.labelledBy}`);
+			const ancestor = this._getCommonAncestor(labelElem);
+
+			const getLabel = () => {
+				if (labelElem.tagName.includes('-')) return labelElem._label;
+				else return labelElem.textContent;
+			};
+
+			this._labelObserver = new MutationObserver((mutations) => {
+				for (let i = 0; i < mutations.length; i++) {
+
+					for (let j = 0; j < mutations[i].removedNodes.length; j++) {
+						if (mutations[i].removedNodes[j] === labelElem) {
+							labelElem = null;
+							break;
+						}
+					}
+
+					if (!labelElem && mutations[i].addedNodes.length > 0) {
+						labelElem = this.getRootNode().querySelector(`#${this.labelledBy}`);
+						break;
+					}
+
+				}
+
+				if (labelElem) {
+					this.label = getLabel();
+				} else {
+					console.warn('LabelledMixin with specified labelledBy but no such element exists.');
+					this.label = undefined;
+				}
+
+			});
+			this._labelObserver.observe(ancestor, { attributes: true, characterData: true, childList: true, subtree: true });
+
+			this.label = getLabel();
+		}
+
+	}
+
+	_getCommonAncestor(labelledByElem) {
+
+		const labelledPath = new WeakMap();
+		let elem = this;
+		while (elem) {
+			labelledPath.set(elem, elem);
+			elem = elem.parentNode;
+		}
+
+		let ancestorElem = labelledByElem.parentNode;
+		while (ancestorElem) {
+			if (labelledPath.has(ancestorElem)) return ancestorElem;
+			ancestorElem = ancestorElem.parentNode;
+		}
+
+	}
+
+};

--- a/mixins/labelled-mixin.js
+++ b/mixins/labelled-mixin.js
@@ -68,7 +68,7 @@ export const LabelledMixin = superclass => class extends superclass {
 					labelElem = null;
 				}
 
-				if (!labelElem && mutation.addedNodes.length > 0) {
+				if (mutation.addedNodes.length > 0) {
 					labelElem = this.getRootNode().querySelector(`#${this.labelledBy}`);
 					return;
 				}

--- a/mixins/labelled-mixin.js
+++ b/mixins/labelled-mixin.js
@@ -78,7 +78,7 @@ export const LabelledMixin = superclass => class extends superclass {
 			if (labelElem) {
 				this.label = getLabel(labelElem);
 			} else {
-				console.warn('LabelledMixin with specified labelledBy but no such element exists.');
+				console.warn(`LabelledMixin: element with labelled-by="${this.labelledBy}", but no such element exists.`);
 				this.label = undefined;
 			}
 

--- a/mixins/labelled-mixin.md
+++ b/mixins/labelled-mixin.md
@@ -1,0 +1,61 @@
+# LabelMixin & LabelledMixin
+
+The `LabelledMixin` enables elements within a custom element's shadowDOM to be labelled by elements within the DOM tree of its host. Normally this is not possible because referencing ids in other DOM scopes is not possible.
+
+Custom elements that extend the `LabelledMixin` may be labelled by native elements, custom elements that extend `LabelMixin`, or by specifying an explicit label.
+
+## Usage
+
+Apply the `LabelledMixin` to the component containing the element that requires a label, and apply the `label` property defined by `LabelledMixin` as needed:
+
+```js
+import { LabelledMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
+
+class CustomInput extends LabelledMixin(LitElement) {
+  render() {
+    return html`
+      <input type="text" aria-label="${ifDefined(this.label)}">
+    `;
+  }
+}
+```
+
+Optionally, to enable custom elements to act as labels, extend the `LabelMixin` and call `updateLabel()` to reflect the label value change when needed:
+
+```js
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
+
+class CustomLabel extends LabelMixin(LitElement) {
+  static get properties() {
+    return {
+      text: { type: String }
+    };
+  }
+  render() {
+    return html`
+      <span>${this.text}</span>
+    `;
+  }
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    this.updateLabel(this.text);
+  }
+}
+```
+
+Consumers can then label custom elements by referencing an `id` using the `LabelledMixin`'s `labelled-by` attribute, or specifying an explicit `label`:
+
+```html
+<!-- Labelling by referencing a native element -->
+<d2l-custom-input labelled-by="label1"></d2l-custom-input>
+<span id="label1">Label 1</span></td>
+
+<!-- Labelling by referencing a custom element -->
+<d2l-custom-input labelled-by="label2"></d2l-custom-input>
+<d2l-custom-label id="label2" text="Label 2"></d2l-custom-label>
+
+<!-- Labelling with an explicit label -->
+<d2l-custom-input label="Explicit Label"></d2l-custom-input>
+```
+
+**Note:** the labelled element (specifying `labelled-by`) and the element it references must reside in the same DOM scope.

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -32,7 +32,7 @@ const labelTag = defineCE(
 	}
 );
 
-describe.only('LabelMixin', () => {
+describe('LabelMixin', () => {
 
 	let elem;
 

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -129,6 +129,7 @@ describe('LabelledMixin', () => {
 			await new Promise(resolve => {
 				setTimeout(() => {
 					expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
+					resolve();
 				}, 100);
 			});
 		});

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -124,8 +124,9 @@ describe('LabelledMixin', () => {
 			const labelElem = elem.querySelector('#label1');
 			const newLabelElem = document.createElement('span');
 			newLabelElem.id = 'label1';
-			newLabelElem.innerText = 'new label value';
+			newLabelElem.textContent = 'new label value';
 			labelElem.parentNode.replaceChild(newLabelElem, labelElem);
+			await nextFrame();
 			await nextFrame();
 			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
 		});

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -54,7 +54,7 @@ describe('LabelMixin', () => {
 
 });
 
-describe.only('LabelledMixin', () => {
+describe('LabelledMixin', () => {
 
 	let elem;
 

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -104,7 +104,7 @@ describe('LabelledMixin', () => {
 		`);
 	});
 
-	describe('labelling with element', () => {
+	describe('labelling with natve element', () => {
 
 		it('initially applies label', async() => {
 			const labelledElem = elem.querySelector('[labelled-by="label1"]');
@@ -124,7 +124,7 @@ describe('LabelledMixin', () => {
 			const labelElem = elem.querySelector('#label1');
 			const newLabelElem = document.createElement('span');
 			newLabelElem.id = 'label1';
-			newLabelElem.textContent = 'new label value';
+			newLabelElem.innerText = 'new label value';
 			labelElem.parentNode.replaceChild(newLabelElem, labelElem);
 			await nextFrame();
 			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -126,12 +126,8 @@ describe('LabelledMixin', () => {
 			newLabelElem.id = 'label1';
 			newLabelElem.textContent = 'new label value';
 			labelElem.parentNode.replaceChild(newLabelElem, labelElem);
-			await new Promise(resolve => {
-				setTimeout(() => {
-					expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
-					resolve();
-				}, 100);
-			});
+			await nextFrame();
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
 		});
 
 		it('updates label when labelledBy changes', async() => {

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -144,7 +144,7 @@ describe('LabelledMixin', () => {
 
 	});
 
-	describe.only('labelling with custom element', () => {
+	describe('labelling with custom element', () => {
 
 		it('initially applies label', async() => {
 			const labelledElem = elem.querySelector('[labelled-by="label2"]');

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -1,0 +1,162 @@
+
+import { defineCE, expect, fixture, html, nextFrame } from '@open-wc/testing';
+import { LabelledMixin, LabelMixin } from '../labelled-mixin.js';
+import { LitElement } from 'lit-element/lit-element.js';
+
+const labelledTag = defineCE(
+	class extends LabelledMixin(LitElement) {
+		render() {
+			return html`
+				<input type="text" aria-label="${this.label}">
+			`;
+		}
+	}
+);
+
+const labelTag = defineCE(
+	class extends LabelMixin(LitElement) {
+		static get properties() {
+			return {
+				text: { type: String }
+			};
+		}
+		render() {
+			return html`
+				<span>${this.text}</span>
+			`;
+		}
+		updated(changedProperties) {
+			super.updated(changedProperties);
+			this.updateLabel(this.text);
+		}
+	}
+);
+
+describe.only('LabelMixin', () => {
+
+	let elem;
+
+	beforeEach(async() => {
+		elem = await fixture(`
+			<${labelTag} text="the label value"></${labelTag}>
+		`);
+	});
+
+	it('reflects label value', async() => {
+		expect(elem.getAttribute('_label')).to.equal('the label value');
+	});
+
+	it('reflects label value change', async() => {
+		elem.text = 'new label value';
+		await nextFrame();
+		expect(elem.getAttribute('_label')).to.equal('new label value');
+	});
+
+});
+
+describe.only('LabelledMixin', () => {
+
+	let elem;
+
+	beforeEach(async() => {
+		elem = await fixture(`
+			<div>
+				<table>
+					<tr>
+						<td><${labelledTag} labelled-by="label1"></${labelledTag}></td>
+						<td><span id="label1">native element</span></td>
+					</tr>
+					<tr>
+						<td><${labelledTag} label="explicit label"></${labelledTag}></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td><${labelledTag} labelled-by="label2"></${labelledTag}></td>
+						<td><${labelTag} id="label2" text="custom elemnt"></${labelTag}></td>
+					</tr>
+				</table>
+				<span id="label3">other element</span>
+			</div>
+		`);
+	});
+
+	describe('labelling with element', () => {
+
+		it('initially applies label', async() => {
+			const labelledElem = elem.querySelector('[labelled-by="label1"]');
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('native element');
+		});
+
+		it('updates label when labelling element text changes', async() => {
+			const labelledElem = elem.querySelector('[labelled-by="label1"]');
+			const labelElem = elem.querySelector('#label1');
+			labelElem.textContent = 'new label value';
+			await nextFrame();
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
+		});
+
+		it('updates label when labelling element is replaced', async() => {
+			const labelledElem = elem.querySelector('[labelled-by="label1"]');
+			const labelElem = elem.querySelector('#label1');
+			const newLabelElem = document.createElement('span');
+			newLabelElem.id = 'label1';
+			newLabelElem.textContent = 'new label value';
+			labelElem.parentNode.replaceChild(newLabelElem, labelElem);
+			await nextFrame();
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
+		});
+
+		it('updates label when labelledBy changes', async() => {
+			const labelledElem = elem.querySelector('[labelled-by="label1"]');
+			labelledElem.labelledBy = 'label3';
+			await nextFrame();
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('other element');
+		});
+
+	});
+
+	describe('labelling with custom element', () => {
+
+		it('initially applies label', async() => {
+			const labelledElem = elem.querySelector('[labelled-by="label2"]');
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('custom elemnt');
+		});
+
+		it('updates label when labelling element text changes', async() => {
+			const labelledElem = elem.querySelector('[labelled-by="label2"]');
+			const labelElem = elem.querySelector('#label2');
+			labelElem.text = 'new label value';
+			await nextFrame();
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
+		});
+
+		it('updates label when labelling element is replaced', async() => {
+			const labelledElem = elem.querySelector('[labelled-by="label2"]');
+			const labelElem = elem.querySelector('#label2');
+			const newLabelElem = document.createElement(labelTag);
+			newLabelElem.id = 'label2';
+			newLabelElem.text = 'new label value';
+			labelElem.parentNode.replaceChild(newLabelElem, labelElem);
+			await nextFrame();
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
+		});
+
+	});
+
+	describe('explicit label', () => {
+
+		it('initially applies label', async() => {
+			const labelledElem = elem.querySelector('[label]');
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('explicit label');
+		});
+
+		it('updates label when explicit label changes', async() => {
+			const labelledElem = elem.querySelector('[label]');
+			labelledElem.label = 'new label value';
+			await nextFrame();
+			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
+		});
+
+	});
+
+});

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -126,9 +126,11 @@ describe('LabelledMixin', () => {
 			newLabelElem.id = 'label1';
 			newLabelElem.textContent = 'new label value';
 			labelElem.parentNode.replaceChild(newLabelElem, labelElem);
-			await nextFrame();
-			await nextFrame();
-			expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
+			await new Promise(resolve => {
+				setTimeout(() => {
+					expect(labelledElem.shadowRoot.querySelector('input').getAttribute('aria-label')).to.equal('new label value');
+				}, 100);
+			});
 		});
 
 		it('updates label when labelledBy changes', async() => {


### PR DESCRIPTION
This PR adds two mixins, `LabelMixin` and `LabelledMixin` that enables elements within custom element's shadowDOM to be labelled by elements outside that shadowDOM.  For instance, it enables the following scenarios as showing in the demo page:

```html
<table>
	<tr>
		<td><d2l-demo-input labelled-by="topping-1"></d2l-demo-input></td>
		<td><span id="topping-1" class="d2l-label-text">Caramel</span></td>
	</tr>
	<tr>
		<td><d2l-demo-input label="Sprinkles"></d2l-demo-input></td>
		<td><span class="d2l-label-text">Sprinkles</span></td>
	</tr>
	<tr>
		<td><d2l-demo-input labelled-by="topping-3"></d2l-demo-input></td>
		<td><d2l-demo-text id="topping-3" text="Hard Chocolate Coating"></d2l-demo-text></td>
	</tr>
</table>
```

The idea is that a labelled custom element containing some element that requires a label, extends the `LabelledMixin` which locates the labelling element to resolve the label.  It further wires up a `MutationObserver` to detect label changes.  If the labelling element is a custom element, then it is required to extend the `LabelMixin`, and call its `updateLabel()` method as necessary - this in turn reflects the label to a private `_label` property that is observed by `LabelledMixin`, which then applies the label to the element requiring the label.

@zinabat : this PR is a follow-up from our previous conversation.  I am interested in your thoughts/confirmation that this would be usable for [d2l-activity-name](https://github.com/BrightspaceHypermediaComponents/foundation-components/blob/master/components/activity/name/d2l-activity-name.js).  I think that it would need to extend `LabelMixin` and call `updateLabel()` as described.  However `d2l-activity-name` wraps `d2l-hc-name`, so somehow `d2l-activity-name` would need to know when to call `updateLabel`, and with what value. The alternative we discussed is that 
[d2l-activity-editor-collection-add](https://github.com/BrightspaceHypermediaComponents/foundation-components/blob/master/components/activity/editor/collection/d2l-activity-editor-collection-add.js#L140) would need to be updated to render a custom list item instead, so that a `label` could be provided for the list-items.