### PR TITLE
d2l-label-change event for LabelMixin.

### DIFF
--- a/mixins/labelled-mixin.js
+++ b/mixins/labelled-mixin.js
@@ -33,8 +33,23 @@ export const LabelMixin = superclass => class extends superclass {
 		};
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		this.addEventListener('d2l-label-change', this._handleLabelChange);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.removeEventListener('d2l-label-change', this._handleLabelChange);
+	}
+
 	updateLabel(text) {
 		this._label = text;
+	}
+
+	_handleLabelChange(e) {
+		e.stopPropagation();
+		this.updateLabel(e.detail);
 	}
 
 };

--- a/mixins/labelled-mixin.md
+++ b/mixins/labelled-mixin.md
@@ -20,7 +20,7 @@ class CustomInput extends LabelledMixin(LitElement) {
 }
 ```
 
-Optionally, to enable custom elements to act as labels, extend the `LabelMixin` and call `updateLabel()` to reflect the label value change when needed:
+Optionally, to enable custom elements to act as labels, extend the `LabelMixin` and call `updateLabel()` to reflect the label value change when needed. Alternatively, a custom element within a labelling element's shadowDOM may dispatch the `d2l-label-change` event to update the label value.
 
 ```js
 import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';

--- a/mixins/test/label-mixin.test.js
+++ b/mixins/test/label-mixin.test.js
@@ -28,6 +28,7 @@ const labelTag = defineCE(
 		}
 		updated(changedProperties) {
 			super.updated(changedProperties);
+			if (!changedProperties.has('text')) return;
 			this.updateLabel(this.text);
 		}
 	}
@@ -56,6 +57,7 @@ describe('LabelMixin', () => {
 		elem = await fixture(`
 			<${labelTag} text="the label value"></${labelTag}>
 		`);
+		await elem.updateComplete;
 	});
 
 	it('reflects label value', async() => {
@@ -64,6 +66,16 @@ describe('LabelMixin', () => {
 
 	it('reflects label value change', async() => {
 		elem.text = 'new label value';
+		await nextFrame();
+		expect(elem.getAttribute('_label')).to.equal('new label value');
+	});
+
+	it('reflects label value from bubbling event', async() => {
+		elem.shadowRoot.querySelector('span').dispatchEvent(new CustomEvent('d2l-label-change', {
+			bubbles: true,
+			composed: true,
+			detail: 'new label value'
+		}));
 		await nextFrame();
 		expect(elem.getAttribute('_label')).to.equal('new label value');
 	});


### PR DESCRIPTION
This PR updates the `LabelMixin` to listen for `d2l-label-change` event which provides consumers greater flexibility to compose their labelling elements - i.e. they may have a child component in their shadowDOM that provides the labelling value.