### PR TITLE
Bump node version used in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: '12'
+          node-version: '14'
       - uses: Brightspace/third-party-actions@actions/cache
         id: cache
         with:
@@ -34,7 +34,7 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: '12'
+          node-version: '14'
       - uses: Brightspace/third-party-actions@actions/cache
         id: cache
         with:
@@ -55,7 +55,7 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: '12'
+          node-version: '14'
       - uses: Brightspace/third-party-actions@actions/cache
         id: cache
         with:
@@ -82,7 +82,7 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: '12'
+          node-version: '14'
       - uses: Brightspace/third-party-actions@actions/cache
         id: cache
         with:

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: '12'
+          node-version: '14'
       - uses: Brightspace/third-party-actions@actions/cache
         id: cache
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: '12'
+          node-version: '14'
       - uses: Brightspace/third-party-actions@actions/cache
         id: cache
         with:

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: '12'
+          node-version: '14'
       - uses: Brightspace/third-party-actions@actions/cache
         id: cache
         with:


### PR DESCRIPTION
We are planning on bumping the version of Puppeteer used in visual-diff and so this PR is to bump the node version to the current LTS version.