### PR TITLE
fix: importing rIC shim for Safari

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -1,5 +1,6 @@
 import '../colors/colors.js';
 import '../scroll-wrapper/scroll-wrapper.js';
+import '../../helpers/requestIdleCallback.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 


### PR DESCRIPTION
Just noticed errors in Safari as it doesn't support `requestIdleCallback`. It doesn't seem to break anything in most scenarios as the class names get applied by the mutation observer.