### PR TITLE
US127106 - Ability to lazy load filter values

### DIFF
--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -27,7 +27,7 @@ The `d2l-filter` component allows a user to filter on one or more dimensions of 
 
 **Events:**
 * `d2l-filter-change`: dispatched when any filter value has changed (may contain info about multiple changes)
-* `d2l-filter-dimension-open`: dispatched when a dimension is opened (if there is only one dimension, this will be dispatched when the dropdown is opened)
+* `d2l-filter-dimension-first-open`: dispatched when a dimension is opened for the first time (if there is only one dimension, this will be dispatched when the dropdown is first opened)
 
 ## Filter Dimension Types
 

--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -27,6 +27,7 @@ The `d2l-filter` component allows a user to filter on one or more dimensions of 
 
 **Events:**
 * `d2l-filter-change`: dispatched when any filter value has changed (may contain info about multiple changes)
+* `d2l-filter-dimension-open`: dispatched when a dimension is opened (if there is only one dimension, this will be dispatched when the dropdown is opened)
 
 ## Filter Dimension Types
 
@@ -59,6 +60,7 @@ The `d2l-filter-dimension-set` component is the main dimension type that will wo
 | Property | Type | Description |
 |--|--|--|
 | `key` | String, required | Unique identifier for the dimension |
+| `loading` | Boolean | Whether the values for this dimension are still loading and a loading spinner should be displayed |
 | `text` | String, required | Text for the dimension in the menu |
 
 #### d2l-filter-dimension-set-value

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -64,6 +64,19 @@
 				</d2l-filter>
 			</template>
 		</d2l-demo-snippet>
+
+		<h2>Loading</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-filter>
+					<d2l-filter-dimension-set key="course" text="Course" loading></d2l-filter-dimension-set>
+				</d2l-filter>
+				<d2l-filter>
+					<d2l-filter-dimension-set key="course" text="Course" loading></d2l-filter-dimension-set>
+					<d2l-filter-dimension-set key="role" text="Role" loading></d2l-filter-dimension-set>
+				</d2l-filter>
+			</template>
+		</d2l-demo-snippet>
 	</d2l-demo-page>
 
 	<script type="module">

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -84,8 +84,8 @@
 			console.log(`Filter selection changed for dimension "${e.detail.dimension}":`, e.detail.value);
 		});
 
-		document.addEventListener('d2l-filter-dimension-open', e => {
-			console.log(`Filter dimension opened: ${e.detail.key}`);
+		document.addEventListener('d2l-filter-dimension-first-open', e => {
+			console.log(`Filter dimension opened for the first time: ${e.detail.key}`);
 		});
 	</script>
 

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -83,6 +83,10 @@
 		document.addEventListener('d2l-filter-change', e => {
 			console.log(`Filter selection changed for dimension "${e.detail.dimension}":`, e.detail.value);
 		});
+
+		document.addEventListener('d2l-filter-dimension-open', e => {
+			console.log(`Filter dimension opened: ${e.detail.key}`);
+		});
 	</script>
 
 </body>

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -10,13 +10,24 @@ class FilterDimensionSet extends LitElement {
 
 	static get properties() {
 		return {
+			/**
+			 * REQUIRED: Unique key to represent this dimension in the filter
+			 */
 			key: { type: String },
+			/**
+			 * Whether the values for this dimension are still loading and a loading spinner should be displayed
+			 */
+			loading: { type: Boolean },
+			/**
+			 * REQUIRED: The text that is displayed for the dimension title
+			 */
 			text: { type: String }
 		};
 	}
 
 	constructor() {
 		super();
+		this.loading = false;
 		this.text = '';
 		this._slot = null;
 	}
@@ -37,7 +48,7 @@ class FilterDimensionSet extends LitElement {
 		changedProperties.forEach((oldValue, prop) => {
 			if (oldValue === undefined) return;
 
-			if (prop === 'text') {
+			if (prop === 'text' || prop === 'loading') {
 				changes.set(prop, this[prop]);
 			}
 		});

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -20,6 +20,7 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
  * This component is in charge of all rendering.
  * @slot - Dimension components used by the filter to construct the different dimensions locally
  * @fires d2l-filter-change - Dispatched when a dimension's value(s) have changed
+ * @fires d2l-filter-dimension-open - Dispatched when a dimension is opened
  */
 class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
@@ -127,7 +128,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		return html`
 			<d2l-dropdown-button-subtle
 				@d2l-dropdown-close="${this._handleDropdownClose}"
-				@d2l-dropdown-open="${this._stopPropagation}"
+				@d2l-dropdown-open="${this._handleDropdownOpen}"
 				@d2l-dropdown-position="${this._stopPropagation}"
 				text="${buttonText}"
 				description="${description}"
@@ -223,6 +224,10 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		this.dispatchEvent(new CustomEvent('d2l-filter-change', { bubbles: true, composed: false, detail: eventDetail }));
 	}
 
+	_dispatchDimensionOpenEvent(key) {
+		this.dispatchEvent(new CustomEvent('d2l-filter-dimension-open', { bubbles: true, composed: false, detail: { key: key } }));
+	}
+
 	_formatFilterCount(count, max) {
 		if (count === 0) return;
 
@@ -304,10 +309,18 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 	_handleDimensionShowStart(e) {
 		this._activeDimensionKey = e.detail.sourceView.getAttribute('data-key');
+		this._dispatchDimensionOpenEvent(this._activeDimensionKey);
 	}
 
 	_handleDropdownClose(e) {
 		this._activeDimensionKey = null;
+		this._stopPropagation(e);
+	}
+
+	_handleDropdownOpen(e) {
+		if (this._dimensions.length === 1) {
+			this._dispatchDimensionOpenEvent(this._dimensions[0].key);
+		}
 		this._stopPropagation(e);
 	}
 

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -13,6 +13,7 @@ import '../menu/menu-item.js';
 import { bodyCompactStyles, bodyStandardStyles } from '../typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
+import { offscreenStyles } from '../offscreen/offscreen.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 /**
@@ -38,7 +39,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	static get styles() {
-		return [bodyCompactStyles, bodyStandardStyles, css`
+		return [bodyCompactStyles, bodyStandardStyles, offscreenStyles, css`
 			div[slot="header"] {
 				padding: 0.9rem 0.3rem;
 			}
@@ -187,7 +188,6 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				<div class="d2l-filter-dimension-header">
 					<d2l-button-icon
 						@click="${this._handleDimensionHide}"
-						id="d2l-filter-dimension-header-return"
 						icon="tier1:chevron-left"
 						text="${this.localize('components.menu-item-return.returnCurrentlyShowing', 'menuTitle', dimensionText)}">
 					</d2l-button-icon>
@@ -204,7 +204,14 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	_createSetDimension(dimension) {
-		return dimension.loading ? html`<d2l-loading-spinner></d2l-loading-spinner>` : html`
+		if (dimension.loading) {
+			return html`
+				<d2l-loading-spinner></d2l-loading-spinner>
+				<div class="d2l-offscreen">${this.localize('components.filter.loading')}</div>
+			`;
+		}
+
+		return html`
 			<d2l-list
 				@d2l-list-selection-change="${this._handleChangeSetDimension}"
 				extend-separators>
@@ -307,7 +314,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	_handleDimensionShowComplete() {
-		const returnButton = this.shadowRoot.getElementById('d2l-filter-dimension-header-return');
+		const returnButton = this.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]');
 		returnButton.focus();
 	}
 

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -11,7 +11,6 @@ import '../menu/menu-item.js';
 
 import { bodyCompactStyles, bodyStandardStyles } from '../typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { getFirstFocusableDescendant } from '../../helpers/focus.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
@@ -180,6 +179,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				<div class="d2l-filter-dimension-header">
 					<d2l-button-icon
 						@click="${this._handleDimensionHide}"
+						id="d2l-filter-dimension-header-return"
 						icon="tier1:chevron-left"
 						text="${this.localize('components.menu-item-return.returnCurrentlyShowing', 'menuTitle', dimensionText)}">
 					</d2l-button-icon>
@@ -292,11 +292,8 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	_handleDimensionShowComplete() {
-		const dimension = this.shadowRoot.querySelector(`[data-key="${this._activeDimensionKey}"]`);
-		const focusable = getFirstFocusableDescendant(dimension);
-		if (focusable) {
-			focusable.focus();
-		}
+		const returnButton = this.shadowRoot.getElementById('d2l-filter-dimension-header-return');
+		returnButton.focus();
 	}
 
 	_handleDimensionShowStart(e) {

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -20,7 +20,7 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
  * This component is in charge of all rendering.
  * @slot - Dimension components used by the filter to construct the different dimensions locally
  * @fires d2l-filter-change - Dispatched when a dimension's value(s) have changed
- * @fires d2l-filter-dimension-open - Dispatched when a dimension is opened
+ * @fires d2l-filter-dimension-first-open - Dispatched when a dimension is opened for the first time
  */
 class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
@@ -83,6 +83,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		super();
 		this.disabled = false;
 		this._dimensions = [];
+		this._openedDimensions = [];
 		this._totalAppliedCount = 0;
 		this._totalMaxCount = 0;
 	}
@@ -224,8 +225,11 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		this.dispatchEvent(new CustomEvent('d2l-filter-change', { bubbles: true, composed: false, detail: eventDetail }));
 	}
 
-	_dispatchDimensionOpenEvent(key) {
-		this.dispatchEvent(new CustomEvent('d2l-filter-dimension-open', { bubbles: true, composed: false, detail: { key: key } }));
+	_dispatchDimensionFirstOpenEvent(key) {
+		if (!this._openedDimensions.includes(key)) {
+			this.dispatchEvent(new CustomEvent('d2l-filter-dimension-first-open', { bubbles: true, composed: false, detail: { key: key } }));
+			this._openedDimensions.push(key);
+		}
 	}
 
 	_formatFilterCount(count, max) {
@@ -309,7 +313,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 	_handleDimensionShowStart(e) {
 		this._activeDimensionKey = e.detail.sourceView.getAttribute('data-key');
-		this._dispatchDimensionOpenEvent(this._activeDimensionKey);
+		this._dispatchDimensionFirstOpenEvent(this._activeDimensionKey);
 	}
 
 	_handleDropdownClose(e) {
@@ -319,7 +323,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 	_handleDropdownOpen(e) {
 		if (this._dimensions.length === 1) {
-			this._dispatchDimensionOpenEvent(this._dimensions[0].key);
+			this._dispatchDimensionFirstOpenEvent(this._dimensions[0].key);
 		}
 		this._stopPropagation(e);
 	}

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -6,6 +6,7 @@ import '../dropdown/dropdown-menu.js';
 import '../hierarchical-view/hierarchical-view.js';
 import '../list/list.js';
 import '../list/list-item.js';
+import '../loading-spinner/loading-spinner.js';
 import '../menu/menu.js';
 import '../menu/menu-item.js';
 
@@ -68,6 +69,11 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			/* Needed to "undo" the menu hover styles */
 			:host(:hover) .d2l-filter-dimension-set-value-text {
 				color: var(--d2l-color-ferrite);
+			}
+
+			d2l-loading-spinner {
+				padding-top: 0.6rem;
+				width: 100%;
 			}
 		`];
 	}
@@ -196,7 +202,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	_createSetDimension(dimension) {
-		return html`
+		return dimension.loading ? html`<d2l-loading-spinner></d2l-loading-spinner>` : html`
 			<d2l-list
 				@d2l-list-selection-change="${this._handleChangeSetDimension}"
 				extend-separators>
@@ -312,6 +318,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			const type = dimension.tagName.toLowerCase();
 			const info = {
 				key: dimension.key,
+				loading: dimension.loading,
 				text: dimension.text,
 				type: type
 			};

--- a/components/filter/test/filter-dimension-set.test.js
+++ b/components/filter/test/filter-dimension-set.test.js
@@ -39,12 +39,14 @@ describe('d2l-filter-dimension-set', () => {
 			const elem = await fixture(dimensionfixture);
 			const eventSpy = spy(elem, 'dispatchEvent');
 			elem.text = 'Test';
+			elem.loading = true;
 
 			const e = await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			expect(e.detail.dimensionKey).to.equal('dim');
 			expect(e.detail.valueKey).to.be.undefined;
-			expect(e.detail.changes.size).to.equal(1);
+			expect(e.detail.changes.size).to.equal(2);
 			expect(e.detail.changes.get('text')).to.equal('Test');
+			expect(e.detail.changes.get('loading')).to.equal(true);
 			expect(eventSpy).to.be.calledOnce;
 		});
 

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -35,6 +35,7 @@ describe('d2l-filter', () => {
 			expect(elem.shadowRoot.querySelector('d2l-loading-spinner')).to.be.null;
 
 			dim.loading = true;
+			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			await elem.updateComplete;
 
 			expect(elem.shadowRoot.querySelector('d2l-loading-spinner')).to.not.be.null;
@@ -84,8 +85,8 @@ describe('d2l-filter', () => {
 				const elem = await fixture(singleSetDimensionFixture);
 				const eventSpy = spy(elem, 'dispatchEvent');
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
-				dropdown.toggleOpen();
 
+				setTimeout(() => dropdown.toggleOpen());
 				const e = await oneEvent(elem, 'd2l-filter-dimension-open');
 				expect(e.detail.key).to.equal('dim');
 				expect(eventSpy).to.be.calledOnce;
@@ -97,7 +98,7 @@ describe('d2l-filter', () => {
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
 				const dimensions = elem.shadowRoot.querySelectorAll('d2l-menu-item');
 
-				dropdown.toggleOpen();
+				setTimeout(() => dropdown.toggleOpen());
 				await oneEvent(dropdown, 'd2l-dropdown-open');
 				expect(eventSpy).to.be.not.be.called;
 

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -278,9 +278,11 @@ describe('d2l-filter', () => {
 			const dimension = elem.querySelector('d2l-filter-dimension-set[key="2"]');
 			expect(dimension.text).to.equal('Dim 2');
 			dimension.text = 'Test';
+			dimension.loading = true;
 
 			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			expect(elem._dimensions[1].text).to.equal('Test');
+			expect(elem._dimensions[1].loading).to.be.true;
 			expect(updateStub).to.be.calledOnce;
 			expect(recountSpy).to.be.not.be.called;
 		});

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -80,19 +80,27 @@ describe('d2l-filter', () => {
 			});
 		});
 
-		describe('d2l-filter-dimension-open', () => {
-			it('single set dimension fires dimension open event', async() => {
+		describe('d2l-filter-dimension-first-open', () => {
+			it('single set dimension fires dimension first open event', async() => {
 				const elem = await fixture(singleSetDimensionFixture);
 				const eventSpy = spy(elem, 'dispatchEvent');
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
 
 				setTimeout(() => dropdown.toggleOpen());
-				const e = await oneEvent(elem, 'd2l-filter-dimension-open');
+				const e = await oneEvent(elem, 'd2l-filter-dimension-first-open');
 				expect(e.detail.key).to.equal('dim');
+				expect(elem._openedDimensions[0]).to.equal('dim');
+
+				setTimeout(() => dropdown.toggleOpen());
+				await oneEvent(dropdown, 'd2l-dropdown-close');
+
+				setTimeout(() => dropdown.toggleOpen());
+				await oneEvent(dropdown, 'd2l-dropdown-open');
+
 				expect(eventSpy).to.be.calledOnce;
 			});
 
-			it('multiple dimensions fire dimension open events', async() => {
+			it('multiple dimensions fire dimension first open events', async() => {
 				const elem = await fixture(multiDimensionFixture);
 				const eventSpy = spy(elem, 'dispatchEvent');
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
@@ -103,13 +111,17 @@ describe('d2l-filter', () => {
 				expect(eventSpy).to.be.not.be.called;
 
 				setTimeout(() => dimensions[0].click());
-				let e = await oneEvent(elem, 'd2l-filter-dimension-open');
+				let e = await oneEvent(elem, 'd2l-filter-dimension-first-open');
 				expect(e.detail.key).to.equal('1');
 				expect(eventSpy).to.be.calledOnce;
 
 				setTimeout(() => dimensions[1].click());
-				e = await oneEvent(elem, 'd2l-filter-dimension-open');
+				e = await oneEvent(elem, 'd2l-filter-dimension-first-open');
 				expect(e.detail.key).to.equal('2');
+				expect(eventSpy).to.be.calledTwice;
+
+				setTimeout(() => dimensions[0].click());
+				await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
 				expect(eventSpy).to.be.calledTwice;
 			});
 		});

--- a/lang/en.js
+++ b/lang/en.js
@@ -7,6 +7,7 @@ export default {
 	"components.calendar.selected": "Selected.",
 	"components.calendar.show": "Show {month}",
 	"components.dialog.close": "Close this dialog",
+	"components.filter.loading": "Loading filters",
 	"components.filter.filterCount": "{number, select, max {99+} all {All} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {No filters applied.} one {1 filter applied.} other {{number} filters applied.}}",
 	"components.filter.filters": "Filters",


### PR DESCRIPTION
Was working on adding the search input, but it actually made sense to get this in first so I can hook into the loading flow when a search is occurring.

This PR does a few things:
- In the multiple dimension scenario, instead of finding the first focusable item in the hierarchical view we now focus on the return button.  This helps with the case where the contents are still loading, and is actually what the design calls for and I just missed it.
- Allow the consumer to set a `loading` property to tell us to show that dimension's loading state (which for the set type is just a loading spinner)
- Fire an event when a dimension is opened for the first time.  This will be used by consumers to tell them to set the `loading` property and start loading that dimension's values if they are using lazy-loading.