### PR TITLE
Enforce 0px height on div created by announce.js helper

### DIFF
--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -17,7 +17,7 @@ export function announce(message) {
 		container.setAttribute('aria-live', 'polite');
 		container.style.display = 'inline-block';
 		container.style.position = 'fixed';
-		container.style.height = '0px';
+		container.style.height = '0';
 		container.style.clip = 'rect(0px,0px,0px,0px)';
 		document.body.appendChild(container);
 	}

--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -17,6 +17,7 @@ export function announce(message) {
 		container.setAttribute('aria-live', 'polite');
 		container.style.display = 'inline-block';
 		container.style.position = 'fixed';
+		container.style.height = '0px';
 		container.style.clip = 'rect(0px,0px,0px,0px)';
 		document.body.appendChild(container);
 	}


### PR DESCRIPTION
Proposed fix for [DE44142](https://rally1.rallydev.com/#/431372673576d/iterationstatus?Iteration=%2Fiteration%2F450584189160&Name=Tooltip%20on%20input-number%20causes%20screen%20jitter%20when%20displayed%2C%20due%20to%20'announced'%20functionality%20&Priority=Low&Project=https%3A%2F%2Frally1.rallydev.com%2Fslm%2Fwebservice%2Fv2.x%2Fproject%2F431372673576&Severity=Minor%20Problem&detail=%2Fdefect%2F602453030253&iteration=u&rankTo=BOTTOM&fdp=true?fdp=true)

My hope here is that enforcing a 0px height onto this temporary div will **not** effect the functionality of said div (which, to my understanding, is only to facilitate screen readers).

At least in the case of the CPD tool, this removes any vertical space taken up by the temporary div, which eliminates the potential for any vertical "scrollbar jitter".

The following GIF shows the effect this has on the CPD tool, where this issue was noticed. The tooltip behaves as normal, and the screen jitter is completely gone.

![TooltipNoScreenJitter](https://user-images.githubusercontent.com/7544134/123139195-f12af400-d423-11eb-8f50-40979278fbfc.gif)


**_If there is any concern about regressions from this change, please let me know._**