### PR TITLE
US122213 - Configure filter empty state

### DIFF
--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -6,6 +6,7 @@
 	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
+		import '../../button/button.js';
 		import '../../filter/filter.js';
 		import '../../filter/filter-dimension-set.js';
 		import '../../filter/filter-dimension-set-value.js';
@@ -65,7 +66,7 @@
 			</template>
 		</d2l-demo-snippet>
 
-		<h2>Loading</h2>
+		<h2>Loading and Empty State</h2>
 		<d2l-demo-snippet>
 			<template>
 				<d2l-filter>
@@ -75,6 +76,7 @@
 					<d2l-filter-dimension-set key="course" text="Course" loading></d2l-filter-dimension-set>
 					<d2l-filter-dimension-set key="role" text="Role" loading></d2l-filter-dimension-set>
 				</d2l-filter>
+				<d2l-button id="finish-loading">Finish loading (in 5 seconds)</d2l-button>
 			</template>
 		</d2l-demo-snippet>
 	</d2l-demo-page>
@@ -86,6 +88,17 @@
 
 		document.addEventListener('d2l-filter-dimension-first-open', e => {
 			console.log(`Filter dimension opened for the first time: ${e.detail.key}`);
+		});
+
+		document.getElementById('finish-loading').addEventListener('click', e => {
+			e.target.disabled = true;
+			setTimeout(() => {
+				const loadingFilters = document.querySelectorAll('d2l-filter-dimension-set[loading]');
+				loadingFilters.forEach(filter => {
+					filter.loading = false;
+				});
+				e.target.textContent = 'Done Loading';
+			}, 5000);
 		});
 	</script>
 

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -68,17 +68,17 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				line-height: unset;
 			}
 
-            .d2l-filter-dimension-info-message {
-                padding: 0.9rem 0;
-                text-align: center;
-            }
+			.d2l-filter-dimension-info-message {
+				padding: 0.9rem 0;
+				text-align: center;
+			}
 
-            /* Needed to "undo" the menu hover styles */
-            :host(:hover) .d2l-filter-dimension-info-message,
-            :host(:hover) .d2l-filter-dimension-set-value-text {
-                color: var(--d2l-color-ferrite);
-                cursor: default;
-            }
+			/* Needed to "undo" the menu hover styles */
+			:host(:hover) .d2l-filter-dimension-info-message,
+			:host(:hover) .d2l-filter-dimension-set-value-text {
+				color: var(--d2l-color-ferrite);
+				cursor: default;
+			}
 
 			d2l-loading-spinner {
 				padding-top: 0.6rem;

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -145,7 +145,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		let dimensionHTML;
 		switch (dimension.type) {
 			case 'd2l-filter-dimension-set':
-				dimensionHTML = this._createSetDimension(dimension);
+				dimensionHTML = html`<div aria-live="polite">${this._createSetDimension(dimension)}</div>`;
 				break;
 		}
 
@@ -207,13 +207,14 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		if (dimension.loading) {
 			return html`
 				<d2l-loading-spinner></d2l-loading-spinner>
-				<div class="d2l-offscreen">${this.localize('components.filter.loading')}</div>
+				<div class="d2l-offscreen" aria-busy="true" role="alert">${this.localize('components.filter.loading')}</div>
 			`;
 		}
 
 		return html`
 			<d2l-list
 				@d2l-list-selection-change="${this._handleChangeSetDimension}"
+				data-key="${dimension.key}"
 				extend-separators>
 				${dimension.values.map(item => html`
 					<d2l-list-item
@@ -258,9 +259,8 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	_handleChangeSetDimension(e) {
-		const singleDimension = this._dimensions.length === 1;
-		const dimensionKey = singleDimension ? this._dimensions[0].key : e.composedPath()[0].parentNode.getAttribute('data-key');
-		const dimension = singleDimension ? this._dimensions[0] : this._dimensions.find(dimension => dimension.key === dimensionKey);
+		const dimensionKey = e.target.getAttribute('data-key');
+		const dimension = this._dimensions.find(dimension => dimension.key === dimensionKey);
 		const valueKey = e.detail.key;
 		const selected = e.detail.selected;
 
@@ -309,7 +309,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	_handleDimensionHide() {
-		this.shadowRoot.querySelector(`[data-key="${this._activeDimensionKey}"]`).hide();
+		this.shadowRoot.querySelector(`d2l-hierarchical-view[data-key="${this._activeDimensionKey}"]`).hide();
 		this._activeDimensionKey = null;
 	}
 

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -214,15 +214,15 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		if (dimension.loading) {
 			return html`
 				<d2l-loading-spinner></d2l-loading-spinner>
-				<div class="d2l-offscreen" aria-busy="true" role="alert">${this.localize('components.filter.loading')}</div>
+				<p class="d2l-offscreen" aria-busy="true" role="alert">${this.localize('components.filter.loading')}</p>
 			`;
 		}
 
 		if (this._isDimensionEmpty(dimension)) {
 			return html`
-                <div class="d2l-filter-dimension-info-message d2l-body-small" role="alert">
+                <p class="d2l-filter-dimension-info-message d2l-body-small" role="alert">
                     ${this.localize('components.filter.noFilters')}
-                </div>
+                </p>
             `;
 		}
 

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -10,7 +10,7 @@ import '../loading-spinner/loading-spinner.js';
 import '../menu/menu.js';
 import '../menu/menu-item.js';
 
-import { bodyCompactStyles, bodyStandardStyles } from '../typography/styles.js';
+import { bodyCompactStyles, bodySmallStyles, bodyStandardStyles } from '../typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
@@ -39,7 +39,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	static get styles() {
-		return [bodyCompactStyles, bodyStandardStyles, offscreenStyles, css`
+		return [bodyCompactStyles, bodySmallStyles, bodyStandardStyles, offscreenStyles, css`
 			div[slot="header"] {
 				padding: 0.9rem 0.3rem;
 			}
@@ -68,10 +68,17 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				line-height: unset;
 			}
 
-			/* Needed to "undo" the menu hover styles */
-			:host(:hover) .d2l-filter-dimension-set-value-text {
-				color: var(--d2l-color-ferrite);
-			}
+            .d2l-filter-dimension-info-message {
+                padding: 0.9rem 0;
+                text-align: center;
+            }
+
+            /* Needed to "undo" the menu hover styles */
+            :host(:hover) .d2l-filter-dimension-info-message,
+            :host(:hover) .d2l-filter-dimension-set-value-text {
+                color: var(--d2l-color-ferrite);
+                cursor: default;
+            }
 
 			d2l-loading-spinner {
 				padding-top: 0.6rem;
@@ -209,6 +216,14 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				<d2l-loading-spinner></d2l-loading-spinner>
 				<div class="d2l-offscreen" aria-busy="true" role="alert">${this.localize('components.filter.loading')}</div>
 			`;
+		}
+
+		if (this._isDimensionEmpty(dimension)) {
+			return html`
+                <div class="d2l-filter-dimension-info-message d2l-body-small" role="alert">
+                    ${this.localize('components.filter.noFilters')}
+                </div>
+            `;
 		}
 
 		return html`
@@ -359,6 +374,15 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		});
 
 		this._setFilterCounts();
+	}
+
+	_isDimensionEmpty(dimension) {
+		switch (dimension.type) {
+			case 'd2l-filter-dimension-set':
+				return dimension.values.length === 0;
+		}
+
+		return false;
 	}
 
 	_setFilterCounts() {

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -42,6 +42,13 @@ describe('d2l-filter', () => {
 		});
 	});
 
+	describe('info messages', () => {
+		it('empty state', async() => {
+			const elem = await fixture('<d2l-filter><d2l-filter-dimension-set key="dim"></d2l-filter-dimension-set></d2l-filter>');
+			expect(elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message').textContent).to.include('No available filters');
+		});
+	});
+
 	describe('events', () => {
 		describe('d2l-filter-change', () => {
 			it('single set dimension fires change events', async() => {

--- a/lang/en.js
+++ b/lang/en.js
@@ -11,6 +11,7 @@ export default {
 	"components.filter.filterCount": "{number, select, max {99+} all {All} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {No filters applied.} one {1 filter applied.} other {{number} filters applied.}}",
 	"components.filter.filters": "Filters",
+	"components.filter.noFilters": "No available filters",
 	"components.filter.singleDimensionDescription": "Filter by: {filterName}",
 	"components.form-element.defaultError": "{label} is invalid.",
 	"components.form-element.defaultFieldLabel": "Field",


### PR DESCRIPTION
This PR does two things:
- Enhance the screen reader experience a bit more for the loading state (until we add more to the loading spinner itself)
- Handle a filter dimension that has no values, and utilize the same screen reader enhancements to announce this as well