### PR TITLE
fix: don't re-render unnecessarily

### DIFF
--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -324,6 +324,14 @@ describe('d2l-input-text', () => {
 			expect(errors).to.be.empty;
 		});
 
+		it('should validate when input value changes', async() => {
+			const elem = await fixture(html`<d2l-input-text label="label" minlength="5" value="123456"></d2l-input-text>`);
+			getInput(elem).value = '123';
+			dispatchEvent(elem, 'input', true);
+			const errors = await elem.validate();
+			expect(errors).to.contain('label must be at least 5 characters');
+		});
+
 	});
 
 	describe('value', () => {


### PR DESCRIPTION
Apparently [Safari has a bug](#1458) (thanks @wongvincent) where if you set the `value` property (even to the same thing it already was), it will always move focus to the end of the input. This is a problem, because we're listening to the `oninput` event on the input and internally reflecting that to our `value` property (so consumers can access it) which in turn causes a re-render which then moves the cursor to the end -- not a good experience as the user types.

The solution is to create our own getter/setter for it, so setting `_value` from `oninput` won't cause a re-render.

While testing this I noticed that hovering while focused also caused an unnecessary re-render so I changed that logic a bit as well.