### PR TITLE
fix: switch search inputs to use text input

### DIFF
--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -1,7 +1,7 @@
 import '../button/button-icon.js';
 import '../colors/colors.js';
+import './input-text.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { classMap } from 'lit-html/directives/class-map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputStyles } from './input-styles.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
@@ -42,9 +42,7 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			/**
 			 * Value of the input
 			 */
-			value: { type: String },
-			_focussed: { type: Boolean, attribute: false },
-			_hovered: { type: Boolean, attribute: false }
+			value: { type: String }
 		};
 	}
 
@@ -54,45 +52,16 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 					display: inline-block;
 					width: 100%;
 				}
-				.d2l-input-search-container {
-					position: relative;
-				}
 				:host([hidden]) {
 					display: none;
-				}
-				.d2l-input {
-					-webkit-appearance: none;
-					overflow: hidden;
-					padding-right: 2.2rem;
-					text-overflow: ellipsis;
-					white-space: nowrap;
-				}
-				:host([dir="rtl"]) .d2l-input {
-					padding-left: 2.2rem;
-					padding-right: 0.75rem;
-				}
-				.d2l-input.d2l-input-focus {
-					padding-right: calc(2.2rem - 1px);
-				}
-				:host([dir="rtl"]) .d2l-input:hover,
-				:host([dir="rtl"]) .d2l-input:focus,
-				:host([dir="rtl"]) .d2l-input.d2l-input-focus {
-					padding-left: calc(2.2rem - 1px);
-					padding-right: calc(0.75rem - 1px);
 				}
 				d2l-button-icon {
 					--d2l-button-icon-min-height: 1.5rem;
 					--d2l-button-icon-min-width: 1.5rem;
 					--d2l-button-icon-border-radius: 4px;
 					--d2l-button-icon-focus-box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px var(--d2l-color-celestine);
-					position: absolute;
-					right: 0.3rem;
-					top: 50%;
-					transform: translateY(-50%);
-				}
-				:host([dir="rtl"]) d2l-button-icon {
-					left: 0.3rem;
-					right: auto;
+					margin-left: 0.3rem;
+					margin-right: 0.3rem;
 				}
 			`
 		];
@@ -100,8 +69,6 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 	constructor() {
 		super();
-		this._focussed = false;
-		this._hovered = false;
 		this._lastSearchValue = '';
 		this.disabled = false;
 		this.noClear = false;
@@ -116,51 +83,40 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		if (this.value !== undefined && this.value !== null) {
 			this._setLastSearchValue(this.value);
 		}
-		this.addEventListener('blur', this._handleBlur);
-		this.addEventListener('focus', this._handleFocus);
-	}
-
-	disconnectedCallback() {
-		this.removeEventListener('blur', this._handleBlur);
-		this.removeEventListener('focus', this._handleFocus);
 	}
 
 	render() {
-		const inputClasses = {
-			'd2l-input': true,
-			'd2l-input-focus': !this.disabled && (this._focussed || this._hovered)
-		};
-		const showSearch = this._computeShowSearch();
+		const search = this._computeShowSearch() ? html`
+			<d2l-button-icon
+				?disabled="${this.disabled}"
+				icon="tier1:search"
+				@click="${this.search}"
+				slot="right"
+				text="${this.localize('components.input-search.search')}"></d2l-button-icon>` : html`
+			<d2l-button-icon
+				@click="${this._handleClearClick}"
+				?disabled="${this.disabled}"
+				icon="tier1:close-default"
+				slot="right"
+				text="${this.localize('components.input-search.clear')}"></d2l-button-icon>`;
 		return html`
-			<div class="d2l-input-search-container"
-				@mouseout="${this._handleMouseLeave}"
-				@mouseover="${this._handleMouseEnter}">
-				<input
-					aria-label="${ifDefined(this.label)}"
-					class="${classMap(inputClasses)}"
-					?disabled="${this.disabled}"
-					@input="${this._handleInput}"
-					@keypress="${this._handleInputKeyPress}"
-					maxlength="${ifDefined(this.maxlength)}"
-					placeholder="${this.placeholder || this.localize('components.input-search.defaultPlaceholder')}"
-					type="search"
-					.value="${this.value}">${showSearch ? html`
-					<d2l-button-icon
-						?disabled="${this.disabled}"
-						icon="tier1:search"
-						@click="${this.search}"
-						text="${this.localize('components.input-search.search')}"></d2l-button-icon>` : html`
-					<d2l-button-icon
-						@click="${this._handleClearClick}"
-						?disabled="${this.disabled}"
-						icon="tier1:close-default"
-						text="${this.localize('components.input-search.clear')}"></d2l-button-icon>`}
-			</div>
+			<d2l-input-text
+				label="${ifDefined(this.label)}"
+				label-hidden
+				?disabled="${this.disabled}"
+				@input="${this._handleInput}"
+				@keypress="${this._handleInputKeyPress}"
+				maxlength="${ifDefined(this.maxlength)}"
+				placeholder="${this.placeholder || this.localize('components.input-search.defaultPlaceholder')}"
+				type="search"
+				.value="${this.value}">
+				${search}
+			</d2l-input-text>
 		`;
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('.d2l-input');
+		const elem = this.shadowRoot.querySelector('d2l-input-text');
 		if (elem) elem.focus();
 	}
 
@@ -189,21 +145,13 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		));
 	}
 
-	_handleBlur() {
-		this._focussed = false;
-	}
-
 	_handleClearClick() {
 		this.value = '';
 		if (this.value !== this.lastSearchValue) {
 			this._setLastSearchValue('');
 			this._dispatchEvent();
 		}
-		this.shadowRoot.querySelector('.d2l-input').focus();
-	}
-
-	_handleFocus() {
-		this._focussed = true;
+		this.shadowRoot.querySelector('d2l-input-text').focus();
 	}
 
 	_handleInput(e) {
@@ -217,14 +165,6 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		e.preventDefault();
 		this._setLastSearchValue(this.value);
 		this._dispatchEvent();
-	}
-
-	_handleMouseEnter() {
-		this._hovered = true;
-	}
-
-	_handleMouseLeave() {
-		this._hovered = false;
 	}
 
 	_setLastSearchValue(val) {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -376,8 +376,8 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 						tabindex="${ifDefined(this.tabindex)}"
 						title="${ifDefined(this.title)}"
 						type="${this._getType()}">
-					<div class="d2l-input-inside-before">${this.dir === 'rtl' ? unit : ''}<slot name="${firstSlotName}" @slotchange="${this._handleSlotChange}"></slot></div>
-					<div class="d2l-input-inside-after">${this.dir !== 'rtl' ? unit : ''}<slot name="${lastSlotName}" @slotchange="${this._handleSlotChange}"></slot></div>
+					<div class="d2l-input-inside-before" @keypress="${this._suppressEvent}">${this.dir === 'rtl' ? unit : ''}<slot name="${firstSlotName}" @slotchange="${this._handleSlotChange}"></slot></div>
+					<div class="d2l-input-inside-after" @keypress="${this._suppressEvent}">${this.dir !== 'rtl' ? unit : ''}<slot name="${lastSlotName}" @slotchange="${this._handleSlotChange}"></slot></div>
 					${ (!isValid && !this.hideInvalidIcon && !this._focused) ? html`<div class="d2l-input-text-invalid-icon" style="${styleMap(invalidIconStyles)}" @click="${this._handleInvalidIconClick}"></div>` : null}
 					${ this.validationError ? html`<d2l-tooltip for=${this._inputId} state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>` : null }
 				</div><div id="after-slot" class="d2l-skeletize" ?hidden="${!this._hasAfterContent}"><slot name="after" @slotchange="${this._handleAfterSlotChange}"></slot></div>
@@ -530,6 +530,10 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 			input.value = this.value;
 		}
 
+	}
+
+	_suppressEvent(e) {
+		e.stopPropagation();
 	}
 
 	_updateInputLayout(container) {

--- a/components/inputs/test/input-search.test.js
+++ b/components/inputs/test/input-search.test.js
@@ -32,7 +32,7 @@ function pressEnter(elem) {
 	});
 	event.keyCode = 13;
 	event.code = 13;
-	elem.shadowRoot.querySelector('.d2l-input').dispatchEvent(event);
+	elem.shadowRoot.querySelector('d2l-input-text').dispatchEvent(event);
 }
 
 describe('d2l-input-search', () => {

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -407,4 +407,33 @@ describe('d2l-input-text', () => {
 
 	});
 
+	describe('events', () => {
+
+		it('should suppress keypress events from slots', async() => {
+
+			const elem = await fixture(html`<d2l-input-text label="label"><div slot="left"></div><div slot="right"></div></d2l-input-text>`);
+			const left = elem.querySelector('div[slot="left"]');
+			const right = elem.querySelector('div[slot="right"]');
+
+			let fired = false;
+			elem.addEventListener('keypress', () => {
+				fired = true;
+			});
+
+			setTimeout(() => {
+				const e = new Event(
+					'keypress',
+					{ bubbles: true, cancelable: true, composed: true }
+				);
+				left.dispatchEvent(e);
+				right.dispatchEvent(e);
+			});
+			await aTimeout(1);
+
+			expect(fired).to.be.false;
+
+		});
+
+	});
+
 });


### PR DESCRIPTION
In fixing #1458 with text-inputs, Dave noticed that search inputs would also be affected and because it wasn't using `d2l-input-text` would need the same fix applied. That got me thinking... why aren't search inputs using text inputs?

I think it was either a chicken & egg situation, or initially because text inputs didn't supports the right/left slots and search needed them search did its own thing. Well that's no longer true, and switching this over yields some pretty nice code duplication savings!