### PR TITLE
fix: restoring a test that was skipped due to Firefox bug

### DIFF
--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -155,7 +155,7 @@ describe('d2l-input-text', () => {
 
 		[
 			{ name: 'aria-invalid', propName: 'ariaInvalid', value: 'true' },
-			/*{name: 'autocomplete', value: 'email'}, bug in Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1583957 */
+			{ name: 'autocomplete', value: 'email' },
 			{ name: 'autofocus', value: true },
 			{ name: 'disabled', value: true },
 			{ name: 'max', value: '5' },


### PR DESCRIPTION
The Firefox bug that caused this test to be skipped has been resolved.