### PR TITLE
Make sure ifrau dialog service has loaded before we try to check for it in iframed FRAs

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -21,10 +21,11 @@ if (window.D2L.DialogMixin.preferNative === undefined) {
 let ifrauDialogService;
 
 async function getIfrauDialogService() {
-	if (!ifrauDialogService && window.ifrauclient) {
-		const ifrauClient = await window.ifrauclient().connect();
-		ifrauDialogService = await ifrauClient.getService('dialogWC', '0.1');
-	}
+	if (!window.ifrauclient) return;
+	if (ifrauDialogService) return ifrauDialogService;
+	
+	const ifrauClient = await window.ifrauclient().connect();
+	ifrauDialogService = await ifrauClient.getService('dialogWC', '0.1');
 
 	return ifrauDialogService;
 }
@@ -102,9 +103,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		super.updated(changedProperties);
 		if (!changedProperties.has('opened')) return;
 
-		let dialogService;
-		if (window.ifrauclient) dialogService = await getIfrauDialogService();
-
+		const dialogService = await getIfrauDialogService();
 		if (this.opened) {
 			if (dialogService) {
 				this._ifrauContextInfo = await dialogService.showBackdrop();

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -18,6 +18,17 @@ if (window.D2L.DialogMixin.preferNative === undefined) {
 	window.D2L.DialogMixin.preferNative = true;
 }
 
+let ifrauDialogService;
+
+async function getIfrauDialogService() {
+	if (ifrauDialogService === undefined && window.ifrauclient) {
+		const ifrauClient = await window.ifrauclient().connect();
+		ifrauDialogService = await ifrauClient.getService('dialogWC', '0.1');
+	}
+
+	return ifrauDialogService;
+}
+
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const abortAction = 'abort';
 const defaultMargin = { top: 100, right: 30, bottom: 30, left: 30 };
@@ -80,9 +91,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		if (this._useNative) {
 			window.addEventListener('d2l-mvc-dialog-open', this._handleMvcDialogOpen);
 		}
-		if (!window.ifrauclient) return;
-		const ifrauClient = await window.ifrauclient().connect();
-		this._ifrauDialogService = await ifrauClient.getService('dialogWC', '0.1');
 	}
 
 	disconnectedCallback() {
@@ -93,14 +101,18 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	async updated(changedProperties) {
 		super.updated(changedProperties);
 		if (!changedProperties.has('opened')) return;
+
+		let dialogService;
+		if (window.ifrauclient) dialogService = await getIfrauDialogService();
+
 		if (this.opened) {
-			if (this._ifrauDialogService) {
-				this._ifrauContextInfo = await this._ifrauDialogService.showBackdrop();
+			if (dialogService) {
+				this._ifrauContextInfo = await dialogService.showBackdrop();
 			}
 			this._open();
 		} else {
-			if (this._ifrauDialogService) {
-				this._ifrauDialogService.hideBackdrop();
+			if (dialogService) {
+				dialogService.hideBackdrop();
 				this._ifrauContextInfo = null;
 			}
 			this._close();

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -21,7 +21,7 @@ if (window.D2L.DialogMixin.preferNative === undefined) {
 let ifrauDialogService;
 
 async function getIfrauDialogService() {
-	if (ifrauDialogService === undefined && window.ifrauclient) {
+	if (!ifrauDialogService && window.ifrauclient) {
 		const ifrauClient = await window.ifrauclient().connect();
 		ifrauDialogService = await ifrauClient.getService('dialogWC', '0.1');
 	}

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -23,7 +23,7 @@ let ifrauDialogService;
 async function getIfrauDialogService() {
 	if (!window.ifrauclient) return;
 	if (ifrauDialogService) return ifrauDialogService;
-	
+
 	const ifrauClient = await window.ifrauclient().connect();
 	ifrauDialogService = await ifrauClient.getService('dialogWC', '0.1');
 


### PR DESCRIPTION
This PR has two goals:
1. Make sure we're always waiting for the dialog service to be created before checking for it (presuming we're in an FRA).
2. Lazy-load the service so we only connect one ifrau client (and only create one dialog service) for all dialog components.

The root of this issue was the discovery (thanks @dbatiste for helping me debug this!) that Lit does not wait for `connectedCallback()` to finish before moving on to `updated()`. So it was possible (in fact, likely) for the check for `this._ifrauDialogService` to run before the service was actually created. This led to dialogs opening in the wrong location in FRAs if they opened too soon after first being attached to the DOM, as they would size themselves against the document.