### PR TITLE
input-date: fix hidden calendar height

### DIFF
--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -194,8 +194,11 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 
 		const hiddenCalendar = this.shadowRoot.querySelector('.d2l-input-date-hidden-calendar');
 		this._hiddenCalendarResizeObserver = new ResizeObserver(() => {
-			this._hiddenCalendarHeight = Math.ceil(parseFloat(getComputedStyle(hiddenCalendar).getPropertyValue('height')));
-			this._hiddenCalendarResizeObserver.disconnect();
+			const hiddenCalendarHeight = Math.ceil(parseFloat(getComputedStyle(hiddenCalendar).getPropertyValue('height')));
+			if (hiddenCalendarHeight > 0) {
+				this._hiddenCalendarHeight = hiddenCalendarHeight;
+				this._hiddenCalendarResizeObserver.disconnect();
+			}
 		});
 		this._hiddenCalendarResizeObserver.observe(hiddenCalendar);
 	}


### PR DESCRIPTION
On initial load sometimes the hidden calendar height would be 0 at first and then because we disconnect it would never be updated, so `min-height` would go from 415 (a better estimate) to 0 and never to a more expected value.