### PR TITLE
fix: Dropdown width should fit content rather than using the maximum width

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -750,10 +750,14 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		}
 
 		// set to max width
-		let widthOverride = this._width ? this._width : maxWidthOverride;
-
-		if (widthOverride && maxWidthOverride && widthOverride > (maxWidthOverride - 20)) widthOverride = maxWidthOverride - 20;
-		if (widthOverride && minWidthOverride && widthOverride < (minWidthOverride - 20)) widthOverride = minWidthOverride - 20;
+		let widthOverride;
+		if (!specialMobileStyle) {
+			widthOverride = this._width;
+		} else {
+			widthOverride = this._width ? this._width : maxWidthOverride;
+			if (widthOverride && maxWidthOverride && widthOverride > (maxWidthOverride - 20)) widthOverride = maxWidthOverride - 20;
+			if (widthOverride && minWidthOverride && widthOverride < (minWidthOverride - 20)) widthOverride = minWidthOverride - 20;
+		}
 
 		const widthStyle = {
 			maxWidth: maxWidthOverride ? `${maxWidthOverride}px` : undefined,


### PR DESCRIPTION
I previously set the width to the maximum if no width was provided. This was causing some whitespace to be added when not necessary (like https://d2l.slack.com/archives/C0PHG3QB0/p1626188846406100). I'm wrapping the width setting to maximum for the tray-style only, as it is still needed there. 