### PR TITLE
Component analyzer: Switch to @custom-elements-manifest/analyzer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Install analyzer
-        run: npm i @custom-elements-manifest/analyzer --no-save
+        run: npm i web-component-analyzer --no-save
       - name: Build
         run: npm run build
       - name: Create custom-elements.json
-        run: npx custom-elements-manifest analyze --globs \"{components,templates}/**/*.js\" --exclude \"**/{demo,test}/*\" --litelement
+        run: npx wca analyze \"{components,templates}/**/*.js\" --format json --outFile custom-elements.json
       - name: Prepare Translations for NPM
         uses: BrightspaceUI/actions/prepare-translations-for-npm@master
       - name: Semantic Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,12 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
+      - name: Install analyzer
+        run: npm i @custom-elements-manifest/analyzer --no-save
       - name: Build
         run: npm run build
       - name: Create custom-elements.json
-        run: npx wca analyze \"{components,templates}/**/*.js\" --format json --outFile custom-elements.json
+        run: npx custom-elements-manifest analyze --globs \"{components,templates}/**/*.js\" --exclude \"**/{demo,test}/*\" --litelement
       - name: Prepare Translations for NPM
         uses: BrightspaceUI/actions/prepare-translations-for-npm@master
       - name: Semantic Release

--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -20,17 +20,18 @@ class ButtonIcon extends ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(
 			/**
 			 * Aligns the leading edge of text if value is set to "text"
 			 * @type {'text'|''}
-			 * @default ""
 			 */
 			hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
 			/**
 			 * REQUIRED: Preset icon key (e.g. "tier1:gear")
+			 * @type {string}
 			 */
 			icon: { type: String, reflect: true },
 
 			/**
 			 * REQUIRED: Accessible text for the button
+			 * @type {string}
 			 */
 			text: { type: String, reflect: true },
 
@@ -141,6 +142,8 @@ class ButtonIcon extends ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(
 	constructor() {
 		super();
 		this.translucent = false;
+
+		/** @internal */
 		this._buttonId = getUniqueId();
 	}
 

--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -77,10 +77,10 @@ export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin
 	/**
 	 * @attr disabled - Disables the button
 	 */
-	get disabled() { return this.__disabled; }
+	get disabled() { return this._disabled; }
 	set disabled(value) {
-		const oldValue = this.__disabled;
-		this.__disabled = value;
+		const oldValue = this._disabled;
+		this._disabled = value;
 		this.requestUpdate('disabled', oldValue);
 	}
 
@@ -88,10 +88,10 @@ export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin
 	 * @attr disabled-tooltip - Tooltip text when disabled
 	 * @type {string}
 	 */
-	get disabledTooltip() { return this.__disabledTooltip; }
+	get disabledTooltip() { return this._disabledTooltip; }
 	set disabledTooltip(value) {
-		const oldValue = this.__disabledTooltip;
-		this.__disabledTooltip = value;
+		const oldValue = this._disabledTooltip;
+		this._disabledTooltip = value;
 		this.requestUpdate('disabledTooltip', oldValue);
 	}
 

--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -65,10 +65,34 @@ export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin
 
 	constructor() {
 		super();
-		this.autofocus = false;
 		this.disabled = false;
-		this.primary = false;
+
+		/** @ignore */
+		this.autofocus = false;
+
+		/** @ignore */
 		this.type = 'button';
+	}
+
+	/**
+	 * @attr disabled - Disables the button
+	 */
+	get disabled() { return this.__disabled; }
+	set disabled(value) {
+		const oldValue = this.__disabled;
+		this.__disabled = value;
+		this.requestUpdate('disabled', oldValue);
+	}
+
+	/**
+	 * @attr disabled-tooltip - Tooltip text when disabled
+	 * @type {string}
+	 */
+	get disabledTooltip() { return this.__disabledTooltip; }
+	set disabledTooltip(value) {
+		const oldValue = this.__disabledTooltip;
+		this.__disabledTooltip = value;
+		this.requestUpdate('disabledTooltip', oldValue);
 	}
 
 	connectedCallback() {
@@ -86,6 +110,7 @@ export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin
 		if (button) button.focus();
 	}
 
+	/** @internal */
 	_getType() {
 		if (this.type === 'submit' || this.type === 'reset') {
 			return this.type;
@@ -93,6 +118,7 @@ export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin
 		return 'button';
 	}
 
+	/** @internal */
 	_handleClick(e) {
 		if (this.disabled) {
 			e.stopPropagation();

--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -18,18 +18,19 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 		return {
 			/**
 			 * A description to be added to the button for accessibility when text on button does not provide enough context
+			 * @type {string}
 			 */
 			description: { type: String },
 
 			/**
 			 * Aligns the leading edge of text if value is set to "text"
 			 * @type {'text'|''}
-			 * @default ""
 			 */
 			hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
 			/**
 			 * Preset icon key (e.g. "tier1:gear")
+			 * @type {string}
 			 */
 			icon: { type: String, reflect: true },
 
@@ -40,6 +41,7 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 
 			/**
 			 * REQUIRED: Text for the button
+			 * @type {string}
 			 */
 			text: { type: String, reflect: true }
 		};
@@ -149,6 +151,8 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 	constructor() {
 		super();
 		this.iconRight = false;
+
+		/** @internal */
 		this._buttonId = getUniqueId();
 	}
 

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -17,6 +17,7 @@ class Button extends ButtonMixin(LitElement) {
 		return {
 			/**
 			 * A description to be added to the button for accessibility when text on button does not provide enough context
+			 * @type {string}
 			 */
 			description: { type: String },
 
@@ -84,6 +85,9 @@ class Button extends ButtonMixin(LitElement) {
 
 	constructor() {
 		super();
+		this.primary = false;
+
+		/** @internal */
 		this._buttonId = getUniqueId();
 	}
 

--- a/mixins/theme-mixin.js
+++ b/mixins/theme-mixin.js
@@ -13,4 +13,15 @@ export const ThemeMixin = superclass => class extends superclass {
 		};
 	}
 
+	/**
+	 * @attr theme
+	 * @type {string}
+	 */
+	get theme() { return this._theme; }
+	set theme(value) {
+		const oldValue = this._theme;
+		this._theme = value;
+		this.requestUpdate('theme', oldValue);
+	}
+
 };

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "mocha": "^8",
     "node-sass": "^6",
     "sinon": "^11",
-    "stylelint": "^13",
-    "web-component-analyzer": "^1"
+    "stylelint": "^13"
   },
   "dependencies": {
     "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
I actually don't think we should make the switch yet as I have a few times run the analyzer and noticed that there was at least one missing component, and we can't have that. I'll work on a way to figure out when that's happening. There also still seems to be a lot of active development going on.

If we don't want to make the switch over yet, the changes here do still work with the web-component-analyzer, and I've been able to make the changes necessary to documentation in such a way that it supports both formats, so we can be updating the jsdoc comments as we go in hopes of using this analyzer while still having Daylight work.