### PR TITLE
Daylight: date & time inputs

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -79,14 +79,30 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 
 	static get properties() {
 		return {
+			/**
+			 * @ignore
+			 */
 			forceInvalid: { type: Boolean, attribute: false },
+			/**
+			 * @ignore
+			 */
 			invalid: { type: Boolean, reflect: true },
 			/**
+			 * @ignore
 			 * Name of the form control. Submitted with the form as part of a name/value pair.
 			 */
 			name: { type: String },
+			/**
+			 * @ignore
+			 */
 			noValidate: { type: Boolean, attribute: 'novalidate' },
+			/**
+			 * @ignore
+			 */
 			validationError: { type: String, attribute: false },
+			/**
+			 * @ignore
+			 */
 			childErrors: { type: Object, attribute: false },
 			_errors: { type: Array, attribute: false }
 		};
@@ -99,11 +115,17 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 
 		this._validationCustoms = new Set();
 		this._validity = new FormElementValidityState({});
+		/** @ignore */
 		this.forceInvalid = false;
+		/** @ignore */
 		this.formValue = null;
+		/** @ignore */
 		this.invalid = false;
+		/** @ignore */
 		this.noValidate = false;
+		/** @ignore */
 		this.validationError = null;
+		/** @ignore */
 		this.childErrors = new Map();
 		this._errors = [];
 
@@ -111,10 +133,12 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		this.shadowRoot.addEventListener('d2l-form-element-errors-change', this._onFormElementErrorsChange);
 	}
 
+	/** @ignore */
 	get formAssociated() {
 		return true;
 	}
 
+	/** @ignore */
 	get validationMessage() {
 		const label = this.label || this.localize('components.form-element.defaultFieldLabel');
 		if (this.validity.valueMissing) {
@@ -123,6 +147,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		return this.localize('components.form-element.defaultError', { label });
 	}
 
+	/** @ignore */
 	get validity() {
 		return this._validity;
 	}

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -159,12 +159,14 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 				errors = [...childErrors, ...errors];
 			}
 			const options = { bubbles: true, composed: true, detail: { errors } };
+			/** @ignore */
 			this.dispatchEvent(new CustomEvent('d2l-form-element-errors-change', options));
 		}
 		if (changedProperties.has('noValidate') || changedProperties.has('forceInvalid') || changedProperties.has('validationError')) {
 			const oldValue = this.invalid;
 			this.invalid = (this.forceInvalid || this.validationError !== null) && !this.noValidate;
 			if (this.invalid !== oldValue) {
+				/** @ignore */
 				this.dispatchEvent(new CustomEvent('invalid-change'));
 			}
 		}

--- a/components/form/form-mixin.js
+++ b/components/form/form-mixin.js
@@ -132,6 +132,7 @@ export const FormMixin = superclass => class extends LocalizeCoreElement(supercl
 			this._errors.set(ele, errors);
 		}
 		const detail = { bubbles: true, composed: true, detail: { errors: this._errors } };
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent('d2l-form-errors-change', detail));
 		this.requestUpdate('_errors');
 		return true;

--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -9,7 +9,6 @@ size:xlarge
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date.js';
   import '@brightspace-ui/core/components/inputs/input-time.js';
-  import '@brightspace-ui/core/components/inputs/input-date-time.js';
 </script>
 <d2l-input-date label="Date Input"></d2l-input-date>
 <d2l-input-time label="Time Input"></d2l-input-time>
@@ -29,8 +28,8 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 name:d2l-input-date
 align:flex-start
 autoSize:false
-size:xlarge
 defaults:{ "label": "Birthdate" }
+size:xlarge
 -->
 ```html
 <script type="module">
@@ -82,8 +81,8 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 name:d2l-input-date-range
 align:flex-start
 autoSize:false
-size:xlarge
 defaults:{ "label": "Availability Range" }
+size:xlarge
 -->
 ```html
 <script type="module">
@@ -142,8 +141,8 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 name:d2l-input-time
 align:flex-start
 autoSize:false
-size:large
 defaults:{ "label": "Time" }
+size:large
 -->
 ```html
 <script type="module">
@@ -195,8 +194,8 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 name:d2l-input-time-range
 align:flex-start
 autoSize:false
-size:large
 defaults:{ "label": "Availability Range" }
+size:large
 -->
 ```html
 <script type="module">
@@ -251,8 +250,8 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 name:d2l-input-date-time
 align:flex-start
 autoSize:false
-size:xlarge
 defaults:{ "label": "Due Date" }
+size:xlarge
 -->
 ```html
 <script type="module">
@@ -303,8 +302,8 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 name:d2l-input-date-time-range
 align:flex-start
 autoSize:false
-size:xlarge
 defaults:{ "label": "Availability Range" }
+size:xlarge
 -->
 ```html
 <script type="module">
@@ -349,7 +348,7 @@ To make your usage of `d2l-input-date-time-range` accessible, use the following 
 
 ## Timezone
 
-The `input-date-time` and `input-date-time-range` components expect an input in UTC (`YYYY-MM-DDTHH:mm:ss.sssZ`). These components will convert a value automatically to the user's timezone to display the date/time to them, and then will provide the value back in UTC. No timezone conversions are needed.
+The `input-date-time` and `input-date-time-range` components expect input in UTC (`YYYY-MM-DDTHH:mm:ss.sssZ`). These components will convert values automatically to the user's timezone to display the date/time to them, and then will provide the value back in UTC. No timezone conversions are needed.
 
 The `input-date`, `input-date-range`, `input-time`, and `input-time-range` components do not handle timezone and so require the input to be in the user's timezone (if applicable), which corresponds to the user's timezone as specified in their account settings. The consumer of the component will need to handle any necessary UTC to local to UTC conversions. The following methods can be used for these conversions:
 * `getLocalDateTimeFromUTCDateTime(utcDateTime)` (where `utcDateTime` is the date/time in the format `YYYY-MM-DDTHH:mm:ss.sssZ`) returns the date/time in the format `YYYY-MM-DDTHH:mm:ss.sss` in the user's local timezone

--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -1,24 +1,40 @@
 # Date & Time Inputs
 
-## Date Inputs
+<!-- docs: demo -->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/inputs/input-date.js';
+  import '@brightspace-ui/core/components/inputs/input-time.js';
+  import '@brightspace-ui/core/components/inputs/input-date-time.js';
+</script>
+<d2l-input-date label="Date Input"></d2l-input-date>
+<d2l-input-time label="Time Input"></d2l-input-time>
+<d2l-input-date-time label="Date-Time Input"></d2l-input-date-time>
+```
+
+## Date Input [d2l-input-date]
 
 The `<d2l-input-date>` component consists of a text input field for typing a date and an attached calendar (`<d2l-calendar>`) dropdown. The dropdown opens on click of the text input, or on enter or down arrow press if the text input is focused. It displays the `value` if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the `d2l-calendar` or entered in the text input.
 
-![example screenshot of date input](../screenshots/date.gif?raw=true)
+Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-MM-DD`) and should be [localized to the user's timezone](#timezone) (if applicable).
 
+<!-- docs: start hidden content -->
+![example screenshot of date input](../screenshots/date.gif?raw=true)
+<!-- docs: end hidden content -->
+
+<!-- docs: demo live
+name: d2l-input-date
+-->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date.js';
 </script>
-<d2l-input-date
-  label="Start Date"
-  value="2020-11-20">
+<d2l-input-date label="Birthdate">
 </d2l-input-date>
 ```
 
-**Properties:**
-
-Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-MM-DD`) and should be [localized to the user's timezone](#timezone) (if applicable).
+<!-- docs: start hidden content -->
+### Properties
 
 | Property | Type | Description |
 |--|--|--|
@@ -31,7 +47,12 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 | `required` | Boolean | Indicates that a value is required |
 | `value` | String, default `''` | Value of the input. |
 
-**Accessibility:**
+### Events
+
+* `change`: dispatched when a date is selected or typed. `value` reflects the selected value and is in ISO 8601 calendar date format (`YYYY-MM-DD`).
+<!-- docs: end hidden content -->
+
+### Accessibility Properties
 
 To make your usage of `d2l-input-date` accessible, use the following properties when applicable:
 
@@ -40,30 +61,29 @@ To make your usage of `d2l-input-date` accessible, use the following properties 
 | `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users |
 
-**Events:**
-
-* `change`: dispatched when a date is selected or typed. `value` reflects the selected value and is in ISO 8601 calendar date format (`YYYY-MM-DD`).
-
-### Date Range Inputs
+## Date Range Input [d2l-input-date-range]
 
 The `<d2l-input-date-range>` component consists of two input-date components - one for the start of a range and one for the end of a range. Values specified for these components (through the `start-value` and/or `end-value` attributes) are displayed if specified, and selected values are reflected.
 
-![example screenshot of date range input](../screenshots/date-range.gif?raw=true)
+Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-MM-DD`) and should be [localized to the user's timezone](#timezone) (if applicable).
 
+<!-- docs: start hidden content -->
+![example screenshot of date range input](../screenshots/date-range.gif?raw=true)
+<!-- docs: end hidden content -->
+
+<!-- docs: demo live
+name: d2l-input-date-range
+-->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date-range.js';
 </script>
-<d2l-input-date-range
-  label="Assignment Dates"
-  end-value="2021-01-01"
-  start-value="2020-11-20">
+<d2l-input-date-range label="Assignment Availability Range">
 </d2l-input-date-range>
 ```
 
-**Properties:**
-
-Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-MM-DD`) and should be [localized to the user's timezone](#timezone) (if applicable).
+<!-- docs: start hidden content -->
+### Properties
 
 | Property | Type | Description |
 |--|--|--|
@@ -81,7 +101,12 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 | `start-label` | String, default `'Start Date'` | Accessible label for the first date input |
 | `start-value` | String, default `''` | Value of the first date input |
 
-**Accessibility:**
+### Events
+
+* `change`: dispatched when a start or end date is selected or typed. `start-value` reflects the value of the first input, `end-value` reflects the value of the second input, and both are in ISO 8601 calendar date format (`YYYY-MM-DD`).
+<!-- docs: end hidden content -->
+
+### Accessibility Properties
 
 To make your usage of `d2l-input-date-range` accessible, use the following properties when applicable:
 
@@ -92,16 +117,19 @@ To make your usage of `d2l-input-date-range` accessible, use the following prope
 | `end-label` | Accessible label for the second date input |
 | `start-label` | Accessible label for the first date input |
 
-**Events:**
-
-* `change`: dispatched when a start or end date is selected or typed. `start-value` reflects the value of the first input, `end-value` reflects the value of the second input, and both are in ISO 8601 calendar date format (`YYYY-MM-DD`).
-
-## Time Inputs
+## Time Input [d2l-input-time]
 
 The `<d2l-input-time>` component consists of a text input field for typing a time and an attached dropdown for time selection. The dropdown opens on click of the text input, or on enter or down arrow press if the text input is focused. It displays the `value` if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
 
-![example screenshot of time input](../screenshots/time.gif?raw=true)
+Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's timezone](#timezone) (if applicable).
 
+<!-- docs: start hidden content -->
+![example screenshot of time input](../screenshots/time.gif?raw=true)
+<!-- docs: end hidden content -->
+
+<!-- docs: demo live
+name: d2l-input-time
+-->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-time.js';
@@ -112,7 +140,8 @@ The `<d2l-input-time>` component consists of a text input field for typing a tim
 </d2l-input-time>
 ```
 
-**Properties:**
+<!-- docs: start hidden content -->
+### Properties
 
 | Property | Type | Description |
 |--|--|--|
@@ -125,7 +154,12 @@ The `<d2l-input-time>` component consists of a text input field for typing a tim
 | `time-interval` | String, default: `thirty` | Number of minutes between times shown in dropdown. Valid values include `five`, `ten`, `fifteen`, `twenty`, `thirty`, and `sixty`. |
 | `value` | String, default `''` | Value of the input. This should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's timezone](#timezone) (if applicable). |
 
-**Accessibility:**
+### Events
+
+* `change`: dispatched when a time is selected or typed. `value` reflects the selected value and is in ISO 8601 time format (`hh:mm:ss`).
+<!-- docs: end hidden content -->
+
+### Accessibility Properties
 
 To make your usage of `d2l-input-time` accessible, use the following properties when applicable:
 
@@ -134,30 +168,29 @@ To make your usage of `d2l-input-time` accessible, use the following properties 
 | `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users |
 
-**Events:**
-
-* `change`: dispatched when a time is selected or typed. `value` reflects the selected value and is in ISO 8601 time format (`hh:mm:ss`).
-
-### Time Range Inputs
+### Time Range Input [d2l-input-time-range]
 
 The `<d2l-input-time-range>` component consists of two input-time components - one for the start of a range and one for the end of a range. Values specified for these components (through the `start-value` and/or `end-value` attributes) are displayed if specified, and selected values are reflected.
 
-![example screenshot of time range input](../screenshots/time-range.gif?raw=true)
+Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's timezone](#timezone) (if applicable).
 
+<!-- docs: start hidden content -->
+![example screenshot of time range input](../screenshots/time-range.gif?raw=true)
+<!-- docs: end hidden content -->
+
+<!-- docs: demo live
+name: d2l-input-time-range
+-->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-time-range.js';
 </script>
-<d2l-input-time-range
-  label="Times"
-  end-value="08:30:00"
-  start-value="13:00:00">
+<d2l-input-time-range label="Times">
 </d2l-input-time-range>
 ```
 
-**Properties:**
-
-Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's timezone](#timezone) (if applicable).
+<!-- docs: start hidden content -->
+### Properties
 
 | Property | Type | Description |
 |--|--|--|
@@ -174,8 +207,9 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 | `start-label` | String, default `'Start Time'` | Accessible label for the first time input |
 | `start-value` | String, default `''` | Value of the first time input |
 | `time-interval` | String, default: `thirty` | Number of minutes between times shown in dropdown. Valid values include `five`, `ten`, `fifteen`, `twenty`, `thirty`, and `sixty`. |
+<!-- docs: end hidden content -->
 
-**Accessibility:**
+### Accessibility Properties
 
 To make your usage of `d2l-input-time-range` accessible, use the following properties when applicable:
 
@@ -186,25 +220,29 @@ To make your usage of `d2l-input-time-range` accessible, use the following prope
 | `end-label` | Accessible label for the second time input |
 | `start-label` | Accessible label for the first time input |
 
-## Date-Time Inputs
+## Date-Time Input [d2l-input-date-time]
 
 The `<d2l-input-date-time>` component consists of a `<d2l-input-date>` and a `<d2l-input-time>` component. The time input only appears once a date is selected. This component displays the `value` if one is specified, and reflects the selected value when one is selected or entered.
 
-![example screenshot of date input](../screenshots/date-time.gif?raw=true)
+Note: All `*value` properties should be in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time (i.e., do NOT localize to the user's timezone).
 
+<!-- docs: start hidden content -->
+![example screenshot of date input](../screenshots/date-time.gif?raw=true)
+<!-- docs: end hidden content -->
+
+<!-- docs: demo live
+name: d2l-input-date-time
+-->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date-time.js';
 </script>
-<d2l-input-date-time
-  label="Start Date"
-  value="2020-11-20T12:00:00.000Z">
+<d2l-input-date-time label="Due Date">
 </d2l-input-date-time>
 ```
 
-**Properties:**
-
-Note: `max-value`, `min-value` and `value` should be in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time (i.e., do NOT localize to the user's timezone).
+<!-- docs: start hidden content -->
+### Properties
 
 | Property | Type | Description |
 |--|--|--|
@@ -217,7 +255,12 @@ Note: `max-value`, `min-value` and `value` should be in ISO 8601 combined date a
 | `time-default-value`| String, default:`'00:00:00'` | Set default value of time input. Accepts ISO 8601 time format (`hh:mm:ss`) and the following keywords: `startOfDay`,`endOfDay`. |
 | `value` | String, default `''` | Value of the input. |
 
-**Accessibility:**
+### Events
+
+* `change`: dispatched when there is a change in selected date or selected time (when date is already selected). `value` reflects the selected value and is in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`).
+<!-- docs: end hidden content -->
+
+### Accessibility Properties
 
 To make your usage of `d2l-input-date-time` accessible, use the following property:
 
@@ -225,30 +268,29 @@ To make your usage of `d2l-input-date-time` accessible, use the following proper
 |--|--|
 | `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/) |
 
-**Events:**
-
-* `change`: dispatched when there is a change in selected date or selected time (when date is already selected). `value` reflects the selected value and is in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`).
-
-### Date-Time Range Inputs
+### Date-Time Range Input [d2l-input-date-time-range]
 
 The `<d2l-input-date-time-range>` component consists of two input-date-time components - one for the start of a range and one for the end of a range. Values specified for these components (through the `start-value` and/or `end-value` attributes) are displayed if specified, and selected values are reflected.
 
-![example screenshot of date-time range input](../screenshots/date-time-range.gif?raw=true)
+Note: All `*value` properties should be in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time (i.e., do NOT localize to the user's timezone).
 
+<!-- docs: start hidden content -->
+![example screenshot of date-time range input](../screenshots/date-time-range.gif?raw=true)
+<!-- docs: end hidden content -->
+
+<!-- docs: demo live
+name: d2l-input-date-time-range
+-->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date-time-range.js';
 </script>
-<d2l-input-date-time-range
-  label="Assignment Dates"
-  start-value="2019-03-02T05:00:00.000"
-  end-value="2019-05-02T12:00:00.000">
+<d2l-input-date-time-range label="Assignment Availability Range">
 </d2l-input-date-time-range>
 ```
 
-**Properties:**
-
-Note: All `*value` properties should be in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time (i.e., do NOT localize to the user's timezone).
+<!-- docs: start hidden content -->
+### Properties
 
 | Property | Type | Description |
 |--|--|--|
@@ -264,7 +306,12 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 | `start-label` | String, default `'Start Date'` | Accessible label for the first date-time input |
 | `start-value` | String, default `''` | Value of the first date-time input |
 
-**Accessibility:**
+### Events
+
+* `change`: dispatched when a start or end date is selected or typed. `start-value` reflects the value of the first input, `end-value` reflects the value of the second input, and both are in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time.
+<!-- docs: end hidden content -->
+
+### Accessibility Properties
 
 To make your usage of `d2l-input-date-time-range` accessible, use the following properties when applicable:
 
@@ -275,13 +322,9 @@ To make your usage of `d2l-input-date-time-range` accessible, use the following 
 | `end-label` | Accessible label for the second date-time input |
 | `start-label` | Accessible label for the first date-time input |
 
-**Events:**
-
-* `change`: dispatched when a start or end date is selected or typed. `start-value` reflects the value of the first input, `end-value` reflects the value of the second input, and both are in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time.
-
 ## Timezone
 
-The `input-date-time` and `input-date-time-range` components expects an input in UTC (`YYYY-MM-DDTHH:mm:ss.sssZ`), will convert automatically to the user's timezone to display the date/time to them, and then will provide the value back as UTC. No timezone conversions are needed.
+The `input-date-time` and `input-date-time-range` components expect an input in UTC (`YYYY-MM-DDTHH:mm:ss.sssZ`). These components will convert a value automatically to the user's timezone to display the date/time to them, and then will provide the value back in UTC. No timezone conversions are needed.
 
 The `input-date`, `input-date-range`, `input-time`, and `input-time-range` components do not handle timezone and so require the input to be in the user's timezone (if applicable), which corresponds to the user's timezone as specified in their account settings. The consumer of the component will need to handle any necessary UTC to local to UTC conversions. The following methods can be used for these conversions:
 * `getLocalDateTimeFromUTCDateTime(utcDateTime)` (where `utcDateTime` is the date/time in the format `YYYY-MM-DDTHH:mm:ss.sssZ`) returns the date/time in the format `YYYY-MM-DDTHH:mm:ss.sss` in the user's local timezone

--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -1,6 +1,10 @@
 # Date & Time Inputs
 
-<!-- docs: demo -->
+<!-- docs: demo
+align:flex-start
+autoSize:false
+size:xlarge
+-->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date.js';
@@ -9,7 +13,6 @@
 </script>
 <d2l-input-date label="Date Input"></d2l-input-date>
 <d2l-input-time label="Time Input"></d2l-input-time>
-<d2l-input-date-time label="Date-Time Input"></d2l-input-date-time>
 ```
 
 ## Date Input [d2l-input-date]
@@ -23,13 +26,17 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 <!-- docs: end hidden content -->
 
 <!-- docs: demo live
-name: d2l-input-date
+name:d2l-input-date
+align:flex-start
+autoSize:false
+size:xlarge
+defaults:{ "label": "Birthdate" }
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date.js';
 </script>
-<d2l-input-date label="Birthdate">
+<d2l-input-date>
 </d2l-input-date>
 ```
 
@@ -72,13 +79,17 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 <!-- docs: end hidden content -->
 
 <!-- docs: demo live
-name: d2l-input-date-range
+name:d2l-input-date-range
+align:flex-start
+autoSize:false
+size:xlarge
+defaults:{ "label": "Availability Range" }
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date-range.js';
 </script>
-<d2l-input-date-range label="Assignment Availability Range">
+<d2l-input-date-range>
 </d2l-input-date-range>
 ```
 
@@ -128,15 +139,17 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 <!-- docs: end hidden content -->
 
 <!-- docs: demo live
-name: d2l-input-time
+name:d2l-input-time
+align:flex-start
+autoSize:false
+size:large
+defaults:{ "label": "Time" }
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-time.js';
 </script>
-<d2l-input-time
-  label="Start Time"
-  value="18:00:00">
+<d2l-input-time>
 </d2l-input-time>
 ```
 
@@ -179,13 +192,17 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 <!-- docs: end hidden content -->
 
 <!-- docs: demo live
-name: d2l-input-time-range
+name:d2l-input-time-range
+align:flex-start
+autoSize:false
+size:large
+defaults:{ "label": "Availability Range" }
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-time-range.js';
 </script>
-<d2l-input-time-range label="Times">
+<d2l-input-time-range>
 </d2l-input-time-range>
 ```
 
@@ -231,13 +248,17 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 <!-- docs: end hidden content -->
 
 <!-- docs: demo live
-name: d2l-input-date-time
+name:d2l-input-date-time
+align:flex-start
+autoSize:false
+size:xlarge
+defaults:{ "label": "Due Date" }
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date-time.js';
 </script>
-<d2l-input-date-time label="Due Date">
+<d2l-input-date-time>
 </d2l-input-date-time>
 ```
 
@@ -279,13 +300,17 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 <!-- docs: end hidden content -->
 
 <!-- docs: demo live
-name: d2l-input-date-time-range
+name:d2l-input-date-time-range
+align:flex-start
+autoSize:false
+size:xlarge
+defaults:{ "label": "Availability Range" }
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date-time-range.js';
 </script>
-<d2l-input-date-time-range label="Assignment Availability Range">
+<d2l-input-date-time-range>
 </d2l-input-date-time-range>
 ```
 

--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -28,14 +28,13 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 name:d2l-input-date
 align:flex-start
 autoSize:false
-defaults:{ "label": "Birthdate" }
 size:xlarge
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date.js';
 </script>
-<d2l-input-date>
+<d2l-input-date label="Birthdate">
 </d2l-input-date>
 ```
 
@@ -81,14 +80,13 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 name:d2l-input-date-range
 align:flex-start
 autoSize:false
-defaults:{ "label": "Availability Range" }
 size:xlarge
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date-range.js';
 </script>
-<d2l-input-date-range>
+<d2l-input-date-range label="Availability Range">
 </d2l-input-date-range>
 ```
 
@@ -141,14 +139,13 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 name:d2l-input-time
 align:flex-start
 autoSize:false
-defaults:{ "label": "Time" }
 size:large
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-time.js';
 </script>
-<d2l-input-time>
+<d2l-input-time label="Time">
 </d2l-input-time>
 ```
 
@@ -194,14 +191,13 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 name:d2l-input-time-range
 align:flex-start
 autoSize:false
-defaults:{ "label": "Availability Range" }
 size:large
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-time-range.js';
 </script>
-<d2l-input-time-range>
+<d2l-input-time-range label="Availability Range">
 </d2l-input-time-range>
 ```
 
@@ -250,14 +246,13 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 name:d2l-input-date-time
 align:flex-start
 autoSize:false
-defaults:{ "label": "Due Date" }
 size:xlarge
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date-time.js';
 </script>
-<d2l-input-date-time>
+<d2l-input-date-time label="Due Date">
 </d2l-input-date-time>
 ```
 
@@ -302,14 +297,13 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 name:d2l-input-date-time-range
 align:flex-start
 autoSize:false
-defaults:{ "label": "Availability Range" }
 size:xlarge
 -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/inputs/input-date-time-range.js';
 </script>
-<d2l-input-date-time-range>
+<d2l-input-date-time-range label="Availability Range">
 </d2l-input-date-time-range>
 ```
 

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -28,7 +28,7 @@ export function getShiftedEndDate(startValue, endValue, prevStartValue, inclusiv
 
 /**
  * A component consisting of two input-date components - one for start of range and one for end of range. Values specified for these components (through start-value and/or end-value attributes) should be localized to the user's timezone if applicable and must be in ISO 8601 calendar date format ("YYYY-MM-DD").
- * @fires change - Dispatched when there is a change in selected start date or selected end date. "start-value" and "end-value" contain the selected values and are formatted in ISO 8601 calendar date format ("YYYY-MM-DD").
+ * @fires change - Dispatched when there is a change to selected start date or selected end date. "start-value" and "end-value" correspond to the selected values and are formatted in ISO 8601 calendar date format ("YYYY-MM-DD").
  */
 class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement)))) {
 

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -28,14 +28,14 @@ export function getShiftedEndDate(startValue, endValue, prevStartValue, inclusiv
 
 /**
  * A component consisting of two input-date components - one for start of range and one for end of range. Values specified for these components (through start-value and/or end-value attributes) should be localized to the user's timezone if applicable and must be in ISO 8601 calendar date format ("YYYY-MM-DD").
- * @fires change - Dispatched when a start or end date is selected or typed. "start-value" and "end-value" reflect the selected values and are in ISO 8601 calendar date format ("YYYY-MM-DD").
+ * @fires change - Dispatched when there is a change in selected start date or selected end date. "start-value" and "end-value" contain the selected values and are formatted in ISO 8601 calendar date format ("YYYY-MM-DD").
  */
 class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement)))) {
 
 	static get properties() {
 		return {
 			/**
-			 * Automatically shift end date when start date changes to keep same range
+			 * Automatically shifts end date when start date changes to keep same range
 			 */
 			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
 			/**
@@ -47,7 +47,7 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Label for the end date input
+			 * Accessible label for the end date input
 			 * @default "End Date"
 			 */
 			endLabel: { attribute: 'end-label', reflect: true, type: String },
@@ -56,15 +56,15 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			endValue: { attribute: 'end-value', reflect: true, type: String },
 			/**
-			 * Validate on inclusive range
+			 * Validates on inclusive range (i.e., it is valid for start and end dates to be equal)
 			 */
 			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
 			/**
-			 * REQUIRED: Accessible label for the range
+			 * REQUIRED: Accessible label for the input fieldset that wraps the date inputs
 			 */
 			label: { type: String, reflect: true },
 			/**
-			 * Hides the label visually
+			 * Hides the fieldset label visually
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
 			/**
@@ -76,11 +76,11 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
-			 * Indicates that a value is required
+			 * Indicates that values are required
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Label for the start date input
+			 * Accessible label for the start date input
 			 * @default "Start Date"
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -47,12 +47,14 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the end date input
+			 * Accessible label for the end date input. Defaults to localized "End Date".
+			 * @type {string}
 			 * @default "End Date"
 			 */
 			endLabel: { attribute: 'end-label', reflect: true, type: String },
 			/**
 			 * Value of the end date input
+			 * @type {string}
 			 */
 			endValue: { attribute: 'end-value', reflect: true, type: String },
 			/**
@@ -61,6 +63,7 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
 			/**
 			 * REQUIRED: Accessible label for the input fieldset that wraps the date inputs
+			 * @type {string}
 			 */
 			label: { type: String, reflect: true },
 			/**
@@ -69,10 +72,12 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
 			/**
 			 * Maximum valid date that could be selected by a user
+			 * @type {string}
 			 */
 			maxValue: { attribute: 'max-value', reflect: true, type: String },
 			/**
 			 * Minimum valid date that could be selected by a user
+			 * @type {string}
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
@@ -80,12 +85,14 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the start date input
+			 * Accessible label for the start date input. Defaults to localized "Start Date".
+			 * @type {string}
 			 * @default "Start Date"
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },
 			/**
 			 * Value of the start date input
+			 * @type {string}
 			 */
 			startValue: { attribute: 'start-value', reflect: true, type: String },
 			_endCalendarOpened: { attribute: false, type: Boolean },
@@ -123,6 +130,7 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 		this._endInputId = getUniqueId();
 	}
 
+	/** @ignore */
 	get validationMessage() {
 		if (this.validity.badInput) {
 			return this.localize('components.input-date-range.errorBadInput', { startLabel: this._computedStartLabel, endLabel: this._computedEndLabel });

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -59,16 +59,16 @@ export function getShiftedEndDateTime(startValue, endValue, prevStartValue, incl
 
 /**
  * A component consisting of two input-date-time components - one for start of range and one for end of range. The time input only appears once a date is selected.
- * @fires change - Dispatched when a start or end date or time is selected or typed. "start-value" and "end-value" reflect the selected values and are in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ").
- * @slot start - Optional content that would appear below the first input-date-time
- * @slot end - Optional content that would appear below the second input-date-time
+ * @fires change - Dispatched when there is a change in selected start date-time or selected end date-time. "start-value" and "end-value" contain the selected values and are formatted in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ").
+ * @slot start - Optional content that would appear below the start input-date-time
+ * @slot end - Optional content that would appear below the end input-date-time
  */
 class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement)))) {
 
 	static get properties() {
 		return {
 			/**
-			 * Automatically shift end date when start date changes to keep same range
+			 * Automatically shifts end date when start date changes to keep same range. If start and end date are equal, automatically shifts end time when start time changes.
 			 */
 			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
 			/**
@@ -80,49 +80,49 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Label for the end input
+			 * Accessible label for the end date-time input
 			 * @default "End Date"
 			 */
 			endLabel: { attribute: 'end-label', reflect: true, type: String },
 			/**
-			 * Value of the end input
+			 * Value of the end date-time input
 			 */
 			endValue: { attribute: 'end-value', reflect: true, type: String },
 			/**
-			 * Validate on inclusive range
+			 * Validates on inclusive range (i.e., it is valid for start and end date-times to be equal)
 			 */
 			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
 			/**
-			 * REQUIRED: Accessible label for the range
+			 * REQUIRED: Accessible label for the input fieldset that wraps the date-time inputs
 			 */
 			label: { type: String, reflect: true },
 			/**
-			 * Hides the label visually
+			 * Hides the fieldset label visually
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
 			/**
-			 * Indicates that any timezone localization will be handeld by the consumer and so any values will not be converted from/to UTC
+			 * Indicates that localization will be handled by the consumer. `*value` will not be converted from/to UTC.
 			 */
 			localized: { reflect: true, type: Boolean },
 			/**
-			 * Maximum valid date/time that could be selected by a user.
+			 * Maximum valid date/time that could be selected by a user
 			 */
 			maxValue: { attribute: 'max-value', reflect: true, type: String },
 			/**
-			 * Minimum valid date/time that could be selected by a user.
+			 * Minimum valid date/time that could be selected by a user
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
-			 * Indicates that a value is required
+			 * Indicates that values are required
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Label for the start input
+			 * Accessible label for the start date-time input
 			 * @default "Start Date"
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },
 			/**
-			 * Value of the start input
+			 * Value of the start date-time input
 			 */
 			startValue: { attribute: 'start-value', reflect: true, type: String },
 			_endDropdownOpened: { type: Boolean },

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -80,12 +80,14 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the end date-time input
+			 * Accessible label for the end date-time input. Defaults to localized "End Date".
+			 * @type {string}
 			 * @default "End Date"
 			 */
 			endLabel: { attribute: 'end-label', reflect: true, type: String },
 			/**
 			 * Value of the end date-time input
+			 * @type {string}
 			 */
 			endValue: { attribute: 'end-value', reflect: true, type: String },
 			/**
@@ -94,6 +96,7 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
 			/**
 			 * REQUIRED: Accessible label for the input fieldset that wraps the date-time inputs
+			 * @type {string}
 			 */
 			label: { type: String, reflect: true },
 			/**
@@ -106,10 +109,12 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 			localized: { reflect: true, type: Boolean },
 			/**
 			 * Maximum valid date/time that could be selected by a user
+			 * @type {string}
 			 */
 			maxValue: { attribute: 'max-value', reflect: true, type: String },
 			/**
 			 * Minimum valid date/time that could be selected by a user
+			 * @type {string}
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
@@ -117,12 +122,14 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the start date-time input
-			 * @default "Start Date"
+			 * Accessible label for the start date-time input. Defaults to localized "Start Date".
+			 * @type {string}
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },
 			/**
 			 * Value of the start date-time input
+			 * @type {string}
+			 * @default "Start Date"
 			 */
 			startValue: { attribute: 'start-value', reflect: true, type: String },
 			_endDropdownOpened: { type: Boolean },
@@ -168,6 +175,7 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 		this._slotOccupied = false;
 	}
 
+	/** @ignore */
 	get validationMessage() {
 		if (this.validity.badInput) {
 			return this.localize('components.input-date-time-range.errorBadInput', { startLabel: this._computedStartLabel, endLabel: this._computedEndLabel });

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -59,7 +59,7 @@ export function getShiftedEndDateTime(startValue, endValue, prevStartValue, incl
 
 /**
  * A component consisting of two input-date-time components - one for start of range and one for end of range. The time input only appears once a date is selected.
- * @fires change - Dispatched when there is a change in selected start date-time or selected end date-time. "start-value" and "end-value" contain the selected values and are formatted in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ").
+ * @fires change - Dispatched when there is a change to selected start date-time or selected end date-time. "start-value" and "end-value" correspond to the selected values and are formatted in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ").
  * @slot start - Optional content that would appear below the start input-date-time
  * @slot end - Optional content that would appear below the end input-date-time
  */
@@ -124,12 +124,12 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 			/**
 			 * Accessible label for the start date-time input. Defaults to localized "Start Date".
 			 * @type {string}
+			 * @default "Start Date"
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },
 			/**
 			 * Value of the start date-time input
 			 * @type {string}
-			 * @default "Start Date"
 			 */
 			startValue: { attribute: 'start-value', reflect: true, type: String },
 			_endDropdownOpened: { type: Boolean },

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -36,7 +36,7 @@ function _getFormattedDefaultTime(defaultValue) {
 
 /**
  * A component that consists of a "<d2l-input-date>" and a "<d2l-input-time>" component. The time input only appears once a date is selected. This component displays the "value" if one is specified, and reflects the selected value when one is selected or entered.
- * @fires change - Dispatched when there is a change in selected date or selected time. "value" reflects the selected value and is in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ").
+ * @fires change - Dispatched when there is a change in selected date or selected time. "value" contains the selected value and is formatted in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ").
  */
 class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement)))) {
 
@@ -47,23 +47,23 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * REQUIRED: Accessible label for the input
+			 * REQUIRED: Accessible label for the input fieldset that wraps the date and time inputs
 			 */
 			label: { type: String },
 			/**
-			 * Hides the label visually (moves it to the input's "aria-label" attribute)
+			 * Hides the fieldset label visually
 			 */
 			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
 			/**
-			 * Indicates that any timezone localization will be handeld by the consumer and so any values will not be converted from/to UTC
+			 * Indicates that localization will be handled by the consumer. `*value` will not be converted from/to UTC.
 			 */
 			localized: { reflect: true, type: Boolean },
 			/**
-			 * Maximum valid date/time that could be selected by a user.
+			 * Maximum valid date/time that could be selected by a user
 			 */
 			maxValue: { attribute: 'max-value', reflect: true, type: String },
 			/**
-			 * Minimum valid date/time that could be selected by a user.
+			 * Minimum valid date/time that could be selected by a user
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
@@ -71,12 +71,12 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Set default value of time portion of the input. Valid values are times in ISO 8601 time format ("hh:mm:ss"), "startOfDay", "endOfDay".
+			 * Default value of time input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
 			 * @type {'startOfDay'|'endOfDay'|string}
 			 */
 			timeDefaultValue: { attribute: 'time-default-value', reflect: true, type: String },
 			/**
-			 * Value of the input. This should be in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ") and in UTC time (i.e., do NOT localize to the user's timezone).
+			 * Value of the input
 			 */
 			value: { type: String },
 			_dropdownOpened: { type: Boolean },

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -36,7 +36,7 @@ function _getFormattedDefaultTime(defaultValue) {
 
 /**
  * A component that consists of a "<d2l-input-date>" and a "<d2l-input-time>" component. The time input only appears once a date is selected. This component displays the "value" if one is specified, and reflects the selected value when one is selected or entered.
- * @fires change - Dispatched when there is a change in selected date or selected time. "value" contains the selected value and is formatted in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ").
+ * @fires change - Dispatched when there is a change to selected date or selected time. "value" corresponds to the selected value and is formatted in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ").
  */
 class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement)))) {
 

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -313,6 +313,7 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 			await this.updateComplete;
 			this._handleInputTimeFocus();
 		}
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-input-date-time-dropdown-toggle',
 			{ bubbles: false, composed: false, detail: { opened: e.detail.opened } }

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -48,6 +48,7 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 			disabled: { type: Boolean },
 			/**
 			 * REQUIRED: Accessible label for the input fieldset that wraps the date and time inputs
+			 * @type {string}
 			 */
 			label: { type: String },
 			/**
@@ -60,10 +61,12 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 			localized: { reflect: true, type: Boolean },
 			/**
 			 * Maximum valid date/time that could be selected by a user
+			 * @type {string}
 			 */
 			maxValue: { attribute: 'max-value', reflect: true, type: String },
 			/**
 			 * Minimum valid date/time that could be selected by a user
+			 * @type {string}
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
@@ -72,7 +75,7 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 			required: { type: Boolean, reflect: true },
 			/**
 			 * Default value of time input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
-			 * @type {'startOfDay'|'endOfDay'|string}
+			 * @type {string}
 			 */
 			timeDefaultValue: { attribute: 'time-default-value', reflect: true, type: String },
 			/**
@@ -165,6 +168,7 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 		this.requestUpdate('value', oldValue);
 	}
 
+	/** @ignore */
 	get validationMessage() {
 		if (this.validity.rangeOverflow || this.validity.rangeUnderflow) {
 			const minDate = this.minValue ? formatDateTime(this.localized ? getDateNoConversion(this.minValue) : getDateFromISODateTime(this.minValue), { format: 'medium' }) : null;

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -367,6 +367,7 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		if (this._calendar) this._calendar.reset();
 		this._dropdownOpened = false;
 		this._textInput.scrollIntoView({ block: 'nearest', behavior: 'smooth', inline: 'nearest' });
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-input-date-dropdown-toggle',
 			{ bubbles: true, composed: false, detail: { opened: false } }
@@ -380,6 +381,7 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 			this._textInput.scrollIntoView({ block: 'nearest', behavior: 'smooth', inline: 'nearest' });
 		}, 150);
 		this._dropdownOpened = true;
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-input-date-dropdown-toggle',
 			{ bubbles: true, composed: false, detail: { opened: true } }

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -23,7 +23,7 @@ export function formatISODateInUserCalDescriptor(val) {
 
 /**
  * A component that consists of a text input field for typing a date and an attached calendar (d2l-calendar) dropdown. It displays the "value" if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the calendar or entered in the text input.
- * @fires change - Dispatched when there is a change in selected date. "value" contains the selected value and is formatted in ISO 8601 calendar date format ("YYYY-MM-DD").
+ * @fires change - Dispatched when there is a change to selected date. "value" corresponds to the selected value and is formatted in ISO 8601 calendar date format ("YYYY-MM-DD").
  */
 class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))) {
 

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -23,7 +23,7 @@ export function formatISODateInUserCalDescriptor(val) {
 
 /**
  * A component that consists of a text input field for typing a date and an attached calendar (d2l-calendar) dropdown. It displays the "value" if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the calendar or entered in the text input.
- * @fires change - Dispatched when a date is selected or typed. "value" reflects the selected value and is in ISO 8601 calendar date format ("YYYY-MM-DD").
+ * @fires change - Dispatched when there is a change in selected date. "value" contains the selected value and is formatted in ISO 8601 calendar date format ("YYYY-MM-DD").
  */
 class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))) {
 
@@ -34,7 +34,7 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * Text to reassure users that they can choose not to provide a value in this field (usually not necessary)
+			 * Text that appears as a placeholder in the input to reassure users that they can choose not to provide a value (usually not necessary)
 			 */
 			emptyText: { type: String, attribute: 'empty-text' },
 			/**
@@ -46,16 +46,15 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
 			/**
-			 * Maximum valid date that could be selected by a user.
+			 * Maximum valid date that could be selected by a user
 			 */
 			maxValue: { attribute: 'max-value', reflect: true, type: String },
 			/**
-			 * Minimum valid date that could be selected by a user.
+			 * Minimum valid date that could be selected by a user
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
-			 * Disables validation of max and min value. The min and max value will still be enforced
-			 * but the component will not be put into an error state or show an error tooltip.
+			 * Disables validation of max and min value. The min and max value will still be enforced but the component will not be put into an error state or show an error tooltip.
 			 */
 			noValidateMinMax: { attribute: 'novalidateminmax', type: Boolean },
 			/**

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -39,6 +39,7 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 			emptyText: { type: String, attribute: 'empty-text' },
 			/**
 			 * REQUIRED: Accessible label for the input
+			 * @type {string}
 			 */
 			label: { type: String },
 			/**
@@ -47,13 +48,16 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
 			/**
 			 * Maximum valid date that could be selected by a user
+			 * @type {string}
 			 */
 			maxValue: { attribute: 'max-value', reflect: true, type: String },
 			/**
 			 * Minimum valid date that could be selected by a user
+			 * @type {string}
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
+			 * @ignore
 			 * Disables validation of max and min value. The min and max value will still be enforced but the component will not be put into an error state or show an error tooltip.
 			 */
 			noValidateMinMax: { attribute: 'novalidateminmax', type: Boolean },
@@ -128,6 +132,7 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		this.disabled = false;
 		this.emptyText = '';
 		this.labelHidden = false;
+		/** @ignore */
 		this.noValidateMinMax = false;
 		this.required = false;
 		this.value = '';
@@ -147,6 +152,7 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		this._dateTimeDescriptor = getDateTimeDescriptorShared();
 	}
 
+	/** @ignore */
 	get validationMessage() {
 		if (this.validity.rangeOverflow || this.validity.rangeUnderflow) {
 			const minDate = this.minValue ? formatDate(getDateFromISODate(this.minValue), { format: 'medium' }) : null;

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -35,7 +35,7 @@ function getValidISOTimeAtInterval(val, timeInterval) {
 
 /**
  * A component consisting of two input-time components - one for start of range and one for end of range. Values specified for these components (through start-value and/or end-value attributes) should be localized to the user's timezone if applicable and must be in ISO 8601 time format ("hh:mm:ss").
- * @fires change - Dispatched when a start or end time is selected or typed. "start-value" and "end-value" reflect the selected values and are in ISO 8601 calendar time format ("hh:mm:ss").
+ * @fires change - Dispatched when there is a change in selected start time or selected end time. "start-value" and "end-value" contain the selected values and are formatted in ISO 8601 calendar time format ("hh:mm:ss").
  */
 
 class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement)))) {
@@ -43,7 +43,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	static get properties() {
 		return {
 			/**
-			 * Automatically shift end time when start time changes to keep same range
+			 * Automatically shifts end time when start time changes to keep same range
 			 */
 			autoShiftTimes: { attribute: 'auto-shift-times', reflect: true, type: Boolean },
 			/**
@@ -55,7 +55,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Label for the end time input
+			 * Accessible label for the end time input
 			 * @default "End Time"
 			 */
 			endLabel: { attribute: 'end-label', reflect: true, type: String },
@@ -64,27 +64,27 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			endValue: { attribute: 'end-value', reflect: true, type: String },
 			/**
-			 * Rounds up to nearest valid interval time (specified with "time-interval") when user types a time
+			 * Rounds typed input up to nearest valid interval time (specified with "time-interval")
 			 */
 			enforceTimeIntervals: { attribute: 'enforce-time-intervals', reflect: true, type: Boolean },
 			/**
-			 * Validate on inclusive range
+			 * Validates on inclusive range (i.e., it is valid for start and end times to be equal)
 			 */
 			inclusiveTimeRange: { attribute: 'inclusive-time-range', reflect: true, type: Boolean },
 			/**
-			 * REQUIRED: Accessible label for the range
+			 * REQUIRED: Accessible label for the input fieldset that wraps the time inputs
 			 */
 			label: { type: String, reflect: true },
 			/**
-			 * Hides the label visually
+			 * Hides the fieldset label visually
 			 */
 			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
 			/**
-			 * Indicates that a value is required
+			 * Indicates that values are required
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Label for the start time input
+			 * Accessible label for the start time input
 			 * @default "Start Time"
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },
@@ -93,7 +93,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			startValue: { attribute: 'start-value', reflect: true, type: String },
 			/**
-			 * Number of minutes between times shown in dropdown
+			 * Number of minutes between times shown in dropdown menu
 			 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
 			 */
 			timeInterval: { attribute: 'time-interval', reflect: true, type: String },

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -55,12 +55,14 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the end time input
+			 * Accessible label for the end time input. Defaults to localized "End Time".
+			 * @type {string}
 			 * @default "End Time"
 			 */
 			endLabel: { attribute: 'end-label', reflect: true, type: String },
 			/**
 			 * Value of the end time input
+			 * @type {string}
 			 */
 			endValue: { attribute: 'end-value', reflect: true, type: String },
 			/**
@@ -73,6 +75,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			inclusiveTimeRange: { attribute: 'inclusive-time-range', reflect: true, type: Boolean },
 			/**
 			 * REQUIRED: Accessible label for the input fieldset that wraps the time inputs
+			 * @type {string}
 			 */
 			label: { type: String, reflect: true },
 			/**
@@ -84,12 +87,14 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the start time input
+			 * Accessible label for the start time input. Defaults to localized "Start Time".
+			 * @type {string}
 			 * @default "Start Time"
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },
 			/**
 			 * Value of the start time input
+			 * @type {string}
 			 */
 			startValue: { attribute: 'start-value', reflect: true, type: String },
 			/**
@@ -155,6 +160,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 		this.requestUpdate('startValue', oldValue);
 	}
 
+	/** @ignore */
 	get validationMessage() {
 		if (this.validity.badInput) {
 			return this.localize('components.input-time-range.errorBadInput', { startLabel: this._computedStartLabel, endLabel: this._computedEndLabel });

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -35,7 +35,7 @@ function getValidISOTimeAtInterval(val, timeInterval) {
 
 /**
  * A component consisting of two input-time components - one for start of range and one for end of range. Values specified for these components (through start-value and/or end-value attributes) should be localized to the user's timezone if applicable and must be in ISO 8601 time format ("hh:mm:ss").
- * @fires change - Dispatched when there is a change in selected start time or selected end time. "start-value" and "end-value" contain the selected values and are formatted in ISO 8601 calendar time format ("hh:mm:ss").
+ * @fires change - Dispatched when there is a change to selected start time or selected end time. "start-value" and "end-value" correspond to the selected values and are formatted in ISO 8601 calendar time format ("hh:mm:ss").
  */
 
 class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement)))) {

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -116,7 +116,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 		return {
 			/**
 			 * Default value of input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
-			 * @type {'startOfDay'|'endOfDay'|string}
+			 * @type {string}
 			 */
 			defaultValue: { type: String, attribute: 'default-value' },
 			/**
@@ -129,6 +129,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 			enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
 			/**
 			 * REQUIRED: Accessible label for the input
+			 * @type {string}
 			 */
 			label: { type: String },
 			/**
@@ -137,6 +138,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
 			/**
 			 * Overrides max-height of the time dropdown menu
+			 * @type {number}
 			 */
 			maxHeight: { type: Number, attribute: 'max-height' },
 			/**
@@ -150,6 +152,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 			timeInterval: { type: String, attribute: 'time-interval' },
 			/**
 			 * Value of the input
+			 * @type {string}
 			 */
 			value: { type: String },
 			_dropdownFirstOpened: { type: Boolean },

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -108,7 +108,7 @@ function initIntervals(size, enforceTimeIntervals) {
 
 /**
  * A component that consists of a text input field for typing a time and an attached dropdown for time selection. It displays the "value" if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
- * @fires change - Dispatched when there is a change in selected time. "value" contains the selected value and is formatted in ISO 8601 time format ("hh:mm:ss").
+ * @fires change - Dispatched when there is a change to selected time. "value" corresponds to the selected value and is formatted in ISO 8601 time format ("hh:mm:ss").
  */
 class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -108,14 +108,14 @@ function initIntervals(size, enforceTimeIntervals) {
 
 /**
  * A component that consists of a text input field for typing a time and an attached dropdown for time selection. It displays the "value" if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
- * @fires change - Dispatched when a time is selected or typed. "value" reflects the selected value and is in ISO 8601 time format ("hh:mm:ss").
+ * @fires change - Dispatched when there is a change in selected time. "value" contains the selected value and is formatted in ISO 8601 time format ("hh:mm:ss").
  */
 class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 
 	static get properties() {
 		return {
 			/**
-			 * Set default value of input. Valid values are times in ISO 8601 time format ("hh:mm:ss"), "startOfDay", "endOfDay".
+			 * Default value of input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
 			 * @type {'startOfDay'|'endOfDay'|string}
 			 */
 			defaultValue: { type: String, attribute: 'default-value' },
@@ -124,7 +124,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * Rounds up to nearest valid interval time (specified with "time-interval") when user types a time
+			 * Rounds typed input up to nearest valid interval time (specified with "time-interval")
 			 */
 			enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
 			/**
@@ -136,7 +136,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
 			/**
-			 * Override max-height on the time dropdown menu
+			 * Overrides max-height of the time dropdown menu
 			 */
 			maxHeight: { type: Number, attribute: 'max-height' },
 			/**
@@ -144,12 +144,12 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Number of minutes between times shown in dropdown
+			 * Number of minutes between times shown in dropdown menu
 			 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
 			 */
 			timeInterval: { type: String, attribute: 'time-interval' },
 			/**
-			 * Value of the input. This should be in ISO 8601 time format ("hh:mm:ss") and should be localized to the user's timezone if applicable.
+			 * Value of the input
 			 */
 			value: { type: String },
 			_dropdownFirstOpened: { type: Boolean },

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -375,6 +375,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 	}
 
 	_handleDropdownClose() {
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-input-time-dropdown-toggle',
 			{ bubbles: true, composed: false, detail: { opened: false } }
@@ -384,6 +385,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 
 	async _handleDropdownOpen() {
 		if (!this._dropdownFirstOpened) this._dropdownFirstOpened = true;
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-input-time-dropdown-toggle',
 			{ bubbles: true, composed: false, detail: { opened: true } }
@@ -408,6 +410,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 		const width = Math.ceil(parseFloat(getComputedStyle(hiddenContent).getPropertyValue('width')));
 		this._hiddenContentWidth = `${width}px`;
 
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-input-time-hidden-content-width-change',
 			{ bubbles: true, composed: false }

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -183,6 +183,7 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 	}
 
 	_languageChange() {
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-localize-behavior-language-changed', { bubbles: true, composed: true }
 		));


### PR DESCRIPTION
Changes:
- prep `input-date-time.md` for Daylight
- component file tweaks to wording to get things like tense consistent
- `@ignore` for some properties coming from mixins, and some events (this is also affecting the old analyzer)