### PR TITLE
fix: US130144: dialogs getting cut off in iframes due to incorrect height settings

### DIFF
--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -29,7 +29,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 			async: { type: Boolean },
 			_hasFooterContent: { type: Boolean, attribute: false },
 			_icon: { type: String, attribute: false },
-			_headerStyle: { type: String, attribute: false },
+			_headerStyle: { type: String, attribute: false }
 		};
 	}
 

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -76,7 +76,6 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 				dialog.d2l-dialog-outer,
 				div.d2l-dialog-outer {
 					border-radius: 8px;
-					height: calc(100% - 3rem);
 					margin: 1.5rem;
 					max-width: 1170px;
 					opacity: 0;
@@ -163,9 +162,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 				
 				dialog.d2l-dialog-outer,
 				div.d2l-dialog-outer {
-					height: calc(var(--d2l-vh, 1vh) * 100 - 42px);
 					margin: 0 !important;
-					min-height: calc(var(--d2l-vh, 1vh) * 100 - 42px);
 					min-width: calc(var(--d2l-vw, 1vw) * 100);
 					top: 42px;
 				}
@@ -200,6 +197,19 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 	render() {
 
+		const heightOverride = {} ;
+		if (this._ifrauContextInfo) {
+			// in iframes, use calculated available height from dialog mixin minus padding
+			heightOverride.height = mediaQueryList.matches
+				? `${this._ifrauContextInfo.availableHeight - 42}px`
+				: `${this._ifrauContextInfo.availableHeight - 60}px`;
+		} else {
+			heightOverride.height = mediaQueryList.matches
+				? 'calc(var(--d2l-vh, 1vh) * 100 - 42px)'
+				: 'calc(100% - 3rem)';
+		}
+		heightOverride.minHeight = heightOverride.height;
+
 		let loading = null;
 		const slotStyles = {};
 		if (this.async && this.asyncState !== asyncStates.complete) {
@@ -223,7 +233,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 		if (!this._titleId) this._titleId = getUniqueId();
 		const inner = html`
-			<div class="d2l-dialog-inner">
+			<div class="d2l-dialog-inner" style=${styleMap(heightOverride)}>
 				<div class="d2l-dialog-header">
 					<div>
 						<h2 id="${this._titleId}" class="${this._headerStyle}">${this.titleText}</h2>

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -30,7 +30,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 			_hasFooterContent: { type: Boolean, attribute: false },
 			_icon: { type: String, attribute: false },
 			_headerStyle: { type: String, attribute: false },
-			_inIframe: { type: Boolean, attribute: 'in-iframe' },
+			_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
 		};
 	}
 
@@ -217,8 +217,8 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 			heightOverride.height = mediaQueryList.matches
 				? `${this._ifrauContextInfo.availableHeight - 42}px`
 				: `${this._ifrauContextInfo.availableHeight - 60}px`;
+			heightOverride.minHeight = heightOverride.height;
 		}
-		heightOverride.minHeight = heightOverride.height;
 
 		let loading = null;
 		const slotStyles = {};

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -217,10 +217,6 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 			heightOverride.height = mediaQueryList.matches
 				? `${this._ifrauContextInfo.availableHeight - 42}px`
 				: `${this._ifrauContextInfo.availableHeight - 60}px`;
-		} else {
-			heightOverride.height = mediaQueryList.matches
-				? 'calc(var(--d2l-vh, 1vh) * 100 - 42px)'
-				: 'calc(100% - 3rem)';
 		}
 		heightOverride.minHeight = heightOverride.height;
 

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -30,7 +30,6 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 			_hasFooterContent: { type: Boolean, attribute: false },
 			_icon: { type: String, attribute: false },
 			_headerStyle: { type: String, attribute: false },
-			_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
 		};
 	}
 
@@ -191,7 +190,6 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 		this._headerStyle = 'd2l-heading-2';
 		this._handleResize = this._handleResize.bind(this);
 		this._handleResize();
-		this._inIframe = false;
 	}
 
 	get asyncContainerCustom() {
@@ -212,7 +210,6 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 		const heightOverride = {} ;
 		if (this._ifrauContextInfo) {
-			this._inIframe = true;
 			// in iframes, use calculated available height from dialog mixin minus padding
 			heightOverride.height = mediaQueryList.matches
 				? `${this._ifrauContextInfo.availableHeight - 42}px`

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -29,7 +29,8 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 			async: { type: Boolean },
 			_hasFooterContent: { type: Boolean, attribute: false },
 			_icon: { type: String, attribute: false },
-			_headerStyle: { type: String, attribute: false }
+			_headerStyle: { type: String, attribute: false },
+			_inIframe: { type: Boolean, attribute: 'in-iframe' },
 		};
 	}
 
@@ -83,6 +84,11 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 					transform: translateY(-50px) scale(0.97);
 					transition: transform 200ms ease-out, opacity 200ms ease-out;
 					width: auto;
+				}
+
+				:host(:not([in-iframe])) dialog.d2l-dialog-outer,
+				:host(:not([in-iframe])) div.d2l-dialog-outer {
+					height: calc(100% - 3rem);
 				}
 
 				/* for screens wider than 1170px + 60px margins */
@@ -166,6 +172,12 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 					min-width: calc(var(--d2l-vw, 1vw) * 100);
 					top: 42px;
 				}
+
+				:host(:not([in-iframe])) dialog.d2l-dialog-outer,
+				:host(:not([in-iframe])) div.d2l-dialog-outer {
+					height: calc(var(--d2l-vh, 1vh) * 100 - 42px);
+					min-height: calc(var(--d2l-vh, 1vh) * 100 - 42px);
+				}
 			}
 		`];
 	}
@@ -179,6 +191,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 		this._headerStyle = 'd2l-heading-2';
 		this._handleResize = this._handleResize.bind(this);
 		this._handleResize();
+		this._inIframe = false;
 	}
 
 	get asyncContainerCustom() {
@@ -199,6 +212,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 		const heightOverride = {} ;
 		if (this._ifrauContextInfo) {
+			this._inIframe = true;
 			// in iframes, use calculated available height from dialog mixin minus padding
 			heightOverride.height = mediaQueryList.matches
 				? `${this._ifrauContextInfo.availableHeight - 42}px`

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -50,6 +50,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			_autoSize: { type: Boolean, attribute: false },
 			_fullscreenWithin: { type: Number },
 			_height: { type: Number },
+			_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
 			_left: { type: Number },
 			_margin: { type: Object },
 			_nestedShowing: { type: Boolean },
@@ -71,6 +72,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._dialogId = getUniqueId();
 		this._fullscreenWithin = 0;
 		this._handleMvcDialogOpen = this._handleMvcDialogOpen.bind(this);
+		this._inIframe = false;
 		this._height = 0;
 		this._margin = { top: defaultMargin.top, right: defaultMargin.right, bottom: defaultMargin.bottom, left: defaultMargin.left };
 		this._parentDialog = null;
@@ -107,6 +109,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		if (this.opened) {
 			if (dialogService) {
 				this._ifrauContextInfo = await dialogService.showBackdrop();
+				this._inIframe = true;
 			}
 			this._open();
 		} else {

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -11,7 +11,7 @@ import { heading3Styles } from '../typography/styles.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
-const mediaQueryList = window.matchMedia('(max-width: 615px)');
+const mediaQueryList = window.matchMedia('(max-width: 615px), (max-height: 420px) and (max-width: 900px)');
 
 /**
  * A generic dialog that provides a slot for arbitrary content and a "footer" slot for workflow buttons. Apply the "data-dialog-action" attribute to workflow buttons to automatically close the dialog with the action value.
@@ -34,7 +34,6 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			 */
 			width: { type: Number },
 			_hasFooterContent: { type: Boolean, attribute: false },
-			_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
 		};
 	}
 
@@ -104,7 +103,6 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		super();
 		this.async = false;
 		this.width = 600;
-		this._inIframe = false;
 		this._handleResize = this._handleResize.bind(this);
 		this._handleResize();
 	}
@@ -139,7 +137,6 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		const heightOverride = {} ;
 		if (mediaQueryList.matches) {
 			if (this._ifrauContextInfo) {
-				this._inIframe = true;
 				// in iframes, use calculated available height from dialog mixin minus padding
 				heightOverride.minHeight = `${this._ifrauContextInfo.availableHeight - 42}px`;
 			}

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -192,6 +192,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 
 	_handleResize() {
 		this._autoSize = !mediaQueryList.matches;
+		this.resize();
 	}
 
 }

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -34,7 +34,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			 */
 			width: { type: Number },
 			_hasFooterContent: { type: Boolean, attribute: false },
-			_inIframe: { type: Boolean, attribute: 'in-iframe' },
+			_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
 		};
 	}
 

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -33,7 +33,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			 * The preferred width (unit-less) for the dialog
 			 */
 			width: { type: Number },
-			_hasFooterContent: { type: Boolean, attribute: false },
+			_hasFooterContent: { type: Boolean, attribute: false }
 		};
 	}
 

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -11,6 +11,8 @@ import { heading3Styles } from '../typography/styles.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
+const mediaQueryList = window.matchMedia('(max-width: 615px)');
+
 /**
  * A generic dialog that provides a slot for arbitrary content and a "footer" slot for workflow buttons. Apply the "data-dialog-action" attribute to workflow buttons to automatically close the dialog with the action value.
  * @slot - Default slot for content inside dialog
@@ -70,7 +72,6 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 
 				.d2l-dialog-outer {
 					margin: 0 !important;
-					min-height: calc(var(--d2l-vh, 1vh) * 100 - 42px);
 					min-width: calc(var(--d2l-vw, 1vw) * 100);
 					top: 42px;
 				}
@@ -97,11 +98,24 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		super();
 		this.async = false;
 		this.width = 600;
+		this._handleResize = this._handleResize.bind(this);
+		this._handleResize();
 	}
 
 	get asyncContainerCustom() {
 		return true;
 	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		if (mediaQueryList.addEventListener) mediaQueryList.addEventListener('change', this._handleResize);
+	}
+
+	disconnectedCallback() {
+		if (mediaQueryList.removeEventListener) mediaQueryList.removeEventListener('change', this._handleResize);
+		super.disconnectedCallback();
+	}
+
 
 	render() {
 
@@ -116,6 +130,16 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			`;
 		}
 
+		const heightOverride = {} ;
+		if (mediaQueryList.matches) {
+			if (this._ifrauContextInfo) {
+				// in iframes, use calculated available height from dialog mixin minus padding
+				heightOverride.minHeight = `${this._ifrauContextInfo.availableHeight - 42}px`;
+			} else {
+				heightOverride.minHeight = 'calc(var(--d2l-vh, 1vh) * 100 - 42px)';
+			}
+		}
+
 		const footerClasses = {
 			'd2l-dialog-footer': true,
 			'd2l-footer-no-content': !this._hasFooterContent
@@ -128,7 +152,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 
 		if (!this._titleId) this._titleId = getUniqueId();
 		const inner = html`
-			<div class="d2l-dialog-inner">
+			<div class="d2l-dialog-inner"  style=${styleMap(heightOverride)}>
 				<div class="d2l-dialog-header">
 					<div>
 						<h2 id="${this._titleId}" class="d2l-heading-3">${this.titleText}</h2>
@@ -162,6 +186,10 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 	_handleFooterSlotChange(e) {
 		const footerContent = e.target.assignedNodes({ flatten: true });
 		this._hasFooterContent = (footerContent && footerContent.length > 0);
+	}
+
+	_handleResize() {
+		this._autoSize = !mediaQueryList.matches;
 	}
 
 }

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -33,7 +33,8 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			 * The preferred width (unit-less) for the dialog
 			 */
 			width: { type: Number },
-			_hasFooterContent: { type: Boolean, attribute: false }
+			_hasFooterContent: { type: Boolean, attribute: false },
+			_inIframe: { type: Boolean, attribute: 'in-iframe' },
 		};
 	}
 
@@ -89,6 +90,11 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 					margin-right: 15px;
 				}
 
+				:host(:not([in-iframe])) dialog.d2l-dialog-outer,
+				:host(:not([in-iframe])) div.d2l-dialog-outer {
+					height: calc(var(--d2l-vh, 1vh) * 100 - 42px);
+					min-height: calc(var(--d2l-vh, 1vh) * 100 - 42px);
+				}
 			}
 
 		`];
@@ -98,6 +104,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		super();
 		this.async = false;
 		this.width = 600;
+		this._inIframe = false;
 		this._handleResize = this._handleResize.bind(this);
 		this._handleResize();
 	}
@@ -116,7 +123,6 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		super.disconnectedCallback();
 	}
 
-
 	render() {
 
 		let loading = null;
@@ -133,10 +139,9 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		const heightOverride = {} ;
 		if (mediaQueryList.matches) {
 			if (this._ifrauContextInfo) {
+				this._inIframe = true;
 				// in iframes, use calculated available height from dialog mixin minus padding
 				heightOverride.minHeight = `${this._ifrauContextInfo.availableHeight - 42}px`;
-			} else {
-				heightOverride.minHeight = 'calc(var(--d2l-vh, 1vh) * 100 - 42px)';
 			}
 		}
 


### PR DESCRIPTION
A couple of the dialog styles were overriding dialog-mixin and adding a height attribute. The problem occurs with iFrames, where a 100vh or 100% is interpreted as the height of the iFrame, rather than the viewport. This was causing super tall dialogs with the footer cut off and buttons inaccessible. 

This PR adds an override to the height of d2l-dialog-inner with the calculated height when given by the ifrauContext (minus required padding). The d2l-dialog-outer height setting is removed. 
When the dialog is NOT in an iframe, the d2l-dialog-outer height is set as previously, with no override for d2l-dialog-inner. Unfortunately, I had to add an attribute, in-iframe, for the CSS to style based on whether or not its in an iframe. Open to naming suggestions here or a way to not have to use an attribute. 

Here is a photo of the issue happening on a test page: 
![image+(3)](https://user-images.githubusercontent.com/83968927/126544437-3bb1e88d-b5bd-47cc-91bb-363c1ef6e5a2.png)

Here is the fixed version: 
![fixed_dialog_iframe](https://user-images.githubusercontent.com/83968927/126544544-c1b236f4-d1ed-4141-983b-a662fa47a2cd.PNG)
