### PR TITLE
fix: remove use of nullish coalescing operator (workaround for `d2l-rubric`)

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -124,7 +124,11 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 
 	get maxFractionDigits() {
 		// emulate Intl's default maxFractionDigits behaviour
-		return this._maxFractionDigits ?? Math.max(this.minFractionDigits, 3);
+		if (!this._maxFractionDigits) {
+			return Math.max(this.minFractionDigits, 3);
+		}
+
+		return this._maxFractionDigits;
 	}
 	set maxFractionDigits(val) {
 		if (isNaN(val) || val < 0 || val > 20 || val < this.minFractionDigits) {
@@ -135,7 +139,11 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 	}
 
 	get minFractionDigits() {
-		return this._minFractionDigits ?? 0;
+		if (!this._minFractionDigits) {
+			return 0;
+		}
+
+		return this._minFractionDigits;
 	}
 	set minFractionDigits(val) {
 		if (isNaN(val) || val < 0 || val > 20 || val < this.minFractionDigits) {

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -124,7 +124,7 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 
 	get maxFractionDigits() {
 		// emulate Intl's default maxFractionDigits behaviour
-		if (!this._maxFractionDigits) {
+		if (this._maxFractionDigits === null || this._maxFractionDigits === undefined) {
 			return Math.max(this.minFractionDigits, 3);
 		}
 
@@ -139,7 +139,7 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 	}
 
 	get minFractionDigits() {
-		if (!this._minFractionDigits) {
+		if (this._minFractionDigits === null || this._minFractionDigits === undefined) {
 			return 0;
 		}
 


### PR DESCRIPTION
This isn't really a defect but it is causing issues with `d2l-rubric` CI and current workflows. Sadly, `d2l-rubric` is still using polymer and uses polymer related tooling for some of it's CI and development workflow. We are planning to upgrade to lit but for now this is a workaround to allow us to use the new `d2l-input-number` component in polymer.