### PR TITLE
US130144: add top override for iframe dialogs to continuously move dialog down the page

### DIFF
--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -209,12 +209,18 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 	render() {
 
 		const heightOverride = {} ;
+		let topOverride = null;
 		if (this._ifrauContextInfo) {
 			// in iframes, use calculated available height from dialog mixin minus padding
 			heightOverride.height = mediaQueryList.matches
 				? `${this._ifrauContextInfo.availableHeight - 42}px`
 				: `${this._ifrauContextInfo.availableHeight - 60}px`;
 			heightOverride.minHeight = heightOverride.height;
+			const iframeTop = this._ifrauContextInfo.top < 0
+				? -this._ifrauContextInfo.top
+				: 0;
+			const startTop = mediaQueryList.matches ? 42 : 0;
+			topOverride = iframeTop + startTop;
 		}
 
 		let loading = null;
@@ -255,7 +261,8 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 		`;
 		return this._render(
 			inner,
-			{ labelId: this._titleId, role: 'dialog' }
+			{ labelId: this._titleId, role: 'dialog' },
+			topOverride
 		);
 	}
 

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -366,7 +366,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this.shadowRoot.querySelector('.d2l-dialog-content').removeEventListener('scroll', this._updateOverflow);
 	}
 
-	_render(inner, info) {
+	_render(inner, info, iframeTopOverride) {
 
 		const styles = {};
 		if (this._autoSize) {
@@ -376,6 +376,8 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			if (this._height) styles.height = `${this._height}px`;
 			if (this._width) styles.width = `${this._width}px`;
 			else styles.width = 'auto';
+		} else if (iframeTopOverride && this._ifrauContextInfo) {
+			styles.top = `${iframeTopOverride}px`;
 		}
 
 		const dialogOuterClasses = {

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -135,10 +135,16 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		}
 
 		const heightOverride = {} ;
+		let topOverride = null;
 		if (mediaQueryList.matches) {
 			if (this._ifrauContextInfo) {
 				// in iframes, use calculated available height from dialog mixin minus padding
 				heightOverride.minHeight = `${this._ifrauContextInfo.availableHeight - 42}px`;
+				heightOverride.top = `${this._top + this._margin.top + 42}px`;
+				const iframeTop = this._ifrauContextInfo.top < 0
+					? -this._ifrauContextInfo.top
+					: 0;
+				topOverride = iframeTop + 42;
 			}
 		}
 
@@ -169,7 +175,8 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		`;
 		return this._render(
 			inner,
-			{ labelId: this._titleId, role: 'dialog' }
+			{ labelId: this._titleId, role: 'dialog' },
+			topOverride
 		);
 	}
 


### PR DESCRIPTION
The last PR, https://github.com/BrightspaceUI/core/pull/1511, got the dialogs to appear the correct height. Now, the override is needed for the "top" of the dialog. Otherwise, it will stay fixed to the top of the page.