### PR TITLE
fix: do not suppress decimal if selection range covers it

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -374,7 +374,9 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 		const key = e.key;
 		let prevent = false;
 		let hintType = HINT_TYPES.NONE;
-		const hasDecimal = e.target.value.indexOf(this._descriptor.symbols.decimal) > -1;
+		const decimalIndex = e.target.value.indexOf(this._descriptor.symbols.decimal);
+		const hasDecimal = decimalIndex > -1 &&
+			(decimalIndex >= e.target.selectionEnd || decimalIndex < e.target.selectionStart);
 		if (key === this._descriptor.symbols.negative) {
 			// negative symbol must be at the end
 			if (this._descriptor.patterns.decimal.negativePattern === '{number}-') {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -243,6 +243,11 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		this._setValue(val, true);
 	}
 
+	get selectionEnd() {
+		const elem = this.shadowRoot.querySelector('.d2l-input');
+		return elem ? elem.selectionEnd : 0;
+	}
+
 	get selectionStart() {
 		const elem = this.shadowRoot.querySelector('.d2l-input');
 		return elem ? elem.selectionStart : 0;

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -61,6 +61,12 @@ function setCursorPosition(elem, pos) {
 		.setSelectionRange(pos, pos);
 }
 
+function setSelectionRange(elem, start, end) {
+	elem.shadowRoot.querySelector('d2l-input-text')
+		.shadowRoot.querySelector('.d2l-input')
+		.setSelectionRange(start, end);
+}
+
 describe('d2l-input-number', () => {
 
 	const documentLocaleSettings = getDocumentLocaleSettings();
@@ -407,6 +413,28 @@ describe('d2l-input-number', () => {
 			const event = dispatchKeypressEvent(elem, '.');
 			expect(event.defaultPrevented).to.be.true;
 			expect(elem._hintType).to.equal(1);
+		});
+
+		it('should suppress decimal symbol if selection range does not cover it', async() => {
+			const elem = await fixtureInit(html`<d2l-input-number label="label" value="10.25"></d2l-input-number>`);
+			setSelectionRange(elem, 0, 2);
+			const event = dispatchKeypressEvent(elem, '.');
+			expect(event.defaultPrevented).to.be.true;
+			expect(elem._hintType).to.equal(1);
+		});
+
+		it('should not suppress decimal symbol if selection range covers it from the left', async() => {
+			const elem = await fixtureInit(html`<d2l-input-number label="label" value="10.25"></d2l-input-number>`);
+			setSelectionRange(elem, 0, 3);
+			const event = dispatchKeypressEvent(elem, '.');
+			expect(event.defaultPrevented).to.be.false;
+		});
+
+		it('should not suppress decimal symbol if selection range covers it from the right', async() => {
+			const elem = await fixtureInit(html`<d2l-input-number label="label" value="10.25"></d2l-input-number>`);
+			setSelectionRange(elem, 2, 5);
+			const event = dispatchKeypressEvent(elem, '.');
+			expect(event.defaultPrevented).to.be.false;
 		});
 
 		it('should suppress decimal symbol only integers are allowed', async() => {


### PR DESCRIPTION
Thanks @margaree for finding this bug! A common user interaction is to tab into the input (which "selects" everything in it) and then type something new. If that first character was a decimal, we'd suppress it since the input already contained a decimal.

This change additionally checks to see if the selection range "covers" the existing decimal and if so, we don't suppress.