### PR TITLE
DE44538: Wait for content to fully render before getting the contentContainer

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -475,6 +475,8 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 
 	async __openedChanged(newValue) {
 
+		await this.updateComplete;
+
 		this.__previousFocusableAncestor =
 			newValue === true
 				? getPreviousFocusableAncestor(this, false, false)


### PR DESCRIPTION
Dave Lockhart found this issue during the testing of d2l-dropdown. In some cases, the _openedChanged function runs before the content inside the dropdown has a chance to fully render. This is causing "this.__getContentContainer()" to return null in some cases, causing Javascript errors in the console. 

Note that this only occurs on Firefox, and only on some dropdowns in the LMS. The dropdown still appears and is clickable despite the error. Adding an await to wait for all updates to complete ensures the content can be found in all cases.

I'll also be certfixing this into 20.21.8, as the console error occurs there as well.