### PR TITLE
Fix filter counts for the manual search type

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -375,11 +375,11 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 					this._totalAppliedCount--;
 				}
 			} else if (prop === 'values') {
-				shouldRecount = true;
+				if (dimension.searchType !== 'manual' || !dimension.searchValue) shouldRecount = true;
 			}
 		});
 
-		if (shouldRecount) this._setFilterCounts();
+		if (shouldRecount) this._setFilterCounts(dimension);
 		if (shouldUpdate) this.requestUpdate();
 	}
 
@@ -486,16 +486,18 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		this.requestUpdate();
 	}
 
-	_setFilterCounts() {
+	_setFilterCounts(dimensionToRecount) {
 		this._totalAppliedCount = 0;
 		this._totalMaxCount = 0;
 
 		this._dimensions.forEach(dimension => {
-			switch (dimension.type) {
-				case 'd2l-filter-dimension-set': {
-					dimension.appliedCount = dimension.values.reduce((total, value) => { return value.selected ? total + 1 : total; }, 0);
-					dimension.maxCount = dimension.values.length;
-					break;
+			if (!dimensionToRecount || dimensionToRecount.key === dimension.key) {
+				switch (dimension.type) {
+					case 'd2l-filter-dimension-set': {
+						dimension.appliedCount = dimension.values.reduce((total, value) => { return value.selected ? total + 1 : total; }, 0);
+						dimension.maxCount = dimension.values.length;
+						break;
+					}
 				}
 			}
 

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -433,8 +433,10 @@ describe('d2l-filter', () => {
 
 			const newDim = document.createElement('d2l-filter-dimension-set');
 			newDim.key = 'newDim';
+			newDim.text = 'New Dim';
 			const newValue = document.createElement('d2l-filter-dimension-set-value');
 			newValue.key = 'newValue';
+			newValue.text = 'New Value';
 			newDim.appendChild(newValue);
 			setTimeout(() => elem.appendChild(newDim));
 			await oneEvent(elem.shadowRoot.querySelector('slot'), 'slotchange');
@@ -537,6 +539,7 @@ describe('d2l-filter', () => {
 
 			const newValue = document.createElement('d2l-filter-dimension-set-value');
 			newValue.key = 'newValue';
+			newValue.text = 'New Value';
 			newValue.selected = true;
 			dimension.appendChild(newValue);
 
@@ -549,6 +552,55 @@ describe('d2l-filter', () => {
 			expect(elem._totalMaxCount).to.equal(3);
 			expect(updateStub).to.be.calledOnce;
 			expect(recountSpy).to.be.calledOnce;
+			expect(recountSpy).to.have.been.calledWith(elem._dimensions[1]);
+		});
+
+		it('value changes update the filter count for the manual search type when no search is applied', async() => {
+			const dimension = elem.querySelector('d2l-filter-dimension-set[key="1"]');
+			elem._dimensions[0].searchType = 'manual';
+			elem._dimensions[0].searchValue = '';
+			expect(elem._dimensions[0].appliedCount).to.equal(1);
+			expect(elem._dimensions[0].maxCount).to.equal(1);
+			expect(elem._totalAppliedCount).to.equal(1);
+			expect(elem._totalMaxCount).to.equal(2);
+
+			const newValue = document.createElement('d2l-filter-dimension-set-value');
+			newValue.key = 'newValue';
+			newValue.text = 'New Value';
+			newValue.selected = true;
+			dimension.appendChild(newValue);
+
+			await oneEvent(elem, 'd2l-filter-dimension-data-change');
+			expect(elem._dimensions[0].values.length).to.equal(2);
+			expect(elem._dimensions[0].appliedCount).to.equal(2);
+			expect(elem._dimensions[0].maxCount).to.equal(2);
+			expect(elem._totalAppliedCount).to.equal(2);
+			expect(elem._totalMaxCount).to.equal(3);
+			expect(updateStub).to.be.calledOnce;
+			expect(recountSpy).to.be.calledOnce;
+			expect(recountSpy).to.be.calledWith(elem._dimensions[0]);
+		});
+
+		it('value changes do not update the filter count for the manual search type when a search is applied', async() => {
+			const dimension = elem.querySelector('d2l-filter-dimension-set[key="1"]');
+			elem._dimensions[0].searchType = 'manual';
+			elem._dimensions[0].searchValue = 'whatever';
+			expect(elem._dimensions[0].appliedCount).to.equal(1);
+			expect(elem._dimensions[0].maxCount).to.equal(1);
+			expect(elem._totalAppliedCount).to.equal(1);
+			expect(elem._totalMaxCount).to.equal(2);
+
+			const valueToRemove = dimension.querySelector('d2l-filter-dimension-set-value');
+			dimension.removeChild(valueToRemove);
+
+			await oneEvent(elem, 'd2l-filter-dimension-data-change');
+			expect(elem._dimensions[0].values.length).to.equal(0);
+			expect(elem._dimensions[0].appliedCount).to.equal(1);
+			expect(elem._dimensions[0].maxCount).to.equal(1);
+			expect(elem._totalAppliedCount).to.equal(1);
+			expect(elem._totalMaxCount).to.equal(2);
+			expect(updateStub).to.be.calledOnce;
+			expect(recountSpy).to.not.be.called;
 		});
 	});
 });


### PR DESCRIPTION
When consumers decide to use the "manual" `search-type`, they have to physically remove options from the filter on search.  This avoids a lot of syncing work on our end and matches how all the consumers currently using HM search work anyways.  But when this happens, we no longer "know" how many options there are and how many are selected.  So we don't want to recount in this scenario.