### PR TITLE
fix: DE44538: Wait for content to fully render before getting the contentContainer

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -454,6 +454,8 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 
 	async __openedChanged(newValue) {
 
+		await this.updateComplete;
+
 		this.__previousFocusableAncestor =
 			newValue === true
 				? getPreviousFocusableAncestor(this, false, false)


### PR DESCRIPTION
Backport to 20.21.8 for https://github.com/BrightspaceUI/core/pull/1523.