### PR TITLE
fix: DE44538: Wait for content to fully render before getting the contentContainer 

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -454,6 +454,8 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 
 	async __openedChanged(newValue) {
 
+		await this.updateComplete;
+
 		this.__previousFocusableAncestor =
 			newValue === true
 				? getPreviousFocusableAncestor(this, false, false)


### PR DESCRIPTION
Backport to 20.21.8 for #1523.

NOTE: this is the second attempt at backporting. The first attempt failed to release due to my mistake in not branching from the last release action. This caused semantic release trying to re-release 1.150.5 rather than the new patch 1.150.6. See https://github.com/BrightspaceUI/core/pull/1530 for the issue.