### PR TITLE
Daylight: tweaks to link and calendar

### DIFF
--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -14,7 +14,7 @@ The `d2l-calendar` component can be used to display a responsively sized calenda
   import '@brightspace-ui/core/components/calendar/calendar.js';
 </script>
 <d2l-calendar
-	selected-value="2020-02-09"
+	selected-value="2020-05-09"
 	summary="Click on a day to select it as the assignment due date.">
 </d2l-calendar>
 ```

--- a/components/link/README.md
+++ b/components/link/README.md
@@ -40,7 +40,7 @@ Same size as the standard link, but bolder.
 
 Import and use the `<d2l-link>` web component instead of the native `<a>` element:
 
-<!-- docs: demo live name:d2l-link -->
+<!-- docs: demo live name:d2l-link autoSize:false size:xsmall -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/link/link.js';


### PR DESCRIPTION
May 2020 is a 6 row so the autoSize then works correctly from the start.

Link using autoSize was resizing when certain properties were changed, so I hard set the size. I'm adding a `xsmall` height, so there will be a separate PR for that in documentation.