### PR TITLE
fix: using getUpdateComplete instead of _getUpdateComplete

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -460,6 +460,15 @@ class Tooltip extends RtlMixin(LitElement) {
 		});
 	}
 
+	async getUpdateComplete() {
+		const fontsPromise = document.fonts ? document.fonts.ready : Promise.resolve();
+		await super.getUpdateComplete();
+		/* wait for the fonts to load because browsers have a font block period
+		where they will render an invisible fallback font face that may result in
+		improper width calculations before the real font is loaded */
+		await fontsPromise;
+	}
+
 	hide() {
 		this._isHovering = false;
 		this._isFocusing = false;
@@ -697,15 +706,6 @@ class Tooltip extends RtlMixin(LitElement) {
 
 	_getContent() {
 		return this.shadowRoot.querySelector('.d2l-tooltip-content');
-	}
-
-	async _getUpdateComplete() {
-		const fontsPromise = document.fonts ? document.fonts.ready : Promise.resolve();
-		await super._getUpdateComplete();
-		/* wait for the fonts to load because browsers have a font block period
-		where they will render an invisible fallback font face that may result in
-		improper width calculations before the real font is loaded */
-		await fontsPromise;
 	}
 
 	_isAboveOrBelow() {

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -87,6 +87,16 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 
 	}
 
+	async getUpdateComplete() {
+		await super.getUpdateComplete();
+		const hasResources = this._hasResources();
+		const resourcesLoaded = this.__resources !== undefined;
+		if (!hasResources || resourcesLoaded) {
+			return;
+		}
+		await this.__resourcesLoadedPromise;
+	}
+
 	localize(key) {
 
 		if (!key || !this.__resources) {
@@ -166,16 +176,6 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 			resourcesLoadedPromises.push(res);
 		}
 		return resourcesLoadedPromises;
-	}
-
-	async _getUpdateComplete() {
-		await super._getUpdateComplete();
-		const hasResources = this._hasResources();
-		const resourcesLoaded = this.__resources !== undefined;
-		if (!hasResources || resourcesLoaded) {
-			return;
-		}
-		await this.__resourcesLoadedPromise;
 	}
 
 	_hasResources() {


### PR DESCRIPTION
Just fixing up an "easy win" in the Lit 2.0 migration. `_getUpdateComplete` [was renamed to](https://lit.dev/docs/releases/upgrade/#update-to-renamed-apis) `getUpdateComplete` but was also backported so we can just start using it now.