### PR TITLE
fix: awaiting updateComplete instead of requestUpdate()

### DIFF
--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -51,7 +51,8 @@ describe('d2l-filter', () => {
 		it('set dimension - empty and search applied (usecase for manual search)', async() => {
 			const elem = await fixture('<d2l-filter><d2l-filter-dimension-set key="dim"></d2l-filter-dimension-set></d2l-filter>');
 			elem._handleSearch({ detail: { value: 'no results' } });
-			await elem.requestUpdate();
+			elem.requestUpdate();
+			await elem.updateComplete;
 
 			const infoMessage = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
 			expect(infoMessage.textContent).to.include('0 search results');
@@ -61,7 +62,8 @@ describe('d2l-filter', () => {
 		it('set dimension - no search results', async() => {
 			const elem = await fixture(singleSetDimensionFixture);
 			elem._handleSearch({ detail: { value: 'no results' } });
-			await elem.requestUpdate();
+			elem.requestUpdate();
+			await elem.updateComplete;
 
 			const infoMessage = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
 			expect(infoMessage.textContent).to.include('0 search results');
@@ -71,14 +73,16 @@ describe('d2l-filter', () => {
 		it('set dimension - search results (offscreen)', async() => {
 			const elem = await fixture(singleSetDimensionFixture);
 			elem._handleSearch({ detail: { value: '1' } });
-			await elem.requestUpdate();
+			elem.requestUpdate();
+			await elem.updateComplete;
 
 			const infoMessage = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
 			expect(infoMessage.textContent).to.include('1 search result');
 			expect(infoMessage.classList.contains('d2l-offscreen')).to.be.true;
 
 			elem._handleSearch({ detail: { value: 'value' } });
-			await elem.requestUpdate();
+			elem.requestUpdate();
+			await elem.updateComplete;
 
 			expect(infoMessage.textContent).to.include('2 search results');
 			expect(infoMessage.classList.contains('d2l-offscreen')).to.be.true;
@@ -117,7 +121,8 @@ describe('d2l-filter', () => {
 			it(`set dimension - automatic search ${testCase.name}`, async() => {
 				const elem = await fixture(singleSetDimensionFixture);
 				elem._handleSearch({ detail: { value: testCase.value } });
-				await elem.requestUpdate();
+				elem.requestUpdate();
+				await elem.updateComplete;
 
 				expect(elem._dimensions[0].values[0].hidden).to.equal(testCase.results[0]);
 				expect(elem._dimensions[0].values[1].hidden).to.equal(testCase.results[1]);
@@ -238,7 +243,8 @@ describe('d2l-filter', () => {
 				const search = elem.shadowRoot.querySelector('d2l-input-search');
 				search.value = 'searching';
 				search.search();
-				await elem.requestUpdate();
+				elem.requestUpdate();
+				await elem.updateComplete;
 
 				expect(elem._dimensions[0].searchValue).to.equal('searching');
 				expect(eventSpy).to.not.have.been.called;
@@ -440,7 +446,8 @@ describe('d2l-filter', () => {
 			newDim.appendChild(newValue);
 			setTimeout(() => elem.appendChild(newDim));
 			await oneEvent(elem.shadowRoot.querySelector('slot'), 'slotchange');
-			await elem.requestUpdate();
+			elem.requestUpdate();
+			await elem.updateComplete;
 
 			expect(elem._dimensions.length).to.equal(2);
 			expect(elem._dimensions[0].key).to.equal('dim');

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -180,7 +180,8 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		this.addEventListener('blur', this._handleBlur);
 		this.addEventListener('d2l-localize-behavior-language-changed', () => {
 			this._dateTimeDescriptor = getDateTimeDescriptorShared(true);
-			this.requestUpdate().then(() => {
+			this.requestUpdate();
+			this.updateComplete.then(() => {
 				const width = Math.ceil(parseFloat(getComputedStyle(this.shadowRoot.querySelector('.d2l-input-date-hidden-text')).getPropertyValue('width')));
 				this._hiddenContentWidth = `${width}px`;
 			});

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -146,7 +146,8 @@ class InputPercent extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Rt
 	async _handleChange(e) {
 		const oldValue = this.value;
 		this.value = e.target.value;
-		await this.requestUpdate();
+		this.requestUpdate();
+		await this.updateComplete;
 
 		if (oldValue !== this.value) {
 			this.dispatchEvent(new CustomEvent(

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -506,7 +506,8 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		const container = e.target.parentNode;
 
 		// requestUpdate needed for legacy Edge
-		this.requestUpdate().then(() => {
+		this.requestUpdate();
+		this.updateComplete.then(() => {
 			this._updateInputLayout(container);
 		});
 	}

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -248,7 +248,8 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 		this.addEventListener('d2l-localize-behavior-language-changed', () => {
 			this._formattedValue = formatTime(getDateFromISOTime(this.value));
 			INTERVALS.clear();
-			this.requestUpdate().then(() => this._onResize(hiddenContent));
+			this.requestUpdate();
+			this.updateComplete.then(() => this._onResize(hiddenContent));
 		});
 
 		await (document.fonts ? document.fonts.ready : Promise.resolve());


### PR DESCRIPTION
Another quick Lit 2.0 fix. `requestUpdate` [no longer returns a Promise](https://lit.dev/docs/releases/upgrade/#litelement) in Lit 2.0, so instead you're supposed to `await elem.updateComplete` which was always a thing we could have done.