### PR TITLE
Daylight: Table

### DIFF
--- a/components/table/README.md
+++ b/components/table/README.md
@@ -1,8 +1,32 @@
-# Table
+# Tables
+
+Tables are used to display tabular data in rows and columns of cells. They can allow users to select rows and sort by columns.
+
+## Best Practices
+<!-- docs: start best practices -->
+<!-- docs: start dos -->
+* Do use tables to display complex data sets.
+<!-- docs: end dos -->
+
+<!-- docs: start donts -->
+* Don’t use tables to display a simple list of objects or entities; consider using the list component for this instead.
+<!-- docs: end donts -->
+<!-- docs: end best practices -->
+
+## Responsive Behavior
+If the browser window is too narrow to accommodate the table’s contents, a scroll button is shown. This button alerts users to the fact that there’s more content to see, and provides a straightforward way for users to scroll horizontally through the table regardless of whether a horizontal scrollbar is visible.
+
+The scroll button sticks to the top of the table, like a sticky header, so that it never falls out of view while the table is on the page.
+
+Note: If the browser window is very narrow — for example, on a mobile device — it may be preferable to replace a wide table with a list, a set of cards, or some other alternate component. However, the responsive table component provides a consistent fallback that will work reasonably well for any table on any page.
+
+## Table Wrapper [d2l-table-wrapper]
 
 The `d2l-table-wrapper` element can be combined with table styles to apply default/light styling, row selection styles, overflow scrolling and sticky headers to native `<table>` elements within your Lit components.
 
+<!-- docs: start hidden content -->
 ![table with default style](./screenshots/default.png?raw=true)
+<!-- docs: end hidden content -->
 
 Because the `<table>` element is part of `d2l-table-wrapper`'s slotted content, your element is responsible for importing and applying `tableStyles`.
 
@@ -40,7 +64,32 @@ class MyElem extends LitElement {
 }
 ```
 
-**Properties:**
+<!-- docs: demo live name:d2l-table-wrapper -->
+```html
+<d2l-table-wrapper>
+  <table class="d2l-table">
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+  <tbody>
+    <tr>
+      <td>Prop</td>
+      <td>Prop</td>
+      <td>Prop</td>
+      <td>Prop</td>
+    </tr>
+  </tbody>
+  </table>
+</d2l-table-wrapper>
+```
+
+<!-- docs: start hidden content -->
+### Properties
 
 | Property | Type | Description |
 |--|--|--|
@@ -59,6 +108,7 @@ For a table style with fewer borders and tighter padding, there's the `light` ty
   <table class="d2l-table">...</table>
 </d2l-table-wrapper>
 ```
+<!-- docs: end hidden content -->
 
 ## Selection
 
@@ -73,12 +123,15 @@ If your table supports row selection, apply the `selected` attribute to `<tr>` r
 </tr>
 ```
 
-## Sortable Column Buttons
+## Sortable Column Buttons [d2l-table-col-sort-button]
 
 When tabular data can be sorted, the `<d2l-table-col-sort-button>` can be used to provide an interactive sort button as well as arrows to indicate the ascending/descending sort direction.
 
+<!-- docs: start hidden content -->
 ![table with sorting](./screenshots/sorting.gif?raw=true)
+<!-- docs: end hidden content -->
 
+<!-- docs: demo live name:d2l-table-col-sort-button -->
 ```html
 <table class="d2l-table">
   <thead>
@@ -98,6 +151,7 @@ When tabular data can be sorted, the `<d2l-table-col-sort-button>` can be used t
 | `desc` | Boolean, default: `false` | Whether sort direction is descending |
 | `nosort` | Booealn, default: `false` | Column is not currently sorted |
 
+<!-- docs: start hidden content -->
 ## Sticky Headers
 
 For long tables, the header row can be made to "stick" in place as the user scrolls.
@@ -109,5 +163,4 @@ For long tables, the header row can be made to "stick" in place as the user scro
   <table class="d2l-table">...</table>
 </d2l-table-wrapper>
 ```
-
-Looking for an enhancement not listed here? Create a GitHub issue!
+<!-- docs: end hidden content -->

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -100,14 +100,6 @@ For a table style with fewer borders and tighter padding, there's the `light` ty
 
 ![table with light style](./screenshots/light.png?raw=true)
 
-<!-- docs: demo -->
-```html
-<script type="module">
-  import '@brightspace-ui/core/components/table/demo/table-test.js';
-</script>
-<d2l-test-table type="light"></d2l-test-table>
-```
-
 ```html
 <d2l-table-wrapper type="light">
   <table class="d2l-table">...</table>
@@ -118,17 +110,8 @@ For a table style with fewer borders and tighter padding, there's the `light` ty
 
 For long tables, the header row can be made to "stick" in place as the user scrolls.
 
-<!-- docs: start hidden content -->
 ![table with sticky headers](./screenshots/sticky.gif?raw=true)
-<!-- docs: end hidden content -->
 
-<!-- docs: demo autoSize:false size:xsmall -->
-```html
-<script type="module">
-  import '@brightspace-ui/core/components/table/demo/table-test.js';
-</script>
-<d2l-test-table sticky-headers></d2l-test-table>
-```
 ```html
 <d2l-table-wrapper sticky-headers>
   <table class="d2l-table">...</table>

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -89,7 +89,7 @@ customElements.define('d2l-test-table', TestTable);
 ### Properties
 
 | Property | Type | Description |
-|--|--|--|
+|---|---|---|
 | `no-column-border` | Boolean, default: `false` | Hides the column borders on "default" table type |
 | `sticky-headers` | Boolean, default: `false` | Whether to make the header row sticky |
 | `type` | String, default: `'default'` | Type of the table style. Can be one of  `default`, `light`. |
@@ -140,9 +140,9 @@ When tabular data can be sorted, the `<d2l-table-col-sort-button>` can be used t
 ### Properties
 
 | Property | Type | Description |
-|--|--|--|
+|---|---|---|
 | `desc` | Boolean, default: `false` | Whether sort direction is descending |
-| `nosort` | Booealn, default: `false` | Column is not currently sorted |
+| `nosort` | Booealn, default: `false` | Column is not currently sorted. Hides the ascending/descending sort icon. |
 
 ## Selection
 

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -2,6 +2,18 @@
 
 Tables are used to display tabular data in rows and columns of cells. They can allow users to select rows and sort by columns.
 
+<!-- docs: start hidden content -->
+![table with default style](./screenshots/default.png?raw=true)
+<!-- docs: end hidden content -->
+
+<!-- docs: demo autoSize:false display:block size:medium -->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/table/demo/table-test.js';
+</script>
+<d2l-test-table></d2l-test-table>
+```
+
 ## Best Practices
 <!-- docs: start best practices -->
 <!-- docs: start dos -->
@@ -24,17 +36,25 @@ Note: If the browser window is very narrow â€” for example, on a mobile device â
 
 The `d2l-table-wrapper` element can be combined with table styles to apply default/light styling, row selection styles, overflow scrolling and sticky headers to native `<table>` elements within your Lit components.
 
-<!-- docs: start hidden content -->
-![table with default style](./screenshots/default.png?raw=true)
-<!-- docs: end hidden content -->
+See [creation of table component](#creation-of-table-component) for how to create a table component that uses the wrapper and shared styles. The example below uses a component similar to the code in the example in that section.
+
+<!-- docs: demo live name:d2l-test-table autoSize:false display:block size:medium -->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/table/demo/table-test.js';
+</script>
+<d2l-test-table></d2l-test-table>
+```
+
+## Creation of Table Component
 
 Because the `<table>` element is part of `d2l-table-wrapper`'s slotted content, your element is responsible for importing and applying `tableStyles`.
 
 ```javascript
 import { html, LitElement } from 'lit-element/lit-element.js';
-import { tableStyles } from '../table-wrapper.js';
+import { tableStyles } from '@brightspace-ui/core/components/table/table-wrapper.js';
 
-class MyElem extends LitElement {
+class TestTable extends LitElement {
 
   static get styles() {
     return tableStyles;
@@ -62,30 +82,7 @@ class MyElem extends LitElement {
   }
 
 }
-```
-
-<!-- docs: demo live name:d2l-table-wrapper -->
-```html
-<d2l-table-wrapper>
-  <table class="d2l-table">
-    <thead>
-      <tr>
-        <th>Property</th>
-        <th>Type</th>
-        <th>Description</th>
-        <th>Default</th>
-      </tr>
-    </thead>
-  <tbody>
-    <tr>
-      <td>Prop</td>
-      <td>Prop</td>
-      <td>Prop</td>
-      <td>Prop</td>
-    </tr>
-  </tbody>
-  </table>
-</d2l-table-wrapper>
+customElements.define('d2l-test-table', TestTable);
 ```
 
 <!-- docs: start hidden content -->
@@ -103,12 +100,66 @@ For a table style with fewer borders and tighter padding, there's the `light` ty
 
 ![table with light style](./screenshots/light.png?raw=true)
 
+<!-- docs: demo -->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/table/demo/table-test.js';
+</script>
+<d2l-test-table type="light"></d2l-test-table>
+```
+
 ```html
 <d2l-table-wrapper type="light">
   <table class="d2l-table">...</table>
 </d2l-table-wrapper>
 ```
+
+## Sticky Headers
+
+For long tables, the header row can be made to "stick" in place as the user scrolls.
+
+<!-- docs: start hidden content -->
+![table with sticky headers](./screenshots/sticky.gif?raw=true)
 <!-- docs: end hidden content -->
+
+<!-- docs: demo autoSize:false size:xsmall -->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/table/demo/table-test.js';
+</script>
+<d2l-test-table sticky-headers></d2l-test-table>
+```
+```html
+<d2l-table-wrapper sticky-headers>
+  <table class="d2l-table">...</table>
+</d2l-table-wrapper>
+```
+<!-- docs: end hidden content -->
+
+## Sortable Column Buttons [d2l-table-col-sort-button]
+
+When tabular data can be sorted, the `<d2l-table-col-sort-button>` can be used to provide an interactive sort button as well as arrows to indicate the ascending/descending sort direction.
+
+![table with sorting](./screenshots/sorting.gif?raw=true)
+
+```html
+<table class="d2l-table">
+  <thead>
+    <tr>
+      <th><d2l-table-col-sort-button>Ascending</d2l-table-col-sort-button></th>
+      <th><d2l-table-col-sort-button desc>Descending</d2l-table-col-sort-button></th>
+      <th><d2l-table-col-sort-button nosort>Not Sorted</d2l-table-col-sort-button></th>
+    </tr>
+  </thead>
+</table>
+```
+
+### Properties
+
+| Property | Type | Description |
+|--|--|--|
+| `desc` | Boolean, default: `false` | Whether sort direction is descending |
+| `nosort` | Booealn, default: `false` | Column is not currently sorted |
 
 ## Selection
 
@@ -122,45 +173,3 @@ If your table supports row selection, apply the `selected` attribute to `<tr>` r
   <td>this row is selected</td>
 </tr>
 ```
-
-## Sortable Column Buttons [d2l-table-col-sort-button]
-
-When tabular data can be sorted, the `<d2l-table-col-sort-button>` can be used to provide an interactive sort button as well as arrows to indicate the ascending/descending sort direction.
-
-<!-- docs: start hidden content -->
-![table with sorting](./screenshots/sorting.gif?raw=true)
-<!-- docs: end hidden content -->
-
-<!-- docs: demo live name:d2l-table-col-sort-button -->
-```html
-<table class="d2l-table">
-  <thead>
-    <tr>
-      <th><d2l-table-col-sort-button>Ascending</d2l-table-col-sort-button></th>
-      <th><d2l-table-col-sort-button desc>Descending</d2l-table-col-sort-button></th>
-      <th><d2l-table-col-sort-button nosort>Not Sorted</d2l-table-col-sort-button></th>
-    </tr>
-  </thead>
-</table>
-```
-
-**Properties:**
-
-| Property | Type | Description |
-|--|--|--|
-| `desc` | Boolean, default: `false` | Whether sort direction is descending |
-| `nosort` | Booealn, default: `false` | Column is not currently sorted |
-
-<!-- docs: start hidden content -->
-## Sticky Headers
-
-For long tables, the header row can be made to "stick" in place as the user scrolls.
-
-![table with sticky headers](./screenshots/sticky.gif?raw=true)
-
-```html
-<d2l-table-wrapper sticky-headers>
-  <table class="d2l-table">...</table>
-</d2l-table-wrapper>
-```
-<!-- docs: end hidden content -->

--- a/components/table/demo/table-test.js
+++ b/components/table/demo/table-test.js
@@ -8,7 +8,11 @@ const fruits = ['Apples', 'Oranges', 'Bananas'];
 const data = [
 	{ name: 'Canada', fruit: { 'apples': 356863, 'oranges': 0, 'bananas': 0 }, selected: false },
 	{ name: 'Australia', fruit: { 'apples': 308298, 'oranges': 398610, 'bananas': 354241 }, selected: false },
-	{ name: 'Mexico', fruit: { 'apples': 716931, 'oranges': 4603253, 'bananas': 2384778 }, selected: false }
+	{ name: 'Mexico', fruit: { 'apples': 716931, 'oranges': 4603253, 'bananas': 2384778 }, selected: false },
+	{ name: 'Brazil', fruit: { 'apples': 1300000, 'oranges': 50000, 'bananas': 6429875 }, selected: false },
+	{ name: 'England', fruit: { 'apples': 345782, 'oranges': 4, 'bananas': 1249875 }, selected: false },
+	{ name: 'Hawaii', fruit: { 'apples': 129875, 'oranges': 856765, 'bananas': 123 }, selected: false },
+	{ name: 'Japan', fruit: { 'apples': 8534, 'oranges': 1325, 'bananas': 78382756 }, selected: false }
 ];
 
 const formatter = new Intl.NumberFormat('en-US');
@@ -17,7 +21,20 @@ class TestTable extends RtlMixin(LitElement) {
 
 	static get properties() {
 		return {
+			/**
+			 * Hides the column borders on "default" table type
+			 * @type {boolean}
+			 */
+			noColumnBorder: { attribute: 'no-column-border', type: Boolean },
+			/**
+			 * Type of table style to apply
+			 * @type {'default'|'light'}
+			 */
 			type: { type: String },
+			/**
+			 * Whether header row is sticky
+			 * @type {boolean}
+			 */
 			stickyHeaders: { attribute: 'sticky-headers', type: Boolean },
 			_sortField: { attribute: false, type: String },
 			_sortDesc: { attribute: false, type: Boolean }
@@ -34,6 +51,7 @@ class TestTable extends RtlMixin(LitElement) {
 
 	constructor() {
 		super();
+		this.noColumnBorder = false;
 		this.sortDesc = false;
 		this.stickyHeaders = false;
 		this.type = 'default';
@@ -48,7 +66,7 @@ class TestTable extends RtlMixin(LitElement) {
 			return a.fruit[this._sortField] - b.fruit[this._sortField];
 		});
 		return html`
-			<d2l-table-wrapper ?sticky-headers="${this.stickyHeaders}" type="${type}">
+			<d2l-table-wrapper ?no-column-border="${this.noColumnBorder}" ?sticky-headers="${this.stickyHeaders}" type="${type}">
 				<table class="d2l-table">
 					<thead>
 						<tr>

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -13,6 +13,7 @@ export class TableColSortButton extends LitElement {
 		return {
 			/**
 			 * Whether the direction is descending
+			 * @type {boolean}
 			 */
 			desc: {
 				reflect: true,
@@ -20,6 +21,7 @@ export class TableColSortButton extends LitElement {
 			},
 			/**
 			 * When present, hides the asc/desc sort icon
+			 * @type {boolean}
 			 */
 			nosort: {
 				reflect: true,

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -12,7 +12,7 @@ export class TableColSortButton extends LitElement {
 	static get properties() {
 		return {
 			/**
-			 * Whether the direction is descending
+			 * Whether sort direction is descending
 			 * @type {boolean}
 			 */
 			desc: {
@@ -20,7 +20,7 @@ export class TableColSortButton extends LitElement {
 				type: Boolean
 			},
 			/**
-			 * When present, hides the asc/desc sort icon
+			 * Column is not currently sorted. Hides the ascending/descending sort icon.
 			 * @type {boolean}
 			 */
 			nosort: {

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -184,7 +184,7 @@ export class TableWrapper extends RtlMixin(LitElement) {
 				type: Boolean
 			},
 			/**
-			 * Whether header row is sticky
+			 * Whether the header row is sticky. Useful for long tables to "stick" the header row in place as the user scrolls.
 			 * @type {boolean}
 			 */
 			stickyHeaders: {
@@ -193,7 +193,7 @@ export class TableWrapper extends RtlMixin(LitElement) {
 				type: Boolean
 			},
 			/**
-			 * Type of table style to apply
+			 * Type of table style to apply. The "light" style has fewer borders and tighter padding.
 			 * @type {'default'|'light'}
 			 */
 			type: {

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -176,6 +176,7 @@ export class TableWrapper extends RtlMixin(LitElement) {
 		return {
 			/**
 			 * Hides the column borders on "default" table type
+			 * @type {boolean}
 			 */
 			noColumnBorder: {
 				attribute: 'no-column-border',
@@ -184,6 +185,7 @@ export class TableWrapper extends RtlMixin(LitElement) {
 			},
 			/**
 			 * Whether header row is sticky
+			 * @type {boolean}
 			 */
 			stickyHeaders: {
 				attribute: 'sticky-headers',


### PR DESCRIPTION
This one was a bit complex to get working in Daylight due to not really being a component. I ended up utilizing the demo test-table for the live demo, partially because it is difficult to create a component in the documentation repo and have that imported into a demo. I added a few rows to the demo in order to better showcase sticky-headers and also added `no-column-border`.

I just kept the gifs for sortable column buttons and selection since that was simpler. Those are also shown in the live demo, though their properties can't be interacted with since it's more a demo of the wrapper.