### PR TITLE
fix: using unsafeSVG and a template

### DIFF
--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -5,7 +5,7 @@ import { iconStyles } from './icon-styles.js';
 import { loadSvg } from '../../generated/icons/presetIconLoader.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { runAsync } from '../../directives/run-async.js';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
 
 class Icon extends RtlMixin(LitElement) {
 
@@ -47,13 +47,13 @@ class Icon extends RtlMixin(LitElement) {
 			return undefined;
 		}
 
-		const elem = document.createElement('div');
-		elem.innerHTML = svgStr;
+		const template = document.createElement('template');
+		template.innerHTML = svgStr;
 
-		const svg = elem.firstChild;
+		const svg = template.content.firstChild;
 		fixSvg(svg);
 
-		return html`${unsafeHTML(elem.innerHTML)}`;
+		return html`${unsafeSVG(template.innerHTML)}`;
 
 	}
 


### PR DESCRIPTION
Just a couple small tweaks to our icon component:

1. I noticed in the Lit documentation that there's a `unsafeSVG` directive which is preferable here to the scarier `unsafeHTML`.
2. Using a `<template>` to temporarily store the SVG DOM while we manipulate it should be slightly better since templates aren't part of the main DOM so the browser skips certain steps (like fetching image paths).