### PR TITLE
Lit 2.0: run-async tests

### DIFF
--- a/components/dialog/demo/dialog-async-content.js
+++ b/components/dialog/demo/dialog-async-content.js
@@ -2,7 +2,7 @@ import '../../list/list.js';
 import '../../list/list-item.js';
 import '../../list/list-item-content.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
-import { InitialStateError, runAsync } from '../../../directives/run-async.js';
+import { InitialStateError, runAsync } from '../../../directives/run-async/run-async.js';
 
 class DialogAsyncContent extends LitElement {
 

--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -4,7 +4,7 @@ import { fixSvg } from './fix-svg.js';
 import { iconStyles } from './icon-styles.js';
 import { loadSvg } from '../../generated/icons/presetIconLoader.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
-import { runAsync } from '../../directives/run-async.js';
+import { runAsync } from '../../directives/run-async/run-async.js';
 import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
 
 class Icon extends RtlMixin(LitElement) {

--- a/directives/run-async/run-async.js
+++ b/directives/run-async/run-async.js
@@ -11,7 +11,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import { AsyncStateEvent } from '../helpers/asyncStateEvent.js';
+import { AsyncStateEvent } from '../../helpers/asyncStateEvent.js';
 import { directive } from 'lit-html/lit-html.js';
 
 const hasAbortController = typeof AbortController === 'function';

--- a/directives/run-async/test/.eslintrc.json
+++ b/directives/run-async/test/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "brightspace/open-wc-testing-config"
+}

--- a/directives/run-async/test/run-async.test.js
+++ b/directives/run-async/test/run-async.test.js
@@ -50,7 +50,6 @@ describe('run-async directive', () => {
 			expect(elem.innerText).to.equal('initial');
 		});
 
-		// TODO: was this actually desired behaviour, or should nothing be rendered?
 		it('should render failure template if InitialStateError occurs but no initial template is provided', async() => {
 
 			const elem = await fixture(html`<p>${runAsync('key', task, {

--- a/directives/run-async/test/run-async.test.js
+++ b/directives/run-async/test/run-async.test.js
@@ -70,7 +70,7 @@ describe('run-async directive', () => {
 			expect(elem.innerText).to.equal('failure');
 		});
 
-		it.only('should render pending template while task is executing', async() => {
+		it('should render pending template while task is executing', async() => {
 			const elem = await createFixture();
 			expect(elem.innerText).to.equal('pending');
 		});

--- a/directives/run-async/test/run-async.test.js
+++ b/directives/run-async/test/run-async.test.js
@@ -1,0 +1,112 @@
+import { expect, fixture } from '@open-wc/testing';
+import { InitialStateError, runAsync } from '../run-async.js';
+import { html } from 'lit-element/lit-element.js';
+
+describe('run-async directive', () => {
+
+	let taskKey, taskInfo, taskResolve, taskReject;
+	function task(key, info) {
+		taskKey = key;
+		taskInfo = info;
+		return new Promise((res, rej) => {
+			taskResolve = res;
+			taskReject = rej;
+		});
+	}
+
+	function createFixture(key = 'some-key', pendingState = true) {
+		return fixture(html`<p>${runAsync(key, task, {
+			initial: () => html`initial`,
+			failure: () => html`failure`,
+			pending: () => html`pending`,
+			success: () => html`success`
+		},
+		{ pendingState: pendingState })}</p>`);
+	}
+
+	afterEach(() => {
+		taskKey = undefined;
+		taskInfo = undefined;
+		taskResolve = undefined;
+		taskReject = undefined;
+	});
+
+	describe('task execution', () => {
+
+		it('should pass key and abort controller to task', async() => {
+			await createFixture('my-key');
+			expect(taskKey).to.equal('my-key');
+			expect(taskInfo.signal).to.not.be.undefined;
+		});
+
+	});
+
+	describe('templates', () => {
+
+		it('should render initial template if InitialStateError occurs', async() => {
+			const elem = await createFixture();
+			taskReject(new InitialStateError());
+			await elem.updateComplete;
+			expect(elem.innerText).to.equal('initial');
+		});
+
+		// TODO: was this actually desired behaviour, or should nothing be rendered?
+		it('should render failure template if InitialStateError occurs but no initial template is provided', async() => {
+
+			const elem = await fixture(html`<p>${runAsync('key', task, {
+				failure: () => html`failure`
+			})}</p>`);
+
+			taskReject(new InitialStateError());
+			await elem.updateComplete;
+			expect(elem.innerText).to.equal('failure');
+
+		});
+
+		it('should render failure template if task is rejected', async() => {
+			const elem = await createFixture();
+			taskReject(new Error('oh no'));
+			await elem.updateComplete;
+			expect(elem.innerText).to.equal('failure');
+		});
+
+		it.only('should render pending template while task is executing', async() => {
+			const elem = await createFixture();
+			expect(elem.innerText).to.equal('pending');
+		});
+
+		it('should render success template when task completes', async() => {
+			const elem = await createFixture();
+			taskResolve();
+			await elem.updateComplete;
+			expect(elem.innerText).to.equal('success');
+		});
+
+	});
+
+	describe('pending-state event', () => {
+
+		it('should fire "pending-state" event', (done) => {
+
+			document.body.addEventListener('pending-state', (e) => {
+				e.detail.promise.then(() => done());
+				taskResolve();
+			});
+
+			createFixture();
+
+		});
+
+		it('should not fire "pending-state" event when option set', async() => {
+
+			let eventFired = false;
+			document.body.addEventListener('pending-state', () => eventFired = true);
+
+			await createFixture('key', false);
+			expect(eventFired).to.be.false;
+
+		});
+
+	});
+
+});

--- a/mixins/async-container/demo/async-item.js
+++ b/mixins/async-container/demo/async-item.js
@@ -1,6 +1,6 @@
 import '../../../components/colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { InitialStateError, runAsync } from '../../../directives/run-async.js';
+import { InitialStateError, runAsync } from '../../../directives/run-async/run-async.js';
 
 class AsyncItem extends LitElement {
 

--- a/mixins/async-container/test/async-item.js
+++ b/mixins/async-container/test/async-item.js
@@ -1,6 +1,6 @@
 import '../../../components/colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { InitialStateError, runAsync } from '../../../directives/run-async.js';
+import { InitialStateError, runAsync } from '../../../directives/run-async/run-async.js';
 
 class AsyncItem extends LitElement {
 


### PR DESCRIPTION
The Lit 2.0 migration of directives is pretty significant, so I wrote some unit tests around the existing Lit 1.0 directive to help avoid regressions.

I'll leave this open until @dbatiste has had a chance to review.

To make room for the tests, I also decided to move the directive into its own directory. Technically this is a breaking change, but a quick code search revealed that we're only using this internally inside core, so seems safe-ish.