### PR TITLE
Lit 2.0: convert run-async directive to class-based syntax

### DIFF
--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
+          sudo apt-get update
           sudo apt-get install language-pack-ko
           sudo apt-get install korean*
       - name: Build

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          sudo apt-get update
           sudo apt-get install language-pack-ko
           sudo apt-get install korean*
       - name: Build

--- a/directives/run-async/run-async.js
+++ b/directives/run-async/run-async.js
@@ -1,4 +1,9 @@
 /**
+ * Originally based on the Polymer run-async Lit 1.0 directive:
+ * https://github.com/PolymerLabs/async-demos/blob/master/packages/await-io/src/run-async.ts
+ * Ported to Lit 2.0
+ */
+/**
  * @license
  * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
@@ -11,16 +16,107 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+import { AsyncDirective } from 'lit-html/async-directive.js';
 import { AsyncStateEvent } from '../../helpers/asyncStateEvent.js';
-import { directive } from 'lit-html/lit-html.js';
+import { directive } from 'lit-html/directive.js';
+import { noChange } from 'lit-html';
 
 const hasAbortController = typeof AbortController === 'function';
-const runs = new WeakMap();
+
 /**
  * Error thrown by async tasks when the task couldn't be started based on the
  * key passed to it.
  */
 export class InitialStateError extends Error {}
+
+class RunAsync extends AsyncDirective {
+
+	constructor(partInfo) {
+		super(partInfo);
+		this.abortController = hasAbortController ? new AbortController() : undefined;
+		this.key = undefined;
+		this.pendingPromise = undefined;
+		this.rejectPending = undefined;
+		this.resolvePending = undefined;
+		this.state = 'initial';
+	}
+
+	render(key, task, templates) {
+
+		const { success, pending, initial, failure } = templates;
+
+		// first time we see a value we save and await the work function.
+		if (this.key !== key) {
+
+			// abort a pending request if there is one
+			if (this.state === 'pending') {
+				if (this.abortController !== undefined) {
+					this.abortController.abort();
+				}
+			}
+
+			const taskPromise = task(key, {
+				signal: hasAbortController ? this.abortController.signal : undefined
+			});
+			// The state is immediately 'pending', since the function has been
+			// executed, but if the function throws an InitialStateError to
+			// indicate that it couldn't even start processing, then we will set
+			// the state to 'initial'.
+			this.key = key;
+			this.pendingPromise = new Promise((res, rej) => {
+				this.resolvePending = res;
+				this.rejectPending = rej;
+			}).catch((error) => {
+				// swallow initial state errors
+				if (!(error instanceof InitialStateError)) {
+					throw error;
+				}
+			});
+			this.state = 'pending';
+			Promise.resolve(taskPromise).then((value) => {
+				this.state = 'success';
+				this.resolvePending();
+				this.setValue(success(value));
+			}, (error) => {
+				this.rejectPending(error);
+				if (error instanceof InitialStateError && typeof initial === 'function') {
+					this.state = 'initial';
+					this.setValue(initial());
+				} else {
+					this.state = 'failure';
+					if (typeof failure === 'function') {
+						this.setValue(failure(error));
+					}
+				}
+			});
+		}
+
+		if ((this.state === 'pending') && typeof pending === 'function') {
+			return pending();
+		}
+
+		return noChange;
+
+	}
+
+	update(part, [key, task, templates, options]) {
+		const renderResult = this.render(key, task, templates);
+		const directiveOptions = Object.assign({ pendingState: true }, options);
+		if (directiveOptions.pendingState) {
+			(async() => {
+				// Wait a microtask for the initial render of the Part to complete
+				await 0;
+				if (this.key === key && this.state === 'pending') {
+					const element = part.parentNode.nodeType === Node.ELEMENT_NODE ? part.parentNode : part.parentNode.host;
+					element.dispatchEvent(new AsyncStateEvent(this.pendingPromise));
+				}
+			})();
+		}
+		return renderResult;
+	}
+
+}
+
 /**
  * Runs an async function whenever the key changes, and calls one of several
  * lit-html template functions depending on the state of the async call:
@@ -38,89 +134,4 @@ export class InitialStateError extends Error {}
  * @param templates The templates to render for each state of the task
  * @param options The directive options, for example whether to dispatch pending-state
  */
-export const runAsync = directive((key, task, templates, options) => (part) => {
-	const directiveOptions = Object.assign({ pendingState: true }, options);
-	const { success, pending, initial, failure } = templates;
-	const currentRunState = runs.get(part);
-	// The first time we see a value we save and await the work function.
-	// TODO(justinfagnani): allow a custom invalidate function
-	if (currentRunState === undefined || currentRunState.key !== key) {
-		// Abort a pending request if there is one
-		if (currentRunState !== undefined && currentRunState.state === 'pending') {
-			if (currentRunState.abortController !== undefined) {
-				currentRunState.abortController.abort();
-			}
-		}
-		const abortController = hasAbortController ? new AbortController() : undefined;
-		const abortSignal = hasAbortController ? abortController.signal : undefined;
-		let resolvePending;
-		let rejectPending;
-		const pendingPromise = new Promise((res, rej) => {
-			resolvePending = res;
-			rejectPending = rej;
-		}).catch((error) => {
-			if (!(error instanceof InitialStateError)) {
-				// swallow initial state errors
-				throw error;
-			}
-		});
-		const promise = task(key, { signal: abortSignal });
-		// The state is immediately 'pending', since the function has been
-		// executed, but if the function throws an InitialStateError to
-		// indicate that it couldn't even start processing, then we will set
-		// the state to 'initial'.
-		const runState = {
-			key,
-			promise,
-			state: 'pending',
-			abortController,
-			resolvePending,
-			rejectPending,
-		};
-		runs.set(part, runState);
-		Promise.resolve(promise).then((value) => {
-			runState.state = 'success';
-			const currentRunState = runs.get(part);
-			runState.resolvePending();
-			if (currentRunState !== runState) {
-				return;
-			}
-			part.setValue(success(value));
-			part.commit();
-		}, (error) => {
-			const currentRunState = runs.get(part);
-			runState.rejectPending(error);
-			if (currentRunState !== runState) {
-				return;
-			}
-			if (error instanceof InitialStateError && typeof initial === 'function') {
-				runState.state = 'initial';
-				part.setValue(initial());
-				part.commit();
-			} else {
-				runState.state = 'failure';
-				if (typeof failure === 'function') {
-					// render success callback
-					part.setValue(failure(error));
-					part.commit();
-				}
-			}
-		});
-		(async() => {
-			// Wait a microtask for the initial render of the Part to complete
-			await 0;
-			const currentRunState = runs.get(part);
-			if (currentRunState === runState && currentRunState.state === 'pending') {
-				const element = part.startNode.parentNode.nodeType === Node.ELEMENT_NODE ? part.startNode.parentNode : part.startNode.parentNode.host;
-				if (directiveOptions.pendingState) {
-					element.dispatchEvent(new AsyncStateEvent(pendingPromise));
-				}
-			}
-		})();
-	}
-	// If the promise has not yet resolved, set/update the defaultContent
-	const latestRunState = runs.get(part);
-	if ((latestRunState === undefined || latestRunState.state === 'pending') && typeof pending === 'function') {
-		part.setValue(pending());
-	}
-});
+export const runAsync = directive(RunAsync);

--- a/directives/run-async/run-async.js
+++ b/directives/run-async/run-async.js
@@ -102,15 +102,11 @@ class RunAsync extends AsyncDirective {
 	update(part, [key, task, templates, options]) {
 		const renderResult = this.render(key, task, templates);
 		const directiveOptions = Object.assign({ pendingState: true }, options);
-		if (directiveOptions.pendingState) {
-			(async() => {
-				// Wait a microtask for the initial render of the Part to complete
-				await 0;
-				if (this.key === key && this.state === 'pending') {
-					const element = part.parentNode.nodeType === Node.ELEMENT_NODE ? part.parentNode : part.parentNode.host;
-					element.dispatchEvent(new AsyncStateEvent(this.pendingPromise));
-				}
-			})();
+		if (directiveOptions.pendingState && this.key === key && this.state === 'pending') {
+			const element = part.parentNode.nodeType === Node.ELEMENT_NODE ? part.parentNode : part.parentNode.host;
+			if (element) {
+				element.dispatchEvent(new AsyncStateEvent(this.pendingPromise));
+			}
 		}
 		return renderResult;
 	}

--- a/directives/run-async/run-async.js
+++ b/directives/run-async/run-async.js
@@ -102,11 +102,15 @@ class RunAsync extends AsyncDirective {
 	update(part, [key, task, templates, options]) {
 		const renderResult = this.render(key, task, templates);
 		const directiveOptions = Object.assign({ pendingState: true }, options);
-		if (directiveOptions.pendingState && this.key === key && this.state === 'pending') {
-			const element = part.parentNode.nodeType === Node.ELEMENT_NODE ? part.parentNode : part.parentNode.host;
-			if (element) {
-				element.dispatchEvent(new AsyncStateEvent(this.pendingPromise));
-			}
+		if (directiveOptions.pendingState) {
+			(async() => {
+				// Wait a microtask for the initial render of the Part to complete
+				await 0;
+				if (this.key === key && this.state === 'pending') {
+					const element = part.parentNode.nodeType === Node.ELEMENT_NODE ? part.parentNode : part.parentNode.host;
+					element.dispatchEvent(new AsyncStateEvent(this.pendingPromise));
+				}
+			})();
 		}
 		return renderResult;
 	}


### PR DESCRIPTION
Building on the new unit tests, this converts the directive to follow the new Lit 2.0 class-based syntax:
https://lit.dev/docs/templates/custom-directives/#async-directives

The big change with the class-based directives is that a `WeakMap` is no longer needed for state, which can instead move into the class. This simplifies things a bit in that you always have access to that state in the callbacks and don't need to keep grabbing it and confirming that it's valid.

Things also get split out into `render()` (which can run on the server) and `update()` which does not. So that's where I put the firing of the `pending-state` event.