### PR TITLE
Change French translation for search placeholder

### DIFF
--- a/lang/fr.js
+++ b/lang/fr.js
@@ -48,7 +48,7 @@ export default {
 	"components.input-number.hintDecimalIncorrectComma": "Pour ajouter une décimale, utilisez la virgule « , »",
 	"components.input-number.hintDecimalIncorrectPeriod": "Pour ajouter une décimale, utilisez le point « . »",
 	"components.input-search.clear": "Effacer la recherche",
-	"components.input-search.defaultPlaceholder": "Recherche en cours…",
+	"components.input-search.defaultPlaceholder": "Rechercher…",
 	"components.input-search.search": "Rechercher",
 	"components.input-time-range.endTime": "Heure de fin",
 	"components.input-time-range.errorBadInput": "{startLabel} doit précéder {endLabel}",


### PR DESCRIPTION
Based on the convo here: https://github.com/BrightspaceUI/core/pull/1553#discussion_r680142768
The government of Canada site uses `Rechercher`, Ontario's site and Quebec's immigration site use `Recherche`, CBC uses both... I think we're probably good with either, rather than "Search in progress" as below.