### PR TITLE
`input-number`: `await` wrapped `input-text` to render so it can focus

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -372,11 +372,13 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 	}
 
 	async focus() {
-		await this.updateComplete;
-		const inputTextElem = this.shadowRoot.querySelector('d2l-input-text');
-		await inputTextElem.updateComplete;
 		const elem = this.shadowRoot.querySelector('d2l-input-text');
-		if (elem) elem.focus();
+		if (elem) {
+			elem.focus();
+		} else {
+			await this.updateComplete;
+			this.focus();
+		}
 	}
 
 	async validate() {

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -371,7 +371,10 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 		});
 	}
 
-	focus() {
+	async focus() {
+		await this.updateComplete;
+		const inputTextElem = this.shadowRoot.querySelector('d2l-input-text');
+		await inputTextElem.updateComplete;
 		const elem = this.shadowRoot.querySelector('d2l-input-text');
 		if (elem) elem.focus();
 	}


### PR DESCRIPTION
[DE43948](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fdefect%2F601576690591&fdp=true?fdp=true): Update score out of field to be d2l-input-numeric in FACE Assignments

When the `input-number` component is re-rendered (e.g. due to conditional rendering), `autofocus` does not work and component validation isn't triggered correctly for reasons unclear.

Awaiting `input-text` to `updateComplete` let's us access the component when it has finished rendering.

This problem surfaced when trying to update the score input in FACE Assignments to use `input-number` over `input-text`.