### PR TITLE
US130430 - Batch filter change events

### DIFF
--- a/components/filter/demo/filter-search-demo.js
+++ b/components/filter/demo/filter-search-demo.js
@@ -46,13 +46,16 @@ class FilterSearchDemo extends LitElement {
 	}
 
 	_handleFilterChange(e) {
-		// eslint-disable-next-line no-console
-		console.log(`Filter selection changed for dimension "${e.detail.dimension}":`, e.detail.value);
+		(e.detail.changes.length === 1) ?
+			console.log(`Filter selection changed for dimension "${e.detail.changes[0].dimension}":`, e.detail.changes[0].value) : // eslint-disable-line no-console
+			console.log('Batch filter selection changed:', e.detail.changes); // eslint-disable-line no-console
 
-		if (e.detail.dimension !== 'event') return;
+		e.detail.changes.forEach(change => {
+			if (change.dimension !== 'event') return;
 
-		this._fullData.find(value => value.key === e.detail.value.key).selected = e.detail.value.selected;
-		this._displayedData.find(value => value.key === e.detail.value.key).selected = e.detail.value.selected;
+			this._fullData.find(value => value.key === change.value.key).selected = change.value.selected;
+			this._displayedData.find(value => value.key === change.value.key).selected = change.value.selected;
+		});
 	}
 
 	_handleFirstOpen(e) {

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -91,7 +91,9 @@
 
 	<script type="module">
 		document.addEventListener('d2l-filter-change', e => {
-			console.log(`Filter selection changed for dimension "${e.detail.dimension}":`, e.detail.value);
+			(e.detail.changes.length === 1) ?
+				console.log(`Filter selection changed for dimension "${e.detail.changes[0].dimension}":`, e.detail.changes[0].value) : // eslint-disable-line no-console
+				console.log('Batch filter selection changed:', e.detail.changes); // eslint-disable-line no-console
 		});
 
 		document.addEventListener('d2l-filter-dimension-first-open', e => {


### PR DESCRIPTION
This is helpful for:
- When someone is clicking around quickly in filter and undoing changes they just did
- For bulk events (clearing and select all)

If the same filter is changed multiple times within a batch, only the final state is sent to minimize work for the consumer.