### PR TITLE
fix: allow ENTER to be pressed to trigger change event

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -496,7 +496,7 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 			// incorrect decimal
 			hintType = key === ',' ? HINT_TYPES.DECIMAL_INCORRECT_PERIOD : HINT_TYPES.DECIMAL_INCORRECT_COMMA;
 			prevent = true;
-		} else if (['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].indexOf(key) === -1) {
+		} else if (['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'Enter'].indexOf(key) === -1) {
 			// not a number
 			prevent = true;
 		}

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -401,6 +401,12 @@ describe('d2l-input-number', () => {
 			expect(event.defaultPrevented).to.be.false;
 		});
 
+		it('should not suppress ENTER key so that input\'s change event can fire', async() => {
+			const elem = await fixtureInit(normalFixture);
+			const event = dispatchKeypressEvent(elem, 'Enter');
+			expect(event.defaultPrevented).to.be.false;
+		});
+
 		it('should suppress negative symbol when cursor is not at beginning', async() => {
 			const elem = await fixtureInit(defaultValueFixture);
 			setCursorPosition(elem, 1);


### PR DESCRIPTION
Another issue @matthe97w uncovered.

Normally, when you press ENTER in a text input it will automatically fire the `change` event if the value has actually changed. But we were accidentally suppressing that as part of our code that suppresses non-numeric characters, which meant focus needed to be lost before the `change` event would fire.

This corrects that.