### PR TITLE
fix: set seconds on manual EOD to 59

### DIFF
--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -224,8 +224,22 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 		if (this.enforceTimeIntervals) {
 			time = getTimeAtInterval(this.timeInterval, time);
 		}
+
+		const isManualEndOfDay = time.getHours() === 23 && time.getMinutes() === 59 && time.getSeconds() === 0;
+		if (isManualEndOfDay) {
+			time = END_OF_DAY;
+		}
+
 		this._value = formatDateInISOTime(time);
 		this._formattedValue = formatTime(time);
+
+		if (isManualEndOfDay) {
+			this.dispatchEvent(new CustomEvent(
+				'change',
+				{ bubbles: true, composed: false }
+			));
+		}
+
 		this.requestUpdate('value', oldValue);
 	}
 


### PR DESCRIPTION
Fixes https://rally1.rallydev.com/#/29180338367ud/custom/486232622040?detail=%2Fdefect%2F605123292669&fdp=true

The issue is that when an EOD time (i.e. 11:59 PM) is entered manually, the seconds value is set to 0, and when the default value of END_OF_DAY is used, the seconds value is set to 59. The causes problems when comparing times.