### PR TITLE
Daylight: Select Lists: add demo to top of page

### DIFF
--- a/components/inputs/docs/input-select-styles.md
+++ b/components/inputs/docs/input-select-styles.md
@@ -2,6 +2,14 @@
 
 A Select List allows the user to select a single option out of a relatively large number of items, or to reduce the visual prominence of an option selection.
 
+<!-- docs: demo -->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/inputs/demo/input-select-test.js';
+</script>
+<d2l-test-input-select></d2l-test-input-select>
+```
+
 ## Best Practices
 <!-- docs: start best practices -->
 <!-- docs: start dos -->


### PR DESCRIPTION
I seem to have missed adding a demo at the top of this page. It is currently the same demo as the one at the bottom, which might be why I left it off, but the page does feel empty without it.