### PR TITLE
Explicit dependency on lit-html 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "focus-visible": "^5",
     "intl-messageformat": "^7",
     "lit-element": "^2",
+    "lit-html": "^1.4.1",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"
   }


### PR DESCRIPTION
Now that we're using the Lit 2.0 directive syntax, we need an explicit dependency on `lit-html` >= `1.4.1` which is when it was added. Without this, some FRAs are failing to install core.

🎩 -tip to @tylergee for noticing this!