### PR TITLE
Fix skeleton stacking context

### DIFF
--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -10,6 +10,9 @@ export const skeletonStyles = css`
 		75% { background-color: var(--d2l-color-sylvite); }
 		100% { background-color: var(--d2l-color-sylvite); }
 	}
+	:host([skeleton]) {
+		opacity: .999;
+	}
 	:host([skeleton]) .d2l-skeletize::before {
 		animation: loadingPulse 1.8s linear infinite;
 		background-color: var(--d2l-color-sylvite);
@@ -20,7 +23,7 @@ export const skeletonStyles = css`
 		position: absolute;
 		right: 0;
 		top: 0;
-		z-index: 4;
+		z-index: 999;
 	}
 	@media (prefers-reduced-motion: reduce) {
 		:host([skeleton]) .d2l-skeletize::before {


### PR DESCRIPTION
The skeleton `z-index` was set to `4` to give room for components to use `z-index` for other purposes without rendering on top of the sekeleton, but because there is no guaranteed stacking context up the tree, the skeleton itself can now render on top of things outside the host component that it shouldn't.

This PR creates a guaranteed stacking context on any host that uses skeletons, and _only while skeletons are visible_.

Using `opacity` to create the stacking context (again, only while the skeletons are visible) seems fairly safe, but there are other options like `transform: perspective(0)`, which seem pretty safe as well.