### PR TITLE
fix: demo snippet styling

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -9,6 +9,7 @@ class DemoSnippet extends LitElement {
 		return {
 			codeViewHidden: { type: Boolean, reflect: true, attribute: 'code-view-hidden' },
 			noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
+			overflowHidden: { type: Boolean, reflect: true, attribute: 'overflow-hidden' },
 			_code: { type: String },
 			_dir: { type: String, attribute: false },
 			_hasSkeleton: { type: Boolean, attribute: false },
@@ -36,6 +37,9 @@ class DemoSnippet extends LitElement {
 				flex: 1 1 auto;
 				position: relative;
 			}
+			:host([overflow-hidden]) .d2l-demo-snippet-demo {
+				overflow: hidden;
+			}
 			.d2l-demo-snippet-demo-padding {
 				padding: 18px;
 			}
@@ -52,6 +56,7 @@ class DemoSnippet extends LitElement {
 				border-top-left-radius: 0;
 				border-top-right-radius: 0;
 				margin: 0;
+				max-width: inherit;
 			}
 			:host([code-view-hidden]) d2l-code-view {
 				display: none;


### PR DESCRIPTION
This allows elements that want to use scroll wrapper and overflow to display correctly in demo snippets. It will hide the overflow and allow scrolling with arrow buttons when `overflow-hidden` is supplied. This also makes the code view always be the same width as the demo snippet when it is part of the snippet. It will still have the maximum width by itself.

These changes were mainly done to support rubrics so we can switch to using the standard demo snippet. It was tested with core demo pages as well as rubrics.

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/9043211/131190781-03633b2f-64df-4d17-bf67-146a813a9c8b.png)|![image](https://user-images.githubusercontent.com/9043211/131190749-7020763f-e540-467e-bf83-0ae300a67c5a.png)|