### PR TITLE
Adding logic for dropdown mobile trays to work in Iframes/ non-responsive screens

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -4,6 +4,7 @@ import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
 import { forceFocusVisible, getComposedActiveElement, getNextFocusable, tryApplyFocus } from '../../helpers/focus.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { getIfrauBackdropService } from '../../helpers/ifrauBackdropService.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -19,16 +20,6 @@ if (window.D2L.DialogMixin.preferNative === undefined) {
 }
 
 let ifrauDialogService;
-
-async function getIfrauDialogService() {
-	if (!window.ifrauclient) return;
-	if (ifrauDialogService) return ifrauDialogService;
-
-	const ifrauClient = await window.ifrauclient().connect();
-	ifrauDialogService = await ifrauClient.getService('dialogWC', '0.1');
-
-	return ifrauDialogService;
-}
 
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const abortAction = 'abort';
@@ -105,16 +96,16 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		super.updated(changedProperties);
 		if (!changedProperties.has('opened')) return;
 
-		const dialogService = await getIfrauDialogService();
+		ifrauDialogService = await getIfrauBackdropService(ifrauDialogService);
 		if (this.opened) {
-			if (dialogService) {
-				this._ifrauContextInfo = await dialogService.showBackdrop();
+			if (ifrauDialogService) {
+				this._ifrauContextInfo = await ifrauDialogService.showBackdrop();
 				this._inIframe = true;
 			}
 			this._open();
 		} else {
-			if (dialogService) {
-				dialogService.hideBackdrop();
+			if (ifrauDialogService) {
+				ifrauDialogService.hideBackdrop();
 				this._ifrauContextInfo = null;
 			}
 			this._close();

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -4,12 +4,12 @@ import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
 import { forceFocusVisible, getComposedActiveElement, getNextFocusable, tryApplyFocus } from '../../helpers/focus.js';
 import { classMap } from 'lit-html/directives/class-map.js';
-import { getIfrauBackdropService } from '../../helpers/ifrauBackdropService.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
+import { tryGetIfrauBackdropService } from '../../helpers/ifrauBackdropService.js';
 
 window.D2L = window.D2L || {};
 window.D2L.DialogMixin = window.D2L.DialogMixin || {};
@@ -18,8 +18,6 @@ window.D2L.DialogMixin.hasNative = (window.HTMLDialogElement !== undefined);
 if (window.D2L.DialogMixin.preferNative === undefined) {
 	window.D2L.DialogMixin.preferNative = true;
 }
-
-let ifrauDialogService;
 
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const abortAction = 'abort';
@@ -96,7 +94,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		super.updated(changedProperties);
 		if (!changedProperties.has('opened')) return;
 
-		ifrauDialogService = await getIfrauBackdropService(ifrauDialogService);
+		const ifrauDialogService = await tryGetIfrauBackdropService();
 		if (this.opened) {
 			if (ifrauDialogService) {
 				this._ifrauContextInfo = await ifrauDialogService.showBackdrop();

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -887,7 +887,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 			}
 			if (this.mobileTray === 'left') {
 				// On non-responsive pages, the innerWidth may be wider than the screen,
-				// override right to stick to right of viewport
+				// override left to stick to left of viewport
 				leftOverride = `${Math.max(window.innerWidth - window.screen.width, 0)}px`;
 			}
 		}

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -4,17 +4,15 @@ import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, getBoundingAncestor, isComposedAncestor, isVisible } from '../../helpers/dom.js';
 import { getComposedActiveElement, getFirstFocusableDescendant, getPreviousFocusableAncestor } from '../../helpers/focus.js';
 import { classMap } from 'lit-html/directives/class-map.js';
-import { getIfrauBackdropService } from '../../helpers/ifrauBackdropService.js';
 import { html } from 'lit-element/lit-element.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
+import { tryGetIfrauBackdropService } from '../../helpers/ifrauBackdropService.js';
 
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const minBackdropHeightMobile = 42;
 const minBackdropWidthMobile = 30;
-
-let ifrauBackdropService;
 
 export const DropdownContentMixin = superclass => class extends LocalizeCoreElement(RtlMixin(superclass)) {
 
@@ -518,7 +516,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 			});
 		};
 
-		ifrauBackdropService = await getIfrauBackdropService(ifrauBackdropService);
+		const ifrauBackdropService = await tryGetIfrauBackdropService();
 
 		if (newValue) {
 

--- a/helpers/ifrauBackdropService.js
+++ b/helpers/ifrauBackdropService.js
@@ -1,5 +1,7 @@
-export async function getIfrauBackdropService(ifrauBackdropService) {
-	if (!window.ifrauclient) return;
+let ifrauBackdropService;
+
+export async function tryGetIfrauBackdropService() {
+	if (!window.ifrauclient) return null;
 	if (ifrauBackdropService) return ifrauBackdropService;
 
 	const ifrauClient = await window.ifrauclient().connect();

--- a/helpers/ifrauBackdropService.js
+++ b/helpers/ifrauBackdropService.js
@@ -1,0 +1,9 @@
+export async function getIfrauBackdropService(ifrauBackdropService) {
+	if (!window.ifrauclient) return;
+	if (ifrauBackdropService) return ifrauBackdropService;
+
+	const ifrauClient = await window.ifrauclient().connect();
+	ifrauBackdropService = await ifrauClient.getService('dialogWC', '0.1');
+
+	return ifrauBackdropService;
+}


### PR DESCRIPTION
Currently, the trays work by being pinned to one side by using something like bottom: 0. However, this doesn't work in iframes, where the inner height and width of the window is actually the height and width of the iframe (much larger than the screen). In those cases, pinning to the bottom requires users to scroll to the bottom of the iframe, rather than having the tray pop up in the viewport. 

This PR leverages the existing IfrauDialogService to add/remove backdrops on iframed pages as needed. I've pulled out the logic into a helper, since it's identical to the dialog-mixin usage. 