### PR TITLE
US126584 - Add selection-single to d2l-filter-dimension-set

### DIFF
--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -64,6 +64,7 @@ The `d2l-filter-dimension-set` component is the main dimension type that will wo
 | `loading` | Boolean | Whether the values for this dimension are still loading and a loading spinner should be displayed |
 | `search-type` | String, default: `automatic` | `automatic` provides basic case-insensitive text comparison searching, `none` disables the search input, and `manual` fires an event for the consumer to handle the search and removal of the values as needed  |
 | `select-all` | Boolean | Whether to show a select all checkbox and selection summary for this dimension  |
+| `selection-single` | Boolean | Whether only one value can be selected at a time for this dimension  |
 | `text` | String, required | Text for the dimension in the menu |
 
 #### d2l-filter-dimension-set-value

--- a/components/filter/demo/filter-search-demo.js
+++ b/components/filter/demo/filter-search-demo.js
@@ -31,7 +31,7 @@ class FilterSearchDemo extends LitElement {
 					<d2l-filter-dimension-set-value key="instructor" text="Instructor"></d2l-filter-dimension-set-value>
 					<d2l-filter-dimension-set-value key="student" text="Student"></d2l-filter-dimension-set-value>
 				</d2l-filter-dimension-set>
-				<d2l-filter-dimension-set key="none-select-all" text="No Search and Search All" search-type="none" select-all>
+				<d2l-filter-dimension-set key="none-select-all" text="No Search and Select All" search-type="none" select-all>
 					<d2l-filter-dimension-set-value key="admin" text="Admin"></d2l-filter-dimension-set-value>
 					<d2l-filter-dimension-set-value key="instructor" text="Instructor"></d2l-filter-dimension-set-value>
 					<d2l-filter-dimension-set-value key="student" text="Student"></d2l-filter-dimension-set-value>

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -41,7 +41,21 @@
 			</template>
 		</d2l-demo-snippet>
 
-		<h2>Multiple Set Dimensions</h2>
+		<h2>Single Set Dimension - Single Selection</h2>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-filter>
+					<d2l-filter-dimension-set key="semester" text="Semester" selection-single>
+						<d2l-filter-dimension-set-value key="fall" text="Fall"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="winter" text="Winter" selected></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="spring" text="Spring"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="summer" text="Summer"></d2l-filter-dimension-set-value>
+					</d2l-filter-dimension-set>
+				</d2l-filter>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Multiple Dimensions</h2>
 		<d2l-demo-snippet>
 			<template>
 				<d2l-filter>
@@ -63,6 +77,12 @@
 						<d2l-filter-dimension-set-value key="instructor" text="Instructor"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="student" text="Student"></d2l-filter-dimension-set-value>
 					</d2l-filter-dimension-set>
+					<d2l-filter-dimension-set key="semester" text="Semester" selection-single>
+						<d2l-filter-dimension-set-value key="fall" text="Fall"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="winter" text="Winter" selected></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="spring" text="Spring"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="summer" text="Summer"></d2l-filter-dimension-set-value>
+					</d2l-filter-dimension-set>
 				</d2l-filter>
 			</template>
 		</d2l-demo-snippet>
@@ -76,6 +96,7 @@
 				<d2l-filter>
 					<d2l-filter-dimension-set key="course" text="Course" loading select-all></d2l-filter-dimension-set>
 					<d2l-filter-dimension-set key="role" text="Role" loading></d2l-filter-dimension-set>
+					<d2l-filter-dimension-set key="semester" text="Semester" loading selection-single></d2l-filter-dimension-set>
 				</d2l-filter>
 				<d2l-button id="finish-loading">Finish loading (in 5 seconds)</d2l-button>
 			</template>

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -28,6 +28,10 @@ class FilterDimensionSet extends LitElement {
 			 */
 			selectAll: { type: Boolean, attribute: 'select-all' },
 			/**
+			 * Whether only one value can be selected at a time for this dimension
+			 */
+			selectionSingle: { type: Boolean, attribute: 'selection-single' },
+			/**
 			 * REQUIRED: The text that is displayed for the dimension title
 			 */
 			text: { type: String }
@@ -39,6 +43,7 @@ class FilterDimensionSet extends LitElement {
 		this.loading = false;
 		this.searchType = 'automatic';
 		this.selectAll = false;
+		this.selectionSingle = false;
 		this.text = '';
 		this._slot = null;
 	}

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -316,7 +316,8 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			<d2l-list
 				id="${SET_DIMENSION_ID_PREFIX}${dimension.key}"
 				@d2l-list-selection-change="${this._handleChangeSetDimension}"
-				extend-separators>
+				extend-separators
+				?selection-single="${dimension.selectionSingle}">
 				${dimension.values.map(item => html`
 					<d2l-list-item
 						?hidden="${item.hidden}"
@@ -496,7 +497,8 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			switch (type) {
 				case 'd2l-filter-dimension-set': {
 					info.searchType = dimension.searchType;
-					if (dimension.selectAll) info.selectAllIdPrefix = SET_DIMENSION_ID_PREFIX;
+					info.selectionSingle = dimension.selectionSingle;
+					if (dimension.selectAll && !dimension.selectionSingle) info.selectAllIdPrefix = SET_DIMENSION_ID_PREFIX;
 					const values = dimension._getValues();
 					info.values = values;
 					break;

--- a/components/filter/test/filter.axe.js
+++ b/components/filter/test/filter.axe.js
@@ -6,7 +6,15 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 const singleSetDimensionFixture = html`
 	<d2l-filter>
 		<d2l-filter-dimension-set key="dim" text="Dim" select-all>
-			<d2l-filter-dimension-set-value key="value" text="Value"></d2l-filter-dimension-set-value>
+			<d2l-filter-dimension-set-value key="value-1" text="Value 1"></d2l-filter-dimension-set-value>
+			<d2l-filter-dimension-set-value key="value-2" text="Value 2" selected></d2l-filter-dimension-set-value>
+		</d2l-filter-dimension-set>
+	</d2l-filter>`;
+const singleSetDimensionSingleSelectionOnFixture = html`
+	<d2l-filter>
+		<d2l-filter-dimension-set key="dim" text="Dim" selection-single>
+			<d2l-filter-dimension-set-value key="value-1" text="Value 1"></d2l-filter-dimension-set-value>
+			<d2l-filter-dimension-set-value key="value-2" text="Value 2" selected></d2l-filter-dimension-set-value>
 		</d2l-filter-dimension-set>
 	</d2l-filter>`;
 const multiDimensionFixture = html`
@@ -22,6 +30,7 @@ const multiDimensionFixture = html`
 describe('d2l-filter', () => {
 	[
 		{ name: 'Single set dimension', fixture: singleSetDimensionFixture },
+		{ name: 'Single set dimension - single selection', fixture: singleSetDimensionSingleSelectionOnFixture },
 		{ name: 'Multiple dimensions', fixture: multiDimensionFixture }
 	].forEach(test => {
 		it(`${test.name}`, async() => {

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -12,6 +12,13 @@ const singleSetDimensionFixture = html`
 			<d2l-filter-dimension-set-value key="2" text="Value 2"></d2l-filter-dimension-set-value>
 		</d2l-filter-dimension-set>
 	</d2l-filter>`;
+const singleSetDimensionSingleSelectionFixture = html`
+	<d2l-filter>
+		<d2l-filter-dimension-set key="dim" text="Dim" selection-single>
+			<d2l-filter-dimension-set-value key="1" text="Value 1" selected></d2l-filter-dimension-set-value>
+			<d2l-filter-dimension-set-value key="2" text="Value 2"></d2l-filter-dimension-set-value>
+		</d2l-filter-dimension-set>
+	</d2l-filter>`;
 const multiDimensionFixture = html`
 	<d2l-filter>
 		<d2l-filter-dimension-set key="1" text="Dim 1">
@@ -146,6 +153,35 @@ describe('d2l-filter', () => {
 				expect(changes[0].dimension).to.equal('dim');
 				expect(changes[0].value.key).to.equal('2');
 				expect(changes[0].value.selected).to.be.true;
+				expect(elem._dimensions[0].values[1].selected).to.be.true;
+
+				setTimeout(() => value.setSelected(false));
+				e = await oneEvent(elem, 'd2l-filter-change');
+				changes = e.detail.changes;
+				expect(changes.length).to.equal(1);
+				expect(changes[0].dimension).to.equal('dim');
+				expect(changes[0].value.key).to.equal('2');
+				expect(changes[0].value.selected).to.be.false;
+				expect(elem._dimensions[0].values[1].selected).to.be.false;
+			});
+
+			it('single set dimension with selection-single on fires change events', async() => {
+				const elem = await fixture(singleSetDimensionSingleSelectionFixture);
+				const value = elem.shadowRoot.querySelector('d2l-list-item[key="2"]');
+				expect(elem._dimensions[0].values[0].selected).to.be.true;
+				expect(elem._dimensions[0].values[1].selected).to.be.false;
+
+				setTimeout(() => value.setSelected(true));
+				let e = await oneEvent(elem, 'd2l-filter-change');
+				let changes = e.detail.changes;
+				expect(changes.length).to.equal(2);
+				expect(changes[0].dimension).to.equal('dim');
+				expect(changes[0].value.key).to.equal('2');
+				expect(changes[0].value.selected).to.be.true;
+				expect(changes[1].dimension).to.equal('dim');
+				expect(changes[1].value.key).to.equal('1');
+				expect(changes[1].value.selected).to.be.false;
+				expect(elem._dimensions[0].values[0].selected).to.be.false;
 				expect(elem._dimensions[0].values[1].selected).to.be.true;
 
 				setTimeout(() => value.setSelected(false));


### PR DESCRIPTION
This PR adds the ability to turn on `selection-single` for the set dimension, so that only one value can be selected from the list.  When the value selected changes, the batched change event will have two changes in the array - one turning on the new filter value, and one turning off the old filter value.  Therefore no special function/handling is needed for a `selection-single` list versus a multi-select one.

This PR doesn't adjust filter counts for this case.  After talking to Jeff, we decided we're going to remove the "All" language and keeping track of the total.  It has the potential to cause more confusion than help, and is not super intuitive in the single selection case anyways.  It also simplifies integrating the future `count-badge`.  This functionality will be removed in the next PR.