### PR TITLE
US126584 - Remove max count functionality in filter

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -41,8 +41,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			disabled: { type: Boolean, reflect: true },
 			_activeDimensionKey: { type: String, attribute: false },
 			_dimensions: { type: Array, attribute: false },
-			_totalAppliedCount: { type: Number, attribute: false },
-			_totalMaxCount: { type: Number, attribute: false }
+			_totalAppliedCount: { type: Number, attribute: false }
 		};
 	}
 
@@ -132,7 +131,6 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		this._dimensions = [];
 		this._openedDimensions = [];
 		this._totalAppliedCount = 0;
-		this._totalMaxCount = 0;
 	}
 
 	firstUpdated(changedProperties) {
@@ -152,7 +150,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		const header = this._buildHeader(singleDimension);
 		const dimensions = this._buildDimensions(singleDimension);
 
-		const filterCount = this._formatFilterCount(this._totalAppliedCount, this._totalMaxCount);
+		const filterCount = this._formatFilterCount(this._totalAppliedCount);
 		let buttonText = singleDimension ? this._dimensions[0].text : this.localize('components.filter.filters');
 		if (filterCount) buttonText = `${buttonText} (${filterCount})`;
 
@@ -218,7 +216,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			return html`<d2l-menu-item text="${dimension.text}" description="${dimensionDescription}">
 				${builtDimension}
 				<div slot="supporting">
-					<span>${this._formatFilterCount(dimension.appliedCount, dimension.maxCount)}</span>
+					<span>${this._formatFilterCount(dimension.appliedCount)}</span>
 				</div>
 			</d2l-menu-item>`;
 		});
@@ -356,16 +354,10 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		}
 	}
 
-	_formatFilterCount(count, max) {
+	_formatFilterCount(count) {
 		if (count === 0) return;
-
-		let number = count;
-		if (count === max) {
-			number = 'all';
-		} else if (count >= 100) {
-			number = 'max';
-		}
-		return this.localize('components.filter.filterCount', { number: number });
+		else if (count >= 100) return '99+';
+		else return `${count}`;
 	}
 
 	_getSlottedNodes(slot) {
@@ -534,21 +526,18 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 	_setFilterCounts(dimensionToRecount) {
 		this._totalAppliedCount = 0;
-		this._totalMaxCount = 0;
 
 		this._dimensions.forEach(dimension => {
 			if (!dimensionToRecount || dimensionToRecount.key === dimension.key) {
 				switch (dimension.type) {
 					case 'd2l-filter-dimension-set': {
 						dimension.appliedCount = dimension.values.reduce((total, value) => { return value.selected ? total + 1 : total; }, 0);
-						dimension.maxCount = dimension.values.length;
 						break;
 					}
 				}
 			}
 
 			this._totalAppliedCount += dimension.appliedCount;
-			this._totalMaxCount += dimension.maxCount;
 		});
 	}
 

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -355,14 +355,11 @@ describe('d2l-filter', () => {
 				values: [{ key: 1, selected: true }, { key: 2, selected: false }, { key: 3, selected: true }]
 			}];
 			expect(elem._totalAppliedCount).to.equal(0);
-			expect(elem._totalMaxCount).to.equal(0);
 
 			elem._setFilterCounts();
 
 			expect(elem._totalAppliedCount).to.equal(2);
-			expect(elem._totalMaxCount).to.equal(3);
 			expect(elem._dimensions[0].appliedCount).to.equal(2);
-			expect(elem._dimensions[0].maxCount).to.equal(3);
 		});
 
 		it('multiple dimensions are counted correctly', async() => {
@@ -383,18 +380,13 @@ describe('d2l-filter', () => {
 				values: [{ key: 1, selected: false }, { key: 2, selected: false }]
 			}];
 			expect(elem._totalAppliedCount).to.equal(0);
-			expect(elem._totalMaxCount).to.equal(0);
 
 			elem._setFilterCounts();
 
 			expect(elem._totalAppliedCount).to.equal(3);
-			expect(elem._totalMaxCount).to.equal(8);
 			expect(elem._dimensions[0].appliedCount).to.equal(2);
-			expect(elem._dimensions[0].maxCount).to.equal(3);
 			expect(elem._dimensions[1].appliedCount).to.equal(1);
-			expect(elem._dimensions[1].maxCount).to.equal(3);
 			expect(elem._dimensions[2].appliedCount).to.equal(0);
-			expect(elem._dimensions[2].maxCount).to.equal(2);
 		});
 
 		it('selection changes in a single set dimension adjusts the count correctly', async() => {
@@ -402,23 +394,17 @@ describe('d2l-filter', () => {
 			const value1 = elem.shadowRoot.querySelector('d2l-list-item[key="1"]');
 			const value2 = elem.shadowRoot.querySelector('d2l-list-item[key="2"]');
 			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(2);
 			expect(elem._dimensions[0].appliedCount).to.equal(1);
-			expect(elem._dimensions[0].maxCount).to.equal(2);
 
 			setTimeout(() => value1.setSelected(false));
 			await oneEvent(elem, 'd2l-filter-change');
 			expect(elem._totalAppliedCount).to.equal(0);
-			expect(elem._totalMaxCount).to.equal(2);
 			expect(elem._dimensions[0].appliedCount).to.equal(0);
-			expect(elem._dimensions[0].maxCount).to.equal(2);
 
 			setTimeout(() => value2.setSelected(true));
 			await oneEvent(elem, 'd2l-filter-change');
 			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(2);
 			expect(elem._dimensions[0].appliedCount).to.equal(1);
-			expect(elem._dimensions[0].maxCount).to.equal(2);
 		});
 
 		it('selection changes with multiple dimensions adjusts the count correctly', async() => {
@@ -426,46 +412,34 @@ describe('d2l-filter', () => {
 			const value1 = elem.shadowRoot.querySelector('[data-key="1"] d2l-list-item[key="1"]');
 			const value2 = elem.shadowRoot.querySelector('[data-key="2"] d2l-list-item[key="1"]');
 			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(2);
 			expect(elem._dimensions[0].appliedCount).to.equal(1);
-			expect(elem._dimensions[0].maxCount).to.equal(1);
 			expect(elem._dimensions[1].appliedCount).to.equal(0);
-			expect(elem._dimensions[1].maxCount).to.equal(1);
 
 			setTimeout(() => value2.setSelected(true));
 			await oneEvent(elem, 'd2l-filter-change');
 			expect(elem._totalAppliedCount).to.equal(2);
-			expect(elem._totalMaxCount).to.equal(2);
 			expect(elem._dimensions[0].appliedCount).to.equal(1);
-			expect(elem._dimensions[0].maxCount).to.equal(1);
 			expect(elem._dimensions[1].appliedCount).to.equal(1);
-			expect(elem._dimensions[1].maxCount).to.equal(1);
 
 			setTimeout(() => value1.setSelected(false));
 			await oneEvent(elem, 'd2l-filter-change');
 			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(2);
 			expect(elem._dimensions[0].appliedCount).to.equal(0);
-			expect(elem._dimensions[0].maxCount).to.equal(1);
 			expect(elem._dimensions[1].appliedCount).to.equal(1);
-			expect(elem._dimensions[1].maxCount).to.equal(1);
 		});
 
 		describe('_formatFilterCount', () => {
 			[
-				{ name: 'No Values', appliedCount: 0, maxCount: 0, result: undefined },
-				{ name: 'None Selected', appliedCount: 0, maxCount: 5, result: undefined },
-				{ name: '1 Selected', appliedCount: 1, maxCount: 5, result: '1' },
-				{ name: '2 Selected', appliedCount: 2, maxCount: 5, result: '2' },
-				{ name: '99 Selected', appliedCount: 99, maxCount: 200, result: '99' },
-				{ name: '100 Selected', appliedCount: 100, maxCount: 200, result: '99+' },
-				{ name: 'All Selected (1)', appliedCount: 1, maxCount: 1, result: 'All' },
-				{ name: 'All Selected (99)', appliedCount: 99, maxCount: 99, result: 'All' },
-				{ name: 'All Selected (100)', appliedCount: 100, maxCount: 100, result: 'All' },
+				{ name: 'None Selected', appliedCount: 0, result: undefined },
+				{ name: '1 Selected', appliedCount: 1, result: '1' },
+				{ name: '2 Selected', appliedCount: 2, result: '2' },
+				{ name: '99 Selected', appliedCount: 99, result: '99' },
+				{ name: '100 Selected', appliedCount: 100, result: '99+' },
+				{ name: '150 Selected', appliedCount: 150, result: '99+' },
 			].forEach((testCase) => {
 				it(`${testCase.name}`, async() => {
 					const elem = await fixture(html`<d2l-filter></d2l-filter>`);
-					const result = elem._formatFilterCount(testCase.appliedCount, testCase.maxCount);
+					const result = elem._formatFilterCount(testCase.appliedCount);
 					expect(result).to.equal(testCase.result);
 				});
 			});
@@ -473,25 +447,22 @@ describe('d2l-filter', () => {
 
 		describe('Opener Count Format', () => {
 			[
-				{ name: 'Single Dim - No Values', count: 0, max: 0, dimensions: [{ key: 1, text: 'Role' }], text: 'Role', description: 'Filter by: Role. 0 filters applied.' },
-				{ name: 'Single Dim - None Selected', count: 0, max: 200, dimensions: [{ key: 1, text: 'Role' }], text: 'Role', description: 'Filter by: Role. 0 filters applied.' },
-				{ name: 'Single Dim - 1 Selected', count: 1, max: 200, dimensions: [{ key: 1, text: 'Role' }], text: 'Role (1)', description: 'Filter by: Role. 1 filter applied.' },
-				{ name: 'Single Dim - 5 Selected', count: 5, max: 200, dimensions: [{ key: 1, text: 'Role' }], text: 'Role (5)', description: 'Filter by: Role. 5 filters applied.' },
-				{ name: 'Single Dim - 100 Selected', count: 100, max: 200, dimensions: [{ key: 1, text: 'Role' }], text: 'Role (99+)', description: 'Filter by: Role. 100 filters applied.' },
-				{ name: 'Single Dim - All Selected', count: 200, max: 200, dimensions: [{ key: 1, text: 'Role' }], text: 'Role (All)', description: 'Filter by: Role. 200 filters applied.' },
-				{ name: 'Multiple Dims - No Values', count: 0, max: 0, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters', description: 'Filters. 0 filters applied.' },
-				{ name: 'Multiple Dims - None Selected', count: 0, max: 200, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters', description: 'Filters. 0 filters applied.' },
-				{ name: 'Multiple Dims - 1 Selected', count: 1, max: 200, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters (1)', description: 'Filters. 1 filter applied.' },
-				{ name: 'Multiple Dims - 5 Selected', count: 5, max: 200, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters (5)', description: 'Filters. 5 filters applied.' },
-				{ name: 'Multiple Dims - 100 Selected', count: 100, max: 200, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters (99+)', description: 'Filters. 100 filters applied.' },
-				{ name: 'Multiple Dims - All Selected', count: 200, max: 200, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters (All)', description: 'Filters. 200 filters applied.' }
+				{ name: 'Single Dim - None Selected', count: 0, dimensions: [{ key: 1, text: 'Role' }], text: 'Role', description: 'Filter by: Role. 0 filters applied.' },
+				{ name: 'Single Dim - 1 Selected', count: 1, dimensions: [{ key: 1, text: 'Role' }], text: 'Role (1)', description: 'Filter by: Role. 1 filter applied.' },
+				{ name: 'Single Dim - 5 Selected', count: 5, dimensions: [{ key: 1, text: 'Role' }], text: 'Role (5)', description: 'Filter by: Role. 5 filters applied.' },
+				{ name: 'Single Dim - 99 Selected', count: 99, dimensions: [{ key: 1, text: 'Role' }], text: 'Role (99)', description: 'Filter by: Role. 99 filters applied.' },
+				{ name: 'Single Dim - 100 Selected', count: 100, dimensions: [{ key: 1, text: 'Role' }], text: 'Role (99+)', description: 'Filter by: Role. 100 filters applied.' },
+				{ name: 'Multiple Dims - None Selected', count: 0, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters', description: 'Filters. 0 filters applied.' },
+				{ name: 'Multiple Dims - 1 Selected', count: 1, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters (1)', description: 'Filters. 1 filter applied.' },
+				{ name: 'Multiple Dims - 5 Selected', count: 5, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters (5)', description: 'Filters. 5 filters applied.' },
+				{ name: 'Multiple Dims - 99 Selected', count: 99, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters (99)', description: 'Filters. 99 filters applied.' },
+				{ name: 'Multiple Dims - 100 Selected', count: 100, dimensions: [{ key: 1, text: 'Role' }, { key: 2, text: 'Course' }], text: 'Filters (99+)', description: 'Filters. 100 filters applied.' }
 			].forEach((testCase) => {
 				it(`${testCase.name}`, async() => {
 					const elem = await fixture(html`<d2l-filter></d2l-filter>`);
 					const opener = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
 					elem._dimensions = testCase.dimensions;
 					elem._totalAppliedCount = testCase.count;
-					elem._totalMaxCount = testCase.max;
 					await elem.updateComplete;
 
 					expect(opener.text).to.equal(testCase.text);
@@ -502,12 +473,11 @@ describe('d2l-filter', () => {
 
 		describe('Menu Item Format', () => {
 			[
-				{ name: 'No Values', dimensions: [{ key: 1, text: 'Role', appliedCount: 0, maxCount: 0 }, { key: 2 }], text: '', description: 'Role. 0 filters applied.' },
-				{ name: 'None Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 0, maxCount: 200 }, { key: 2 }], text: '', description: 'Role. 0 filters applied.' },
-				{ name: '1 Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 1, maxCount: 200 }, { key: 2 }], text: '1', description: 'Role. 1 filter applied.' },
-				{ name: '5 Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 5, maxCount: 200 }, { key: 2 }], text: '5', description: 'Role. 5 filters applied.' },
-				{ name: '100 Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 100, maxCount: 200 }, { key: 2 }], text: '99+', description: 'Role. 100 filters applied.' },
-				{ name: 'All Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 200, maxCount: 200 }, { key: 2 }], text: 'All', description: 'Role. 200 filters applied.' },
+				{ name: 'None Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 0 }, { key: 2 }], text: '', description: 'Role. 0 filters applied.' },
+				{ name: '1 Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 1 }, { key: 2 }], text: '1', description: 'Role. 1 filter applied.' },
+				{ name: '5 Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 5 }, { key: 2 }], text: '5', description: 'Role. 5 filters applied.' },
+				{ name: '99 Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 99 }, { key: 2 }], text: '99', description: 'Role. 99 filters applied.' },
+				{ name: '100 Selected', dimensions: [{ key: 1, text: 'Role', appliedCount: 100 }, { key: 2 }], text: '99+', description: 'Role. 100 filters applied.' },
 			].forEach((testCase) => {
 				it(`${testCase.name}`, async() => {
 					const elem = await fixture(html`<d2l-filter></d2l-filter>`);
@@ -529,7 +499,6 @@ describe('d2l-filter', () => {
 			const elem = await fixture(singleSetDimensionFixture);
 			expect(elem._dimensions.length).to.equal(1);
 			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(2);
 
 			const newDim = document.createElement('d2l-filter-dimension-set');
 			newDim.key = 'newDim';
@@ -537,6 +506,7 @@ describe('d2l-filter', () => {
 			const newValue = document.createElement('d2l-filter-dimension-set-value');
 			newValue.key = 'newValue';
 			newValue.text = 'New Value';
+			newValue.selected = true;
 			newDim.appendChild(newValue);
 			setTimeout(() => elem.appendChild(newDim));
 			await oneEvent(elem.shadowRoot.querySelector('slot'), 'slotchange');
@@ -546,8 +516,7 @@ describe('d2l-filter', () => {
 			expect(elem._dimensions.length).to.equal(2);
 			expect(elem._dimensions[0].key).to.equal('dim');
 			expect(elem._dimensions[1].key).to.equal('newDim');
-			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(3);
+			expect(elem._totalAppliedCount).to.equal(2);
 		});
 	});
 
@@ -618,17 +587,13 @@ describe('d2l-filter', () => {
 			const value = elem.querySelector('d2l-filter-dimension-set[key="2"] d2l-filter-dimension-set-value');
 			expect(value.selected).to.be.false;
 			expect(elem._dimensions[1].appliedCount).to.equal(0);
-			expect(elem._dimensions[1].maxCount).to.equal(1);
 			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(2);
 			value.selected = true;
 
 			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			expect(elem._dimensions[1].values[0].selected).to.be.true;
 			expect(elem._dimensions[1].appliedCount).to.equal(1);
-			expect(elem._dimensions[1].maxCount).to.equal(1);
 			expect(elem._totalAppliedCount).to.equal(2);
-			expect(elem._totalMaxCount).to.equal(2);
 			expect(updateStub).to.be.calledOnce;
 			expect(recountSpy).to.be.not.be.called;
 		});
@@ -636,7 +601,6 @@ describe('d2l-filter', () => {
 		it('value changes update the filter count', async() => {
 			const dimension = elem.querySelector('d2l-filter-dimension-set[key="2"]');
 			expect(elem._dimensions[1].appliedCount).to.equal(0);
-			expect(elem._dimensions[1].maxCount).to.equal(1);
 
 			const newValue = document.createElement('d2l-filter-dimension-set-value');
 			newValue.key = 'newValue';
@@ -648,9 +612,7 @@ describe('d2l-filter', () => {
 			expect(elem._dimensions[1].values[0].selected).to.be.false;
 			expect(elem._dimensions[1].values[1].selected).to.be.true;
 			expect(elem._dimensions[1].appliedCount).to.equal(1);
-			expect(elem._dimensions[1].maxCount).to.equal(2);
 			expect(elem._totalAppliedCount).to.equal(2);
-			expect(elem._totalMaxCount).to.equal(3);
 			expect(updateStub).to.be.calledOnce;
 			expect(recountSpy).to.be.calledOnce;
 			expect(recountSpy).to.have.been.calledWith(elem._dimensions[1]);
@@ -661,9 +623,7 @@ describe('d2l-filter', () => {
 			elem._dimensions[0].searchType = 'manual';
 			elem._dimensions[0].searchValue = '';
 			expect(elem._dimensions[0].appliedCount).to.equal(1);
-			expect(elem._dimensions[0].maxCount).to.equal(1);
 			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(2);
 
 			const newValue = document.createElement('d2l-filter-dimension-set-value');
 			newValue.key = 'newValue';
@@ -674,9 +634,7 @@ describe('d2l-filter', () => {
 			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			expect(elem._dimensions[0].values.length).to.equal(2);
 			expect(elem._dimensions[0].appliedCount).to.equal(2);
-			expect(elem._dimensions[0].maxCount).to.equal(2);
 			expect(elem._totalAppliedCount).to.equal(2);
-			expect(elem._totalMaxCount).to.equal(3);
 			expect(updateStub).to.be.calledOnce;
 			expect(recountSpy).to.be.calledOnce;
 			expect(recountSpy).to.be.calledWith(elem._dimensions[0]);
@@ -687,9 +645,7 @@ describe('d2l-filter', () => {
 			elem._dimensions[0].searchType = 'manual';
 			elem._dimensions[0].searchValue = 'whatever';
 			expect(elem._dimensions[0].appliedCount).to.equal(1);
-			expect(elem._dimensions[0].maxCount).to.equal(1);
 			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(2);
 
 			const valueToRemove = dimension.querySelector('d2l-filter-dimension-set-value');
 			dimension.removeChild(valueToRemove);
@@ -697,9 +653,7 @@ describe('d2l-filter', () => {
 			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			expect(elem._dimensions[0].values.length).to.equal(0);
 			expect(elem._dimensions[0].appliedCount).to.equal(1);
-			expect(elem._dimensions[0].maxCount).to.equal(1);
 			expect(elem._totalAppliedCount).to.equal(1);
-			expect(elem._totalMaxCount).to.equal(2);
 			expect(updateStub).to.be.calledOnce;
 			expect(recountSpy).to.not.be.called;
 		});

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "إغلاق مربع الحوار هذا",
 	"components.dropdown.close": "إغلاق",
 	"components.filter.loading": "يتم تحميل عوامل التصفية",
-	"components.filter.filterCount": "{number, select, max {99+} all {كل} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {لم يتم تطبيق عوامل تصفية.} one {تم تطبيق عامل تصفية واحد.} other {{number} من عوامل التصفية التي تم تطبيقها.}}",
 	"components.filter.filters": "عوامل التصفية",
 	"components.filter.noFilters": "ما من عوامل تصفية متوفرة",

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Cau'r dialog hwn",
 	"components.dropdown.close": "Cau",
 	"components.filter.loading": "Wrthi’n llwytho hidlyddion",
-	"components.filter.filterCount": "{number, select, max {99+} all {I gyd} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Ni chymhwyswyd hidlwyr.} one {1 hidlydd wedi'i gymhwyso.} other {{number} hidlydd wedi'u cymhwyso.}}",
 	"components.filter.filters": "Hidlyddion",
 	"components.filter.noFilters": "Dim hidlyddion ar gael",

--- a/lang/da.js
+++ b/lang/da.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Luk denne dialogboks",
 	"components.dropdown.close": "Luk",
 	"components.filter.loading": "Indlæser filtre",
-	"components.filter.filterCount": "{number, select, max {99+} all {alle} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Ingen filtre anvendt.} one {1 filter anvendt.} other {{number} filtre anvendt.}}",
 	"components.filter.filters": "Filtre",
 	"components.filter.noFilters": "Ingen tilgængelige filtre",

--- a/lang/de.js
+++ b/lang/de.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Dieses Dialogfeld schließen",
 	"components.dropdown.close": "Schließen",
 	"components.filter.loading": "Filter werden geladen",
-	"components.filter.filterCount": "{number, select, max {99+} all {Alle} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Keine Filter angewendet.} one {1 Filter angewendet.} other {{number} Filter angewendet.}}",
 	"components.filter.filters": "Filter",
 	"components.filter.noFilters": "Keine verfügbaren Filter",

--- a/lang/en.js
+++ b/lang/en.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Close this dialog",
 	"components.dropdown.close": "Close",
 	"components.filter.loading": "Loading filters",
-	"components.filter.filterCount": "{number, select, max {99+} all {All} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {No filters applied.} one {1 filter applied.} other {{number} filters applied.}}",
 	"components.filter.filters": "Filters",
 	"components.filter.noFilters": "No available filters",

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Cerrar este cuadro de diálogo",
 	"components.dropdown.close": "Cerrar",
 	"components.filter.loading": "Cargando filtros",
-	"components.filter.filterCount": "{number, select, max {99+} all {Todos} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Sin filtros aplicados.} one {1 filtro aplicado.} other {{number} filtros aplicados.}}",
 	"components.filter.filters": "Filtros",
 	"components.filter.noFilters": "No hay filtros disponibles",

--- a/lang/es.js
+++ b/lang/es.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Cerrar este cuadro de diálogo",
 	"components.dropdown.close": "Cerrar",
 	"components.filter.loading": "Cargando filtros",
-	"components.filter.filterCount": "{number, select, max {99+} all {Todos} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Sin filtros aplicados.} one {1 filtro aplicado.} other {{number} filtros aplicados.}}",
 	"components.filter.filters": "Filtros",
 	"components.filter.noFilters": "No hay filtros disponibles",

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Fermer cette boîte de dialogue",
 	"components.dropdown.close": "Fermer",
 	"components.filter.loading": "Chargement des filtres",
-	"components.filter.filterCount": "{number, select, max {99+} all {Tout} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Aucun filtre appliqué.} one {1 filtre appliqué.} other {{number} filtres appliqués.}}",
 	"components.filter.filters": "Filtres",
 	"components.filter.noFilters": "Aucun filtre disponible",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Fermer cette boîte de dialogue",
 	"components.dropdown.close": "Fermer",
 	"components.filter.loading": "Chargement des filtres",
-	"components.filter.filterCount": "{number, select, max {99+} all {Tous} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Aucun filtre appliqué.} one {1 filtre appliqué.} other {{number} filtres appliqués.}}",
 	"components.filter.filters": "Filtres",
 	"components.filter.noFilters": "Aucun filtre disponible",

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "このダイアログを閉じる",
 	"components.dropdown.close": "閉じる",
 	"components.filter.loading": "フィルタのロード中",
-	"components.filter.filterCount": "{number, select, max {99 以上} all {すべて} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {フィルタは適用されていません。} one {1 つのフィルタが適用されています。} other {{number} 個のフィルタが適用されています。}}",
 	"components.filter.filters": "フィルタ",
 	"components.filter.noFilters": "使用可能なフィルタはありません",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "이 대화 상자 닫기",
 	"components.dropdown.close": "닫기",
 	"components.filter.loading": "필터 로드 중",
-	"components.filter.filterCount": "{number, select, max {99+} all {전체} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {적용된 필터 없음.} one {1개 필터 적용.} other {{number}개 필터 적용.}}",
 	"components.filter.filters": "개 필터",
 	"components.filter.noFilters": "사용 가능한 필터가 없습니다",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Dit dialoogvenster sluiten",
 	"components.dropdown.close": "Sluiten",
 	"components.filter.loading": "Laden van filters",
-	"components.filter.filterCount": "{number, select, max {99+} all {Alle} other {{number}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {No filters applied.} one {1 filter applied.} other {{number} filters applied.}}",
 	"components.filter.filters": "Filters",
 	"components.filter.noFilters": "Geen beschikbare filters",

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Fechar esta caixa de diálogo",
 	"components.dropdown.close": "Fechar",
 	"components.filter.loading": "Carregar filtros",
-	"components.filter.filterCount": "{number, select, max {99+} all {Todos} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Nenhum filtro aplicado.} one {Um filtro aplicado.} other {{number} filtros aplicados.}}",
 	"components.filter.filters": "Filtros",
 	"components.filter.noFilters": "Não há filtros disponíveis",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Stäng dialogrutan",
 	"components.dropdown.close": "Stäng",
 	"components.filter.loading": "Läser in filter",
-	"components.filter.filterCount": "{number, select, max {99+} all {Alla} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Inga filter tillämpade.} one {1 filter tillämpat.} other {{number} filter tillämpade.}}",
 	"components.filter.filters": "Filter",
 	"components.filter.noFilters": "Inga tillgängliga filter",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "Bu iletişim kutusunu kapat",
 	"components.dropdown.close": "Kapat",
 	"components.filter.loading": "Filtreler yükleniyor",
-	"components.filter.filterCount": "{number, select, max {99+} all {Tümü} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {Filtre uygulanmadı.} one {1 filtre uygulandı.} other {{number} filtre uygulandı.}}",
 	"components.filter.filters": "Filtre",
 	"components.filter.noFilters": "Uygun filtre yok",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "關閉此對話方塊",
 	"components.dropdown.close": "關閉",
 	"components.filter.loading": "正在載入篩選條件",
-	"components.filter.filterCount": "{number, select, max {99+} all {全部} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {未套用篩選條件。} one {已套用 1 項篩選條件。} other {已套用 {number} 項篩選條件。}}",
 	"components.filter.filters": "篩選器",
 	"components.filter.noFilters": "沒有可用的篩選條件",

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -9,7 +9,6 @@ export default {
 	"components.dialog.close": "关闭此对话框",
 	"components.dropdown.close": "关闭",
 	"components.filter.loading": "正在加载筛选器",
-	"components.filter.filterCount": "{number, select, max {99+} all {所有} other {{number}}}",
 	"components.filter.filterCountDescription": "{number, plural, zero {未应用筛选器。} one {已应用 1 个筛选器。} other {已应用 {number} 个筛选器。}}",
 	"components.filter.filters": "个筛选条件",
 	"components.filter.noFilters": "无可用筛选器",


### PR DESCRIPTION
We're no longer going to say "All" when every filter has been selected, since this implies having everything selected is the same as having nothing selected (which might not be true).