### PR TITLE
fix: don't reflect LTR direction attribute for performance

### DIFF
--- a/mixins/rtl-mixin.js
+++ b/mixins/rtl-mixin.js
@@ -11,7 +11,10 @@ export const RtlMixin = dedupeMixin(superclass => class extends superclass {
 	constructor() {
 		super();
 		const dir = document.documentElement.getAttribute('dir');
-		if (dir) this._dir = dir;
+		// avoid reflecting "ltr" for better performance
+		if (dir && dir !== 'ltr') {
+			this._dir = dir;
+		}
 	}
 
 });

--- a/mixins/test/rtl-mixin.test.js
+++ b/mixins/test/rtl-mixin.test.js
@@ -1,0 +1,37 @@
+
+import { defineCE, expect, fixture, html } from '@open-wc/testing';
+import { LitElement } from 'lit-element/lit-element.js';
+import { RtlMixin } from '../rtl-mixin.js';
+
+const rtlMixinTag = defineCE(
+	class extends RtlMixin(LitElement) {
+		render() {
+			return html`<p>hello</p>`;
+		}
+	}
+);
+
+describe('RtlMixin', () => {
+
+	afterEach(() => {
+		document.documentElement.removeAttribute('dir');
+	});
+
+	it('does not get a "dir" attribute if none is set on the document', async() => {
+		const elem = await fixture(`<${rtlMixinTag}></${rtlMixinTag}>`);
+		expect(elem.hasAttribute('dir')).to.be.false;
+	});
+
+	it('does not get a "dir" attribute if document direction is "ltr"', async() => {
+		document.documentElement.setAttribute('dir', 'ltr');
+		const elem = await fixture(`<${rtlMixinTag}></${rtlMixinTag}>`);
+		expect(elem.hasAttribute('dir')).to.be.false;
+	});
+
+	it('does get dir="rtl" attribute if document direction is "rtl"', async() => {
+		document.documentElement.setAttribute('dir', 'rtl');
+		const elem = await fixture(`<${rtlMixinTag}></${rtlMixinTag}>`);
+		expect(elem.getAttribute('dir')).to.equal('rtl');
+	});
+
+});


### PR DESCRIPTION
In doing some performance tracing, you end up seeing a non-zero amount of time spent setting `dir="ltr"` on every element, some of which is causing a style recalculation/repaint.

Since are styles only ever target `dir="rtl"` we can optimize the performance by not reflecting the attribute when the document direction is left-to-right.