### PR TITLE
feat: input-date: add opened property 

### DIFF
--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -49,6 +49,7 @@ size:xlarge
 | `label-hidden` | Boolean | Hides the label visually (moves it to the input's `aria-label` attribute) |
 | `max-value` | String | Maximum valid date that could be selected by a user. |
 | `min-value` | String | Minimum valid date that could be selected by a user. |
+| `opened` | Boolean | Whether or not the calendar dropdown is open |
 | `required` | Boolean | Indicates that a value is required |
 | `value` | String, default `''` | Value of the input. |
 

--- a/components/inputs/test/input-date.test.js
+++ b/components/inputs/test/input-date.test.js
@@ -45,6 +45,78 @@ describe('d2l-input-date', () => {
 
 	});
 
+	describe('open and close behaviour', () => {
+		describe('interacting with opened', () => {
+			let dropdown, dropdownContent, elem;
+
+			beforeEach(async() => {
+				elem = await fixture(basicFixture);
+				elem.opened = true;
+				await elem.updateComplete;
+				dropdown = getChildElem(elem, 'd2l-dropdown');
+				dropdownContent = getChildElem(elem, 'd2l-dropdown-content');
+				await oneEvent(dropdown, 'd2l-dropdown-open');
+			});
+
+			it('should open dropdown when true', async() => {
+				await dropdownContent.updateComplete;
+				expect(dropdownContent.opened).to.be.true;
+			});
+
+			it('should close dropdown when false', async() => {
+				expect(dropdownContent.opened).to.be.true;
+				elem.opened = false;
+				await elem.updateComplete;
+				await oneEvent(dropdown, 'd2l-dropdown-close');
+				expect(dropdownContent.opened).to.be.false;
+			});
+		});
+
+		describe('interacting with dropdown', () => {
+			let dropdown, dropdownOpener, elem, eventObj;
+
+			beforeEach(async() => {
+				elem = await fixture(basicFixture);
+
+				dropdown = getChildElem(elem, 'd2l-dropdown');
+				dropdownOpener = getChildElem(elem, '.d2l-dropdown-opener');
+
+				eventObj = new Event(
+					'mouseup',
+					{ bubbles: true, composed: true }
+				);
+
+				dropdownOpener.dispatchEvent(eventObj);
+				await oneEvent(dropdown, 'd2l-dropdown-open');
+			});
+
+			it('should set opened to true when dropdown open', async() => {
+				expect(elem.opened).to.be.true;
+			});
+
+			it('should set opened to false when dropdown closed', async() => {
+				dropdownOpener.dispatchEvent(eventObj);
+				await oneEvent(dropdown, 'd2l-dropdown-close');
+				expect(elem.opened).to.be.false;
+			});
+		});
+
+		it('should open on enter', async() => {
+			const elem = await fixture(basicFixture);
+
+			const dropdown = getChildElem(elem, 'd2l-dropdown');
+			const dropdownOpener = getChildElem(elem, '.d2l-dropdown-opener');
+
+			const eventObj = document.createEvent('Events');
+			eventObj.initEvent('keydown', true, true);
+			eventObj.keyCode = 13;
+			dropdownOpener.dispatchEvent(eventObj);
+			await oneEvent(dropdown, 'd2l-dropdown-open');
+
+			expect(elem.opened).to.be.true;
+		});
+	});
+
 	describe('utility functions', () => {
 		describe('formatISODateInUserCalDescriptor', () => {
 			it('should return correct date when input is valid', () => {

--- a/components/inputs/test/input-date.visual-diff.html
+++ b/components/inputs/test/input-date.visual-diff.html
@@ -48,6 +48,15 @@
 			<div class="visual-diff">
 				<d2l-input-date id="value" value="2019-12-20"></d2l-input-date>
 			</div>
+			<div class="visual-diff">
+				<d2l-input-date id="opened" value="2019-12-20" opened></d2l-input-date>
+			</div>
+			<div class="visual-diff">
+				<d2l-input-date id="opened-disabled" opened disabled></d2l-input-date>
+			</div>
+			<div class="visual-diff">
+				<d2l-input-date id="opened-skeleton" opened skeleton></d2l-input-date>
+			</div>
 		</div>
 	</body>
 </html>

--- a/components/inputs/test/input-date.visual-diff.js
+++ b/components/inputs/test/input-date.visual-diff.js
@@ -2,7 +2,7 @@ import { getRect, getRectTooltip, open, reset } from './input-helper.js';
 import puppeteer from 'puppeteer';
 import VisualDiff from '@brightspace-ui/visual-diff';
 
-describe.only('d2l-input-date', () => {
+describe('d2l-input-date', () => {
 
 	const visualDiff = new VisualDiff('input-date', __dirname);
 
@@ -10,57 +10,17 @@ describe.only('d2l-input-date', () => {
 
 	before(async() => {
 		browser = await puppeteer.launch();
-		page = await visualDiff.createPage(browser, { viewport: { width: 800, height: 1200 } });
+		page = await visualDiff.createPage(browser, { viewport: { width: 800, height: 1100 } });
 		await page.goto(`${visualDiff.getBaseUrl()}/components/inputs/test/input-date.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
-
-		// #opened being opened causes issues with focus with other date inputs being opened.
-		// Putting this first in case tests are run in isolation.
-		await page.$eval('#opened', (elem) => elem.removeAttribute('opened'));
 	});
 
 	after(async() => await browser.close());
 
-	[
-		'disabled',
-		'empty-text',
-		'label',
-		'label-hidden',
-		'opened-disabled',
-		'opened-skeleton',
-		'placeholder',
-		'required',
-		'value'
-	].forEach((name) => {
-		it(name, async function() {
-			const rect = await visualDiff.getRect(page, `#${name}`);
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
-		});
-	});
-
-	it('value-focus', async function() {
-		await page.$eval('#value', (elem) => {
-			elem.focus();
-			elem._inputTextFocusShowTooltip = true;
-		});
-		const rect = await getRectTooltip(page, '#value');
-		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
-	});
-
-	it('empty-text-focus', async function() {
-		await page.$eval('#empty-text', (elem) => elem.focus());
-		const rect = await visualDiff.getRect(page, '#empty-text');
-		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
-	});
-
 	describe('opened behavior', () => {
-		before(async() => {
-			await page.reload();
-		});
 
 		after(async() => {
-			await page.reload();
-			await page.$eval('#opened', (elem) => elem.removeAttribute('opened'));
+			await page.$eval('#opened-skeleton', (elem) => elem.removeAttribute('opened'));
 		});
 
 		it('intially opened', async function() {
@@ -68,8 +28,18 @@ describe.only('d2l-input-date', () => {
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 
-		it('opened-disabled remove disabled', async function() {
+		it('opened-disabled', async function() {
 			await page.$eval('#opened', (elem) => elem.removeAttribute('opened'));
+			const rect = await visualDiff.getRect(page, '#opened-disabled');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('opened-skeleton', async function() {
+			const rect = await visualDiff.getRect(page, '#opened-skeleton');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('opened-disabled remove disabled', async function() {
 			await page.$eval('#opened-disabled', (elem) => elem.removeAttribute('disabled'));
 			const rect = await getRect(page, '#opened-disabled');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -81,6 +51,40 @@ describe.only('d2l-input-date', () => {
 			const rect = await getRect(page, '#opened-skeleton');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
+	});
+
+	describe('basic', () => {
+
+		[
+			'disabled',
+			'empty-text',
+			'label',
+			'label-hidden',
+			'placeholder',
+			'required',
+			'value'
+		].forEach((name) => {
+			it(name, async function() {
+				const rect = await visualDiff.getRect(page, `#${name}`);
+				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			});
+		});
+
+		it('value-focus', async function() {
+			await page.$eval('#value', (elem) => {
+				elem.focus();
+				elem._inputTextFocusShowTooltip = true;
+			});
+			const rect = await getRectTooltip(page, '#value');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('empty-text-focus', async function() {
+			await page.$eval('#empty-text', (elem) => elem.focus());
+			const rect = await visualDiff.getRect(page, '#empty-text');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
 	});
 
 	describe('localization', () => {
@@ -297,14 +301,14 @@ describe.only('d2l-input-date', () => {
 			});
 
 			it('open with enter', async function() {
-				await page.$eval('#empty-text', (elem) => elem.focus());
+				await page.$eval('#empty-text', (elem) => elem.focus()); // here
 				await openKey(page, '#empty-text');
 				const rect = await getRect(page, '#empty-text');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('open with click', async function() {
-				await page.$eval('#empty-text', (elem) => elem.focus());
+				await page.$eval('#empty-text', (elem) => elem.focus()); // here
 				await openClick(page, '#empty-text');
 				const rect = await getRect(page, '#empty-text');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -322,14 +326,14 @@ describe.only('d2l-input-date', () => {
 			});
 
 			it('open with enter', async function() {
-				await page.$eval('#empty-text', (elem) => elem.focus());
+				await page.$eval('#empty-text', (elem) => elem.focus()); // here
 				await openKey(page, '#placeholder');
 				const rect = await getRect(page, '#placeholder');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('open with click', async function() {
-				await page.$eval('#empty-text', (elem) => elem.focus());
+				await page.$eval('#empty-text', (elem) => elem.focus()); // here
 				await openClick(page, '#placeholder');
 				const rect = await getRect(page, '#placeholder');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });

--- a/components/inputs/test/input-date.visual-diff.js
+++ b/components/inputs/test/input-date.visual-diff.js
@@ -2,7 +2,7 @@ import { getRect, getRectTooltip, open, reset } from './input-helper.js';
 import puppeteer from 'puppeteer';
 import VisualDiff from '@brightspace-ui/visual-diff';
 
-describe('d2l-input-date', () => {
+describe.only('d2l-input-date', () => {
 
 	const visualDiff = new VisualDiff('input-date', __dirname);
 
@@ -10,9 +10,13 @@ describe('d2l-input-date', () => {
 
 	before(async() => {
 		browser = await puppeteer.launch();
-		page = await visualDiff.createPage(browser, { viewport: { width: 800, height: 900 } });
+		page = await visualDiff.createPage(browser, { viewport: { width: 800, height: 1200 } });
 		await page.goto(`${visualDiff.getBaseUrl()}/components/inputs/test/input-date.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
+
+		// #opened being opened causes issues with focus with other date inputs being opened.
+		// Putting this first in case tests are run in isolation.
+		await page.$eval('#opened', (elem) => elem.removeAttribute('opened'));
 	});
 
 	after(async() => await browser.close());
@@ -22,6 +26,8 @@ describe('d2l-input-date', () => {
 		'empty-text',
 		'label',
 		'label-hidden',
+		'opened-disabled',
+		'opened-skeleton',
 		'placeholder',
 		'required',
 		'value'
@@ -45,6 +51,36 @@ describe('d2l-input-date', () => {
 		await page.$eval('#empty-text', (elem) => elem.focus());
 		const rect = await visualDiff.getRect(page, '#empty-text');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+	});
+
+	describe('opened behavior', () => {
+		before(async() => {
+			await page.reload();
+		});
+
+		after(async() => {
+			await page.reload();
+			await page.$eval('#opened', (elem) => elem.removeAttribute('opened'));
+		});
+
+		it('intially opened', async function() {
+			const rect = await getRect(page, '#opened');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('opened-disabled remove disabled', async function() {
+			await page.$eval('#opened', (elem) => elem.removeAttribute('opened'));
+			await page.$eval('#opened-disabled', (elem) => elem.removeAttribute('disabled'));
+			const rect = await getRect(page, '#opened-disabled');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('opened-skeleton remove skeleton', async function() {
+			await page.$eval('#opened-disabled', (elem) => elem.removeAttribute('opened'));
+			await page.$eval('#opened-skeleton', (elem) => elem.removeAttribute('skeleton'));
+			const rect = await getRect(page, '#opened-skeleton');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
 	});
 
 	describe('localization', () => {
@@ -89,12 +125,10 @@ describe('d2l-input-date', () => {
 	});
 
 	describe('calendar dropdown', () => {
-		before(async() => {
-			await page.reload();
-		});
 
-		it('disabled does not open', async function() {
-			await page.$eval('#disabled', (elem) => {
+		async function openClick(page, selector) {
+			return await page.$eval(selector, (elem) => {
+				elem.focus();
 				const input = elem.shadowRoot.querySelector('d2l-input-text');
 				const e = new Event(
 					'mouseup',
@@ -102,14 +136,44 @@ describe('d2l-input-date', () => {
 				);
 				input.dispatchEvent(e);
 			});
-			const rect = await getRect(page, '#disabled');
+		}
+
+		async function openKey(page, selector, keyCode) {
+			keyCode = keyCode || 13;
+			return await page.$eval(selector, (elem, keyCode) => {
+				elem.focus();
+				const input = elem.shadowRoot.querySelector('d2l-input-text');
+				const eventObj = document.createEvent('Events');
+				eventObj.initEvent('keydown', true, true);
+				eventObj.keyCode = keyCode;
+				input.dispatchEvent(eventObj);
+			}, keyCode);
+		}
+
+		async function setValue(page, selector, value) {
+			await page.$eval(selector, async(elem, value) => {
+				elem.focus();
+				const input = elem.shadowRoot.querySelector('d2l-input-text');
+				input.value = value;
+				const e = new Event(
+					'change',
+					{ bubbles: true, composed: false }
+				);
+				input.dispatchEvent(e);
+			}, value);
+			await page.$eval(selector, (elem) => elem.blur());
+		}
+
+		it('disabled does not open', async function() {
+			await openClick(page, '#disabled');
+			const rect = await visualDiff.getRect(page, '#disabled');
+			rect.height += 50; // ensure no dropdown below
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 
 		describe('with min and max', () => {
-			afterEach(async() => {
-				await reset(page, '#min-max');
-			});
+
+			afterEach(async() => await reset(page, '#min-max'));
 
 			it('open', async function() {
 				await open(page, '#min-max');
@@ -118,13 +182,7 @@ describe('d2l-input-date', () => {
 			});
 
 			it('open with enter', async function() {
-				await page.$eval('#min-max', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keydown', true, true);
-					eventObj.keyCode = 13;
-					input.dispatchEvent(eventObj);
-				});
+				await openKey(page, '#min-max');
 
 				const rect = await getRect(page, '#min-max');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -132,102 +190,53 @@ describe('d2l-input-date', () => {
 
 			describe('out of range date typed', () => {
 				// min-value="2018-02-13" max-value="2018-02-27"
-				before(async() => {
-					await page.$eval('#min-max', (elem) => {
-						const input = elem.shadowRoot.querySelector('d2l-input-text');
-						input.value = '10/12/2017';
-						const e = new Event(
-							'change',
-							{ bubbles: true, composed: false }
-						);
-						input.dispatchEvent(e);
-					});
-				});
 
 				describe('behavior', () => {
-					beforeEach(async() => {
-						await page.$eval('#min-max', (elem) => {
-							elem.blur();
-						});
-					});
+					before(async() => await setValue(page, '#min-max', '10/12/2017'));
 
-					afterEach(async() => {
-						await reset(page, '#min-max');
-					});
+					afterEach(async() => await reset(page, '#min-max'));
 
 					it('focus', async function() {
-						await page.$eval('#min-max', (elem) => {
-							const input = elem.shadowRoot.querySelector('d2l-input-text');
-							input.focus();
-						});
+						await page.$eval('#min-max', (elem) => elem.focus());
 						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
 					it('open', async function() {
-						await page.$eval('#min-max', (elem) => {
-							const input = elem.shadowRoot.querySelector('d2l-input-text');
-							const e = new Event(
-								'mouseup',
-								{ bubbles: true, composed: true }
-							);
-							input.dispatchEvent(e);
-						});
-						const rect = await getRect(page, '#min-max');
-						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
-					});
-
-					it('open with enter', async function() {
-						await page.$eval('#min-max', (elem) => {
-							const input = elem.shadowRoot.querySelector('d2l-input-text');
-							const eventObj = document.createEvent('Events');
-							eventObj.initEvent('keydown', true, true);
-							eventObj.keyCode = 13;
-							input.dispatchEvent(eventObj);
-						});
+						await openClick(page, '#min-max');
 						const rect = await getRect(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
 					it('open then tab', async function() {
-						await page.$eval('#min-max', (elem) => {
-							const input = elem.shadowRoot.querySelector('d2l-input-text');
-							const e = new Event(
-								'mouseup',
-								{ bubbles: true, composed: true }
-							);
-							input.dispatchEvent(e);
-						});
+						await openClick(page, '#min-max');
 						await page.waitForTimeout(100);
 						await page.keyboard.press('Tab');
+						const rect = await getRect(page, '#min-max');
+						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+					});
+
+					it('open with enter', async function() {
+						await openKey(page, '#min-max');
 						const rect = await getRect(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});
 
 				describe('behavior on key interaction', () => {
+
 					describe('value before min', () => {
+						before(async() => await setValue(page, '#min-max', '10/12/2017'));
+
 						it('left arrow', async function() {
-							await page.$eval('#min-max', (elem) => {
-								const input = elem.shadowRoot.querySelector('d2l-input-text');
-								const eventObj = document.createEvent('Events');
-								eventObj.initEvent('keydown', true, true);
-								eventObj.keyCode = 13;
-								input.dispatchEvent(eventObj);
-							});
+							await openKey(page, '#min-max');
 							await page.keyboard.press('ArrowLeft');
 							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 						});
 
 						it('right arrow', async function() {
-							await page.$eval('#min-max', (elem) => {
-								const input = elem.shadowRoot.querySelector('d2l-input-text');
-								const eventObj = document.createEvent('Events');
-								eventObj.initEvent('keydown', true, true);
-								eventObj.keyCode = 13;
-								input.dispatchEvent(eventObj);
-							});
+							await openKey(page, '#min-max');
 							await page.keyboard.press('ArrowRight');
 							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -235,34 +244,17 @@ describe('d2l-input-date', () => {
 					});
 
 					describe('value before min same year', () => {
-						before(async() => {
-							await page.$eval('#min-max', (elem) => {
-								const input = elem.shadowRoot.querySelector('d2l-input-text');
-								input.value = '01/02/2018';
-							});
-						});
+						before(async() => await setValue(page, '#min-max', '01/02/2018'));
 
 						it('left arrow', async function() {
-							await page.$eval('#min-max', (elem) => {
-								const input = elem.shadowRoot.querySelector('d2l-input-text');
-								const eventObj = document.createEvent('Events');
-								eventObj.initEvent('keydown', true, true);
-								eventObj.keyCode = 13;
-								input.dispatchEvent(eventObj);
-							});
+							await openKey(page, '#min-max');
 							await page.keyboard.press('ArrowLeft');
 							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 						});
 
 						it('right arrow', async function() {
-							await page.$eval('#min-max', (elem) => {
-								const input = elem.shadowRoot.querySelector('d2l-input-text');
-								const eventObj = document.createEvent('Events');
-								eventObj.initEvent('keydown', true, true);
-								eventObj.keyCode = 13;
-								input.dispatchEvent(eventObj);
-							});
+							await openKey(page, '#min-max');
 							await page.keyboard.press('ArrowRight');
 							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -270,27 +262,12 @@ describe('d2l-input-date', () => {
 					});
 
 					describe('value after max', () => {
-						before(async() => {
-							await page.$eval('#min-max', (elem) => {
-								const input = elem.shadowRoot.querySelector('d2l-input-text');
-								input.value = '01/12/2019';
-							});
-						});
+						before(async() => await setValue(page, '#min-max', '01/12/2019'));
 
-						after(async() => {
-							await page.$eval('#min-max', (elem) => {
-								elem.blur();
-							});
-						});
+						after(async() => await page.$eval('#min-max', (elem) => elem.blur()));
 
 						it('left arrow', async function() {
-							await page.$eval('#min-max', (elem) => {
-								const input = elem.shadowRoot.querySelector('d2l-input-text');
-								const eventObj = document.createEvent('Events');
-								eventObj.initEvent('keydown', true, true);
-								eventObj.keyCode = 13;
-								input.dispatchEvent(eventObj);
-							});
+							await openKey(page, '#min-max');
 							await page.keyboard.press('ArrowLeft');
 							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -298,13 +275,7 @@ describe('d2l-input-date', () => {
 						});
 
 						it('right arrow', async function() {
-							await page.$eval('#min-max', (elem) => {
-								const input = elem.shadowRoot.querySelector('d2l-input-text');
-								const eventObj = document.createEvent('Events');
-								eventObj.initEvent('keydown', true, true);
-								eventObj.keyCode = 13;
-								input.dispatchEvent(eventObj);
-							});
+							await openKey(page, '#min-max');
 							await page.keyboard.press('ArrowRight');
 							const rect = await getRect(page, '#min-max');
 							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -315,10 +286,34 @@ describe('d2l-input-date', () => {
 			});
 		});
 
-		describe('with placeholder', () => {
-			afterEach(async() => {
-				await reset(page, '#placeholder');
+		describe('with empty-text', () => {
+
+			afterEach(async() => await reset(page, '#empty-text'));
+
+			it('open', async function() {
+				await open(page, '#empty-text');
+				const rect = await getRect(page, '#empty-text');
+				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
+
+			it('open with enter', async function() {
+				await page.$eval('#empty-text', (elem) => elem.focus());
+				await openKey(page, '#empty-text');
+				const rect = await getRect(page, '#empty-text');
+				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			});
+
+			it('open with click', async function() {
+				await page.$eval('#empty-text', (elem) => elem.focus());
+				await openClick(page, '#empty-text');
+				const rect = await getRect(page, '#empty-text');
+				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			});
+		});
+
+		describe('with placeholder', () => {
+
+			afterEach(async() => await reset(page, '#placeholder'));
 
 			it('open', async function() {
 				await open(page, '#placeholder');
@@ -327,36 +322,32 @@ describe('d2l-input-date', () => {
 			});
 
 			it('open with enter', async function() {
-				await page.$eval('#placeholder', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keydown', true, true);
-					eventObj.keyCode = 13;
-					input.dispatchEvent(eventObj);
-				});
+				await page.$eval('#empty-text', (elem) => elem.focus());
+				await openKey(page, '#placeholder');
+				const rect = await getRect(page, '#placeholder');
+				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			});
 
+			it('open with click', async function() {
+				await page.$eval('#empty-text', (elem) => elem.focus());
+				await openClick(page, '#placeholder');
 				const rect = await getRect(page, '#placeholder');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 		});
 
 		describe('with value', () => {
-			before(async() => {
-				await page.reload();
-			});
 
-			afterEach(async() => {
-				await reset(page, '#value');
-			});
+			afterEach(async() => await reset(page, '#value'));
 
 			it('open', async function() {
-				await open(page, '#value');
+				await openClick(page, '#value');
 				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('tab on open', async function() {
-				await open(page, '#value');
+				await openClick(page, '#value');
 				await page.keyboard.press('Tab');
 				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
@@ -374,6 +365,7 @@ describe('d2l-input-date', () => {
 			});
 
 			it('set to today', async function() {
+				await open(page, '#value');
 				await page.$eval('#value', (elem) => {
 					const button = elem.shadowRoot.querySelector('d2l-button-subtle[text="Set to Today"]');
 					button.click();
@@ -383,6 +375,7 @@ describe('d2l-input-date', () => {
 			});
 
 			it('clear', async function() {
+				await open(page, '#value');
 				await page.$eval('#value', (elem) => {
 					const button = elem.shadowRoot.querySelector('d2l-button-subtle[text="Clear"]');
 					button.click();
@@ -413,94 +406,52 @@ describe('d2l-input-date', () => {
 			});
 
 			it('open with click after text input', async function() {
-				await page.$eval('#value', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					input.value = '01/10/2030';
-					const e = new Event(
-						'mouseup',
-						{ bubbles: true, composed: true }
-					);
-					input.dispatchEvent(e);
-				});
+				await setValue(page, '#value', '01/10/2030');
+				await openClick(page, '#value');
 				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('open with click after empty text input', async function() {
-				await page.$eval('#value', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					input.value = '';
-					const e = new Event(
-						'mouseup',
-						{ bubbles: true, composed: true }
-					);
-					input.dispatchEvent(e);
-				});
+				await setValue(page, '#value', '');
+				await openClick(page, '#value');
 				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('open with enter after text input', async function() {
-				await page.$eval('#value', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					input.value = '11/21/2031';
-					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keydown', true, true);
-					eventObj.keyCode = 13;
-					input.dispatchEvent(eventObj);
-				});
+				await setValue(page, '#value', '11/21/2031');
+				await openKey(page, '#value');
+
+				await page.waitForTimeout(100);
 				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('open with enter after empty text input', async function() {
-				await page.$eval('#value', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					input.value = '';
-					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keydown', true, true);
-					eventObj.keyCode = 13;
-					input.dispatchEvent(eventObj);
-				});
+				await setValue(page, '#value', '');
+				await openKey(page, '#value');
 				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('open with down arrow after text input', async function() {
-				await page.$eval('#value', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					input.value = '08/30/2032';
-					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keydown', true, true);
-					eventObj.keyCode = 40;
-					input.dispatchEvent(eventObj);
-				});
+				await setValue(page, '#value', '08/30/2032');
+				await openKey(page, '#value', 40);
 				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('open with down arrow after empty text input', async function() {
-				await page.$eval('#value', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					input.value = '';
-					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keydown', true, true);
-					eventObj.keyCode = 40;
-					input.dispatchEvent(eventObj);
-				});
+				await setValue(page, '#value', '');
+				await openKey(page, '#value', 40);
 				const rect = await getRect(page, '#value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 			});
 
 			it('open then close', async function() {
 				// test to confirm that when focus returns to the input on close the tooltip does not appear
-				await page.$eval('#value', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keydown', true, true);
-					eventObj.keyCode = 13;
-					input.dispatchEvent(eventObj);
-				});
+				await openKey(page, '#value');
 				await page.$eval('#value', (elem) => {
 					const eventObj = document.createEvent('Events');
 					eventObj.initEvent('keyup', true, true);
@@ -513,13 +464,8 @@ describe('d2l-input-date', () => {
 		});
 
 		describe('required', () => {
-			before(async() => {
-				await page.reload();
-			});
 
-			afterEach(async() => {
-				await reset(page, '#required');
-			});
+			afterEach(async() => await reset(page, '#required'));
 
 			it('required focus then blur', async function() {
 				await page.$eval('#required', (elem) => elem.focus());
@@ -544,14 +490,8 @@ describe('d2l-input-date', () => {
 			});
 
 			it('open required with enter after empty text input', async function() {
-				await page.$eval('#required-value', (elem) => {
-					const input = elem.shadowRoot.querySelector('d2l-input-text');
-					input.value = '';
-					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keydown', true, true);
-					eventObj.keyCode = 13;
-					input.dispatchEvent(eventObj);
-				});
+				await setValue(page, '#required-value', '');
+				await openKey(page, '#required-value');
 				const rect = await getRect(page, '#required-value');
 				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 				await reset(page, '#required-value');
@@ -566,6 +506,11 @@ describe('d2l-input-date', () => {
 		].forEach((name) => {
 			before(async() => {
 				await page.reload();
+				await page.$eval('#opened', (elem) => elem.removeAttribute('opened'));
+			});
+
+			after(async() => {
+				await page.$eval(`#${name}`, (elem) => elem.skeleton = false);
 			});
 
 			it(name, async function() {


### PR DESCRIPTION
Adding `opened` in order to more easily be able to change the opened state of the dropdown

This would technically be slightly breaking if anyone was relying on `_dropdownOpened` but that does not seem to be the case.

Previous PR https://github.com/BrightspaceUI/core/pull/1618