### PR TITLE
fix: avoid and defer measuring slot sizes to improve performance

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -590,9 +590,11 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		if (!this._isIntersecting) return;
 
 		const firstContainer = this.shadowRoot.querySelector('.d2l-input-inside-before');
-		const firstSlotHasNodes = firstContainer.firstElementChild.assignedNodes({ flatten: true }).length > 0;
+		const firstSlotHasNodes = firstContainer.querySelector('slot').assignedNodes({ flatten: true }).length > 0
+			|| (this.unit && this.dir === 'rtl');
 		const lastContainer = this.shadowRoot.querySelector('.d2l-input-inside-after');
-		const lastSlotHasNodes = lastContainer.firstElementChild.assignedNodes({ flatten: true }).length > 0;
+		const lastSlotHasNodes = lastContainer.querySelector('slot').assignedNodes({ flatten: true }).length > 0
+			|| (this.unit && this.dir !== 'rtl');
 
 		if (firstSlotHasNodes) {
 			requestAnimationFrame(() => this._firstSlotWidth = firstContainer.getBoundingClientRect().width);


### PR DESCRIPTION
Our text inputs have some code that measures the widths of its slots in order to apply that same amount of padding, essentially reserving room for the absolutely positioned slots.

This measuring via `getBoundingClientRect()` forces the browser to paint the screen -- possibly before it's ready to do so. In performance speak, this is called a [forced synchronous layout](https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing#avoid_forced_synchronous_layouts).

When the page just has one or two of these components on a page, it's not super noticeable... but the grades "spreadsheet view" could potentially have _thousands_ of them, and the more elements on the screen the longer it takes to paint, which creates an exponentially slower page.

The solution is multi-pronged:

**Avoid measuring completely if we can**

We can actually look inside the slots and if they have no nodes inside them, we can safely assume that their width is zero and then do absolutely no work. This is best-case scenario and actually applies to the grades page which isn't using slots. Win!

**If the slots are in use, move the measuring inside a `requestAnimationFrame`**

This will defer the callback until the next time things have painted, so chances are the measure operation will be free. A bunch of sequential measures can also be batched this way. This solution isn't perfect, as rAF tries to run 60 times per second so with thousands of inputs on a page they're not all going to render quick enough to batch these calls.

**Wait until it's visible on the screen to measure**

The code was already using a `MutationObserver` to re-run the calculation for the case where the input was hidden initially and then shown later. We can turn that into an `IntersectionObserver` instead which will accomplish the same thing but also won't run for visible inputs until they appear in the viewport.