### PR TITLE
testing performance of text input

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,19 @@
+name: Performance
+on: pull_request
+jobs:
+  build:
+    name: Performance
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Brightspace/third-party-actions@actions/checkout
+      - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm run test:perf

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -8,6 +8,7 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
 import { inputStyles } from './input-styles.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
+import { PerfMonitor } from '../../helpers/perfMonitor.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
@@ -264,6 +265,7 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		this._handleFocus = this._handleFocus.bind(this);
 		this._handleMouseEnter = this._handleMouseEnter.bind(this);
 		this._handleMouseLeave = this._handleMouseLeave.bind(this);
+		this._perfMonitor = new PerfMonitor(this);
 	}
 
 	get value() { return this._value; }
@@ -310,6 +312,11 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		return super.validity;
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		this._perfMonitor.hostConnected();
+	}
+
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		if (this._intersectionObserver) this._intersectionObserver.disconnect();
@@ -351,6 +358,9 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 	}
 
 	render() {
+
+		this._perfMonitor.hostUpdated();
+
 		const isFocusedOrHovered = !this.disabled && (this._focused || this._hovered);
 		const inputClasses = {
 			'd2l-input': true,

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -312,11 +312,6 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		return super.validity;
 	}
 
-	connectedCallback() {
-		super.connectedCallback();
-		this._perfMonitor.hostConnected();
-	}
-
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		if (this._intersectionObserver) this._intersectionObserver.disconnect();

--- a/components/inputs/test/input-text.perf.js
+++ b/components/inputs/test/input-text.perf.js
@@ -1,0 +1,24 @@
+import '../input-text.js';
+import { expect, html } from '@open-wc/testing';
+
+describe('d2l-input-text', () => {
+
+	it('normal', async() => {
+		await expect(html`<d2l-input-text label="label"></d2l-input-text>`)
+			.to.be.performant(1500);
+	});
+
+	it('slots', async() => {
+		await expect(html`<d2l-input-text label="label">
+			<span slot="left">left</span>
+			<span slot="right">right</span>
+			<span slot="after">after</span>
+		</d2l-input-text>`).to.be.performant(1500);
+	});
+
+	it('unit', async() => {
+		await expect(html`<d2l-input-text label="label" unit="%"></d2l-input-text>`)
+			.to.be.performant(1500);
+	});
+
+});

--- a/helpers/perfMonitor.js
+++ b/helpers/perfMonitor.js
@@ -5,10 +5,6 @@ export class PerfMonitor {
 		this.host = host;
 	}
 
-	hostConnected() {
-		this.connectedTime = window.performance.now();
-	}
-
 	hostUpdated() {
 		if (!window.d2lPerfTestInProgress || this.renderedTime !== undefined) return;
 		setTimeout(async() => {

--- a/helpers/perfMonitor.js
+++ b/helpers/perfMonitor.js
@@ -1,0 +1,25 @@
+export class PerfMonitor {
+
+	constructor(host) {
+		this.constructedTime = window.performance.now();
+		this.host = host;
+	}
+
+	hostConnected() {
+		this.connectedTime = window.performance.now();
+	}
+
+	hostUpdated() {
+		if (!window.d2lPerfTestInProgress || this.renderedTime !== undefined) return;
+		setTimeout(async() => {
+			await this.host.updateComplete;
+			this.renderedTime = window.performance.now();
+			this.host.dispatchEvent(
+				new CustomEvent(
+					'd2l-component-perf',
+					{ bubbles: true, composed: true, detail: { value: Math.round(this.renderedTime - this.constructedTime) } })
+			);
+		});
+	}
+
+}

--- a/karma.perf.conf.js
+++ b/karma.perf.conf.js
@@ -1,0 +1,33 @@
+/* eslint-env node */
+const { createDefaultConfig } = require('@open-wc/testing-karma');
+const merge = require('deepmerge');
+
+const defaultPattern = '+(components|directives|helpers|mixins|templates)/**/*.perf.js';
+
+module.exports = config => {
+	config.set(
+		merge(createDefaultConfig(config), {
+			files: [
+				// runs all files ending with .test in the test folder,
+				// can be overwritten by passing a --grep flag. examples:
+				//
+				// npm run test -- --grep test/foo/bar.test.js
+				// npm run test -- --grep test/bar/*
+				'tools/resize-observer-test-error-handler.js',
+				{ pattern: 'tools/perf-test-helper.js', type: 'module' },
+				{ pattern: config.grep ? config.grep : defaultPattern, type: 'module' },
+			],
+			// see the karma-esm docs for all options
+			esm: {
+				// if you are using 'bare module imports' you will need this option
+				nodeResolve: true,
+			},
+			client: {
+				mocha: {
+					timeout: 10000
+				}
+			}
+		}),
+	);
+	return config;
+};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test": "npm run lint && npm run test:headless && npm run test:axe",
     "test:axe": "karma start karma.axe.conf.js",
     "test:headless": "karma start",
-    "test:headless:watch": "karma start --auto-watch=true --single-run=false"
+    "test:headless:watch": "karma start --auto-watch=true --single-run=false",
+    "test:perf": "karma start karma.perf.conf.js"
   },
   "files": [
     "custom-elements.json",

--- a/tools/perf-test-helper.js
+++ b/tools/perf-test-helper.js
@@ -1,0 +1,45 @@
+import chai from '@open-wc/testing/import-wrappers/chai.js';
+import { fixture } from '@open-wc/testing';
+
+const numComponents = 1000;
+
+export async function runTest(element) {
+	return new Promise((resolve) => {
+
+		let total = 0;
+		let count = 0;
+		window.d2lPerfTestInProgress = true;
+		document.body.addEventListener('d2l-component-perf', (e) => {
+			count++;
+			total += e.detail.value;
+			if (count === numComponents) {
+				const avg = Math.round(total / count);
+				delete window.d2lPerfTestInProgress;
+				resolve(avg);
+			}
+		});
+
+		for (let i = 0; i < numComponents; i++) {
+			fixture(element);
+		}
+
+	});
+}
+
+export const chaiPerf = (_chai, utils) => {
+
+	utils.addMethod(_chai.Assertion.prototype, 'performant', function perfTest(baseline) {
+		// eslint-disable-next-line no-invalid-this
+		const fixture = this._obj;
+		const result = runTest(fixture).then(results => {
+			new _chai.Assertion(results).to.be.below(baseline);
+		});
+		// eslint-disable-next-line no-invalid-this
+		this.then = result.then.bind(result);
+		// eslint-disable-next-line no-invalid-this
+		return this;
+	});
+
+};
+
+chai.use(chaiPerf);


### PR DESCRIPTION
This adds some experimental performance testing of our components to core, starting with `<d2l-input-text>`.

How this works:

- Components add a "performance monitor" controller. Once we go to Lit 2, this can be a proper Reactive Controller and all the hooks will work automatically.
- The performance monitor calculates the amount of time that passes between when the component is connected and when it renders. It then fires an event that we can listen for elsewhere.
- I've created a special Chai plugin so you can create a fixture and then assert that `.it.is.performant(val)`. The value you pass in there is the expected average render time of the component. Coming up with this value is going to take a bit of trial & error. I'm hoping the variance in CI isn't too high.

For now I'll make this GitHub Action not be merge-blocking, since I'm worried there will be variance and reliability issues.