### PR TITLE
fix: US130195 - Lower z-index for primary-secondary footer

### DIFF
--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -677,9 +677,6 @@ class TemplatePrimarySecondary extends FocusVisiblePolyfillMixin(RtlMixin(Locali
 				box-shadow: 0 -2px 4px rgba(73, 76, 78, 0.2); /* ferrite */
 				padding: 0.75rem 1rem;
 			}
-			header, footer {
-				z-index: 2; /* ensures the footer box-shadow is over main areas with background colours set */
-			}
 
 			:host([resizable]) .d2l-template-primary-secondary-divider:focus,
 			:host([resizable]) .d2l-template-primary-secondary-divider:hover,

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -676,6 +676,10 @@ class TemplatePrimarySecondary extends FocusVisiblePolyfillMixin(RtlMixin(Locali
 				background-color: white;
 				box-shadow: 0 -2px 4px rgba(73, 76, 78, 0.2); /* ferrite */
 				padding: 0.75rem 1rem;
+				z-index: 1; /* ensures the footer box-shadow is over main areas with background colours set */
+			}
+			header {
+				z-index: 2; /* ensures the header box-shadow is over main areas with background colours set */
 			}
 
 			:host([resizable]) .d2l-template-primary-secondary-divider:focus,


### PR DESCRIPTION
This is required to get the dropdown trays (specifically user-profile-card" to render correctly on top of the primary-secondary footer. Without this, the footer goes overtop of the close button of the tray making it not clickable. With this change, the page functions normally, and the dropdown can go on top of the footer when it opens.  The z-index was added here for a previous bug (https://github.com/BrightspaceUI/core/pull/770), which looks like it it is still fixed when the footer has a z-index of 1. I took a look at the LMS and the primary-secondary pages appear to look the same.

Here's a before and after:
![profile-z-index](https://user-images.githubusercontent.com/83968927/132711388-d416ef6a-fef6-4f56-aa0a-3c1c61c65247.PNG)
![user-profile-after](https://user-images.githubusercontent.com/83968927/132711391-3d27311e-73e0-4ede-9cfd-d1950c707621.PNG)

I was wondering why this issue didn't appear with the date-picker, and it seems to do with the HTML order that determines the stacking context on each page.