### PR TITLE
HierarchicalView performance fix

### DIFF
--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -113,7 +113,21 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 		this.__isChildView();
 
+		if (typeof(IntersectionObserver) === 'function') {
+			this.__intersectionObserver = new IntersectionObserver((entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						this.__autoSize(this);
+					}
+				});
+			});
+			this.__intersectionObserver.observe(this);
+		}
+
 		requestAnimationFrame(() => {
+			if (typeof(IntersectionObserver) !== 'function') {
+				this.__autoSize(this);
+			}
 			this.__startResizeObserver();
 
 			if (!this.childView) {
@@ -131,7 +145,10 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.removeEventListener('focus', this.__focusCapture);
 		this.removeEventListener('focusout', this.__focusOutCapture);
 		window.removeEventListener('resize', this.__onWindowResize);
-		if (this.__intersectionObserver) this.__intersectionObserver.disconnect();
+		if (this.__intersectionObserver) {
+			this.__intersectionObserver.disconnect();
+			this.__isAutoSized = false;
+		}
 	}
 
 	firstUpdated(changedProperties) {
@@ -156,19 +173,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.addEventListener('keypress', stopPropagation);
 
 		this.__isChildView();
-
-		if (typeof(IntersectionObserver) === 'function') {
-			this.__intersectionObserver = new IntersectionObserver((entries) => {
-				entries.forEach((entry) => {
-					if (entry.isIntersecting) {
-						this.__autoSize(this);
-					}
-				});
-			});
-			this.__intersectionObserver.observe(this);
-		} else {
-			this.__autoSize(this);
-		}
 
 	}
 

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -98,8 +98,12 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		super();
 
 		/** @ignore */
+		this.childView = false;
+		/** @ignore */
 		this.hierarchicalView = true;
 		this.__focusPrevious = false;
+		this.__intersectionObserver = null;
+		this.__isAutoSized = false;
 		this.__resizeObserver = null;
 		this.__hideAnimations = [];
 	}
@@ -110,7 +114,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.__isChildView();
 
 		requestAnimationFrame(() => {
-			this.__autoSize(this);
 			this.__startResizeObserver();
 
 			if (!this.childView) {
@@ -128,6 +131,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.removeEventListener('focus', this.__focusCapture);
 		this.removeEventListener('focusout', this.__focusOutCapture);
 		window.removeEventListener('resize', this.__onWindowResize);
+		if (this.__intersectionObserver) this.__intersectionObserver.disconnect();
 	}
 
 	firstUpdated(changedProperties) {
@@ -152,6 +156,20 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.addEventListener('keypress', stopPropagation);
 
 		this.__isChildView();
+
+		if (typeof(IntersectionObserver) === 'function') {
+			this.__intersectionObserver = new IntersectionObserver((entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						this.__autoSize(this);
+					}
+				});
+			});
+			this.__intersectionObserver.observe(this);
+		} else {
+			this.__autoSize(this);
+		}
+
 	}
 
 	getActiveView() {
@@ -261,16 +279,20 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__autoSize(view) {
-		if (this.childView || view.offsetParent === null) return;
+		if (this.__isAutoSized || this.childView) return;
+		requestAnimationFrame(() => {
 
-		let rect;
-		if (view === this) {
-			rect = this.shadowRoot.querySelector('.d2l-hierarchical-view-content').getBoundingClientRect();
-		} else {
-			rect = view.getBoundingClientRect();
-		}
-		this.style.height = `${rect.height}px`;
+			if (view.offsetParent === null) return;
 
+			this.__isAutoSized = true;
+			let rect;
+			if (view === this) {
+				rect = this.shadowRoot.querySelector('.d2l-hierarchical-view-content').getBoundingClientRect();
+			} else {
+				rect = view.getBoundingClientRect();
+			}
+			this.style.height = `${rect.height}px`;
+		});
 	}
 
 	__dispatchHideComplete(data) {


### PR DESCRIPTION
In hierarchical view's `connectedCallback`, it's making a call to `this.__autoSize()` (inside an rAF). That method checks `offsetParent` and gets a bounding rectangle -- both of which force layout. But hierarchical view is almost always inside a menu, which is almost always hidden inside a dropdown -- so there's nothing to calculate (yet).

This change adds an intersection observer (my new favourite toy) to determine when the hierarchical view first becomes visible. At that point it can automatically size itself.