### PR TITLE
Removing duplicate js import

### DIFF
--- a/components/status-indicator/README.md
+++ b/components/status-indicator/README.md
@@ -106,7 +106,6 @@ The state is used to apply a meaningful colour to the status indicator to assist
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
-  import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
 </script>
 <style>
   .status-format {


### PR DESCRIPTION
@GeorgePlukov, I also noticed the bullet points (Best Practices) somehow get periods added at render time. Any idea how to stop that? Couldn't find anything about it on the web.