### PR TITLE
fix: switching Arabic font on Windows to "Segoe UI"

### DIFF
--- a/components/typography/typography.js
+++ b/components/typography/typography.js
@@ -67,7 +67,7 @@ if (!document.head.querySelector('#d2l-typography-font-face')) {
 
 		.d2l-typography:lang(ar),
 		.d2l-typography :lang(ar) {
-			font-family: 'Arabic Transparent', 'Arabic Typesetting', 'Geeza Pro', sans-serif;
+			font-family: 'Segoe UI', 'Geeza Pro', sans-serif;
 		}
 
 		.d2l-typography:lang(zh),

--- a/components/typography/typography.scss
+++ b/components/typography/typography.scss
@@ -16,7 +16,7 @@
 
 	&:lang(ar),
 	& :lang(ar) {
-		font-family: 'Arabic Transparent', 'Arabic Typesetting', 'Geeza Pro', sans-serif;
+		font-family: 'Segoe UI', 'Geeza Pro', sans-serif;
 	}
 
 	&:lang(zh),


### PR DESCRIPTION
The existing fonts we were using -- specifically "Arabic Typesetting" -- resulted in really small, really serif-y and were hard to read both in Arabic and with Latin characters:

<img width="280" alt="Screen Shot 2021-09-16 at 11 23 33 AM" src="https://user-images.githubusercontent.com/5491151/133640121-392675d8-23d3-4632-a576-4062d89f508c.png">

Mostly we never noticed this because most machines don't actually have "Arabic Transparent" or "Arabic Typesetting" installed, and when that's the case it falls back to Windows' default "sans-serif" font of "Segoe UI". So this change just uses "Segoe UI" on Windows (and keeps Geeza Pro on macOS). Segoe UI should be on all Windows machines dating back to at least Vista, but even if it's not available this change means it'll use the system's default sans-serif font which should still be fine.

With the change:
<img width="309" alt="Screen Shot 2021-09-16 at 11 22 11 AM" src="https://user-images.githubusercontent.com/5491151/133640728-9fb0fed0-59a8-46c0-8559-4bb1f367cc80.png">
