### PR TITLE
Update d2l-selection-input to not delay dispatching d2l-selection-change.

### DIFF
--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -56,6 +56,19 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(L
 		this._checkboxId = getUniqueId();
 	}
 
+	get selectionInfo() {
+		return this._selectionInfo;
+	}
+
+	set selectionInfo(val) {
+		const oldVal = this._selectionInfo;
+		if (oldVal !== val) {
+			this._selectionInfo = val;
+			this.selected = (this._selectionInfo.state === SelectionInfo.states.all);
+			this.requestUpdate('selectionInfo', oldVal);
+		}
+	}
+
 	connectedCallback() {
 		super.connectedCallback();
 		if (this.selectable) {

--- a/components/list/test/list-item-checkbox-mixin.test.js
+++ b/components/list/test/list-item-checkbox-mixin.test.js
@@ -32,10 +32,10 @@ describe('ListItemCheckboxMixin', () => {
 	describe('Does not render checkbox or action area when not selectable', () => {
 		const cases = [{
 			input: '',
-			expected: { selectable: undefined, disabled: undefined, selected: undefined }
+			expected: { selectable: undefined, disabled: undefined, selected: false }
 		}, {
 			input: 'disabled',
-			expected: { selectable: undefined, disabled: true, selected: undefined }
+			expected: { selectable: undefined, disabled: true, selected: false }
 		}, {
 			input: 'disabled selected',
 			expected: { selectable: undefined, disabled: true, selected: true }
@@ -60,7 +60,7 @@ describe('ListItemCheckboxMixin', () => {
 	describe('Dispatches custom event when checkbox is checked', () => {
 		const cases = [{
 			input: 'selectable',
-			initial: { selectable: true, disabled: undefined, selected: undefined },
+			initial: { selectable: true, disabled: undefined, selected: false },
 			expected: { selectable: true, disabled: undefined, selected: true }
 		}, {
 			input: 'selectable selected',
@@ -89,7 +89,7 @@ describe('ListItemCheckboxMixin', () => {
 	describe('Dispatches custom event when action area is clicked', () => {
 		const cases = [{
 			input: 'selectable',
-			initial: { selectable: true, disabled: undefined, selected: undefined },
+			initial: { selectable: true, disabled: undefined, selected: false },
 			expected: { selectable: true, disabled: undefined, selected: true }
 		}, {
 			input: 'selectable selected',
@@ -123,8 +123,8 @@ describe('ListItemCheckboxMixin', () => {
 			expected: { selectable: true, disabled: true, selected: true }
 		}, {
 			input: 'disabled selectable',
-			initial: { selectable: true, disabled: true, selected: undefined },
-			expected: { selectable: true, disabled: true, selected: undefined }
+			initial: { selectable: true, disabled: true, selected: false },
+			expected: { selectable: true, disabled: true, selected: false }
 		}];
 		for (const test of cases) {
 			it(test.input, async() => {

--- a/components/selection/selection-input.js
+++ b/components/selection/selection-input.js
@@ -125,13 +125,11 @@ class Input extends SkeletonMixin(LabelledMixin(LitElement)) {
 			|| (changedProperties.has('_indeterminate') && !(changedProperties.get('_indeterminate') === undefined && this._indeterminate === false))) {
 
 			// dispatch the event for all selected changes (not just when the user interacts directly with the input)
-			requestAnimationFrame(() => {
-				this.dispatchEvent(new CustomEvent('d2l-selection-change', {
-					bubbles: true,
-					composed: true,
-					detail: { key: this.key, indeterminate: this._indeterminate, selected: this.selected }
-				}));
-			});
+			this.dispatchEvent(new CustomEvent('d2l-selection-change', {
+				bubbles: true,
+				composed: true,
+				detail: { key: this.key, indeterminate: this._indeterminate, selected: this.selected }
+			}));
 
 		}
 	}

--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -164,6 +164,13 @@ export const SelectionMixin = superclass => class extends RtlMixin(superclass) {
 		const target = e.composedPath()[0];
 		if (this._selectionSelectables.has(target)) return;
 		this._selectionSelectables.set(target, target);
+
+		if (this.selectionSingle && target.selected) {
+			// check invalid usage/state - make sure no others are selected
+			this._selectionSelectables.forEach(selectable => {
+				if (selectable.selected && selectable !== target) selectable.selected = false;
+			});
+		}
 	}
 
 	_handleSelectionObserverSubscribe(e) {


### PR DESCRIPTION
This PR updates `d2l-selection-input` to not delay dispatching `d2l-selection-change` event with rAF.  In the single selection scenario, two events are dispatched if a previously selected item becomes unselected as a result of a newly selected item.  By not delaying the dispatch statement, the two events should be dispatched in the same frame, making consumer code less fragile.  Also, I think this also improves some jankiness observed when toggling the selected state.