### PR TITLE
Update the SelectionMixin to update observers when new inputs are subscribed.

### DIFF
--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -171,6 +171,8 @@ export const SelectionMixin = superclass => class extends RtlMixin(superclass) {
 				if (selectable.selected && selectable !== target) selectable.selected = false;
 			});
 		}
+
+		this._updateSelectionObservers();
 	}
 
 	_handleSelectionObserverSubscribe(e) {

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -193,9 +193,9 @@ describe('SelectionObserverMixin', () => {
 	beforeEach(async() => {
 		el = await fixture(`
 			<div>
-				<d2l-selection-action selection-for="d2l-test-selection"></d2l-selection-action>
-				<d2l-selection-select-all selection-for="d2l-test-selection"></d2l-selection-select-all>
-				<d2l-selection-summary selection-for="some-other-selection"></d2l-selection-summary>
+				<d2l-selection-action id="obs1" selection-for="d2l-test-selection"></d2l-selection-action>
+				<d2l-selection-select-all id="obs2" selection-for="d2l-test-selection"></d2l-selection-select-all>
+				<d2l-selection-summary id="obs3" selection-for="some-other-selection"></d2l-selection-summary>
 				<d2l-test-selection id="d2l-test-selection">
 					<d2l-selection-input key="key1" label="label1"></d2l-selection-input>
 					<d2l-selection-input key="key2" label="label2" selected></d2l-selection-input>
@@ -203,8 +203,15 @@ describe('SelectionObserverMixin', () => {
 				</d2l-test-selection>
 			</div>
 		`);
+		await el.querySelector('#obs1').updateComplete;
+		await el.querySelector('#obs2').updateComplete;
+		await el.querySelector('#obs3').updateComplete;
+		await el.querySelector('[key="key1"]').updateComplete;
+		await el.querySelector('[key="key2"]').updateComplete;
+		await el.querySelector('[key="key3"]').updateComplete;
 		collection = el.querySelector('#d2l-test-selection');
 		await collection.updateComplete;
+
 		await nextFrame();
 		await nextFrame(); // Limit test flake
 	});
@@ -237,6 +244,7 @@ describe('SelectionObserverMixin', () => {
 	it('unregisters and registers the SelectionMixin component', async() => {
 		const observer = el.querySelector('d2l-selection-action');
 		const provider = el.querySelector('#d2l-test-selection');
+
 		expect(observer._provider).to.equal(provider);
 		expect(observer.selectionInfo.state).to.equal(SelectionInfo.states.some);
 
@@ -251,6 +259,7 @@ describe('SelectionObserverMixin', () => {
 		await observer.updateComplete;
 		expect(observer._provider).to.equal(newProvider);
 		expect(observer.selectionInfo.state).to.equal(SelectionInfo.states.none);
+
 	});
 
 });


### PR DESCRIPTION
This PR addresses a timing issues that manifest in this test error:

>SelectionObserverMixin
    :heavy_multiplication_x: unregisters and registers the SelectionMixin component
      Chrome 93.0.4577.63 (Mac OS 10.15.7)
    AssertionError: expected ‘none’ to equal ‘some’

If inputs were subscribed after the observers, the observer's `selectionInfo` could be out of date if the newly subscribed inputs result in a change in a selection change, because up until now, subscribing inputs did not cause the observers to be notified with updated `selectionInfo`.  It is not guaranteed that the inputs will be subscribed before the observers or vice versa.  I think that this issue could actually manifest itself in the wild, not just a test.

Previously (before my changes  [initial nested list](https://github.com/BrightspaceUI/core/commit/a3fede8948657006424f6b0f2bef7571179a6c8c#diff-5be73e9f32aadc4298d99871946bd4f635c28adca782b586953a492fffe3bb0e) and [remove rAF from selection-input](https://github.com/BrightspaceUI/core/commit/39b1f1aba080b2ed63e7418091239718a2f406ae#diff-5be73e9f32aadc4298d99871946bd4f635c28adca782b586953a492fffe3bb0e)) the `d2l-selection-change` event was being dispatched from a custom `selected` setter, and it was also being delayed using `requestAnimationFrame` in order for observers to be initialized with the correct selection info in these scenarios.

This change updates the `SelectionMixin` so that observers will be notified with new selectionInfo when new inputs are subscribed.