### PR TITLE
Reformat the d2l-filter-change event

### DIFF
--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -26,7 +26,7 @@ The `d2l-filter` component allows a user to filter on one or more dimensions of 
 | `disabled` | Boolean, default: `false` | Disables the dropdown opener for the filter |
 
 **Events:**
-* `d2l-filter-change`: dispatched when any filter value has changed (may contain info about multiple changes)
+* `d2l-filter-change`: dispatched when any filter value has changed (may contain info about multiple dimensions and multiple changes in each)
 * `d2l-filter-dimension-first-open`: dispatched when a dimension is opened for the first time (if there is only one dimension, this will be dispatched when the dropdown is first opened)
 * `d2l-filter-dimension-search`: dispatched when a dimension that supports searching and has the "manual" search-type is searched
 

--- a/components/filter/demo/filter-search-demo.js
+++ b/components/filter/demo/filter-search-demo.js
@@ -50,16 +50,19 @@ class FilterSearchDemo extends LitElement {
 	}
 
 	_handleFilterChange(e) {
-		(e.detail.changes.length === 1) ?
-			console.log(`Filter selection changed for dimension "${e.detail.changes[0].dimension}":`, e.detail.changes[0].value) : // eslint-disable-line no-console
-			console.log('Batch filter selection changed:', e.detail.changes); // eslint-disable-line no-console
+		(e.detail.dimensions.length === 1) ?
+			console.log(`Filter selection changed for dimension "${e.detail.dimensions[0].dimensionKey}":`, e.detail.dimensions[0].changes) : // eslint-disable-line no-console
+			console.log('Batch filter selection changed:', e.detail.dimensions); // eslint-disable-line no-console
 
-		e.detail.changes.forEach(change => {
-			if (change.dimension === 'event') {
-				this._fullData.find(value => value.key === change.value.key).selected = change.value.selected;
-			} else if (change.dimension === 'event-single') {
-				this._fullDataSingle.find(value => value.key === change.value.key).selected = change.value.selected;
-			}
+		e.detail.dimensions.forEach(dimension => {
+			if (!dimension.dimensionKey.includes('event')) return;
+			dimension.changes.forEach(change => {
+				if (dimension.dimensionKey === 'event') {
+					this._fullData.find(value => value.key === change.valueKey).selected = change.selected;
+				} else if (change.dimension === 'event-single') {
+					this._fullDataSingle.find(value => value.key === change.valueKey).selected = change.selected;
+				}
+			});
 		});
 	}
 

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -112,9 +112,9 @@
 
 	<script type="module">
 		document.addEventListener('d2l-filter-change', e => {
-			(e.detail.changes.length === 1) ?
-				console.log(`Filter selection changed for dimension "${e.detail.changes[0].dimension}":`, e.detail.changes[0].value) : // eslint-disable-line no-console
-				console.log('Batch filter selection changed:', e.detail.changes); // eslint-disable-line no-console
+			(e.detail.dimensions.length === 1) ?
+				console.log(`Filter selection changed for dimension "${e.detail.dimensions[0].dimensionKey}":`, e.detail.dimensions[0].changes) : // eslint-disable-line no-console
+				console.log('Batch filter selection changed:', e.detail.dimensions); // eslint-disable-line no-console
 		});
 
 		document.addEventListener('d2l-filter-dimension-first-open', e => {

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -155,24 +155,27 @@ describe('d2l-filter', () => {
 
 				setTimeout(() => value.setSelected(true));
 				let e = await oneEvent(elem, 'd2l-filter-change');
-				let changes = e.detail.changes;
+				let dimensions = e.detail.dimensions;
+				expect(dimensions.length).to.equal(1);
+				expect(dimensions[0].dimensionKey).to.equal('dim');
+				let changes = dimensions[0].changes;
 				expect(changes.length).to.equal(1);
-				expect(changes[0].dimension).to.equal('dim');
-				expect(changes[0].value.key).to.equal('2');
-				expect(changes[0].value.selected).to.be.true;
+				expect(changes[0].valueKey).to.equal('2');
+				expect(changes[0].selected).to.be.true;
 				expect(elem._dimensions[0].values[1].selected).to.be.true;
 
 				setTimeout(() => value.setSelected(false));
 				e = await oneEvent(elem, 'd2l-filter-change');
-				changes = e.detail.changes;
-				expect(changes.length).to.equal(1);
-				expect(changes[0].dimension).to.equal('dim');
-				expect(changes[0].value.key).to.equal('2');
-				expect(changes[0].value.selected).to.be.false;
+				dimensions = e.detail.dimensions;
+				expect(dimensions.length).to.equal(1);
+				expect(dimensions[0].dimensionKey).to.equal('dim');
+				changes = dimensions[0].changes;
+				expect(changes[0].valueKey).to.equal('2');
+				expect(changes[0].selected).to.be.false;
 				expect(elem._dimensions[0].values[1].selected).to.be.false;
 			});
 
-			it.skip('single set dimension with selection-single on fires change events', async() => {
+			it('single set dimension with selection-single on fires change events', async() => {
 				const elem = await fixture(singleSetDimensionSingleSelectionFixture);
 				const value = elem.shadowRoot.querySelector('d2l-list-item[key="2"]');
 				expect(elem._dimensions[0].values[0].selected).to.be.true;
@@ -180,24 +183,25 @@ describe('d2l-filter', () => {
 
 				setTimeout(() => value.setSelected(true));
 				let e = await oneEvent(elem, 'd2l-filter-change');
-				let changes = e.detail.changes;
-				expect(changes.length).to.equal(2);
-				expect(changes[0].dimension).to.equal('dim');
-				expect(changes[0].value.key).to.equal('2');
-				expect(changes[0].value.selected).to.be.true;
-				expect(changes[1].dimension).to.equal('dim');
-				expect(changes[1].value.key).to.equal('1');
-				expect(changes[1].value.selected).to.be.false;
+				let dimensions = e.detail.dimensions;
+				expect(dimensions.length).to.equal(1);
+				expect(dimensions[0].dimensionKey).to.equal('dim');
+				expect(dimensions[0].changes.length).to.equal(2);
+				expect(dimensions[0].changes[0].valueKey).to.equal('2');
+				expect(dimensions[0].changes[0].selected).to.be.true;
+				expect(dimensions[0].changes[1].valueKey).to.equal('1');
+				expect(dimensions[0].changes[1].selected).to.be.false;
 				expect(elem._dimensions[0].values[0].selected).to.be.false;
 				expect(elem._dimensions[0].values[1].selected).to.be.true;
 
 				setTimeout(() => value.setSelected(false));
 				e = await oneEvent(elem, 'd2l-filter-change');
-				changes = e.detail.changes;
-				expect(changes.length).to.equal(1);
-				expect(changes[0].dimension).to.equal('dim');
-				expect(changes[0].value.key).to.equal('2');
-				expect(changes[0].value.selected).to.be.false;
+				dimensions = e.detail.dimensions;
+				expect(dimensions.length).to.equal(1);
+				expect(dimensions[0].dimensionKey).to.equal('dim');
+				expect(dimensions[0].changes.length).to.equal(1);
+				expect(dimensions[0].changes[0].valueKey).to.equal('2');
+				expect(dimensions[0].changes[0].selected).to.be.false;
 				expect(elem._dimensions[0].values[1].selected).to.be.false;
 			});
 
@@ -210,20 +214,22 @@ describe('d2l-filter', () => {
 
 				setTimeout(() => value1.setSelected(false));
 				let e = await oneEvent(elem, 'd2l-filter-change');
-				let changes = e.detail.changes;
-				expect(changes.length).to.equal(1);
-				expect(changes[0].dimension).to.equal('1');
-				expect(changes[0].value.key).to.equal('1');
-				expect(changes[0].value.selected).to.be.false;
+				let dimensions = e.detail.dimensions;
+				expect(dimensions.length).to.equal(1);
+				expect(dimensions[0].dimensionKey).to.equal('1');
+				expect(dimensions[0].changes.length).to.equal(1);
+				expect(dimensions[0].changes[0].valueKey).to.equal('1');
+				expect(dimensions[0].changes[0].selected).to.be.false;
 				expect(elem._dimensions[0].values[0].selected).to.be.false;
 
 				setTimeout(() => value2.setSelected(true));
 				e = await oneEvent(elem, 'd2l-filter-change');
-				changes = e.detail.changes;
-				expect(changes.length).to.equal(1);
-				expect(changes[0].dimension).to.equal('2');
-				expect(changes[0].value.key).to.equal('1');
-				expect(changes[0].value.selected).to.be.true;
+				dimensions = e.detail.dimensions;
+				expect(dimensions.length).to.equal(1);
+				expect(dimensions[0].dimensionKey).to.equal('2');
+				expect(dimensions[0].changes.length).to.equal(1);
+				expect(dimensions[0].changes[0].valueKey).to.equal('1');
+				expect(dimensions[0].changes[0].selected).to.be.true;
 				expect(elem._dimensions[1].values[0].selected).to.be.true;
 			});
 
@@ -239,15 +245,17 @@ describe('d2l-filter', () => {
 					value2.setSelected(true);
 				});
 				const e = await oneEvent(elem, 'd2l-filter-change');
-				const changes = e.detail.changes;
-				expect(changes.length).to.equal(2);
-				expect(changes[0].dimension).to.equal('1');
-				expect(changes[0].value.key).to.equal('1');
-				expect(changes[0].value.selected).to.be.false;
+				const dimensions = e.detail.dimensions;
+				expect(dimensions.length).to.equal(2);
+				expect(dimensions[0].dimensionKey).to.equal('1');
+				expect(dimensions[0].changes.length).to.equal(1);
+				expect(dimensions[0].changes[0].valueKey).to.equal('1');
+				expect(dimensions[0].changes[0].selected).to.be.false;
 				expect(elem._dimensions[0].values[0].selected).to.be.false;
-				expect(changes[1].dimension).to.equal('2');
-				expect(changes[1].value.key).to.equal('1');
-				expect(changes[1].value.selected).to.be.true;
+				expect(dimensions[1].dimensionKey).to.equal('2');
+				expect(dimensions[1].changes.length).to.equal(1);
+				expect(dimensions[1].changes[0].valueKey).to.equal('1');
+				expect(dimensions[1].changes[0].selected).to.be.true;
 				expect(elem._dimensions[1].values[0].selected).to.be.true;
 			});
 
@@ -265,11 +273,12 @@ describe('d2l-filter', () => {
 					value.setSelected(true);
 				});
 				const e = await oneEvent(elem, 'd2l-filter-change');
-				const changes = e.detail.changes;
-				expect(changes.length).to.equal(1);
-				expect(changes[0].dimension).to.equal('1');
-				expect(changes[0].value.key).to.equal('1');
-				expect(changes[0].value.selected).to.be.true;
+				const dimensions = e.detail.dimensions;
+				expect(dimensions.length).to.equal(1);
+				expect(dimensions[0].dimensionKey).to.equal('1');
+				expect(dimensions[0].changes.length).to.equal(1);
+				expect(dimensions[0].changes[0].valueKey).to.equal('1');
+				expect(dimensions[0].changes[0].selected).to.be.true;
 				expect(elem._dimensions[0].values[0].selected).to.be.true;
 				expect(setupSpy.callCount).to.equal(4);
 				expect(dispatchSpy.callCount).to.equal(1);


### PR DESCRIPTION
This is a step to make the upcoming clear button PR cleaner.  In order to pass info about whether a dimension has been cleared, the `d2l-filter-change` event has been reformatted.  I've also broken out `_dispatchChangeEventNow` and `_setDimensionChangeEvent`, which will be used when clearing to set all values and then immediately send the event.

Before:
```
detail: {
  changes: [
    {
      dimension: "course",
      value: { key: "art", selected: false },
    },
    {
      dimension: "course",
      value: { key: "biology", selected: true },
    },
    {
      dimension: "role",
      value: { key: "admin", selected: false },
    },
    { ... }
  ]
}
```
Now:
```
detail: {
  dimensions: [
    {
      dimensionKey: "course",
      changes: [
            { valueKey: "art", selected: false },
            { valueKey: "biology", selected: true }
      ],
      (eventually info about whether this dimension was just cleared)
    },
    {
      dimensionKey: "role",
      changes: [
            { valueKey: "admin", selected: false }
      ],
      (eventually info about whether this dimension was just cleared)
    },
    { ... }
  ],
  (eventually info about whether all dimensions were just cleared)
}
```