### PR TITLE
DE45328 - Delay hierarchical-view-resize event to prevent ResizeObserver errors

### DIFF
--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -333,8 +333,11 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 			composed: true,
 			detail: contentRect
 		};
-		/** @ignore */
-		this.dispatchEvent(new CustomEvent('d2l-hierarchical-view-resize', eventDetails));
+		// To avoid ResizeObserver undelivered notifications error, wait a frame to send the event
+		requestAnimationFrame(() => {
+			/** @ignore */
+			this.dispatchEvent(new CustomEvent('d2l-hierarchical-view-resize', eventDetails));
+		});
 	}
 
 	__focusCapture(e) {
@@ -521,7 +524,10 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__onViewResize(e) {
-		this.style.height = `${e.detail.height}px`;
+		if (this._height !== e.detail.height) {
+			this._height = e.detail.height;
+			this.style.height = `${e.detail.height}px`;
+		}
 	}
 
 	__onWindowResize() {

--- a/components/menu/test/menu-rtl.visual-diff.js
+++ b/components/menu/test/menu-rtl.visual-diff.js
@@ -38,7 +38,7 @@ describe('d2l-menu rtl', () => {
 			// this scenario also tests height change when going from 1 menu item to 2 within nested menu
 			await page.$eval('#nested-item', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
+					item.addEventListener('d2l-hierarchical-view-show-complete', () => requestAnimationFrame(resolve), { once: true });
 					item.click();
 				});
 			});
@@ -55,7 +55,7 @@ describe('d2l-menu rtl', () => {
 			// this scenario also tests height change going from 3 menu items to 2 within nested menu
 			await page.$eval('#nested-item-long', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
+					item.addEventListener('d2l-hierarchical-view-show-complete', () => requestAnimationFrame(resolve), { once: true });
 					item.click();
 				});
 			});
@@ -71,7 +71,7 @@ describe('d2l-menu rtl', () => {
 		it('opens custom submenu on click', async function() {
 			await page.$eval('#custom-view-item', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
+					item.addEventListener('d2l-hierarchical-view-show-complete', () => requestAnimationFrame(resolve), { once: true });
 					item.click();
 				});
 			});

--- a/components/menu/test/menu.visual-diff.js
+++ b/components/menu/test/menu.visual-diff.js
@@ -110,7 +110,7 @@ describe('d2l-menu', () => {
 			// this scenario also tests height change when going from 1 menu item to 2 within nested menu
 			await page.$eval('#nested-item', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
+					item.addEventListener('d2l-hierarchical-view-show-complete', () => requestAnimationFrame(resolve), { once: true });
 					item.click();
 				});
 			});
@@ -132,7 +132,7 @@ describe('d2l-menu', () => {
 		it('opens submenu on enter', async function() {
 			await page.$eval('#nested-item', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
+					item.addEventListener('d2l-hierarchical-view-show-complete', () => requestAnimationFrame(resolve), { once: true });
 					const eventObj = document.createEvent('Events');
 					eventObj.initEvent('keydown', true, true);
 					eventObj.keyCode = 13;
@@ -166,7 +166,7 @@ describe('d2l-menu', () => {
 			// this scenario also tests height change going from 3 menu items to 2 within nested menu
 			await page.$eval('#nested-item-long', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
+					item.addEventListener('d2l-hierarchical-view-show-complete', () => requestAnimationFrame(resolve), { once: true });
 					item.click();
 				});
 			});
@@ -182,7 +182,7 @@ describe('d2l-menu', () => {
 		it('opens custom submenu on click', async function() {
 			await page.$eval('#custom-view-item', item => {
 				return new Promise((resolve) => {
-					item.addEventListener('d2l-hierarchical-view-show-complete', resolve, { once: true });
+					item.addEventListener('d2l-hierarchical-view-show-complete', () => requestAnimationFrame(resolve), { once: true });
 					item.click();
 				});
 			});


### PR DESCRIPTION
In the filter, the combination of the dropdown header and hierarchical-view content rendering at the same time means Safari sometimes throws the `ResizeObserver loop completed with undelivered notifications` error.  This didn't occur when the filter header was smaller, but adding the clear button means it might trigger a resize.

I tested in `filter`, `menu`, `dropdown` and `hierarchical-view` and don't see any behaviour change with delaying this event a frame.