### PR TITLE
Don't wipe out shadowroot styles in non-Chromium browsers

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -141,7 +141,7 @@ class HtmlBlock extends LitElement {
 
 		if (this._renderContainer) return;
 
-		this.shadowRoot.innerHTML = '<div class="d2l-html-block-rendered"></div><slot></slot>';
+		this.shadowRoot.innerHTML += '<div class="d2l-html-block-rendered"></div><slot></slot>';
 
 		const stampHTML = async template => {
 			const fragment = template ? document.importNode(template.content, true) : null;


### PR DESCRIPTION
In non-Chromium browsers, setting the shadowroot's innerHTML this way wipes out its styles (thanks for looking into that, @dlockhart!). This means the host styles don't get applied and wrapping stops functioning. Instead of replacing the inner HTML, append to it instead to ensure we keep any styles that may be there.