### PR TITLE
removing web component polyfill from demos

### DIFF
--- a/components/alert/demo/alert-toast.html
+++ b/components/alert/demo/alert-toast.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../button/button.js';
 		import '../../demo/demo-page.js';

--- a/components/alert/demo/alert.html
+++ b/components/alert/demo/alert.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import '../alert.js';

--- a/components/alert/test/alert-toast.visual-diff.html
+++ b/components/alert/test/alert-toast.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../../test/typography-preload.js';
 		import '../alert-toast.js';
 	</script>
 	<title>d2l-alert-toast</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		#hidden {

--- a/components/alert/test/alert.visual-diff.html
+++ b/components/alert/test/alert.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../alert.js';
 	</script>
 	<title>d2l-alert</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		#hidden {

--- a/components/backdrop/demo/backdrop.html
+++ b/components/backdrop/demo/backdrop.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../backdrop.js';

--- a/components/backdrop/test/backdrop.visual-diff.html
+++ b/components/backdrop/test/backdrop.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../backdrop.js';
 	</script>
 	<title>d2l-backdrop</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		.visual-diff {

--- a/components/breadcrumbs/demo/breadcrumbs.html
+++ b/components/breadcrumbs/demo/breadcrumbs.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../breadcrumb.js';

--- a/components/breadcrumbs/test/breadcrumbs.visual-diff.html
+++ b/components/breadcrumbs/test/breadcrumbs.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../breadcrumb.js';
@@ -11,7 +10,6 @@
 		</script>
 		<title>d2l-breadcrumbs</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/button/demo/button-icon.html
+++ b/components/button/demo/button-icon.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../button-icon.js';

--- a/components/button/demo/button-subtle.html
+++ b/components/button/demo/button-subtle.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../button-subtle.js';

--- a/components/button/demo/button.html
+++ b/components/button/demo/button.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../button.js';

--- a/components/button/demo/floating-buttons-in-frame.html
+++ b/components/button/demo/floating-buttons-in-frame.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 		</script>

--- a/components/button/demo/floating-buttons-in-tabs.html
+++ b/components/button/demo/floating-buttons-in-tabs.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../button.js';

--- a/components/button/demo/floating-buttons-page.html
+++ b/components/button/demo/floating-buttons-page.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../button.js';

--- a/components/button/demo/floating-buttons.html
+++ b/components/button/demo/floating-buttons.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../button.js';

--- a/components/button/test/button-icon.visual-diff.html
+++ b/components/button/test/button-icon.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../button-icon.js';
@@ -11,7 +10,6 @@
 	</script>
 	<title>d2l-button-icon</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		.translucent-container {

--- a/components/button/test/button-subtle.visual-diff.html
+++ b/components/button/test/button-subtle.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../button-subtle.js';
@@ -11,7 +10,6 @@
 	</script>
 	<title>d2l-button-subtle</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/button/test/button.visual-diff.html
+++ b/components/button/test/button.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../button.js';
@@ -11,7 +10,6 @@
 		</script>
 		<title>d2l-button</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/button/test/floating-buttons.visual-diff.html
+++ b/components/button/test/floating-buttons.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../../demo/demo-snippet.js';
@@ -11,7 +10,6 @@
 	</script>
 	<title>d2l-floating-buttons</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/calendar/demo/calendar.html
+++ b/components/calendar/demo/calendar.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../calendar.js';

--- a/components/calendar/test/calendar.visual-diff.html
+++ b/components/calendar/test/calendar.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en" data-timezone='{"name": "est", "identifier": "America/Toronto"}'>
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../calendar.js';
@@ -13,7 +12,6 @@
 	</script>
 	<title>d2l-calendar</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/card/demo/card.html
+++ b/components/card/demo/card.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../../button/button.js';

--- a/components/card/test/card-content-meta.visual-diff.html
+++ b/components/card/test/card-content-meta.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../card-content-meta.js';
 	</script>
 	<title>d2l-card-content-meta</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		body {

--- a/components/card/test/card-content-title.visual-diff.html
+++ b/components/card/test/card-content-title.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../card-content-title.js';
 	</script>
 	<title>d2l-card-content-title</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		body {

--- a/components/card/test/card-footer-link.visual-diff.html
+++ b/components/card/test/card-footer-link.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../card-footer-link.js';
 	</script>
 	<title>d2l-card-footer-link</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		body {

--- a/components/card/test/card.visual-diff.html
+++ b/components/card/test/card.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../button/button.js';
 		import '../../button/button-icon.js';
@@ -16,7 +15,6 @@
 	</script>
 	<title>d2l-card</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		body {

--- a/components/colors/demo/colors.html
+++ b/components/colors/demo/colors.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import './color-swatch.js';

--- a/components/colors/test/colors.visual-diff.html
+++ b/components/colors/test/colors.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../colors/colors.js';
 		import '../../typography/typography.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>colors</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/count-badge/demo/count-badge.html
+++ b/components/count-badge/demo/count-badge.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../count-badge.js';

--- a/components/count-badge/test/count-badge.visual-diff.html
+++ b/components/count-badge/test/count-badge.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../count-badge.js';
 		import '../../typography/typography.js';
@@ -11,7 +10,6 @@
 	</script>
 	<title>d2l-count-badge</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/demo/demo/demo-snippet.html
+++ b/components/demo/demo/demo-snippet.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../demo-page.js';
 			import '../../button/button-icon.js';

--- a/components/dialog/demo/dialog-confirm.html
+++ b/components/dialog/demo/dialog-confirm.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script>
 			//window.D2L = { DialogMixin: { preferNative: false } };
 		</script>

--- a/components/dialog/demo/dialog-fullscreen.html
+++ b/components/dialog/demo/dialog-fullscreen.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script>
 			//window.D2L = { DialogMixin: { preferNative: false } };
 		</script>

--- a/components/dialog/demo/dialog-nested.html
+++ b/components/dialog/demo/dialog-nested.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script>
 			//window.D2L = { DialogMixin: { preferNative: false } };
 		</script>

--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script>
 			//window.D2L = { DialogMixin: { preferNative: false } };
 		</script>

--- a/components/dialog/test/dialog-confirm.visual-diff.html
+++ b/components/dialog/test/dialog-confirm.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script>
 		const preferNative = (window.location.search.indexOf('preferNative=false') === -1);
 		window.D2L = { DialogMixin: { preferNative: preferNative } };
@@ -14,7 +13,6 @@
 	</script>
 	<title>d2l-dialog-confirm</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/dialog/test/dialog-fullscreen.visual-diff.html
+++ b/components/dialog/test/dialog-fullscreen.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script>
 		const preferNative = (window.location.search.indexOf('preferNative=false') === -1);
 		window.D2L = { DialogMixin: { preferNative: preferNative } };
@@ -16,7 +15,6 @@
 	</script>
 	<title>d2l-dialog-fullscreen</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/dialog/test/dialog-ifrau.visual-diff.html
+++ b/components/dialog/test/dialog-ifrau.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script>
 		const preferNative = (window.location.search.indexOf('preferNative=false') === -1);
 		window.D2L = { DialogMixin: { preferNative: preferNative } };
@@ -14,7 +13,6 @@
 	</script>
 	<title>d2l-dialog-ifrau</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/dialog/test/dialog-mixin.visual-diff.html
+++ b/components/dialog/test/dialog-mixin.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script>
 		const preferNative = (window.location.search.indexOf('preferNative=false') === -1);
 		window.D2L = { DialogMixin: { preferNative: preferNative } };
@@ -14,7 +13,6 @@
 	</script>
 	<title>d2l-dialog-mixin</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/dialog/test/dialog.visual-diff.html
+++ b/components/dialog/test/dialog.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script>
 		const preferNative = (window.location.search.indexOf('preferNative=false') === -1);
 		window.D2L = { DialogMixin: { preferNative: preferNative } };
@@ -14,7 +13,6 @@
 	</script>
 	<title>d2l-dialog</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/dropdown/demo/dropdown-button.html
+++ b/components/dropdown/demo/dropdown-button.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import '../dropdown-button.js';

--- a/components/dropdown/demo/dropdown-context-menu.html
+++ b/components/dropdown/demo/dropdown-context-menu.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import '../dropdown-context-menu.js';

--- a/components/dropdown/demo/dropdown-menu.html
+++ b/components/dropdown/demo/dropdown-menu.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import '../../menu/menu.js';

--- a/components/dropdown/demo/dropdown-more.html
+++ b/components/dropdown/demo/dropdown-more.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import '../../menu/menu.js';

--- a/components/dropdown/demo/dropdown-tabs.html
+++ b/components/dropdown/demo/dropdown-tabs.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import '../../tabs/tabs.js';

--- a/components/dropdown/demo/dropdown.html
+++ b/components/dropdown/demo/dropdown.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import '../../button/button.js';

--- a/components/dropdown/test/dropdown-content-contained.visual-diff.html
+++ b/components/dropdown/test/dropdown-content-contained.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../../test/typography-preload.js';
 		import '../../button/button.js';
@@ -11,7 +10,6 @@
 	</script>
 	<title>d2l-dropdown-content</title>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		body {

--- a/components/dropdown/test/dropdown-content.visual-diff.html
+++ b/components/dropdown/test/dropdown-content.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../../test/typography-preload.js';
 		import '../../button/button.js';
@@ -11,7 +10,6 @@
 	</script>
 	<title>d2l-dropdown-content</title>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 

--- a/components/dropdown/test/dropdown-menu.visual-diff.html
+++ b/components/dropdown/test/dropdown-menu.visual-diff.html
@@ -3,7 +3,6 @@
 
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../../menu/menu.js';
@@ -14,7 +13,6 @@
 	</script>
 	<title>d2l-dropdown-menu</title>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 

--- a/components/dropdown/test/dropdown-openers.visual-diff.html
+++ b/components/dropdown/test/dropdown-openers.visual-diff.html
@@ -3,7 +3,6 @@
 
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../dropdown-button-subtle.js';
@@ -15,7 +14,6 @@
 	</script>
 	<title>d2l-dropdown-openers</title>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 

--- a/components/expand-collapse/demo/expand-collapse-content.html
+++ b/components/expand-collapse/demo/expand-collapse-content.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../button/button.js';
 		import '../../demo/demo-page.js';

--- a/components/expand-collapse/test/expand-collapse-content.visual-diff.html
+++ b/components/expand-collapse/test/expand-collapse-content.visual-diff.html
@@ -3,14 +3,12 @@
 
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../expand-collapse-content.js';
 	</script>
 	<title>d2l-expand-collapse-content</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		ul {

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -3,7 +3,6 @@
 
 <head>
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import '../../button/button.js';

--- a/components/focus-trap/demo/focus-trap.html
+++ b/components/focus-trap/demo/focus-trap.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../../inputs/input-checkbox.js';

--- a/components/form/demo/form-native.html
+++ b/components/form/demo/form-native.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import './form-native-demo.js';

--- a/components/form/demo/form.html
+++ b/components/form/demo/form.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import './form-demo.js';

--- a/components/form/test/form-error-summary.visual-diff.html
+++ b/components/form/test/form-error-summary.visual-diff.html
@@ -3,14 +3,12 @@
 
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../form-errory-summary.js';
 		import '../../typography/typography.js';
 	</script>
 	<title>d2l-form-error-summary</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		#no-errors {

--- a/components/hierarchical-view/demo/hierarchical-view.html
+++ b/components/hierarchical-view/demo/hierarchical-view.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../hierarchical-view.js';

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../html-block.js';

--- a/components/html-block/test/html-block.visual-diff.html
+++ b/components/html-block/test/html-block.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../html-block.js';
 	</script>
 	<title>d2l-html-block</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		body {

--- a/components/icons/demo/icon-custom.html
+++ b/components/icons/demo/icon-custom.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../icon-custom.js';

--- a/components/icons/demo/icon.html
+++ b/components/icons/demo/icon.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../icon.js';

--- a/components/icons/test/icon-custom.visual-diff.html
+++ b/components/icons/test/icon-custom.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../colors/colors.js';
 			import '../../typography/typography.js';
@@ -12,7 +11,6 @@
 		</script>
 		<title>d2l-icon</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/icons/test/icon.visual-diff.html
+++ b/components/icons/test/icon.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../colors/colors.js';
 			import '../../typography/typography.js';
@@ -12,7 +11,6 @@
 		</script>
 		<title>d2l-icon</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/demo/input-checkbox.html
+++ b/components/inputs/demo/input-checkbox.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-checkbox.js';

--- a/components/inputs/demo/input-date-range.html
+++ b/components/inputs/demo/input-date-range.html
@@ -2,10 +2,8 @@
 <html lang="en" data-timezone='{"name":"Canada - Toronto", "identifier":"America/Toronto"}'>
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-date-range.js';

--- a/components/inputs/demo/input-date-time-range.html
+++ b/components/inputs/demo/input-date-time-range.html
@@ -2,10 +2,8 @@
 <html lang="en" data-timezone='{"name":"Canada - Toronto", "identifier":"America/Toronto"}'>
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-date-time-range.js';

--- a/components/inputs/demo/input-date-time.html
+++ b/components/inputs/demo/input-date-time.html
@@ -2,10 +2,8 @@
 <html lang="en" data-timezone='{"name":"Canada - Toronto", "identifier":"America/Toronto"}'>
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-date-time.js';

--- a/components/inputs/demo/input-date.html
+++ b/components/inputs/demo/input-date.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-date.js';

--- a/components/inputs/demo/input-number.html
+++ b/components/inputs/demo/input-number.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-number.js';

--- a/components/inputs/demo/input-percent.html
+++ b/components/inputs/demo/input-percent.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-percent.js';

--- a/components/inputs/demo/input-radio.html
+++ b/components/inputs/demo/input-radio.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-radio-spacer.js';

--- a/components/inputs/demo/input-search.html
+++ b/components/inputs/demo/input-search.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-search.js';

--- a/components/inputs/demo/input-select.html
+++ b/components/inputs/demo/input-select.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import './input-select-test.js';

--- a/components/inputs/demo/input-text.html
+++ b/components/inputs/demo/input-text.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../button/button-icon.js';
 			import '../../demo/demo-page.js';

--- a/components/inputs/demo/input-textarea.html
+++ b/components/inputs/demo/input-textarea.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-textarea.js';

--- a/components/inputs/demo/input-time-range.html
+++ b/components/inputs/demo/input-time-range.html
@@ -2,10 +2,8 @@
 <html lang="en" data-timezone='{"name":"Canada - Toronto", "identifier":"America/Toronto"}'>
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-time-range.js';

--- a/components/inputs/demo/input-time.html
+++ b/components/inputs/demo/input-time.html
@@ -2,10 +2,8 @@
 <html lang="en" data-timezone='{"name":"Canada - Toronto", "identifier":"America/Toronto"}'>
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../input-time.js';

--- a/components/inputs/test/input-checkbox.visual-diff.html
+++ b/components/inputs/test/input-checkbox.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-checkbox.js';
@@ -11,7 +10,6 @@
 		</script>
 		<title>d2l-input-checkbox visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-date-range.visual-diff.html
+++ b/components/inputs/test/input-date-range.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-date-range.js';
@@ -14,7 +13,6 @@
 		</script>
 		<title>d2l-input-date-range visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<style>
 			d2l-input-date-range {

--- a/components/inputs/test/input-date-time-range.visual-diff.html
+++ b/components/inputs/test/input-date-time-range.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-date-time-range.js';
@@ -14,7 +13,6 @@
 		</script>
 		<title>d2l-input-date-time-range visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<style>
 			d2l-input-date-time-range#hidden-labels,

--- a/components/inputs/test/input-date-time.visual-diff.html
+++ b/components/inputs/test/input-date-time.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-date-time.js';
@@ -14,7 +13,6 @@
 		</script>
 		<title>d2l-input-date-time visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-date.visual-diff.html
+++ b/components/inputs/test/input-date.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../../test/typography-preload.js';
 			import '../input-date.js';
@@ -21,7 +20,6 @@
 		</style>
 		<title>d2l-input-date visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-label.visual-diff.html
+++ b/components/inputs/test/input-label.visual-diff.html
@@ -3,13 +3,11 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 		</script>
 		<title>d2l-input-label visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-number.visual-diff.html
+++ b/components/inputs/test/input-number.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-number.js';
@@ -11,7 +10,6 @@
 		</script>
 		<title>d2l-input-number visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-percent.visual-diff.html
+++ b/components/inputs/test/input-percent.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-percent.js';
@@ -11,7 +10,6 @@
 		</script>
 		<title>d2l-input-percent visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-radio.visual-diff.html
+++ b/components/inputs/test/input-radio.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-radio-spacer.js';
@@ -12,7 +11,6 @@
 		</script>
 		<title>d2l-input-radio visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-search.visual-diff.html
+++ b/components/inputs/test/input-search.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-search.js';
@@ -12,7 +11,6 @@
 		</script>
 		<title>d2l-input-search visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-select.visual-diff.html
+++ b/components/inputs/test/input-select.visual-diff.html
@@ -3,14 +3,12 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../demo/input-select-test.js';
 		</script>
 		<title>d2l-input-select visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-text.visual-diff.html
+++ b/components/inputs/test/input-text.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../button/button-icon.js';
 			import '../../icons/icon.js';
@@ -12,7 +11,6 @@
 		</script>
 		<title>d2l-input-text visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<style>
 		#wc-override-padding {

--- a/components/inputs/test/input-textarea.visual-diff.html
+++ b/components/inputs/test/input-textarea.visual-diff.html
@@ -3,14 +3,12 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-textarea.js';
 		</script>
 		<title>d2l-input-textarea visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/inputs/test/input-time-range.visual-diff.html
+++ b/components/inputs/test/input-time-range.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-time-range.js';
@@ -14,7 +13,6 @@
 		</script>
 		<title>d2l-input-time-range visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<style>
 			d2l-input-time-range {

--- a/components/inputs/test/input-time.visual-diff.html
+++ b/components/inputs/test/input-time.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-time.js';
@@ -17,7 +16,6 @@
 		</script>
 		<title>d2l-input-time visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/link/demo/link.html
+++ b/components/link/demo/link.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../link.js';

--- a/components/link/test/link.visual-diff.html
+++ b/components/link/test/link.visual-diff.html
@@ -3,14 +3,12 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../link.js';
 		</script>
 		<title>d2l-link</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/list/demo/list-drag-and-drop.html
+++ b/components/list/demo/list-drag-and-drop.html
@@ -2,10 +2,8 @@
 <html lang="en">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import './list-demo-drag-and-drop-usage.js';

--- a/components/list/demo/list-item-actions.html
+++ b/components/list/demo/list-item-actions.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../button/button-icon.js';
 			import '../../demo/demo-page.js';

--- a/components/list/demo/list-item-layouts.html
+++ b/components/list/demo/list-item-layouts.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../button/button-icon.js';
 			import '../../demo/demo-page.js';

--- a/components/list/demo/list.html
+++ b/components/list/demo/list.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../button/button-icon.js';
 			import '../../demo/demo-page.js';

--- a/components/list/test/list-item-drag-handle.visual-diff.html
+++ b/components/list/test/list-item-drag-handle.visual-diff.html
@@ -2,13 +2,11 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../list-item-drag-handle.js';
 		</script>
 		<title>d2l-list-item-drag-handle</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/list/test/list-item-placement-marker.visual-diff.html
+++ b/components/list/test/list-item-placement-marker.visual-diff.html
@@ -2,13 +2,11 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../list-item-placement-marker.js';
 		</script>
 		<title>d2l-list-item-placement-marker</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/list/test/list.visual-diff.html
+++ b/components/list/test/list.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../colors/colors.js';
 			import '../../button/button-icon.js';
@@ -18,7 +17,6 @@
 		</script>
 		<title>d2l-list</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/loading-spinner/demo/loading-spinner.html
+++ b/components/loading-spinner/demo/loading-spinner.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../loading-spinner.js';

--- a/components/menu/demo/checkbox-menu.html
+++ b/components/menu/demo/checkbox-menu.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../menu.js';

--- a/components/menu/demo/menu.html
+++ b/components/menu/demo/menu.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import './custom-menu-item.js';

--- a/components/menu/demo/radio-menu.html
+++ b/components/menu/demo/radio-menu.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../menu.js';

--- a/components/menu/test/menu-checkbox.visual-diff.html
+++ b/components/menu/test/menu-checkbox.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../menu.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>d2l-menu (checkbox)</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/menu/test/menu-radio.visual-diff.html
+++ b/components/menu/test/menu-radio.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../menu.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>d2l-menu (radio)</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/menu/test/menu-rtl.visual-diff.html
+++ b/components/menu/test/menu-rtl.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en" dir="rtl">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import './custom-view.js';
@@ -14,7 +13,6 @@
 	</script>
 	<title>d2l-menu</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/menu/test/menu.visual-diff.html
+++ b/components/menu/test/menu.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import './custom-view.js';
@@ -13,7 +12,6 @@
 	</script>
 	<title>d2l-menu</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../meter-linear.js';

--- a/components/meter/test/meter-circle.visual-diff.html
+++ b/components/meter/test/meter-circle.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../colors/colors.js';
 		import '../../typography/typography.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>d2l-meter-circle</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/meter/test/meter-linear.visual-diff.html
+++ b/components/meter/test/meter-linear.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../colors/colors.js';
 		import '../meter-linear.js';
 	</script>
 	<title>d2l-meter-linear</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/meter/test/meter-radial.visual-diff.html
+++ b/components/meter/test/meter-radial.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../colors/colors.js';
 		import '../../typography/typography.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>d2l-meter-radial</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/more-less/demo/more-less.html
+++ b/components/more-less/demo/more-less.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../more-less.js';

--- a/components/more-less/test/more-less.visual-diff.html
+++ b/components/more-less/test/more-less.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../colors/colors.js';
 		import '../../typography/typography.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>d2l-more-less</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		.visual-diff { width: 250px; }

--- a/components/offscreen/demo/offscreen.html
+++ b/components/offscreen/demo/offscreen.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../offscreen.js';

--- a/components/offscreen/test/offscreen.visual-diff.html
+++ b/components/offscreen/test/offscreen.visual-diff.html
@@ -3,14 +3,12 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../offscreen.js';
 			import '../demo/offscreen-demo.js';
 		</script>
 		<title>d2l-offscreen</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body>

--- a/components/overflow-group/demo/overflow-group.html
+++ b/components/overflow-group/demo/overflow-group.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../overflow-group.js';

--- a/components/overflow-group/test/overflow-group.visual-diff.html
+++ b/components/overflow-group/test/overflow-group.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../../demo/demo-page.js';
@@ -22,7 +21,6 @@
 		</script>
 		<title>d2l-overflow-group</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/scroll-wrapper/demo/scroll-wrapper.html
+++ b/components/scroll-wrapper/demo/scroll-wrapper.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import './scroll-wrapper-test.js';

--- a/components/selection/demo/selection.html
+++ b/components/selection/demo/selection.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../selection-action.js';

--- a/components/selection/test/selection.visual-diff.html
+++ b/components/selection/test/selection.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../selection-action.js';
@@ -13,7 +12,6 @@
 	</script>
 	<title>d2l-selection</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		body {

--- a/components/skeleton/demo/skeleton-mixin.html
+++ b/components/skeleton/demo/skeleton-mixin.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import './skeleton-test-box.js';

--- a/components/skeleton/test/skeleton.visual-diff.html
+++ b/components/skeleton/test/skeleton.visual-diff.html
@@ -3,7 +3,6 @@
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script>
 			const rtl = (window.location.search.indexOf('dir=rtl') !== -1);
 			if (rtl) document.documentElement.setAttribute('dir', 'rtl');
@@ -30,7 +29,6 @@
 		</style>
 		<title>d2l-skeleton</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">

--- a/components/status-indicator/demo/status-indicator.html
+++ b/components/status-indicator/demo/status-indicator.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../demo/demo-page.js';
 		import '../status-indicator.js';

--- a/components/status-indicator/test/status-indicator.visual-diff.html
+++ b/components/status-indicator/test/status-indicator.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../status-indicator.js';
 	</script>
 	<title>d2l-status-indicator</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 </head>
 <body class="d2l-typography">

--- a/components/switch/demo/switch.html
+++ b/components/switch/demo/switch.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../switch.js';

--- a/components/switch/test/switch-visibility.visual-diff.html
+++ b/components/switch/test/switch-visibility.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script>
 		const rtl = (window.location.search.indexOf('dir=rtl') !== -1);
 		if (rtl) document.documentElement.setAttribute('dir', 'rtl');
@@ -13,7 +12,6 @@
 	</script>
 	<title>d2l-switch-visibility</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		.visual-diff {

--- a/components/switch/test/switch.visual-diff.html
+++ b/components/switch/test/switch.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script>
 		const rtl = (window.location.search.indexOf('dir=rtl') !== -1);
 		if (rtl) document.documentElement.setAttribute('dir', 'rtl');
@@ -15,7 +14,6 @@
 	</script>
 	<title>d2l-switch</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		body {

--- a/components/table/demo/table.html
+++ b/components/table/demo/table.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import './table-test.js';

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../../button/button-subtle.js';

--- a/components/tabs/test/tabs.visual-diff.html
+++ b/components/tabs/test/tabs.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script>
 		const rtl = (window.location.search.indexOf('dir=rtl') !== -1);
 		if (rtl) document.documentElement.setAttribute('dir', 'rtl');
@@ -17,7 +16,6 @@
 	</script>
 	<title>d2l-tabs</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		.visual-diff {

--- a/components/tooltip/demo/tooltip.html
+++ b/components/tooltip/demo/tooltip.html
@@ -3,10 +3,8 @@
 
 <head>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../button/button.js';
 		import '../../colors/colors.js';

--- a/components/tooltip/test/tooltip.visual-diff.html
+++ b/components/tooltip/test/tooltip.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../../test/typography-preload.js';
 		import '../../button/button.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>d2l-tooltip</title>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 

--- a/components/typography/demo/typography.html
+++ b/components/typography/demo/typography.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 		</script>

--- a/components/typography/test/typography.visual-diff.html
+++ b/components/typography/test/typography.visual-diff.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../colors/colors.js';
 		import '../typography.js';
 	</script>
 	<title>d2l-typography</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>.visual-diff { overflow: auto; }</style>
 </head>

--- a/directives/animate/demo/index.html
+++ b/directives/animate/demo/index.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../../components/demo/demo-page.js';
 			import './animate-test.js';

--- a/helpers/demo/announce.html
+++ b/helpers/demo/announce.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../components/demo/demo-page.js';
 			import './announce-test.js';

--- a/helpers/demo/dismissible.html
+++ b/helpers/demo/dismissible.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../components/demo/demo-page.js';
 			import './dismissible-test.js';

--- a/helpers/demo/gestures.html
+++ b/helpers/demo/gestures.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../components/demo/demo-page.js';
 		</script>

--- a/index.html
+++ b/index.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
 	<link rel="stylesheet" href="components/demo/styles.css" type="text/css">
-	<script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import './components/colors/colors.js';
 		import './components/typography/typography.js';
 	</script>
 	<title>core-ui</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		body {

--- a/mixins/async-container/demo/async-container.html
+++ b/mixins/async-container/demo/async-container.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../../components/demo/demo-page.js';
 			import '../../../components/button/button.js';

--- a/mixins/async-container/test/async-container-mixin.visual-diff.html
+++ b/mixins/async-container/test/async-container-mixin.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../../components/typography/typography.js';
 			import '../demo/async-container.js';
@@ -10,7 +9,6 @@
 		</script>
 		<title>d2l-async-container-mixin</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<style>
 			d2l-async-demo-container {

--- a/mixins/demo/arrow-keys-mixin.html
+++ b/mixins/demo/arrow-keys-mixin.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../components/demo/demo-page.js';
 			import './arrow-keys-test.js';

--- a/mixins/demo/labelled-mixin.html
+++ b/mixins/demo/labelled-mixin.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../components/demo/demo-page.js';
 			import '../../components/inputs/input-checkbox.js';
@@ -60,7 +59,6 @@
 
 		</script>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body unresolved>

--- a/mixins/demo/localize-mixin.html
+++ b/mixins/demo/localize-mixin.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../components/demo/demo-page.js';
 			import './localize-test.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1174,12 +1174,6 @@
       "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.0.tgz",
       "integrity": "sha512-L5O/+UPum8erOleNjKq6k58GVl3fNsEQdSOyh0EUhNmi7tHUyRuCJy1uqJiWydWcLARE5IPsMoPYMZmUGrz1JA=="
     },
-    "@webcomponents/webcomponentsjs": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.6.0.tgz",
-      "integrity": "sha512-Moog+Smx3ORTbWwuPqoclr+uvfLnciVd6wdCaVscHPrxbmQ/IJKm3wbB7hpzJtXWjAq2l/6QMlO85aZiOdtv5Q==",
-      "dev": true
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@open-wc/testing": "^2",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
-    "@webcomponents/webcomponentsjs": "^2",
     "axe-core": "^4",
     "chalk": "^4",
     "deepmerge": "^4",

--- a/templates/primary-secondary/demo/index.html
+++ b/templates/primary-secondary/demo/index.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../../components/demo/demo-page.js';
 			import '../primary-secondary.js';

--- a/templates/primary-secondary/demo/overflow-hidden.html
+++ b/templates/primary-secondary/demo/overflow-hidden.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../../components/demo/demo-page.js';
 			import '../primary-secondary.js';

--- a/templates/primary-secondary/demo/width-type-normal.html
+++ b/templates/primary-secondary/demo/width-type-normal.html
@@ -2,10 +2,8 @@
 <html lang="en">
 	<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../../components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '../../../components/demo/demo-page.js';
 			import '../primary-secondary.js';

--- a/templates/primary-secondary/test/primary-secondary-desktop.visual-diff.html
+++ b/templates/primary-secondary/test/primary-secondary-desktop.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../../components/typography/typography.js';
 		import '../primary-secondary.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>d2l-template-primary-secondary</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		html {

--- a/templates/primary-secondary/test/primary-secondary-mobile.visual-diff.html
+++ b/templates/primary-secondary/test/primary-secondary-mobile.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../../components/typography/typography.js';
 		import '../primary-secondary.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>d2l-template-primary-secondary</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		html {

--- a/templates/primary-secondary/test/primary-secondary-persist.visual-diff.html
+++ b/templates/primary-secondary/test/primary-secondary-persist.visual-diff.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '../../../components/typography/typography.js';
 		import '../primary-secondary.js';
@@ -10,7 +9,6 @@
 	</script>
 	<title>d2l-template-primary-secondary</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<meta charset="UTF-8">
 	<style>
 		html {


### PR DESCRIPTION
Now that we're not testing legacy-Edge in SauceLabs, I think it's a good time to stop including the web component polyfill for it in our demos.

I've also removed the `<meta http-equiv="X-UA-Compatible" content="ie=edge">` from our demos, which was a way to tell legacy-Edge to never emulate old versions of IE... which we also don't care about anymore.

Apologies for all the file changes -- they're the same change in every demo/visual-diff HTML file.