### PR TITLE
skip flaky test

### DIFF
--- a/components/form/test/form-error-summary.test.js
+++ b/components/form/test/form-error-summary.test.js
@@ -23,7 +23,8 @@ describe('d2l-form-error-summary', () => {
 
 	describe('focus', () => {
 
-		it('should focus first error', async() => {
+		// flaky on Firefox
+		it.skip('should focus first error', async() => {
 			errorSummary.errors = [
 				{ href: '#first-error', message: 'An error occured' },
 				{ href: '#second-error', message: 'A different error occured' }


### PR DESCRIPTION
Skipping this flaky test which is failing in Firefox a lot since the move to `@web/test-runner`. I'll investigate it separately.