### PR TITLE
Cleanup legacy-Edge from Tests

### DIFF
--- a/components/alert/test/alert.test.js
+++ b/components/alert/test/alert.test.js
@@ -22,7 +22,6 @@ describe('d2l-alert', () => {
 
 		it('should fire "d2l-alert-close" event when close button is clicked', async() => {
 			const alert = await fixture(alertFixture);
-			await alert.updateComplete; // legacy edge
 			const closeButton = alert.shadowRoot.querySelector('d2l-button-icon');
 			setTimeout(() => closeButton.click());
 			await oneEvent(alert, 'd2l-alert-close');
@@ -31,7 +30,6 @@ describe('d2l-alert', () => {
 
 		it('should fire "d2l-alert-close" event when close is called', async() => {
 			const alert = await fixture(alertFixture);
-			await alert.updateComplete; // legacy edge
 			setTimeout(() => alert.close());
 			await oneEvent(alert, 'd2l-alert-close');
 			expect(alert.hasAttribute('hidden')).to.be.true;
@@ -39,7 +37,6 @@ describe('d2l-alert', () => {
 
 		it('should fire "d2l-alert-closed" event when close button is clicked', async() => {
 			const alert = await fixture(alertFixture);
-			await alert.updateComplete; // legacy edge
 			const closeButton = alert.shadowRoot.querySelector('d2l-button-icon');
 			setTimeout(() => closeButton.click());
 			await oneEvent(alert, 'd2l-alert-closed');
@@ -48,7 +45,6 @@ describe('d2l-alert', () => {
 
 		it('should fire "d2l-alert-closed" event when close is called', async() => {
 			const alert = await fixture(alertFixture);
-			await alert.updateComplete; // legacy edge
 			setTimeout(() => alert.close());
 			await oneEvent(alert, 'd2l-alert-closed');
 			expect(alert.hasAttribute('hidden')).to.be.true;
@@ -56,7 +52,6 @@ describe('d2l-alert', () => {
 
 		it('should fire "d2l-alert-button-press" event when action button is clicked', async() => {
 			const alert = await fixture(alertFixture);
-			await alert.updateComplete; // legacy edge
 			const actionButton = alert.shadowRoot.querySelector('d2l-button-subtle');
 			setTimeout(() => actionButton.click());
 			await oneEvent(alert, 'd2l-alert-button-press');
@@ -64,7 +59,6 @@ describe('d2l-alert', () => {
 
 		it('calling preventDefault on close action should prevent alert from closing', async() => {
 			const alert = await fixture(alertFixture);
-			await alert.updateComplete; // legacy edge
 			const closeButton = alert.shadowRoot.querySelector('d2l-button-icon');
 			setTimeout(() => closeButton.click());
 			alert.addEventListener('d2l-alert-closed', (e) => {

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -89,7 +89,7 @@ class Card extends RtlMixin(LitElement) {
 				flex-grow: 1;
 				flex-shrink: 1;
 				overflow: hidden;
-				width: 100%; /* required for Edge and FF when align-items: flex-start is specified */
+				width: 100%; /* required for Legacy-Edge and FF when align-items: flex-start is specified */
 			}
 			.d2l-card-link-text {
 				display: inline-block;

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -114,7 +114,7 @@ class CodeView extends LitElement {
 			return;
 		}
 
-		// Edge & IE11 there may be more than one node so concat textContent
+		// Legacy-Edge there may be more than one node so concat textContent
 		let code = this._formatCode(nodes.reduce((code, node) => code + node.textContent, ''));
 
 		try {

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -55,7 +55,7 @@ export const dialogStyles = css`
 	}
 
 	:host([_state="showing"]) > .d2l-dialog-outer {
-		/* must target direct child to avoid ancestor from interfering with closing child dialogs in Edge/IE11 */
+		/* must target direct child to avoid ancestor from interfering with closing child dialogs in Legacy-Edge */
 		transform: translateY(0);
 	}
 

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -509,7 +509,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 			if (!this.noAutoFocus && this.__applyFocus) {
 				const focusable = getFirstFocusableDescendant(this);
 				if (focusable) {
-					// bumping this to the next frame is required to prevent IE/Edge from crazily invoking click on the focused element
+					// bumping this to the next frame is required to prevent Legacy-Edge from crazily invoking click on the focused element
 					requestAnimationFrame(() => focusable.focus());
 				} else {
 					content.setAttribute('tabindex', '-1');
@@ -1006,7 +1006,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 			const content = this.__getContentContainer();
 			const focusable = getFirstFocusableDescendant(content);
 			if (focusable) {
-				// bumping this to the next frame is required to prevent IE/Edge from crazily invoking click on the focused element
+				// bumping this to the next frame is required to prevent Legacy-Edge from crazily invoking click on the focused element
 				requestAnimationFrame(() => focusable.focus());
 			} else {
 				content.setAttribute('tabindex', '-1');

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -76,7 +76,6 @@ describe('d2l-html-block', () => {
 
 	it('should not explode if no replacements', async() => {
 		const htmlBlock = await fixture(emptyReplacementFixture);
-		await htmlBlock.updateComplete; // legacy edge
 		expect(htmlBlock.shadowRoot.querySelector('.d2l-html-block-rendered').innerHTML)
 			.to.equal('');
 	});

--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -228,13 +228,13 @@ class InputCheckbox extends SkeletonMixin(RtlMixin(LitElement)) {
 	}
 
 	/**
-	 * This is needed only for IE11 and Edge AND going from indeterminate to checked/unchecked.
+	 * This is needed only for Legacy-Edge AND going from indeterminate to checked/unchecked.
 	 * When the indeterminate state is set, and the checkbox is clicked, the _handleChange
 	 * function is NOT triggered, therefore we have to detect the click and handle it ourselves.
 	 */
 	_handleClick() {
 		const browserType = window.navigator.userAgent;
-		if (this.indeterminate && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
+		if (this.indeterminate && (browserType.indexOf('Edge') > -1)) {
 			this.simulateClick();
 		}
 	}

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -497,11 +497,11 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		this.requestValidate(true);
 
 		/**
-		 * This is needed only for IE11 and Edge
+		 * This is needed only for Legacy-Edge
 		 * the _handleChange function is NOT triggered, therefore we have to detect the blur and handle it ourselves.
 		 */
 		const browserType = window.navigator.userAgent;
-		if (this._prevValue !== e.target.value && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
+		if (this._prevValue !== e.target.value && (browserType.indexOf('Edge') > -1)) {
 			this._handleChange();
 		}
 	}

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -295,11 +295,11 @@ class InputTextArea extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))
 		this.requestValidate(true);
 
 		/**
-		 * This is needed only for legacy Edge since the _handleChange function is NOT
+		 * This is needed only for Legacy-Edge since the _handleChange function is NOT
 		 * triggered, therefore we have to detect the blur and handle it ourselves.
 		 */
 		const browserType = window.navigator.userAgent;
-		if (this._prevValue !== e.target.value && (browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) {
+		if (this._prevValue !== e.target.value && (browserType.indexOf('Edge') > -1)) {
 			this._handleChange();
 		}
 	}

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -356,41 +356,7 @@ describe('d2l-input-text', () => {
 			expect(elem.value).to.equal('hello');
 		});
 
-		it('should fire "change" event because of blur event on edge', async() => {
-			const browserType = window.navigator.userAgent;
-			if (!(browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) return;
-
-			const elem = await fixture(normalFixture);
-			getInput(elem).value = 'hello';
-			setTimeout(() => {
-				dispatchEvent(elem, 'input', true);
-				dispatchEvent(elem, 'blur', true);
-			});
-			await oneEvent(elem, 'change');
-			expect(elem.value).to.equal('hello');
-		});
-
-		it('should NOT fire "change" event on initial blur event on edge if no change made', async() => {
-			const browserType = window.navigator.userAgent;
-			if (!(browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) return;
-
-			const elem = await fixture(normalFixture);
-			let fired = false;
-			elem.addEventListener('change', () => {
-				fired = true;
-			});
-			setTimeout(() => {
-				dispatchEvent(elem, 'blur', true);
-			});
-			await aTimeout(1);
-			expect(fired).to.be.false;
-			expect(elem.value).to.equal('');
-		});
-
-		it('should NOT fire "change" event because of blur event on non-edge', async() => {
-			const browserType = window.navigator.userAgent;
-			if ((browserType.indexOf('Trident') > -1 || browserType.indexOf('Edge') > -1)) return;
-
+		it('should NOT fire "change" event because of blur event', async() => {
 			const elem = await fixture(normalFixture);
 			let fired = false;
 			elem.addEventListener('change', () => {

--- a/components/inputs/test/input-time-range.test.js
+++ b/components/inputs/test/input-time-range.test.js
@@ -82,7 +82,6 @@ describe('d2l-input-time-range', () => {
 	describe('values', () => {
 		it('should fire "change" event when start value changes', async() => {
 			const elem = await fixture(basicFixture);
-			await elem.updateComplete; // legacy edge
 			const inputElem = getChildElem(elem, 'd2l-input-time.d2l-input-time-range-start');
 			inputElem.value = '01:30:00';
 			setTimeout(() => dispatchEvent(inputElem, 'change'));
@@ -122,8 +121,7 @@ describe('d2l-input-time-range', () => {
 			clock.restore();
 		});
 
-		// timing out in legacy-Edge via GitHub Actions
-		it.skip('should update startValue as expected when set through property', async() => {
+		it('should update startValue as expected when set through property', async() => {
 			const elem = await fixture('<d2l-input-time-range label="label" time-interval="ten" enforce-time-intervals></d2l-input-time-range>');
 			elem.startValue = '12:05:00';
 			await elem.updateComplete;
@@ -150,8 +148,7 @@ describe('d2l-input-time-range', () => {
 			expect(inputElem.value).to.equal('14:00:00');
 		});
 
-		// timing out in legacy-Edge via GitHub Actions
-		describe.skip('initial values are corrected', () => {
+		describe('initial values are corrected', () => {
 			[
 				{ enforceTimeIntervals: true, validStart: true, validEnd: true },
 				{ enforceTimeIntervals: true, validStart: true, validEnd: false },
@@ -189,7 +186,6 @@ describe('d2l-input-time-range', () => {
 						${testCase.enforceTimeIntervals ? 'enforce-time-intervals' : null}
 					></d2l-input-time-range>`;
 					const elem = await fixture(caseFixture);
-					await elem.updateComplete; // legacy edge
 					expect(elem.startValue).to.equal(expectedStartTime);
 					expect(elem.endValue).to.equal(expectedEndTime);
 				});

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -425,7 +425,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 			e.dataTransfer.setData('text/plain', `${this.dropText}`);
 		}
 
-		//legacy edge doesn't support setDragImage. Experience is not degraded for legacy edge by doing this fix.
+		// Legacy-Edge doesn't support setDragImage. Experience is not degraded for Legacy-Edge by doing this fix.
 		if (e.dataTransfer.setDragImage) {
 			const nodeImage = this.shadowRoot.querySelector('.d2l-list-item-drag-image') || this;
 			e.dataTransfer.setDragImage(nodeImage, 50, 50);

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -214,7 +214,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			:host([_open-dir="bottom"][align="start"]) .d2l-tooltip-pointer,
 			:host([_open-dir="top"][align="end"][dir="rtl"]) .d2l-tooltip-pointer,
 			:host([_open-dir="bottom"][align="end"][dir="rtl"]) .d2l-tooltip-pointer {
-				left: ${contentHorizontalPadding + (pointerRotatedLength - pointerLength) / 2}px; /* needed for browsers that don't support min like IE11 and Edge Legacy */
+				left: ${contentHorizontalPadding + (pointerRotatedLength - pointerLength) / 2}px; /* needed for browsers that don't support min like Legacy-Edge */
 				left: min(${contentHorizontalPadding + (pointerRotatedLength - pointerLength) / 2}px, calc(50% - ${pointerLength / 2}px));
 				right: auto;
 			}
@@ -224,7 +224,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			:host([_open-dir="top"][align="start"][dir="rtl"]) .d2l-tooltip-pointer,
 			:host([_open-dir="bottom"][align="start"][dir="rtl"]) .d2l-tooltip-pointer {
 				left: auto;
-				right: ${contentHorizontalPadding + (pointerRotatedLength - pointerLength) / 2}px; /* needed for browsers that don't support min like IE11 and Edge Legacy */
+				right: ${contentHorizontalPadding + (pointerRotatedLength - pointerLength) / 2}px; /* needed for browsers that don't support min like Legacy-Edge */
 				right: min(${contentHorizontalPadding + (pointerRotatedLength - pointerLength) / 2}px, calc(50% - ${pointerLength / 2}px));
 			}
 
@@ -294,7 +294,7 @@ class Tooltip extends RtlMixin(LitElement) {
 				position: absolute;
 			}
 
-			/* increase specificty for Edge Legacy so the d2l-body-small color doesn't override it */
+			/* increase specificty for Legacy-Edge so the d2l-body-small color doesn't override it */
 			.d2l-tooltip-content.d2l-tooltip-content {
 				color: inherit;
 			}

--- a/mixins/test/localize-mixin.test.js
+++ b/mixins/test/localize-mixin.test.js
@@ -152,7 +152,6 @@ describe('LocalizeMixin', () => {
 			let elem, errorSpy;
 			beforeEach(async() => {
 				elem = await fixture(f);
-				await elem.updateComplete; // legacy edge
 				errorSpy = stub(console, 'error');
 			});
 
@@ -212,7 +211,7 @@ describe('LocalizeMixin', () => {
 				setTimeout(() => {
 					expect(renderCount).to.equal(1);
 					done();
-				}, 500); // larger timeout for legacy-Edge
+				}, 300);
 			});
 		});
 
@@ -225,7 +224,6 @@ describe('LocalizeMixin', () => {
 		let elem;
 		beforeEach(async() => {
 			elem = await fixture(multiMixinFixture);
-			await elem.updateComplete; // legacy edge
 		});
 
 		it('should localize text from all mixins', () => {


### PR DESCRIPTION
Just some follow up legacy-Edge cleanup (and a bit of IE11 cleanup) after @svanherk removed it from our unit testing.

I've only cleaned up things that would impact our testing code -- there are still a bunch of legacy-Edge hacks/references in the actual code which I think we want to leave in until we get the official "all clear".