### PR TITLE
DE45295: Fixing date-picker positioning on legacy screens

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -726,13 +726,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 				+ Math.min(this._ifrauContextInfo.top, 0);
 			bottomOverride = `${screenHeight}px`;
 		}
-		let bottomOfScreen = Math.max(window.innerHeight - window.screen.height, 0);
-		if (!this._ifrauContextInfo && bottomOfScreen > 0) {
-			// Window is taller than the screen,
-			// override bottom to stick to bottom of viewport
-			bottomOfScreen -= window.pageYOffset;
-			bottomOverride = `${Math.max(bottomOfScreen, 0)}px`;
-		}
 
 		const widthOverride = '100vw';
 

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -404,10 +404,15 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 		if (this._dropdown && !this._dropdown.openedAbove && !fullCalendarVisible) {
 			this._dropdown.querySelector('d2l-calendar').scrollIntoView({ block: 'nearest', behavior: 'smooth', inline: 'nearest' });
 		}
-		// use setTimeout to wait for keyboard to open on mobile devices
-		setTimeout(() => {
-			this._textInput.scrollIntoView({ block: 'nearest', behavior: 'smooth', inline: 'nearest' });
-		}, 150);
+
+		// if keyboard opens (in all cases except mobile calendar view),
+		// ensure text input is in viewport
+		if (!(mediaQueryList.matches && this._dropdown.opened)) {
+			// use setTimeout to wait for keyboard to open on mobile devices
+			setTimeout(() => {
+				this._textInput.scrollIntoView({ block: 'nearest', behavior: 'smooth', inline: 'nearest' });
+			}, 150);
+		}
 		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-input-date-dropdown-toggle',


### PR DESCRIPTION
Legacy screens are not responsive, meaning setting bottom: 0 will put the date-picker way at the bottom of the page rather than at the bottom of the screen. I initially tried to remedy this by setting the bottom to be the difference between window and screen sizes, but that hasn't been working consistently as Mark found in his testing. 

I've got a new approach where the bottom is still set to zero (at the bottom of the page), but the calendar is scrolled into view and fully visible. Once the calendar is closed, the focus is shifted back to the text input for the date. I don't think moving to the bottom of the page should be an issue since there is no guarantee we can see the text input anyways, it could be blocked behind the tray. Note that this change will affect the non-responsive pages only, such as the quiz or discussion editing pages. The web component and MVC pages should continue to work as normal.

Previous behaviour, very inconsistent, needs scrolling:
![legacy-date-picker-bug](https://user-images.githubusercontent.com/83968927/134950152-899a98af-d9c7-4409-ab26-d1b58f877eaa.gif)


New behaviour: Always down at the bottom: 
![legacy-date-picker-bug-fixed](https://user-images.githubusercontent.com/83968927/134950174-669c70a9-8edb-4c17-a86c-a6e344779d58.gif)
