### PR TITLE
US131477 - Fix esc behaviour in filter

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -24,6 +24,7 @@ import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
+const ESCAPE_KEY_CODE = 27;
 const SET_DIMENSION_ID_PREFIX = 'list-';
 
 /**
@@ -201,6 +202,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		}
 		return html`
 			<d2l-hierarchical-view
+				@d2l-hierarchical-view-hide-start="${this._handleDimensionHideStart}"
 				@d2l-hierarchical-view-show-complete="${this._handleDimensionShowComplete}"
 				@d2l-hierarchical-view-show-start="${this._handleDimensionShowStart}"
 				data-key="${dimension.key}">
@@ -292,7 +294,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		`;
 
 		return html`
-			<div slot="header">
+			<div slot="header" @keyup="${this._handleEscKeyPress}">
 				${header}
 				${actions}
 			</div>
@@ -490,6 +492,9 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 	_handleDimensionHide() {
 		this.shadowRoot.querySelector(`d2l-hierarchical-view[data-key="${this._activeDimensionKey}"]`).hide();
+	}
+
+	_handleDimensionHideStart() {
 		this._activeDimensionKey = null;
 	}
 
@@ -513,6 +518,13 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			this._dispatchDimensionFirstOpenEvent(this._dimensions[0].key);
 		}
 		this._stopPropagation(e);
+	}
+
+	_handleEscKeyPress(e) {
+		if (this._activeDimensionKey && e.keyCode === ESCAPE_KEY_CODE) {
+			e.stopPropagation();
+			this._handleDimensionHide();
+		}
 	}
 
 	_handleSearch(e) {

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -847,7 +847,34 @@ describe('d2l-filter', () => {
 		});
 	});
 
-	describe('esc behaviour in nested dimensions', () => {
+	describe('esc behaviour with multiple dimensions', () => {
+		it('if there is no active dimension, do not change esc behaviour', async() => {
+			const elem = await fixture(multiDimensionFixture);
+			const hideStub = stub(elem, '_handleDimensionHide');
+			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
+			const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
+			await dropdownContent.updateComplete;
+
+			setTimeout(() => dropdown.toggleOpen());
+			await oneEvent(dropdown, 'd2l-dropdown-open');
+			expect(dropdownContent.opened).to.be.true;
+
+			const event = new CustomEvent('keyup', {
+				detail: 0,
+				bubbles: true,
+				cancelable: true,
+				composed: true
+			});
+			event.key = 'Escape';
+			event.keyCode = 27;
+
+			const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
+			setTimeout(() => dimension.dispatchEvent(event));
+			await oneEvent(dropdown, 'd2l-dropdown-close');
+			expect(dropdownContent.opened).to.be.false;
+			expect(hideStub).to.not.be.called;
+		});
+
 		it('clicking esc in the header goes back to the dimension list', async() => {
 			const elem = await fixture(multiDimensionFixture);
 			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -846,4 +846,71 @@ describe('d2l-filter', () => {
 			expect(searchSpy).to.be.calledWith(elem._dimensions[0]);
 		});
 	});
+
+	describe('esc behaviour in nested dimensions', () => {
+		it('clicking esc in the header goes back to the dimension list', async() => {
+			const elem = await fixture(multiDimensionFixture);
+			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
+			const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
+			await dropdownContent.updateComplete;
+			const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
+
+			setTimeout(() => dropdown.toggleOpen());
+			await oneEvent(dropdown, 'd2l-dropdown-open');
+
+			setTimeout(() => dimension.click());
+			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
+			expect(elem._activeDimensionKey).to.not.be.null;
+
+			const event = new CustomEvent('keyup', {
+				detail: 0,
+				bubbles: true,
+				cancelable: true,
+				composed: true
+			});
+			event.key = 'Escape';
+			event.keyCode = 27;
+
+			const returnButton = elem.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]');
+			setTimeout(() => returnButton.dispatchEvent(event));
+			await oneEvent(elem, 'd2l-hierarchical-view-hide-complete');
+			expect(elem._activeDimensionKey).to.be.null;
+			expect(elem.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]')).to.be.null;
+			expect(elem.shadowRoot.querySelector('d2l-button-subtle[slot="header"]')).to.not.be.null;
+			expect(dropdownContent.opened).to.be.true;
+		});
+
+		it('set dimension - clicking esc in the content goes back to the dimension list', async() => {
+			const elem = await fixture(multiDimensionFixture);
+			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
+			const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
+			await dropdownContent.updateComplete;
+			const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
+
+			setTimeout(() => dropdown.toggleOpen());
+			await oneEvent(dropdown, 'd2l-dropdown-open');
+
+			setTimeout(() => dimension.click());
+			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
+			expect(elem._activeDimensionKey).to.not.be.null;
+
+			const event = new CustomEvent('keyup', {
+				detail: 0,
+				bubbles: true,
+				cancelable: true,
+				composed: true
+			});
+			event.key = 'Escape';
+			event.keyCode = 27;
+
+			const firstListItem = elem.shadowRoot.querySelector('d2l-list-item');
+			firstListItem.focus();
+			setTimeout(() => firstListItem.dispatchEvent(event));
+			await oneEvent(elem, 'd2l-hierarchical-view-hide-complete');
+			expect(elem._activeDimensionKey).to.be.null;
+			expect(elem.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]')).to.be.null;
+			expect(elem.shadowRoot.querySelector('d2l-button-subtle[slot="header"]')).to.not.be.null;
+			expect(dropdownContent.opened).to.be.true;
+		});
+	});
 });

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -849,10 +849,10 @@ describe('d2l-filter', () => {
 
 	describe('esc behaviour with multiple dimensions', () => {
 		it('if there is no active dimension, do not change esc behaviour', async() => {
-			const elem = await fixture(multiDimensionFixture);
+			const elem = await fixture(singleSetDimensionFixture);
 			const hideStub = stub(elem, '_handleDimensionHide');
 			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
-			const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
+			const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-content');
 			await dropdownContent.updateComplete;
 
 			setTimeout(() => dropdown.toggleOpen());
@@ -868,11 +868,11 @@ describe('d2l-filter', () => {
 			event.key = 'Escape';
 			event.keyCode = 27;
 
-			const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
-			setTimeout(() => dimension.dispatchEvent(event));
+			const clearButton = elem.shadowRoot.querySelector('[slot="header"] d2l-button-subtle');
+			setTimeout(() => clearButton.dispatchEvent(event));
 			await oneEvent(dropdown, 'd2l-dropdown-close');
 			expect(dropdownContent.opened).to.be.false;
-			expect(hideStub).to.not.be.called;
+			expect(hideStub).to.not.have.been.called;
 		});
 
 		it('clicking esc in the header goes back to the dimension list', async() => {


### PR DESCRIPTION
Thanks to @annabelsegalld2l for catching this!  Pressing `esc` in the header of a nested dimension would close the dropdown (because `dropdown` was handling it), whereas pressing it in the content/list would return to the dimension list (because `hierarchical-view` was handling it).  We want it to always return to the dimension list so I need to handle it manually in the header.  This also fixes a bug where I wasn't setting `this._activeDimensionKey` to `null` if the `esc` method was used instead of the back button, so the header wasn't updating correctly.