### PR TITLE
US131477 - Hide select all when loading or empty

### DIFF
--- a/components/filter/demo/filter-search-demo.js
+++ b/components/filter/demo/filter-search-demo.js
@@ -30,7 +30,7 @@ class FilterSearchDemo extends LitElement {
 					<d2l-filter-dimension-set-value key="instructor" text="Instructor"></d2l-filter-dimension-set-value>
 					<d2l-filter-dimension-set-value key="student" text="Student"></d2l-filter-dimension-set-value>
 				</d2l-filter-dimension-set>
-				<d2l-filter-dimension-set key="event" text="Event on Search" search-type="manual">
+				<d2l-filter-dimension-set key="event" text="Event on Search" select-all search-type="manual">
 					${this._fullData.map(value => html`
 						<d2l-filter-dimension-set-value key="${value.key}" text="${value.text}" ?selected="${value.selected}"></d2l-filter-dimension-set-value>
 					`)}

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -259,11 +259,10 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			</d2l-input-search>
 		`;
 
-		const selectAll = !dimension.selectAllIdPrefix || dimension.searchValue ? null : html`
+		const selectAll = !dimension.selectAllIdPrefix || dimension.searchValue || dimension.loading || this._isDimensionEmpty(dimension) ? null : html`
 			<div class="d2l-filter-dimension-select-all">
 				<d2l-selection-select-all
-					selection-for="${dimension.selectAllIdPrefix}${dimension.key}"
-					?disabled="${dimension.loading || this._isDimensionEmpty(dimension)}">
+					selection-for="${dimension.selectAllIdPrefix}${dimension.key}">
 				</d2l-selection-select-all>
 				<d2l-selection-summary
 					selection-for="${dimension.selectAllIdPrefix}${dimension.key}"

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -40,18 +40,18 @@ describe('d2l-filter', () => {
 	});
 
 	describe('loading', () => {
-		it('single set dimension - loading spinner and select all disabled', async() => {
+		it('single set dimension - loading spinner and select all hidden', async() => {
 			const elem = await fixture(singleSetDimensionFixture);
 			const dim = elem.querySelector('d2l-filter-dimension-set');
 			expect(elem.shadowRoot.querySelector('d2l-loading-spinner')).to.be.null;
-			expect(elem.shadowRoot.querySelector('d2l-selection-select-all').disabled).to.be.false;
+			expect(elem.shadowRoot.querySelector('d2l-selection-select-all')).to.not.be.null;
 
 			dim.loading = true;
 			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			await elem.updateComplete;
 
 			expect(elem.shadowRoot.querySelector('d2l-loading-spinner')).to.not.be.null;
-			expect(elem.shadowRoot.querySelector('d2l-selection-select-all').disabled).to.be.true;
+			expect(elem.shadowRoot.querySelector('d2l-selection-select-all')).to.be.null;
 		});
 	});
 


### PR DESCRIPTION
The disabled state of select all is a bit hard to see and isn't providing any value in the loading and empty states, so we now just hide it instead of disabling it.