### PR TITLE
Support nested content in custom list-items.

### DIFF
--- a/components/list/demo/list-item-custom.js
+++ b/components/list/demo/list-item-custom.js
@@ -71,6 +71,13 @@ class DemoListItemCustom extends ListItemMixin(LitElement) {
 		return this._renderListItem(itemTemplates);
 	}
 
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (changedProperties.has('key')) {
+			this.label = `Label for ${this.key}`;
+		}
+	}
+
 }
 
 customElements.define('d2l-demo-list-item-custom', DemoListItemCustom);

--- a/components/list/demo/list-item-custom.js
+++ b/components/list/demo/list-item-custom.js
@@ -1,0 +1,76 @@
+import '../list-item-content.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
+import { ListItemMixin } from '../list-item-mixin.js';
+
+const demoData = {
+	'L1-1': {
+		primaryText: 'Earth Sciences (L1)',
+		supportingText: 'Earth science or geoscience includes all fields of natural science related to planet Earth. This is a branch of science dealing with the physical and chemical constitution of Earth and its atmosphere. Earth science can be considered to be a branch of planetary science, but with a much older history.',
+		nested: [ 'L2-1', 'L2-2', 'L2-3' ]
+	},
+	'L1-2': {
+		primaryText: 'Biology (L1)',
+		supportingText: ''
+	},
+	'L1-3': {
+		primaryText: 'Computer Science (L3)',
+		supportingText: ''
+	},
+	'L2-1': {
+		primaryText: 'Introductory Earth Sciences (L2)',
+		supportingText: 'This course explores the geological processes of the Earth\'s interior and surface. These include volcanism, earthquakes, mountain building, glaciation and weathering. Students will gain an appreciation of how these processes have controlled the evolution of our planet and the role of geology in meeting society\'s current and future demand for sustainable energy and mineral resources.',
+		nested: [ 'L3-1', 'L3-2', 'L3-3' ]
+	},
+	'L2-2': {
+		primaryText: 'Flow and Transport Through Fractured Rocks (L2)',
+		supportingText: 'Fractures are ubiquitous in geologic media and important in disciplines such as physical and contaminant hydrogeology, geotechnical engineering, civil and environmental engineering, petroleum engineering among other areas. Despite the importance of fractures, its characterization and predictions of groundwater flow and contaminant transport are fraught with significant difficulties. Students are taught to deal with fractures in hydrogeology, to conceptualize them, and to build reliable models for predicting groundwater flow and contaminant transport.'
+	},
+	'L2-3': {
+		primaryText: 'Applied Wetland Science (L2)',
+		supportingText: 'Advanced concepts on wetland ecosystems in the context of regional and global earth systems processes such as carbon and nitrogen cycling and climate change, applications of wetland paleoecology, use of isotopes and other geochemical tools in wetland science, and wetland engineering in landscape rehabilitation and ecotechnology. Current issues in Canada and abroad will be examined.'
+	},
+	'L3-1': {
+		primaryText: 'Glaciation (L3)',
+		supportingText: 'Supporting Info'
+	},
+	'L3-2': {
+		primaryText: 'Weathering (L3)',
+		supportingText: 'Supporting Info'
+	},
+	'L3-3': {
+		primaryText: 'Volcanism (L3)',
+		supportingText: 'Supporting Info'
+	}
+};
+
+class DemoListItemCustom extends ListItemMixin(LitElement) {
+
+	constructor() {
+		super();
+		this.selectable = true;
+	}
+
+	render() {
+		const itemTemplates = {
+			content: html`
+				<d2l-list-item-content>
+					<div>${demoData[this.key].primaryText}</div>
+					<div slot="supporting-info">${demoData[this.key].supportingText}</div>
+				</d2l-list-item-content>
+			`
+		};
+
+		if (demoData[this.key].nested && demoData[this.key].nested.length > 0) {
+			itemTemplates.nested = html`
+				<d2l-list separators="all">
+					${demoData[this.key].nested.map(itemKey => html`<d2l-demo-list-item-custom selectable key="${itemKey}"></d2l-demo-list-item-custom>`)}
+				</d2l-list>
+			`;
+		}
+
+		return this._renderListItem(itemTemplates);
+	}
+
+}
+
+customElements.define('d2l-demo-list-item-custom', DemoListItemCustom);

--- a/components/list/demo/list-nested.html
+++ b/components/list/demo/list-nested.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+		<script type="module">
+			import '../../button/button-subtle.js';
+			import '../../button/button-icon.js';
+			import '../../demo/demo-page.js';
+			import '../../dropdown/dropdown-menu.js';
+			import '../../dropdown/dropdown-more.js';
+			import '../list-item-button.js';
+			import '../list-item-content.js';
+			import './list-item-custom.js';
+			import '../list-item.js';
+			import '../list-header.js';
+			import '../list.js';
+			import '../../menu/menu.js';
+			import '../../menu/menu-item.js';
+			import '../../selection/selection-action.js';
+		</script>
+	</head>
+	<body unresolved>
+
+		<d2l-demo-page page-title="d2l-list-item (nested)">
+
+			<h2>Nested</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list>
+						<d2l-list-header slot="header">
+							<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+							<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+						</d2l-list-header>
+						<d2l-list-item selectable key="L1-1">
+							<d2l-list-item-content>
+								<div>Earth Sciences (L1)</div>
+								<div slot="supporting-info">Earth science or geoscience includes all fields of natural science related to planet Earth. This is a branch of science dealing with the physical and chemical constitution of Earth and its atmosphere. Earth science can be considered to be a branch of planetary science, but with a much older history.</div>
+							</d2l-list-item-content>
+							<d2l-list slot="nested" separators="all">
+								<d2l-list-item selectable key="L2-1">
+									<d2l-list-item-content>
+										<div>Introductory Earth Sciences (L2)</div>
+										<div slot="supporting-info">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain building, glaciation and weathering. Students will gain an appreciation of how these processes have controlled the evolution of our planet and the role of geology in meeting society's current and future demand for sustainable energy and mineral resources.</div>
+									</d2l-list-item-content>
+									<d2l-list slot="nested" separators="all">
+										<d2l-list-item selectable key="L3-1">
+											<d2l-list-item-content>
+												<div>Glaciation (L3)</div>
+												<div slot="supporting-info">Supporting Info</div>
+											</d2l-list-item-content>
+											<d2l-list slot="nested" separators="all">
+												<d2l-list-item selectable key="L4-1">
+													<d2l-list-item-content>
+														<div>Ice Sheets (L4)</div>
+														<div slot="supporting-info">Supporting Info</div>
+													</d2l-list-item-content>
+													<d2l-list slot="nested" separators="all">
+														<d2l-list-item selectable key="L5-1">
+															<d2l-list-item-content>
+																<div>Topic 1 (L5)</div>
+																<div slot="supporting-info">Supporting Info</div>
+															</d2l-list-item-content>
+														</d2l-list-item>
+														<d2l-list-item selectable key="L5-2">
+															<d2l-list-item-content>
+																<div>Topic 2 (L5)</div>
+																<div slot="supporting-info">Supporting Info</div>
+															</d2l-list-item-content>
+															<d2l-list slot="nested" separators="all">
+																<d2l-list-item selectable key="L6-1">
+																	<d2l-list-item-content>
+																		<div>Sub-Topic 1 (L6)</div>
+																		<div slot="supporting-info">Supporting Info</div>
+																	</d2l-list-item-content>
+																	<d2l-list slot="nested" separators="all">
+																		<d2l-list-item selectable key="L7-1">
+																			<d2l-list-item-content>
+																				<div>Sub-Topic 1 (L7)</div>
+																				<div slot="supporting-info">Supporting Info</div>
+																			</d2l-list-item-content>
+																			<d2l-list slot="nested" separators="all">
+																				<d2l-list-item selectable selected key="L8-1">
+																					<d2l-list-item-content>
+																						<div>Sub-Topic 1 (L8)</div>
+																						<div slot="supporting-info">Supporting Info</div>
+																					</d2l-list-item-content>
+																				</d2l-list-item>
+																				<d2l-list-item selectable key="L8-2">
+																					<d2l-list-item-content>
+																						<div>Sub-Topic 2 (L8)</div>
+																						<div slot="supporting-info">Supporting Info</div>
+																					</d2l-list-item-content>
+																				</d2l-list-item>
+																			</d2l-list>
+																		</d2l-list-item>
+																		<d2l-list-item selectable key="L7-2">
+																			<d2l-list-item-content>
+																				<div>Sub-Topic 2 (L7)</div>
+																				<div slot="supporting-info">Supporting Info</div>
+																			</d2l-list-item-content>
+																		</d2l-list-item>
+																	</d2l-list>
+																</d2l-list-item>
+																<d2l-list-item selectable key="L6-2">
+																	<d2l-list-item-content>
+																		<div>Sub-Topic 2 (L6)</div>
+																		<div slot="supporting-info">Supporting Info</div>
+																	</d2l-list-item-content>
+																</d2l-list-item>
+															</d2l-list>
+														</d2l-list-item>
+													</d2l-list>
+												</d2l-list-item>
+												<d2l-list-item selectable key="L4-2">
+													<d2l-list-item-content>
+														<div>Alpine Glaciers (L4)</div>
+														<div slot="supporting-info">Supporting Info</div>
+													</d2l-list-item-content>
+												</d2l-list-item>
+											</d2l-list>
+										</d2l-list-item>
+										<d2l-list-item selectable key="L3-2">
+											<d2l-list-item-content>
+												<div>Weathering (L3)</div>
+												<div slot="supporting-info">Supporting Info</div>
+											</d2l-list-item-content>
+										</d2l-list-item>
+										<d2l-list-item selectable key="L3-3">
+											<d2l-list-item-content>
+												<div>Volcanism (L3)</div>
+												<div slot="supporting-info">Supporting Info</div>
+											</d2l-list-item-content>
+										</d2l-list-item>
+									</d2l-list>
+								</d2l-list-item>
+								<d2l-list-item selectable key="L2-2">
+									<d2l-list-item-content>
+										<div>Flow and Transport Through Fractured Rocks (L2)</div>
+										<div slot="supporting-info">Fractures are ubiquitous in geologic media and important in disciplines such as physical and contaminant hydrogeology, geotechnical engineering, civil and environmental engineering, petroleum engineering among other areas. Despite the importance of fractures, its characterization and predictions of groundwater flow and contaminant transport are fraught with significant difficulties. Students are taught to deal with fractures in hydrogeology, to conceptualize them, and to build reliable models for predicting groundwater flow and contaminant transport.</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+								<d2l-list-item selectable key="L2-3">
+									<d2l-list-item-content>
+										<div>Applied Wetland Science (L2)</div>
+										<div slot="supporting-info">Advanced concepts on wetland ecosystems in the context of regional and global earth systems processes such as carbon and nitrogen cycling and climate change, applications of wetland paleoecology, use of isotopes and other geochemical tools in wetland science, and wetland engineering in landscape rehabilitation and ecotechnology. Current issues in Canada and abroad will be examined.</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+							</d2l-list>
+							<div slot="actions">
+								<d2l-button-icon text="My Button" icon="tier1:preview"></d2l-button-icon>
+								<d2l-dropdown-more text="Open!">
+									<d2l-dropdown-menu>
+										<d2l-menu label="Astronomy">
+											<d2l-menu-item text="Introduction"></d2l-menu-item>
+											<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+										</d2l-menu>
+									</d2l-dropdown-menu>
+								</d2l-dropdown-more>
+							</div>
+						</d2l-list-item>
+						<d2l-list-item selectable key="L1-2">
+							<div>Biology (L1)</div>
+						</d2l-list-item>
+						<d2l-list-item selectable key="L1-3">
+							<div>Computer Science (L1)</div>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Nested Custom</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list>
+						<d2l-list-header slot="header">
+							<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+							<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+						</d2l-list-header>
+						<d2l-demo-list-item-custom key="L1-1"></d2l-demo-list-item-custom>
+						<d2l-demo-list-item-custom key="L1-2"></d2l-demo-list-item-custom>
+						<d2l-demo-list-item-custom key="L1-3"></d2l-demo-list-item-custom>
+					</d2l-list>
+				</template>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+
+	</body>
+</html>

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -123,21 +123,9 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(L
 		}
 	}
 
-	_onNestedSlotChange(e) {
-		if (!this.selectable) return;
-
-		const nestedList = e.target.assignedNodes().find(node => (node.nodeType === Node.ELEMENT_NODE && node.tagName === 'D2L-LIST'));
-		if (this._selectionProvider === nestedList) return;
-
-		if (this._selectionProvider && this._selectionProvider !== nestedList) {
-			this._selectionProvider.unsubscribeObserver(this);
-			this._selectionProvider = null;
-		}
-
-		if (nestedList) {
-			this._selectionProvider = nestedList;
-			this._selectionProvider.subscribeObserver(this);
-		}
+	_onSelectionProviderConnected(e) {
+		e.stopPropagation();
+		this._updateNestedSelectionProvider();
 	}
 
 	_renderCheckbox() {
@@ -168,4 +156,29 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(L
 			</div>
 			` : nothing;
 	}
+
+	_updateNestedSelectionProvider() {
+		if (!this.selectable) return;
+
+		const nestedSlot = this.shadowRoot.querySelector('slot[name="nested"]');
+		let nestedNodes = nestedSlot.assignedNodes();
+		if (nestedNodes.length === 0) {
+			nestedNodes = [...nestedSlot.childNodes];
+		}
+
+		const nestedList = nestedNodes.find(node => (node.nodeType === Node.ELEMENT_NODE && node.tagName === 'D2L-LIST'));
+
+		if (this._selectionProvider === nestedList) return;
+
+		if (this._selectionProvider && this._selectionProvider !== nestedList) {
+			this._selectionProvider.unsubscribeObserver(this);
+			this._selectionProvider = null;
+		}
+
+		if (nestedList) {
+			this._selectionProvider = nestedList;
+			this._selectionProvider.subscribeObserver(this);
+		}
+	}
+
 };

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -333,7 +333,7 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 		this._hovering = false;
 	}
 
-	_renderListItem({ illustration, content, actions } = {}) {
+	_renderListItem({ illustration, content, actions, nested } = {}) {
 		const classes = {
 			'd2l-visible-on-ancestor-target': true,
 			'd2l-list-item-content-extend-separators': this._extendSeparators,
@@ -388,8 +388,8 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 						class="d2l-list-item-actions-container">
 						<slot name="actions" class="d2l-list-item-actions">${actions}</slot>
 					</div>
-					<div slot="nested">
-						<slot name="nested" @slotchange="${this._onNestedSlotChange}"></slot>
+					<div slot="nested" @d2l-selection-provider-connected="${this._onSelectionProviderConnected}">
+						<slot name="nested">${nested}</slot>
 					</div>
 				</d2l-list-item-generic-layout>
 				<div class="d2l-list-item-active-border"></div>

--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -59,6 +59,10 @@ export const SelectionMixin = superclass => class extends RtlMixin(superclass) {
 		this.addEventListener('d2l-selection-change', this._handleSelectionChange);
 		this.addEventListener('d2l-selection-observer-subscribe', this._handleSelectionObserverSubscribe);
 		this.addEventListener('d2l-selection-input-subscribe', this._handleSelectionInputSubscribe);
+		requestAnimationFrame(() => {
+			this.dispatchEvent(new CustomEvent('d2l-selection-provider-connected', { bubbles: true, composed: true }));
+		});
+
 	}
 
 	disconnectedCallback() {

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -108,6 +108,15 @@ describe('SelectionMixin', () => {
 		await nextFrame();
 	});
 
+	it('dispatches d2l-selection-provider-connected event when connected', async() => {
+		setTimeout(() => {
+			const parentNode = el.parentNode;
+			parentNode.removeChild(el);
+			parentNode.appendChild(el);
+		});
+		await oneEvent(el, 'd2l-selection-provider-connected');
+	});
+
 	it('registers observers', async() => {
 		expect(el._selectionObservers.size).to.equal(2);
 	});


### PR DESCRIPTION
This PR updates the wire-up of a parent list-item as an observer of a nested list to be done via a custom `d2l-selection-provider-connected` event rather than `slotchange` event.  This is because consumers of the `ListItemMixin` (such as HM components) may populate the nested slot with "default" content, such that the `slotchange` event does not get dispatched. It also updates the demo page to help facilitate testing, although it is not included in the demo index because it is subject to change since the docs and demos will be rewritten.