### PR TITLE
Use LabelledMixin in our input components

### DIFF
--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -221,6 +221,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 				@mouseover="${this._handleInputTimeFocus}"
 				label="${this.localize('components.input-date-time.time')}"
 				label-hidden
+				.labelRequired="${false}"
 				max-height="430"
 				?required="${this.required}"
 				?skeleton="${this.skeleton}"
@@ -245,6 +246,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 						id="${this._inputId}"
 						label="${this.localize('components.input-date-time.date')}"
 						label-hidden
+						.labelRequired="${false}"
 						max-value="${ifDefined(this._maxValueLocalized)}"
 						min-value="${ifDefined(this._minValueLocalized)}"
 						?opened="${dateOpened}"

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -17,6 +17,7 @@ import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getDefaultTime } from './input-time.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { LabelledMixin } from '../../mixins/labelled-mixin.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
@@ -38,7 +39,7 @@ function _getFormattedDefaultTime(defaultValue) {
  * A component that consists of a "<d2l-input-date>" and a "<d2l-input-time>" component. The time input only appears once a date is selected. This component displays the "value" if one is specified, and reflects the selected value when one is selected or entered.
  * @fires change - Dispatched when there is a change to selected date or selected time. "value" corresponds to the selected value and is formatted in ISO 8601 combined date and time format ("YYYY-MM-DDTHH:mm:ss.sssZ").
  */
-class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement)))) {
+class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -46,11 +47,6 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 			 * Disables the input
 			 */
 			disabled: { type: Boolean },
-			/**
-			 * REQUIRED: Accessible label for the input fieldset that wraps the date and time inputs
-			 * @type {string}
-			 */
-			label: { type: String },
 			/**
 			 * Hides the fieldset label visually
 			 */
@@ -191,10 +187,6 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
-		if (!this.label) {
-			console.warn('d2l-input-date-time component requires label text');
-		}
-
 		if (this.value) this._preventDefaultValidation = true;
 	}
 
@@ -239,7 +231,7 @@ class InputDateTime extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(R
 			${tooltip}
 			<d2l-input-fieldset
 				label="${ifDefined(this.label)}"
-				?label-hidden="${this.labelHidden}"
+				?label-hidden="${this.labelHidden || this.labelledBy}"
 				?required="${this.required}"
 				?skeleton="${this.skeleton}">
 				<div class="d2l-input-date-time-container">

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -269,6 +269,7 @@ class InputDate extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCor
 					id="${this._inputId}"
 					label="${ifDefined(this.label)}"
 					?label-hidden="${this.labelHidden || this.labelledBy}"
+					.labelRequired="${false}"
 					live="assertive"
 					@mouseup="${this._handleMouseup}"
 					placeholder="${shortDateFormat}"

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -11,6 +11,7 @@ import { formatDateInISO, getDateFromISODate, getDateTimeDescriptorShared, getTo
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { LabelledMixin } from '../../mixins/labelled-mixin.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
@@ -26,7 +27,7 @@ export function formatISODateInUserCalDescriptor(val) {
  * A component that consists of a text input field for typing a date and an attached calendar (d2l-calendar) dropdown. It displays the "value" if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the calendar or entered in the text input.
  * @fires change - Dispatched when there is a change to selected date. "value" corresponds to the selected value and is formatted in ISO 8601 calendar date format ("YYYY-MM-DD").
  */
-class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))) {
+class InputDate extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -38,11 +39,6 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 			 * Text that appears as a placeholder in the input to reassure users that they can choose not to provide a value (usually not necessary)
 			 */
 			emptyText: { type: String, attribute: 'empty-text' },
-			/**
-			 * REQUIRED: Accessible label for the input
-			 * @type {string}
-			 */
-			label: { type: String },
 			/**
 			 * Hides the label visually (moves it to the input's "aria-label" attribute)
 			 */
@@ -177,10 +173,6 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 	async firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
-		if (!this.label) {
-			console.warn('d2l-input-date component requires label text');
-		}
-
 		this._textInput = this.shadowRoot.querySelector('d2l-input-text');
 
 		this.addEventListener('blur', this._handleBlur);
@@ -276,7 +268,7 @@ class InputDate extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitEl
 					hide-invalid-icon
 					id="${this._inputId}"
 					label="${ifDefined(this.label)}"
-					?label-hidden="${this.labelHidden}"
+					?label-hidden="${this.labelHidden || this.labelledBy}"
 					live="assertive"
 					@mouseup="${this._handleMouseup}"
 					placeholder="${shortDateFormat}"

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -4,6 +4,7 @@ import { formatNumber, getNumberDescriptor, parseNumber } from '@brightspace-ui/
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { LabelledMixin } from '../../mixins/labelled-mixin.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
@@ -67,7 +68,7 @@ function roundPrecisely(val, maxFractionDigits) {
  * @slot right - Slot within the input on the right side. Useful for an "icon" or "button-icon".
  * @fires change - Dispatched when an alteration to the value is committed (typically after focus is lost) by the user. The `value` attribute reflects a JavaScript Number which is parsed from the formatted input value.
  */
-class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))) {
+class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -96,11 +97,6 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 			 * @type {string}
 			 */
 			inputWidth: { attribute: 'input-width', type: String },
-			/**
-			 * Label for the input
-			 * @type {string}
-			 */
-			label: { type: String },
 			/**
 			 * Hides the label visually (moves it to the input's `aria-label` attribute)
 			 * @type {boolean}
@@ -302,9 +298,6 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-		if (!this.label) {
-			console.warn('d2l-input-number component requires label text');
-		}
 		this.addEventListener('d2l-localize-behavior-language-changed', () => {
 			this._descriptor = getNumberDescriptor();
 			if (this._formattedValue.length > 0) {
@@ -329,7 +322,8 @@ class InputNumber extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Lit
 				id="${this._inputId}"
 				input-width="${this.inputWidth}"
 				label="${ifDefined(this.label)}"
-				?label-hidden="${this.labelHidden}"
+				?label-hidden="${this.labelHidden || this.labelledBy}"
+				.labelRequired="${false}"
 				name="${ifDefined(this.name)}"
 				placeholder="${ifDefined(this.placeholder)}"
 				?required="${this.required}"

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -2,6 +2,7 @@ import './input-number.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { LabelledMixin } from '../../mixins/labelled-mixin.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
@@ -11,7 +12,7 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  * @slot after - Slot beside the input on the right side. Useful for an "icon" or "button-icon".
  * @fires change - Dispatched when an alteration to the value is committed (typically after focus is lost) by the user. The `value` attribute reflects a JavaScript Number which is parsed from the formatted input value.
  */
-class InputPercent extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement)))) {
+class InputPercent extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -30,11 +31,6 @@ class InputPercent extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Rt
 			 * @type {string}
 			 */
 			inputWidth: { attribute: 'input-width', type: String },
-			/**
-			 * REQUIRED: Label for the input
-			 * @type {string}
-			 */
-			label: { type: String },
 			/**
 			 * Hides the label visually (moves it to the input's "aria-label" attribute)
 			 * @type {boolean}
@@ -106,13 +102,6 @@ class InputPercent extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Rt
 		this.requestUpdate('value', oldValue);
 	}
 
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
-		if (!this.label) {
-			console.warn('d2l-input-percent component requires label text');
-		}
-	}
-
 	render() {
 		return html`
 			<d2l-input-number
@@ -123,7 +112,8 @@ class InputPercent extends SkeletonMixin(FormElementMixin(LocalizeCoreElement(Rt
 				.forceInvalid="${this.invalid}"
 				input-width="${ifDefined(this.inputWidth)}"
 				label="${ifDefined(this.label)}"
-				?label-hidden="${this.labelHidden}"
+				?label-hidden="${this.labelHidden || this.labelledBy}"
+				.labelRequired="${false}"
 				max="100"
 				max-fraction-digits="${ifDefined(this.maxFractionDigits)}"
 				min="0"

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -311,7 +311,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 	connectedCallback() {
 		super.connectedCallback();
 		if (this.ariaLabel) {
-			this._labelRequired = false;
+			this.labelRequired = false;
 		}
 	}
 

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -7,6 +7,7 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
 import { inputStyles } from './input-styles.js';
+import { LabelledMixin } from '../../mixins/labelled-mixin.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import { PerfMonitor } from '../../helpers/perfMonitor.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
@@ -21,7 +22,7 @@ import { styleMap } from 'lit-html/directives/style-map.js';
  * @fires change - Dispatched when an alteration to the value is committed (typically after focus is lost) by the user
  * @fires input - Dispatched immediately after changes by the user
  */
-class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
+class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -71,11 +72,6 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 			 * @type {string}
 			 */
 			inputWidth: { attribute: 'input-width', type: String },
-			/**
-			 * REQUIRED: Label for the input
-			 * @type {string}
-			 */
-			label: { type: String },
 			/**
 			 * Hides the label visually (moves it to the input's "aria-label" attribute)
 			 * @type {boolean}
@@ -312,6 +308,13 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		return super.validity;
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		if (this.ariaLabel) {
+			this._labelRequired = false;
+		}
+	}
+
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		if (this._intersectionObserver) this._intersectionObserver.disconnect();
@@ -434,7 +437,7 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 			</div>
 			${offscreenContainer}
 		`;
-		if (this.label && !this.labelHidden) {
+		if (this.label && !this.labelHidden && !this.labelledBy) {
 			return html`
 				<label class="d2l-input-label d2l-skeletize" for="${this._inputId}">${this.label}${this.unit ? html`<span class="d2l-offscreen"> ${this.unit}</span>` : ''}</label>
 				${input}`;
@@ -471,7 +474,7 @@ class InputText extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
 	}
 
 	_getAriaLabel() {
-		if (this.label && this.labelHidden) {
+		if (this.label && (this.labelHidden || this.labelledBy)) {
 			return this.label;
 		}
 		if (this.hasAttribute('aria-label')) {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -310,7 +310,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 
 	connectedCallback() {
 		super.connectedCallback();
-		if (this.ariaLabel) {
+		if (this.hasAttribute('aria-label')) {
 			this.labelRequired = false;
 		}
 	}

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -6,6 +6,7 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
 import { inputStyles } from './input-styles.js';
+import { LabelledMixin } from '../../mixins/labelled-mixin.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
@@ -16,7 +17,7 @@ import { styleMap } from 'lit-html/directives/style-map.js';
  * @fires change - Dispatched when an alteration to the value is committed (typically after focus is lost) by the user
  * @fires input - Dispatched immediately after changes by the user
  */
-class InputTextArea extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))) {
+class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -35,11 +36,6 @@ class InputTextArea extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))
 			 * @type {boolean}
 			 */
 			disabled: { type: Boolean, reflect: true },
-			/**
-			 * REQUIRED: Label for the input
-			 * @type {string}
-			 */
-			label: { type: String },
 			/**
 			 * Hides the label visually (moves it to the input's "aria-label" attribute)
 			 * @type {boolean}
@@ -232,7 +228,7 @@ class InputTextArea extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))
 			${offscreenContainer}
 		`;
 
-		if (this.label && !this.labelHidden) {
+		if (this.label && !this.labelHidden && !this.labelledBy) {
 			return html`
 				<label class="d2l-input-label d2l-skeletize" for="${this._textareaId}">${this.label}</label>
 				${textarea}`;
@@ -281,7 +277,7 @@ class InputTextArea extends FormElementMixin(SkeletonMixin(RtlMixin(LitElement))
 	}
 
 	_getAriaLabel() {
-		if (this.label && this.labelHidden) {
+		if (this.label && (this.labelHidden || this.labelledBy)) {
 			return this.label;
 		}
 		// check aria-label for backwards compatibility in order to replace old Polymer impl

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -12,6 +12,7 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputLabelStyles } from './input-label-styles.js';
 import { inputStyles } from './input-styles.js';
+import { LabelledMixin } from '../../mixins/labelled-mixin.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
@@ -110,7 +111,7 @@ function initIntervals(size, enforceTimeIntervals) {
  * A component that consists of a text input field for typing a time and an attached dropdown for time selection. It displays the "value" if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
  * @fires change - Dispatched when there is a change to selected time. "value" corresponds to the selected value and is formatted in ISO 8601 time format ("hh:mm:ss").
  */
-class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
+class InputTime extends LabelledMixin(SkeletonMixin(FormElementMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -127,11 +128,6 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 			 * Rounds typed input up to nearest valid interval time (specified with "time-interval")
 			 */
 			enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
-			/**
-			 * REQUIRED: Accessible label for the input
-			 * @type {string}
-			 */
-			label: { type: String },
 			/**
 			 * Hides the label visually (moves it to the input's "aria-label" attribute)
 			 */
@@ -247,9 +243,6 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 
 	async firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-		if (!this.label) {
-			console.warn('d2l-input-time component requires label text');
-		}
 
 		if (this.value === undefined) {
 			const time = getDefaultTime(this.defaultValue, this.enforceTimeIntervals, this.timeInterval);
@@ -297,7 +290,7 @@ class InputTime extends SkeletonMixin(FormElementMixin(LitElement)) {
 				<div>${formattedWideTimePM}</div>
 			</div>
 			<label
-				class="${this.label && !this.labelHidden ? 'd2l-input-label d2l-skeletize' : 'd2l-offscreen'}"
+				class="${this.label && !this.labelHidden && !this.labelledBy ? 'd2l-input-label d2l-skeletize' : 'd2l-offscreen'}"
 				for="${this._dropdownId}-input"
 				id="${this._dropdownId}-label">${this.label}</label>
 			<d2l-dropdown class="d2l-skeletize" ?disabled="${disabled}">

--- a/components/inputs/test/input-date-time.axe.js
+++ b/components/inputs/test/input-date-time.axe.js
@@ -26,10 +26,10 @@ describe('d2l-input-date-time', () => {
 	});
 
 	it('labelled-by', async() => {
-		const elem = await fixture(html`
+		const elem = await fixture(html`<div>
 			<d2l-input-date-time labelled-by="label"></d2l-input-date-time>
 			<span id="label">label text</span>
-		`);
+		</div>`);
 		await expect(elem).to.be.accessible({ ignoredRules: ['color-contrast'] }); // color-contrast takes a while and should be covered by axe tests in the individual components
 	});
 

--- a/components/inputs/test/input-date-time.axe.js
+++ b/components/inputs/test/input-date-time.axe.js
@@ -25,4 +25,12 @@ describe('d2l-input-date-time', () => {
 		await expect(elem).to.be.accessible({ ignoredRules: ['color-contrast'] }); // color-contrast takes a while and should be covered by axe tests in the individual components
 	});
 
+	it('labelled-by', async() => {
+		const elem = await fixture(html`
+			<d2l-input-date-time labelled-by="label"></d2l-input-date-time>
+			<span id="label">label text</span>
+		`);
+		await expect(elem).to.be.accessible({ ignoredRules: ['color-contrast'] }); // color-contrast takes a while and should be covered by axe tests in the individual components
+	});
+
 });

--- a/components/inputs/test/input-date.axe.js
+++ b/components/inputs/test/input-date.axe.js
@@ -30,4 +30,12 @@ describe('d2l-input-date', () => {
 		await expect(elem).to.be.accessible();
 	});
 
+	it('labelled-by', async() => {
+		const elem = await fixture(html`<div>
+			<d2l-input-date labelled-by="label"></d2l-input-date>
+			<span id="label">label text</span>
+		</div>`);
+		await expect(elem).to.be.accessible();
+	});
+
 });

--- a/components/inputs/test/input-number.axe.js
+++ b/components/inputs/test/input-number.axe.js
@@ -32,6 +32,14 @@ describe('d2l-input-number', () => {
 		await expect(elem).to.be.accessible();
 	});
 
+	it('labelled-by', async() => {
+		const elem = await fixture(html`<div>
+			<d2l-input-number labelled-by="label"></d2l-input-number>
+			<span id="label">label</span>
+		</div>`);
+		await expect(elem).to.be.accessible();
+	});
+
 	it('focused', async() => {
 		const elem = await fixture(html`<d2l-input-number label="label"></d2l-input-number>`);
 		elem.focus();

--- a/components/inputs/test/input-percent.axe.js
+++ b/components/inputs/test/input-percent.axe.js
@@ -32,6 +32,14 @@ describe('d2l-input-percent', () => {
 		await expect(elem).to.be.accessible();
 	});
 
+	it('labelled-by', async() => {
+		const elem = await fixture(html`<div>
+			<d2l-input-percent labelled-by="label"></d2l-input-percent>
+			<span id="label">label</span>
+		</div>`);
+		await expect(elem).to.be.accessible();
+	});
+
 	it('focused', async() => {
 		const elem = await fixture(html`<d2l-input-percent label="label"></d2l-input-percent>`);
 		elem.focus();

--- a/components/inputs/test/input-search.test.js
+++ b/components/inputs/test/input-search.test.js
@@ -3,8 +3,8 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-search label="search"></d2l-input-search>`;
-const valueSetFixture = html`<d2l-input-search value="foo"></d2l-input-search>`;
-const noClearFixture = html`<d2l-input-search value="foo" no-clear></d2l-input-search>`;
+const valueSetFixture = html`<d2l-input-search label="search" value="foo"></d2l-input-search>`;
+const noClearFixture = html`<d2l-input-search label="search" value="foo" no-clear></d2l-input-search>`;
 
 function assertSearchVisibility(elem, isVisible) {
 	const visibleButton = elem.shadowRoot.querySelector('d2l-button-icon');

--- a/components/inputs/test/input-text.axe.js
+++ b/components/inputs/test/input-text.axe.js
@@ -34,4 +34,17 @@ describe('d2l-input-text', () => {
 		await expect(elem).to.be.accessible();
 	});
 
+	it('labelled-by', async() => {
+		const elem = await fixture(html`
+			<d2l-input-text labelled-by="label"></d2l-input-text>
+			<span id="label">label</span>
+		`);
+		await expect(elem).to.be.accessible();
+	});
+
+	it('aria-label', async() => {
+		const elem = await fixture(html`<d2l-input-text aria-label="label"></d2l-input-text>`);
+		await expect(elem).to.be.accessible();
+	});
+
 });

--- a/components/inputs/test/input-text.axe.js
+++ b/components/inputs/test/input-text.axe.js
@@ -35,10 +35,10 @@ describe('d2l-input-text', () => {
 	});
 
 	it('labelled-by', async() => {
-		const elem = await fixture(html`
+		const elem = await fixture(html`<div>
 			<d2l-input-text labelled-by="label"></d2l-input-text>
 			<span id="label">label</span>
-		`);
+		</div>`);
 		await expect(elem).to.be.accessible();
 	});
 

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -110,6 +110,7 @@ describe('d2l-input-text', () => {
 		it('should focus even if component has not rendered', async() => {
 			const container = await fixture(html`<div></div>`);
 			const newInput = document.createElement('d2l-input-text');
+			newInput.setAttribute('label', 'label');
 			container.appendChild(newInput);
 			await newInput.focus();
 			const activeElement = getComposedActiveElement();
@@ -135,6 +136,15 @@ describe('d2l-input-text', () => {
 			const elem = await fixture(html`<d2l-input-text aria-label="new label"></d2l-input-text>`);
 			expect(getLabel(elem)).to.be.null;
 			expect(getInput(elem).getAttribute('aria-label')).to.equal('new label');
+		});
+
+		it('should put labelled-by label on "aria-label"', async() => {
+			const elem = await fixture(html`
+				<d2l-input-text labelled-by="label"></d2l-input-text>
+				<span id="label">label</span>
+			`);
+			expect(getLabel(elem)).to.be.null;
+			expect(getInput(elem).getAttribute('aria-label')).to.equal('label');
 		});
 
 	});

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -143,6 +143,7 @@ describe('d2l-input-text', () => {
 				<d2l-input-text labelled-by="label"></d2l-input-text>
 				<span id="label">label</span>
 			`);
+			await aTimeout(100); // for Safari
 			expect(getLabel(elem)).to.be.null;
 			expect(getInput(elem).getAttribute('aria-label')).to.equal('label');
 		});

--- a/components/inputs/test/input-textarea.axe.js
+++ b/components/inputs/test/input-textarea.axe.js
@@ -34,6 +34,14 @@ describe('d2l-input-textarea', () => {
 		await expect(elem).to.be.accessible();
 	});
 
+	it('labelled-by', async() => {
+		const elem = await fixture(html`<div>
+			<d2l-input-textarea labelled-by="label"></d2l-input-textarea>
+			<span id="label">label</span>
+		</div>`);
+		await expect(elem).to.be.accessible();
+	});
+
 	it('no border', async() => {
 		const elem = await fixture(html`<d2l-input-textarea label="label" no-border></d2l-input-textarea>`);
 		await expect(elem).to.be.accessible();

--- a/components/inputs/test/input-time.axe.js
+++ b/components/inputs/test/input-time.axe.js
@@ -13,6 +13,14 @@ describe('d2l-input-time', () => {
 		await expect(elem).to.be.accessible({ ignoredRules: ['color-contrast'] }); //Color-contrast is slow and hidden label uses the same colors as default
 	});
 
+	it('labelled-by', async() => {
+		const elem = await fixture(html`<div>
+			<d2l-input-time labelled-by="label" time-interval="sixty"></d2l-input-time>
+			<span id="label">label text</span>
+		</div>`);
+		await expect(elem).to.be.accessible({ ignoredRules: ['color-contrast'] }); //Color-contrast is slow and hidden label uses the same colors as default
+	});
+
 	it('disabled', async() => {
 		const elem = await fixture(html`<d2l-input-time label="label text" time-interval="sixty" disabled></d2l-input-time>`);
 		await expect(elem).to.be.accessible();

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -82,7 +82,7 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(L
 		if (this.selectable) {
 			if (!this.key) console.warn('ListItemCheckboxMixin requires a key.');
 		} else {
-			this._labelRequired = false;
+			this.labelRequired = false;
 		}
 		if (!this.key) this.setSelected(undefined, true);
 	}

--- a/mixins/labelled-mixin.js
+++ b/mixins/labelled-mixin.js
@@ -84,7 +84,7 @@ export const LabelledMixin = superclass => class extends superclass {
 			 */
 			labelledBy: { type: String, reflect: true, attribute: 'labelled-by' },
 			/**
-			 * Explicitly defined label used to provide context for accessibility
+			 * REQUIRED: Explicitly defined label for the element
 			 * @type {string}
 			 */
 			label: { type: String }

--- a/mixins/labelled-mixin.js
+++ b/mixins/labelled-mixin.js
@@ -93,8 +93,8 @@ export const LabelledMixin = superclass => class extends superclass {
 
 	constructor() {
 		super();
+		this.labelRequired = true;
 		this._labelElem = null;
-		this._labelRequired = true;
 		this._missingLabelErrorHasBeenThrown = false;
 	}
 
@@ -135,7 +135,7 @@ export const LabelledMixin = superclass => class extends superclass {
 	}
 
 	_throwError(err) {
-		if (!this._labelRequired || this._missingLabelErrorHasBeenThrown) return;
+		if (!this.labelRequired || this._missingLabelErrorHasBeenThrown) return;
 		this._missingLabelErrorHasBeenThrown = true;
 		setTimeout(() => { throw err; }); // we don't want to prevent rendering
 	}


### PR DESCRIPTION
`LabelledMixin` is a pretty sweet way to get consistent labelling & missing label exception handling across all our components. It also supports `labelled-by`, which is pretty sweet.

So this PR updates almost all of our inputs to use it: `d2l-input-text`, `d2l-input-textarea`, `d2l-input-date`, `d2l-input-time`, `d2l-input-date-time`, `d2l-input-number` and `d2l-input-percent`.

There are a few like the date/time range components and the checkbox/radio components where it would either be difficult (the ranges have multiple labels) or weird (checkboxes and radios use fieldsets), so I left those for now.