### PR TITLE
fix: add img to interactive tooltip roles to suppress tooltip warning

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -54,6 +54,7 @@ const interactiveRoles = {
 	'checkbox': true,
 	'combobox': true,
 	'heading': true,
+	'img': true,
 	'link': true,
 	'listbox': true,
 	'menuitem': true,


### PR DESCRIPTION
Currently, the count badges are throwing accessibility warnings with the tooltip, even though they have the correct role. Adding the img role to the interactive roles removes the warning. 

I did also try out the announced property on the tooltip (made for custom elements), but it's behaviour was not quite what I wanted. When it announces the tooltip text, it announces the text of all the tooltips on the page (which would get super repetitive).