### PR TITLE
fix: port `aria-label` logic to `d2l-input-textarea`

### DIFF
--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -185,6 +185,13 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 		return super.validity;
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		if (this.hasAttribute('aria-label')) {
+			this.labelRequired = false;
+		}
+	}
+
 	render() {
 
 		// convert \n to <br> for html mirror


### PR DESCRIPTION
This ports over the setting of `labelRequired` to `false` when `area-label` is present on the element similar to how `d2l-input-input` does this. This help minimize the changes needed in some areas (mainly rubrics).