### PR TITLE
Export html-block content styles directly for consumption in other components

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -3,6 +3,104 @@ import { css, LitElement } from 'lit-element/lit-element.js';
 import { htmlBlockMathRenderer } from '../../helpers/mathjax.js';
 import { requestInstance } from '../../mixins/provider-mixin.js';
 
+export const contentStyles = css`
+	h1, h2, h3, h4, h5, h6, b, strong, b *, strong * {
+		font-weight: bold;
+	}
+	h1 {
+		font-size: 2em;
+		line-height: 37px;
+		margin: 21.43px 0;
+	}
+	h2 {
+		font-size: 1.5em;
+		line-height: 27px;
+		margin: 19.92px 0;
+	}
+	h3 {
+		font-size: 1.2em;
+		line-height: 23px;
+		margin: 18.72px 0;
+	}
+	h4 {
+		font-size: 1em;
+		line-height: 20px;
+		margin: 21.28px 0;
+	}
+	h5 {
+		font-size: 0.83em;
+		line-height: 16px;
+		margin: 22.13px 0;
+	}
+	h6 {
+		font-size: 0.67em;
+		line-height: 13px;
+		margin: 24.97px 0;
+	}
+	pre {
+		font-family: Monospace;
+		font-size: 13px;
+		margin: 13px 0;
+	}
+	p {
+		margin: 0.5em 0 1em 0;
+	}
+	ul, ol {
+		list-style-position: outside;
+		margin: 1em 0;
+		padding-left: 3em;
+	}
+	ul, ul[type="disc"] {
+		list-style-type: disc;
+	}
+	ul ul, ul ol,
+	ol ul, ol ol {
+		margin-bottom: 0;
+		margin-top: 0;
+	}
+	ul ul, ol ul, ul[type="circle"] {
+		list-style-type: circle;
+	}
+	ul ul ul, ul ol ul,
+	ol ul ul, ol ol ul,
+	ul[type="square"] {
+		list-style-type: square;
+	}
+	a,
+	a:visited,
+	a:link,
+	a:active {
+		color: var(--d2l-color-celestine);
+		cursor: pointer;
+		text-decoration: none;
+	}
+	a:hover,
+	a:focus {
+		color: var(--d2l-color-celestine-minus-1);
+		outline-width: 0;
+		text-decoration: underline;
+	}
+	@media print {
+		a,
+		a:visited,
+		a:link,
+		a:active {
+			color: var(--d2l-color-ferrite);
+		}
+	}
+	mjx-assistive-mml math {
+		position: absolute;
+	}
+	:host([dir="rtl"]) {
+		text-align: right;
+	}
+	:host([dir="rtl"]) ul,
+	:host([dir="rtl"]) ol {
+		padding-left: 0;
+		padding-right: 3em;
+	}
+`;
+
 let renderers;
 
 const getRenderers = () => {
@@ -19,7 +117,7 @@ const getRenderers = () => {
 class HtmlBlock extends LitElement {
 
 	static get styles() {
-		return css`
+		return [ contentStyles, css`
 			:host {
 				display: block;
 				overflow-wrap: break-word;
@@ -34,102 +132,7 @@ class HtmlBlock extends LitElement {
 			::slotted(*) {
 				display: none;
 			}
-			h1, h2, h3, h4, h5, h6, b, strong, b *, strong * {
-				font-weight: bold;
-			}
-			h1 {
-				font-size: 2em;
-				line-height: 37px;
-				margin: 21.43px 0;
-			}
-			h2 {
-				font-size: 1.5em;
-				line-height: 27px;
-				margin: 19.92px 0;
-			}
-			h3 {
-				font-size: 1.2em;
-				line-height: 23px;
-				margin: 18.72px 0;
-			}
-			h4 {
-				font-size: 1em;
-				line-height: 20px;
-				margin: 21.28px 0;
-			}
-			h5 {
-				font-size: 0.83em;
-				line-height: 16px;
-				margin: 22.13px 0;
-			}
-			h6 {
-				font-size: 0.67em;
-				line-height: 13px;
-				margin: 24.97px 0;
-			}
-			pre {
-				font-family: Monospace;
-				font-size: 13px;
-				margin: 13px 0;
-			}
-			p {
-				margin: 0.5em 0 1em 0;
-			}
-			ul, ol {
-				list-style-position: outside;
-				margin: 1em 0;
-				padding-left: 3em;
-			}
-			ul, ul[type="disc"] {
-				list-style-type: disc;
-			}
-			ul ul, ul ol,
-			ol ul, ol ol {
-				margin-bottom: 0;
-				margin-top: 0;
-			}
-			ul ul, ol ul, ul[type="circle"] {
-				list-style-type: circle;
-			}
-			ul ul ul, ul ol ul,
-			ol ul ul, ol ol ul,
-			ul[type="square"] {
-				list-style-type: square;
-			}
-			a,
-			a:visited,
-			a:link,
-			a:active {
-				color: var(--d2l-color-celestine);
-				cursor: pointer;
-				text-decoration: none;
-			}
-			a:hover,
-			a:focus {
-				color: var(--d2l-color-celestine-minus-1);
-				outline-width: 0;
-				text-decoration: underline;
-			}
-			@media print {
-				a,
-				a:visited,
-				a:link,
-				a:active {
-					color: var(--d2l-color-ferrite);
-				}
-			}
-			mjx-assistive-mml math {
-				position: absolute;
-			}
-			:host([dir="rtl"]) {
-				text-align: right;
-			}
-			:host([dir="rtl"]) ul,
-			:host([dir="rtl"]) ol {
-				padding-left: 0;
-				padding-right: 3em;
-			}
-		`;
+		`];
 	}
 
 	disconnectedCallback() {


### PR DESCRIPTION
We want/need to consume these styles in the editing mode of the HTML editor to align better with how content will look on render. So let's export them explicitly.