### PR TITLE
Use slightly more specific name for html-block content styles export

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -117,7 +117,7 @@ const getRenderers = () => {
 class HtmlBlock extends LitElement {
 
 	static get styles() {
-		return [ contentStyles, css`
+		return [ htmlBlockContentStyles, css`
 			:host {
 				display: block;
 				overflow-wrap: break-word;


### PR DESCRIPTION
Upon attempting to import this into the HTML editor, I realized that the name was awfully generic. While it didn't conflict with anything in the editor, `contentStyles` seems like the sort of name a consumer might use for something internal.