### PR TITLE
docs: updating input documentation to include labelled-by

### DIFF
--- a/components/inputs/README.md
+++ b/components/inputs/README.md
@@ -12,7 +12,7 @@ There are various input components available:
 
 ## Labelling Inputs
 
-All inputs *must* have a label. Web component-based inputs like `<d2l-input-checkbox>`, `<d2l-input-number>`, `<d2l-input-search>`, `<d2l-input-text>`, and `<d2l-input-textarea>` come with built-in labels. For the rest, labelling is accomplished visually using a `<label>` element or with a hidden label via the `aria-label` attribute.
+All inputs *must* have a label. Web component-based inputs like `<d2l-input-checkbox>`, `<d2l-input-number>`, `<d2l-input-percent>`, `<d2l-input-search>`, `<d2l-input-text>`, and `<d2l-input-textarea>` come with built-in labels. For the rest, labelling is accomplished visually using a `<label>` element or with a hidden label via the `aria-label` attribute.
 
 Groups of inputs (like checkboxes or radios) should be wrapped in a `<fieldset>` which can have label styles applied to it.
 

--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -86,6 +86,7 @@ size:xlarge
 | `disabled` | Boolean | Disables the input |
 | `empty-text` | String | Text to reassure users that they can choose not to provide a value in this field (usually not necessary) |
 | `label-hidden` | Boolean | Hides the label visually (moves it to the input's `aria-label` attribute) |
+| `labelled-by` | String | HTML id of an element in the same shadow root which acts as the input's label |
 | `max-value` | String | Maximum valid date that could be selected by a user. |
 | `min-value` | String | Minimum valid date that could be selected by a user. |
 | `opened` | Boolean | Indicates if the calendar dropdown is open |
@@ -105,6 +106,7 @@ To make your usage of `d2l-input-date` accessible, use the following properties 
 |--|--|
 | `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users |
+| `labelled-by` | String | Use when another visible element should act as the label |
 
 ## Date Range Input [d2l-input-date-range]
 
@@ -227,6 +229,7 @@ size:large
 | `disabled` | Boolean | Disables the input |
 | `enforce-time-intervals` | Boolean | Rounds up to nearest valid interval time (specified with `time-interval`) when user types a time |
 | `label-hidden` | Boolean | Hides the label visually (moves it to the input's `aria-label` attribute) |
+| `labelled-by` | String | HTML id of an element in the same shadow root which acts as the input's label |
 | `opened` | Boolean | Indicates if the dropdown is open |
 | `required` | Boolean | Indicates that a value is required |
 | `time-interval` | String, default: `thirty` | Number of minutes between times shown in dropdown. Valid values include `five`, `ten`, `fifteen`, `twenty`, `thirty`, and `sixty`. |
@@ -245,6 +248,7 @@ To make your usage of `d2l-input-time` accessible, use the following properties 
 |--|--|
 | `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users |
+| `labelled-by` | String | Use when another visible element should act as the label |
 
 ### Time Range Input [d2l-input-time-range]
 
@@ -361,6 +365,7 @@ size:xlarge
 | `label` | String, **required** | Accessible label for the input |
 | `disabled` | Boolean | Disables the input |
 | `label-hidden` | Boolean | Hides the fieldset label visually |
+| `labelled-by` | String | HTML id of an element in the same shadow root which acts as the input's label |
 | `localized` | Boolean | Indicates that any timezone localization will be handeld by the consumer and so any values will not be converted from/to UTC |
 | `max-value` | String | Maximum valid date/time that could be selected by a user |
 | `min-value` | String | Minimum valid date/time that could be selected by a user |
@@ -382,6 +387,7 @@ To make your usage of `d2l-input-date-time` accessible, use the following proper
 |--|--|
 | `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/) |
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users |
+| `labelled-by` | String | Use when another visible element should act as the label |
 
 ## Date-Time Range Input [d2l-input-date-time-range]
 

--- a/components/inputs/docs/input-numeric.md
+++ b/components/inputs/docs/input-numeric.md
@@ -52,6 +52,7 @@ The `<d2l-input-number>` element is similar to `<d2l-input-text>`, except it's i
 | `disabled` | Boolean, default: `false` | Disables the input. |
 | `input-width` | String, default: `4rem` | Restricts the maximum width of the input box without impacting the width of the label. |
 | `label-hidden` | Boolean, default: `false` | Hides the label visually (moves it to the input's `aria-label` attribute). |
+| `labelled-by` | String | HTML id of an element in the same shadow root which acts as the input's label |
 | `max` | Number | Maximum value allowed. |
 | `max-exclusive` | Boolean, default: `false` | Indicates whether the max value is exclusive. |
 | `max-fraction-digits` | Number, default: Greater of `minFractionDigits` or `3` | Maximum number of digits allowed after the decimal place. Must be between 0 and 20 and greater than or equal to `minFractionDigits` |
@@ -84,6 +85,7 @@ To make your usage of `d2l-input-number` accessible, use the following propertie
 |---|---|
 | `label` | **REQUIRED.** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users. |
+| `labelled-by` | String | Use when another visible element should act as the label |
 | `unit` | Use to render the unit (offscreen) as part of the label. |
 | `title` | Use for additional screen reader and mouseover context. |
 

--- a/components/inputs/docs/input-text.md
+++ b/components/inputs/docs/input-text.md
@@ -86,6 +86,7 @@ The `<d2l-input-text>` element is a simple wrapper around the native `<input typ
 | `disabled` | Boolean | Disables the input |
 | `input-width` | String, default: `100%` | Restricts the maximum width of the input box without impacting the width of the label |
 | `label-hidden` | Boolean | Hides the label visually (moves it to the input's `aria-label` attribute) |
+| `labelled-by` | String | HTML id of an element in the same shadow root which acts as the input's label |
 | `max` | String | For number inputs, maximum value |
 | `maxlength` | Number | Imposes an upper character limit |
 | `min` | String | For number inputs, minimum value |
@@ -138,6 +139,7 @@ To make your usage of `d2l-input-text` accessible, use the following properties 
 | `description` | Use when label on input does not provide enough context. |
 | `label` | **REQUIRED**  [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users |
+| `labelled-by` | String | Use when another visible element should act as the label |
 | `unit` | Use to render the unit (offscreen) as part of the label. |
 | `title` | Text for additional screen reader and mouseover context |
 
@@ -209,6 +211,7 @@ The `<d2l-input-textarea>` is a wrapper around the native `<textarea>` element t
 | `disabled` | Boolean | Disables the `textarea` |
 | `label` | String, required | Label for the `textarea` |
 | `label-hidden` | Boolean | Hides the label visually (moves it to the `textarea`'s `aria-label` attribute) |
+| `labelled-by` | String | HTML id of an element in the same shadow root which acts as the input's label |
 | `max-rows` | Number, default: 11 | Maximum number of rows before scrolling. Less than 1 allows `textarea` to grow infinitely. |
 | `maxlength` | Number | Imposes an upper character limit |
 | `minlength` | Number | Imposes a lower character limit |
@@ -246,6 +249,7 @@ To make your usage of `d2l-input-textarea` accessible, use the following propert
 | `description` | Use when label on `textarea` does not provide enough context. |
 | `label` | **REQUIRED**  [Acts as a primary label on the `textarea`](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users |
+| `labelled-by` | String | Use when another visible element should act as the label |
 
 ### Methods
 


### PR DESCRIPTION
Realized I forgot to add `labelled-by` to the input Markdown documentation.