### PR TITLE
Temporary: Downgrade Sauce Version to 0.6.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          npm install @web/test-runner-saucelabs --no-save
+          npm install @web/test-runner-saucelabs@0.6.3 --no-save
       - name: Build
         run: npm run build
       - name: SauceLabs


### PR DESCRIPTION
Looks like Sauce made a breaking change by deprecating one of their attributes, tunnel-identifier (see https://docs.saucelabs.com/dev/cli/sauce-connect-proxy/). The test runner picks up the new changes in this PR, merged today: https://github.com/saucelabs/node-saucelabs/releases/tag/6.2.0. This is an internal change that we don't have control over, but downgrading to 0.6.3 of the sauce runner fixes the issue for now.

We should remove this line once the changes are fixed on Sauce's side. It might take a few days though, as their repo doesn't get updated too often.