### PR TITLE
Fix background-color for hovering/focusing list-items that have nested lists.

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -75,11 +75,13 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 			:host([draggable]) .d2l-list-item-drag-image {
 				transform: rotate(-1deg);
 			}
+			:host([dragging]) .d2l-list-item-drag-image {
+				background: white;
+			}
 			:host([draggable]) d2l-list-item-generic-layout {
 				transform: rotate(1deg);
 			}
 			d2l-list-item-generic-layout {
-				background: white;
 				border-bottom: 1px solid var(--d2l-color-mica);
 				border-top: 1px solid var(--d2l-color-mica);
 			}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9042472/137547734-46ce71aa-c977-4775-b0fa-ebf312824ff9.png)


After: 
![image](https://user-images.githubusercontent.com/9042472/137547603-19804d90-8de6-4b0b-a0d7-4e7be02762cb.png)
