### PR TITLE
Create HTML data attribute context controller

### DIFF
--- a/helpers/htmlAttributeObserverController.js
+++ b/helpers/htmlAttributeObserverController.js
@@ -11,10 +11,14 @@ export class HtmlAttributeObserverController {
 	constructor(host, attribute) {
 		this._host = host;
 		this._attribute = attribute;
+
+		this.value = undefined;
 	}
 
 	hostConnected() {
-		this.value = document.documentElement.getAttribute(this._attribute);
+		this.value = document.documentElement.hasAttribute(this._attribute)
+			? document.documentElement.getAttribute(this._attribute)
+			: undefined;
 		if (controllerCallbacks.size === 0) contextObserver.observe(document.documentElement, { attributes: true });
 		controllerCallbacks.set(this, this._handleContextChange.bind(this));
 	}
@@ -25,7 +29,9 @@ export class HtmlAttributeObserverController {
 
 	_handleContextChange(attributeName) {
 		if (attributeName !== this._attribute) return;
-		this.value = document.documentElement.getAttribute(this._attribute);
+		this.value = document.documentElement.hasAttribute(this._attribute)
+			? document.documentElement.getAttribute(this._attribute)
+			: undefined;
 		this._host.requestUpdate();
 	}
 

--- a/helpers/test/htmlAttributeObserverController.test.js
+++ b/helpers/test/htmlAttributeObserverController.test.js
@@ -62,9 +62,9 @@ describe('htmlAttributeObserverController', () => {
 			expect(elem.getRenderedVal()).to.equal(testAttrVal);
 		});
 
-		it('returns null if attribute not present', async() => {
+		it('returns undefined if attribute not present', async() => {
 			const elem = await fixture(`<${testHost()}></${testHost()}>`);
-			expect(elem.getControllerVal()).to.equal(null);
+			expect(elem.getControllerVal()).to.equal(undefined);
 			expect(elem.getRenderedVal()).to.equal('');
 		});
 
@@ -80,12 +80,12 @@ describe('htmlAttributeObserverController', () => {
 			expect(elem.getRenderedVal()).to.equal(testAttrVal);
 		});
 
-		it('returns null if attribute is removed', async() => {
+		it('returns undefined if attribute is removed', async() => {
 			setAttribute();
 			const elem = await fixture(`<${testHost()}></${testHost()}>`);
 			removeAttribute();
 			await oneEvent(elem, controllerUpdateEvent);
-			expect(elem.getControllerVal()).to.equal(null);
+			expect(elem.getControllerVal()).to.equal(undefined);
 			expect(elem.getRenderedVal()).to.equal('');
 		});
 
@@ -95,7 +95,7 @@ describe('htmlAttributeObserverController', () => {
 			await elem.updateComplete;
 
 			setAttribute();
-			expect(elem.getControllerVal()).to.equal(null);
+			expect(elem.getControllerVal()).to.equal(undefined);
 			expect(elem.getRenderedVal()).to.equal('');
 		});
 
@@ -112,7 +112,7 @@ describe('htmlAttributeObserverController', () => {
 			await oneEvent(elem, controllerUpdateEvent);
 			expect(elem.getControllerVal()).to.equal(testAttrVal);
 			expect(elem.getRenderedVal()).to.equal(testAttrVal);
-			expect(otherElem.getControllerVal()).to.equal(null);
+			expect(otherElem.getControllerVal()).to.equal(undefined);
 			expect(otherElem.getRenderedVal()).to.equal('');
 		});
 


### PR DESCRIPTION
The goal here is to create a faux reactive controller that other components can use to verify when the document html data attributes have been set on the page via a mutation observer on the document element. Multiple controllers can subscribe, but if any mutation matches, we disconnect the observer and move on.