### PR TITLE
Remove pinned sauce version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          npm install @web/test-runner-saucelabs@0.6.3 --no-save
+          npm install @web/test-runner-saucelabs --no-save
       - name: Build
         run: npm run build
       - name: SauceLabs


### PR DESCRIPTION
https://github.com/BrightspaceUI/core/pull/1811 downgraded the sauce version to 0.6.3 since some internal breaking changes were failing our tests. This PR reverts to the latest sauce version available, since the issue is now fixed. 