### PR TITLE
Add public method to the list to help get the selected items.

### DIFF
--- a/components/list/README.md
+++ b/components/list/README.md
@@ -152,7 +152,7 @@ The `d2l-list` is the container to create a styled list of items using `d2l-list
 
 - `getListItemCount`: returns the length of the items within the list
 - `getListItemIndex` (Object): returns the index of the given element within the list
-- `getSelectedItems` (Array): returns the selected items; pass `true` to include nested lists
+- `getSelectedListItems` (Array): returns the selected items; pass `true` to include nested lists
 - `getSelectionInfo` (Object): returns a `SelectionInfo` object containing the `state` (`none`, `some`, `all`), and the `keys` (Array) for the selected items
 
 ## Selection Lists

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -97,12 +97,12 @@ class List extends SelectionMixin(LitElement) {
 		return this._getItems().indexOf(item);
 	}
 
-	getSelectedItems(includeNested) {
+	getSelectedListItems(includeNested) {
 		let selectedItems = [];
 		this._getItems().forEach(item => {
 			if (item.selected) selectedItems.push(item);
 			if (includeNested && item._selectionProvider) {
-				selectedItems = [...selectedItems, ...item._selectionProvider.getSelectedItems(includeNested)];
+				selectedItems = [...selectedItems, ...item._selectionProvider.getSelectedListItems(includeNested)];
 			}
 		});
 		return selectedItems;

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -66,14 +66,14 @@ describe('d2l-list', () => {
 			expect(e.detail.length).to.equal(2);
 		});
 
-		it('getSelectedItems returns empty array when no items selected', async() => {
-			expect(elem.getSelectedItems().length).to.equal(0);
+		it('getSelectedListItems returns empty array when no items selected', async() => {
+			expect(elem.getSelectedListItems().length).to.equal(0);
 		});
 
-		it('getSelectedItems returns array including selected items', async() => {
+		it('getSelectedListItems returns array including selected items', async() => {
 			setTimeout(() => clickItemInput(elem.querySelector('[key="L1-1"]')));
 			await oneEvent(elem, 'd2l-list-selection-changes');
-			expect(elem.getSelectedItems().length).to.equal(1);
+			expect(elem.getSelectedListItems().length).to.equal(1);
 		});
 
 	});
@@ -120,26 +120,26 @@ describe('d2l-list', () => {
 			expect(e.detail.length).to.equal(3);
 		});
 
-		it('getSelectedItems returns empty array when no items selected', async() => {
-			expect(elem.getSelectedItems().length).to.equal(0);
+		it('getSelectedListItems returns empty array when no items selected', async() => {
+			expect(elem.getSelectedListItems().length).to.equal(0);
 		});
 
-		it('getSelectedItems returns array with root selected items only', async() => {
+		it('getSelectedListItems returns array with root selected items only', async() => {
 			setTimeout(() => clickItemInput(elem.querySelector('[key="L1-1"]')));
 			await oneEvent(elem, 'd2l-list-selection-changes');
-			expect(elem.getSelectedItems().length).to.equal(1);
+			expect(elem.getSelectedListItems().length).to.equal(1);
 		});
 
-		it('getSelectedItems returns array including nested selected items', async() => {
+		it('getSelectedListItems returns array including nested selected items', async() => {
 			setTimeout(() => clickItemInput(elem.querySelector('[key="L1-1"]')));
 			await oneEvent(elem, 'd2l-list-selection-changes');
-			expect(elem.getSelectedItems(true).length).to.equal(3);
+			expect(elem.getSelectedListItems(true).length).to.equal(3);
 		});
 
-		it('getSelectedItems returns array excluding indeterminate items', async() => {
+		it('getSelectedListItems returns array excluding indeterminate items', async() => {
 			setTimeout(() => clickItemInput(elem.querySelector('[key="L2-1"]')));
 			await oneEvent(elem, 'd2l-list-selection-changes');
-			expect(elem.getSelectedItems(true).length).to.equal(1);
+			expect(elem.getSelectedListItems(true).length).to.equal(1);
 		});
 
 	});


### PR DESCRIPTION
When consumers implement custom list-items with nested lists baked into their shadowDOM, it can be challenging for consumers to get the selected items for the list.  This PR adds a helper method `getSelectedListItems(includeNested)` that returns the selected items, optionally including nested lists in its query.