### PR TITLE
Re-connect template observer if html-block is re-connected to the DOM

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -135,6 +135,14 @@ class HtmlBlock extends LitElement {
 		`];
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		if (!this._templateObserver) return;
+
+		const template = this.querySelector('template');
+		if (template) this._templateObserver.observe(template.content, { attributes: true, childList: true, subtree: true });
+	}
+
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		if (this._templateObserver) this._templateObserver.disconnect();


### PR DESCRIPTION
If an `html-block` is detached from the DOM, we disconnect its template observer. However, when re-connecting to the DOM, we never re-attach it. This leads to an interesting problem where if the template contents change, there's no way for the component to pick up and act on that change.