### PR TITLE
feat: US133079: Removing the touchstart event, fixing opener check

### DIFF
--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -210,14 +210,14 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	}
 
 	__onKeypress(e) {
-		if (isComposedAncestor(e.srcElement, this.getOpenerElement())) {
+		if (e.srcElement === this || isComposedAncestor(this.getOpenerElement(), e.srcElement)) {
 			this.__onOpenerKeyPress(e);
 		}
 	}
 
 	__onMouseEnter(e) {
 		if (!this.openOnHover) return;
-		if (isComposedAncestor(e.srcElement, this.getOpenerElement())) {
+		if (e.srcElement === this || isComposedAncestor(this.getOpenerElement(), e.srcElement)) {
 			this.__onOpenerMouseEnter(e);
 		} else if (isComposedAncestor(this.__getContentElement(), e.srcElement)) {
 			this.__onDropdownMouseEnter(e);
@@ -226,7 +226,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 
 	__onMouseLeave(e) {
 		if (!this.openOnHover) return;
-		if (isComposedAncestor(e.srcElement, this.getOpenerElement())) {
+		if (e.srcElement === this || isComposedAncestor(this.getOpenerElement(), e.srcElement)) {
 			this.__onOpenerMouseLeave(e);
 		} else if (isComposedAncestor(this.__getContentElement(), e.srcElement)) {
 			this.__onDropdownMouseLeave(e);
@@ -234,7 +234,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	}
 
 	__onMouseUp(e) {
-		if (isComposedAncestor(e.srcElement, this.getOpenerElement())) {
+		if (e.srcElement === this || isComposedAncestor(this.getOpenerElement(), e.srcElement)) {
 			this.__onOpenerMouseUp(e);
 		} else if (this.openOnHover && isComposedAncestor(this.__getContentElement(), e.srcElement)) {
 			this.__onDropdownMouseUp();

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -64,7 +64,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.__onMouseUp = this.__onMouseUp.bind(this);
 		this.__onMouseEnter = this.__onMouseEnter.bind(this);
 		this.__onMouseLeave = this.__onMouseLeave.bind(this);
-		this.__onTouchStart = this.__onTouchStart.bind(this);
 		this._contentRendered = null;
 		this._openerRendered = null;
 	}
@@ -77,7 +76,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.addEventListener('mouseup', this.__onMouseUp);
 		this.addEventListener('mouseenter', this.__onMouseEnter);
 		this.addEventListener('mouseleave', this.__onMouseLeave);
-		this.addEventListener('touchstart', this.__onTouchStart);
 
 		if (this.openOnHover) {
 			document.body.addEventListener('mouseup', this._onOutsideClick);
@@ -91,7 +89,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.removeEventListener('mouseup', this.__onMouseUp);
 		this.removeEventListener('mouseenter', this.__onMouseEnter);
 		this.removeEventListener('mouseleave', this.__onMouseLeave);
-		this.removeEventListener('touchstart', this.__onTouchStart);
 
 		if (this.openOnHover) {
 			document.body.removeEventListener('mouseup', this._onOutsideClick);
@@ -172,6 +169,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 			return;
 		}
 		content.toggleOpen(applyFocus);
+		this._isOpen = !this._isOpen;
 	}
 
 	__getContentElement() {
@@ -204,6 +202,13 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this._closeTimerStart();
 	}
 
+	__onDropdownMouseUp() {
+		this._isOpen = true;
+		this._isFading = false;
+		this._isOpenedViaClick = true;
+		this._closeTimerStop();
+	}
+
 	__onKeypress(e) {
 		if (isComposedAncestor(e.srcElement, this.getOpenerElement())) {
 			this.__onOpenerKeyPress(e);
@@ -231,6 +236,8 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	__onMouseUp(e) {
 		if (isComposedAncestor(e.srcElement, this.getOpenerElement())) {
 			this.__onOpenerMouseUp(e);
+		} else if (this.openOnHover && isComposedAncestor(this.__getContentElement(), e.srcElement)) {
+			this.__onDropdownMouseUp();
 		}
 	}
 
@@ -294,27 +301,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 				this.openDropdown(true);
 			}
 		} else this.toggleOpen(false);
-	}
-
-	/* used by open-on-hover option */
-	__onOpenerTouch(e) {
-		//Prevents touch from triggering mouseover/hover behavior
-		e.preventDefault();
-		this._closeTimerStop();
-		if (this._isOpen) {
-			this.closeDropdown();
-		}
-		else {
-			this._isOpenedViaClick = true;
-			this.openDropdown(true);
-		}
-	}
-
-	__onTouchStart(e) {
-		if (!this.openOnHover) return;
-		if (isComposedAncestor(e.srcElement, this.getOpenerElement())) {
-			this.__onOpenerTouch(e);
-		}
 	}
 
 	/* used by open-on-hover option */

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -517,7 +517,23 @@ describe('d2l-dropdown', () => {
 				expect(content.opened).to.be.true;
 			});
 
-			it('hovering then clicking does not close dropdown, can hover out', async() => {
+			it('hovering then clicking content does not close dropdown, can hover out', async() => {
+				opener.dispatchEvent(new Event('mouseenter', { bubbles: true }));
+				await oneEvent(content, 'd2l-dropdown-open');
+				expect(content.opened).to.be.true;
+
+				setTimeout(() => dropdown.querySelector('#non_focusable_inside').dispatchEvent(new Event('mouseup', { bubbles: true })));
+				// wait 100ms to ensure dropdown did not close
+				await aTimeout(100);
+				expect(content.opened).to.be.true;
+
+				setTimeout(() => dropdown.querySelector('#non_focusable_inside').dispatchEvent(new Event('mouseleave', { bubbles: true })));
+				setTimeout(() => dropdown.querySelector('#non_focusable_outside').dispatchEvent(new Event('mouseenter')));
+				await aTimeout(800);
+				expect(content.opened).to.be.true;
+			});
+
+			it('hovering then clicking opener does not close dropdown, can hover out', async() => {
 				opener.dispatchEvent(new Event('mouseenter', { bubbles: true }));
 				await oneEvent(content, 'd2l-dropdown-open');
 				expect(content.opened).to.be.true;
@@ -527,6 +543,7 @@ describe('d2l-dropdown', () => {
 				await aTimeout(100);
 				expect(content.opened).to.be.true;
 
+				opener.dispatchEvent(new Event('mouseleave', { bubbles: true }));
 				setTimeout(() => dropdown.querySelector('#non_focusable_outside').dispatchEvent(new Event('mouseenter')));
 				await aTimeout(800);
 				expect(content.opened).to.be.true;


### PR DESCRIPTION
After some testing, looks like the touchstart event is a duplicate of the clicking action. Removing that listener will simplify the code a bit!

Also, I changed the dropdown click behaviour to lock open the dropdown, so that if users click on the dropdown, they can hover away and the dropdown will not close. This is consistent with the old user-profile card. Clicking inside the dropdown, similar to clicking the opener, should allow the dropdown to be kept open. I added a test for this as well.

Also, I fixed the opener check in the listeners. There are generally two cases with the mouseup/leave events:

- Src element is the opener itself (ie. d2l-dropdown-more, this is how most of our buttons work)
- Src element is some element within the button (ie. a span within the opening button)
- We can now cover both those cases. Previously, we were only covering the first case, since the content within a button failed the check to see if it was an ancestor of the button.