### PR TITLE
Add `fullscreen` property to `DemoSnippet`

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -8,9 +8,9 @@ class DemoSnippet extends LitElement {
 	static get properties() {
 		return {
 			codeViewHidden: { type: Boolean, reflect: true, attribute: 'code-view-hidden' },
+			fullscreen: { type: Boolean, reflect: true },
 			noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
 			overflowHidden: { type: Boolean, reflect: true, attribute: 'overflow-hidden' },
-			fullscreen: { type: Boolean, reflect: true },
 			_code: { type: String },
 			_dir: { type: String, attribute: false },
 			_hasSkeleton: { type: Boolean, attribute: false },

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -70,6 +70,7 @@ class DemoSnippet extends LitElement {
 
 	constructor() {
 		super();
+		this.fullscreen = false;
 		this._dir = document.documentElement.dir;
 		this._hasSkeleton = false;
 		this._skeletonOn = false;

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -10,6 +10,7 @@ class DemoSnippet extends LitElement {
 			codeViewHidden: { type: Boolean, reflect: true, attribute: 'code-view-hidden' },
 			noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
 			overflowHidden: { type: Boolean, reflect: true, attribute: 'overflow-hidden' },
+			fullscreen: { type: Boolean, reflect: true },
 			_code: { type: String },
 			_dir: { type: String, attribute: false },
 			_hasSkeleton: { type: Boolean, attribute: false },
@@ -29,6 +30,9 @@ class DemoSnippet extends LitElement {
 			}
 			:host([hidden]) {
 				display: none;
+			}
+			:host([fullscreen]) {
+				max-width: unset;
 			}
 			.d2l-demo-snippet-demo-wrapper {
 				display: flex;


### PR DESCRIPTION
## Description
Add a `fullscreen` property to `DemoSnippet`. This will enable consumers to have fullscreen demo snippets.