### PR TITLE
Add compose mixins helper

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -21,6 +21,25 @@ import { AsyncStateEvent } from '@brightspace-ui/core/helpers/asyncStateEvent.js
 const asyncStateEvent = new AsyncStateEvent(pendingPromise);
 ```
 
+## composeMixins
+
+A helper function for cleanly incorporating a list of mixins into a base class. Designed for use with Lit components with a large amount of reusable functionality.
+
+```js
+// other imports...
+import { composeMixins } from '@brightspace-ui/core/helpers/composeMixins.js';
+
+class ExampleComponent extends composeMixins(
+  LitElement,
+  EntityMixin,
+  LocalizeMixin,
+) {
+  // ...
+}
+```
+
+Read more about mixins on [the `open-wc` docs](https://open-wc.org/docs/development/dedupe-mixin/#what-is-a-mixin).
+
 ## Dismissible
 
 Dismissible components are those that should be dismissible when the user presses
@@ -192,4 +211,3 @@ import '@brightspace-ui/core/helpers/viewport-size.js';
     min-width: calc(var(--d2l-vw, 1vw) * 100);
 }
 ```
-

--- a/helpers/composeMixins.js
+++ b/helpers/composeMixins.js
@@ -1,0 +1,2 @@
+export const composeMixins = (base, ...mixins) =>
+	mixins.reduce((subclass, superclass) => superclass(subclass), base);


### PR DESCRIPTION
Proposed addition as an aside from some of the [rubrics Lit conversion work](https://github.com/Brightspace/d2l-rubric/pull/1295#discussion_r743976360) that Mango is doing

#### Before
```js
class ExampleComponent extends LocalizeMixin(EntityMixin(LitElement)) {
  // ...
}
```

#### After
```js
class ExampleComponent extends composeMixins(
  LitElement,
  EntityMixin,
  LocalizeMixin,
) {
  // ...
}
```

Using the helper is more readable, allows for cleaner diffs, and makes it easier to add and arrange mixins in a logical fashion.