### PR TITLE
feat: Removing IE11 CSS variable setters

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -325,9 +325,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 				if (isNaN(newVerticalOffset)) {
 					newVerticalOffset = 20;
 				}
-				// for IE11
-				if (window.ShadyCSS) window.ShadyCSS.styleSubtree(this, { '--d2l-dropdown-verticaloffset': `${newVerticalOffset}px` });
-				else this.style.setProperty('--d2l-dropdown-verticaloffset', `${newVerticalOffset}px`);
+				this.style.setProperty('--d2l-dropdown-verticaloffset', `${newVerticalOffset}px`);
 			}
 		});
 	}

--- a/components/loading-spinner/loading-spinner.js
+++ b/components/loading-spinner/loading-spinner.js
@@ -170,13 +170,9 @@ class LoadingSpinner extends LitElement {
 	updated(changedProperties) {
 		changedProperties.forEach((oldValue, propName) => {
 			if (propName === 'color') {
-				// for IE11
-				if (window.ShadyCSS) window.ShadyCSS.styleSubtree(this, { '--d2l-loading-spinner-color': this.color });
-				else this.style.setProperty('--d2l-loading-spinner-color', this.color);
+				this.style.setProperty('--d2l-loading-spinner-color', this.color);
 			} else if (propName === 'size') {
-				// for IE11
-				if (window.ShadyCSS) window.ShadyCSS.styleSubtree(this, { '--d2l-loading-spinner-size': `${this.size}px` });
-				else this.style.setProperty('--d2l-loading-spinner-size', `${this.size}px`);
+				this.style.setProperty('--d2l-loading-spinner-size', `${this.size}px`);
 			}
 		});
 	}


### PR DESCRIPTION
Legacy edge is gone so we are safe to remove these styleSubtree CSS setters 🎉 
I did test on a current Edge version to make sure it was still working by setting the vertical-offset attribute.