### PR TITLE
Visual diffs: add a requestAnimationFrame to mobile dropdowns

### DIFF
--- a/components/dropdown/test/dropdown-content.visual-diff.js
+++ b/components/dropdown/test/dropdown-content.visual-diff.js
@@ -88,6 +88,9 @@ describe('d2l-dropdown-content', () => {
 			const selector = `#${testName}`;
 			await open(page, selector);
 			await page.waitForTimeout(50);
+			await page.$eval (selector, async(elem)  => {
+				requestAnimationFrame(async() => await elem.updateComplete);
+			});
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
 		});
 	});

--- a/components/filter/test/filter.visual-diff.js
+++ b/components/filter/test/filter.visual-diff.js
@@ -187,6 +187,10 @@ describe('d2l-filter', () => {
 				it(type, async function() {
 					const selector = `#${type}`;
 					await open(page, selector);
+					page.waitForTimeout(50);
+					await page.$eval (selector, async(elem)  => {
+						requestAnimationFrame(async() => await elem.updateComplete);
+					});
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false });
 				});
 			});
@@ -309,6 +313,10 @@ describe('d2l-filter', () => {
 				it(type, async function() {
 					const selector = `#${type}`;
 					await open(page, selector);
+					page.waitForTimeout(50);
+					await page.$eval (selector, async(elem)  => {
+						requestAnimationFrame(async() => await elem.updateComplete);
+					});
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false });
 				});
 			});


### PR DESCRIPTION
For dropdowns with empty content, the focus should go to the close button on the mobile tray. Sometimes, the tests get flaky because the close button is not getting focused on. The dropdown requests a new frame before focusing, so adding that to the test as will **should** stop the flakiness. 

I'll rerun a couple of times to make sure the flake doesn't happen again.