### PR TITLE
fix: fixing hovering dropdown focus behaviour on click - should not force focus

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -472,7 +472,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 				|| isComposedAncestor(this.__getOpener(), activeElement)) {
 				return;
 			}
-
 			this.close();
 		}, 0);
 	}
@@ -1023,7 +1022,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 			}
 		}
 		/** Dispatched when user focus enters the dropdown content (trap-focus option only) */
-		this.dispatchEvent(new CustomEvent('d2l-dropdown-focus-enter'));
+		this.dispatchEvent(new CustomEvent('d2l-dropdown-focus-enter', { detail:{ applyFocus: this.__applyFocus } }));
 	}
 
 	async _handleMobileResize() {

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -260,7 +260,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 			} else {
 				this._isOpenedViaClick = true;
 				this._isHovering = false;
-				this.openDropdown(true);
+				this.openDropdown(false);
 			}
 		} else this.toggleOpen(false);
 	}


### PR DESCRIPTION
Just lumped two one-liners into one PR here. 

1. The hovering dropdown was previously forcing focus on click events, similar to keyboard openings. I've changed it to not apply focus, to be consistent with our other dropdown behaviour (note that the PR that George is working on might force focus anyways, but not visibly).
2. Adding an applyFocus detail to the focus-enter event. This will allow consumers to know if the focus was actually applied to the first element. The focus-enter event will always be dispatched regardless of applying focus, so adding the detail lets consumers know when to override that focus (ie. profile card will use this to force focus on another element, but only on keyboard events).