### PR TITLE
fix: remove optional chaining syntax to prevent transpile errors in activities

### DIFF
--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -309,7 +309,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 		} else {
 			const inputTime = this.shadowRoot.querySelector('d2l-input-time');
 			let time;
-			if (e.detail?.setToNow) time = _getFormattedDefaultTime('now');
+			if (e.detail && e.detail.setToNow) time = _getFormattedDefaultTime('now');
 			else time = inputTime ? inputTime.value : _getFormattedDefaultTime(this.timeDefaultValue);
 			this.value = this.localized ? _formatLocalDateTimeInISO(newDate, time) : getUTCDateTimeFromLocalDateTime(newDate, time);
 		}


### PR DESCRIPTION
Older tools like polymer don't recognize the ?. syntax, leading to some transpile errors. See https://github.com/BrightspaceHypermediaComponents/activities/runs/4291411518?check_suite_focus=true for an example. 