### PR TITLE
Support synchronous (non-deferred) rendering in html-block

### DIFF
--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -10,6 +10,10 @@
 			import { provideInstance } from '../../../mixins/provider-mixin.js';
 
 			class DemoReplacementRenderer {
+				get canRenderInline() {
+					return true;
+				}
+
 				async render(elem) {
 					const elemsToReplace = elem.querySelectorAll('[data-replace-me-id]');
 					if (elemsToReplace.length === 0) return elem;
@@ -184,6 +188,119 @@
 								</mrow>
 							</math>
 						</template>
+					</d2l-html-block>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>HTML Block (math, no deferred rendering)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-html-block>
+						<div class="no-deferred-rendering">
+							<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+								<mi>x</mi>
+								<mo>=</mo>
+								<mrow>
+									<mfrac>
+										<mrow>
+											<mo>&#x2212;</mo>
+											<mi>b</mi>
+											<mo>&#xB1;</mo>
+											<msqrt>
+												<msup>
+													<mi>b</mi>
+													<mn>2</mn>
+												</msup>
+												<mo>&#x2212;</mo>
+												<mn>4</mn>
+												<mi>a</mi>
+												<mi>c</mi>
+											</msqrt>
+										</mrow>
+										<mrow>
+											<mn>2</mn>
+											<mi>a</mi>
+										</mrow>
+									</mfrac>
+								</mrow>
+								<mtext>.</mtext>
+							</math>
+							<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+								<msup>
+									<mrow>
+										<mo>(</mo>
+										<mrow>
+											<munderover>
+												<mo>∑<!-- ∑ --></mo>
+												<mrow class="MJX-TeXAtom-ORD">
+													<mi>k</mi>
+													<mo>=</mo>
+													<mn>1</mn>
+												</mrow>
+												<mi>n</mi>
+											</munderover>
+											<msub>
+												<mi>a</mi>
+												<mi>k</mi>
+											</msub>
+											<msub>
+												<mi>b</mi>
+												<mi>k</mi>
+											</msub>
+										</mrow>
+										<mo>)</mo>
+									</mrow>
+									<mrow class="MJX-TeXAtom-ORD">
+										<mspace width="negativethinmathspace"></mspace>
+										<mspace width="negativethinmathspace"></mspace>
+										<mn>2</mn>
+									</mrow>
+								</msup>
+								<mo>≤<!-- ≤ --></mo>
+								<mrow>
+									<mo>(</mo>
+									<mrow>
+										<munderover>
+											<mo>∑<!-- ∑ --></mo>
+											<mrow class="MJX-TeXAtom-ORD">
+												<mi>k</mi>
+												<mo>=</mo>
+												<mn>1</mn>
+											</mrow>
+											<mi>n</mi>
+										</munderover>
+										<msubsup>
+											<mi>a</mi>
+											<mi>k</mi>
+											<mn>2</mn>
+										</msubsup>
+									</mrow>
+									<mo>)</mo>
+								</mrow>
+								<mrow>
+									<mo>(</mo>
+									<mrow>
+										<munderover>
+											<mo>∑<!-- ∑ --></mo>
+											<mrow class="MJX-TeXAtom-ORD">
+												<mi>k</mi>
+												<mo>=</mo>
+												<mn>1</mn>
+											</mrow>
+											<mi>n</mi>
+										</munderover>
+										<msubsup>
+											<mi>b</mi>
+											<mi>k</mi>
+											<mn>2</mn>
+										</msubsup>
+									</mrow>
+									<mo>)</mo>
+								</mrow>
+							</math>
+							<p>The wizard (<span data-replace-me-id="0">Elmer Fudd</span>) quickly jinxed the gnomes before they vaporized.</p>
+						</div>
 					</d2l-html-block>
 				</template>
 			</d2l-demo-snippet>

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -196,8 +196,8 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-html-block>
-						<div class="no-deferred-rendering">
+					<d2l-html-block no-deferred-rendering>
+						<div>
 							<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
 								<mi>x</mi>
 								<mo>=</mo>

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -140,7 +140,7 @@ class HtmlBlock extends LitElement {
 			:host([no-deferred-rendering="true"]) div.d2l-html-block-rendered {
 				display: none;
 			}
-			:host([no-deferred-rendering="false"])::slotted(*) {
+			:host([no-deferred-rendering="false"]) ::slotted(*) {
 				display: none;
 			}
 		`];

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -120,7 +120,7 @@ class HtmlBlock extends LitElement {
 
 	static get properties() {
 		return {
-			_noDeferredRendering: { Type: Boolean, attribute: 'no-deferred-rendering', reflect: true }
+			_noDeferredRendering: { type: Boolean, attribute: 'no-deferred-rendering', reflect: true }
 		};
 	}
 
@@ -137,10 +137,10 @@ class HtmlBlock extends LitElement {
 			:host([hidden]) {
 				display: none;
 			}
-			:host([no-deferred-rendering="true"]) div.d2l-html-block-rendered {
+			:host([no-deferred-rendering]) div.d2l-html-block-rendered {
 				display: none;
 			}
-			:host([no-deferred-rendering="false"]) ::slotted(*) {
+			:host(:not([no-deferred-rendering])) ::slotted(*) {
 				display: none;
 			}
 		`];

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -229,12 +229,12 @@ class HtmlBlock extends LitElement {
 	}
 
 	async _render(slot) {
-		if (this.noDeferredRendering) await this._renderInline();
+		if (this.noDeferredRendering) await this._renderInline(slot);
 		else this._stamp(slot);
 	}
 
-	async _renderInline() {
-		const noDeferredRenderingContainer = this._findSlottedElement('DIV');
+	async _renderInline(slot) {
+		const noDeferredRenderingContainer = this._findSlottedElement('DIV', slot);
 		if (!noDeferredRenderingContainer) return;
 		await this._processRenderers(noDeferredRenderingContainer);
 	}

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -214,7 +214,7 @@ class HtmlBlock extends LitElement {
 
 	async _processRenderers(elem) {
 		for (const renderer of getRenderers()) {
-			if (this._noDeferredRendering && !renderer.canRenderInline) continue;
+			if (this.noDeferredRendering && !renderer.canRenderInline) continue;
 
 			if (this._contextObserverController && renderer.contextAttributes) {
 				const contextValues = new Map();

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -259,7 +259,6 @@ class HtmlBlock extends LitElement {
 
 		if (this._templateObserver) this._templateObserver.disconnect();
 		if (template) {
-			this._noDeferredRendering = false;
 			this._templateObserver = new MutationObserver(() => stampHTML(template));
 			this._templateObserver.observe(template.content, { attributes: true, childList: true, subtree: true });
 		}

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -120,7 +120,7 @@ class HtmlBlock extends LitElement {
 
 	static get properties() {
 		return {
-			_deferRendering: { Type: Boolean, attribute: 'defer-rendering', reflect: true }
+			_noDeferredRendering: { Type: Boolean, attribute: 'no-deferred-rendering', reflect: true }
 		};
 	}
 
@@ -137,10 +137,10 @@ class HtmlBlock extends LitElement {
 			:host([hidden]) {
 				display: none;
 			}
-			:host([defer-rendering="false"]) div.d2l-html-block-rendered {
+			:host([no-deferred-rendering="true"]) div.d2l-html-block-rendered {
 				display: none;
 			}
-			:host([defer-rendering])::slotted(*) {
+			:host([no-deferred-rendering="false"])::slotted(*) {
 				display: none;
 			}
 		`];
@@ -148,6 +148,7 @@ class HtmlBlock extends LitElement {
 
 	constructor() {
 		super();
+		this._noDeferredRendering = false;
 
 		const rendererContextAttributes = getRenderers().reduce((attrs, currentRenderer) => {
 			if (currentRenderer.contextAttributes) currentRenderer.contextAttributes.forEach(attr => attrs.push(attr));
@@ -214,7 +215,7 @@ class HtmlBlock extends LitElement {
 
 	async _render(elem) {
 		for (const renderer of getRenderers()) {
-			if (!this._deferRendering && !renderer.canRenderInline) continue;
+			if (this._noDeferredRendering && !renderer.canRenderInline) continue;
 
 			if (this._contextObserverController && renderer.contextAttributes) {
 				const contextValues = new Map();
@@ -232,7 +233,7 @@ class HtmlBlock extends LitElement {
 		const noDeferredRenderingContainer = this.querySelector('div.no-deferred-rendering');
 		if (!noDeferredRenderingContainer) return;
 
-		this._deferRendering = false;
+		this._noDeferredRendering = true;
 		await this._render(noDeferredRenderingContainer);
 	}
 
@@ -254,7 +255,7 @@ class HtmlBlock extends LitElement {
 
 		if (this._templateObserver) this._templateObserver.disconnect();
 		if (template) {
-			this._deferRendering = true;
+			this._noDeferredRendering = false;
 			this._templateObserver = new MutationObserver(() => stampHTML(template));
 			this._templateObserver.observe(template.content, { attributes: true, childList: true, subtree: true });
 		}

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -102,8 +102,8 @@ describe('d2l-html-block', () => {
 		</d2l-html-block>
 	`;
 	const noDeferredRenderingReplacementFixture = html`
-		<d2l-html-block>
-			<div class="no-deferred-rendering"><span data-replace-id="1">first</span><span data-no-inline-replace-id="2">second</span></div>
+		<d2l-html-block no-deferred-rendering>
+			<div><span data-replace-id="1">first</span><span data-no-inline-replace-id="2">second</span></div>
 		</d2l-html-block>
 	`;
 

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -91,7 +91,6 @@ describe('d2l-html-block', () => {
 			<template></template>
 		</d2l-html-block>
 	`;
-
 	const replacementFixture = html`
 		<d2l-html-block>
 			<template><span data-replace-id="1">first</span><span data-replace-id="2">second</span></template>
@@ -140,7 +139,7 @@ describe('d2l-html-block', () => {
 		const replacementComplete = oneEvent(document, 'd2l-test-replacement-complete');
 		const htmlBlock = await fixture(noDeferredRenderingReplacementFixture);
 		await replacementComplete;
-		const spans = htmlBlock.shadowRoot.querySelectorAll('span');
+		const spans = htmlBlock.querySelectorAll('span');
 		expect(spans[0].innerHTML).to.equal('1');
 		expect(spans[1].innerHTML).to.equal('second');
 	});

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -4,6 +4,12 @@ let mathJaxLoaded;
 
 export class HtmlBlockMathRenderer {
 
+	get canRenderInline() {
+		// The custom MathJax ShadowAdaptor creates a new document and renders
+		// its contents to the DOM.
+		return false;
+	}
+
 	get contextAttributes() {
 		return [mathjaxContextAttribute];
 	}


### PR DESCRIPTION
This is a shot at supporting synchronous rendering within the html-block component. There are a couple things to point out here:
- We can't synchronously render math. The MathJax shadowDOM adaptor is incompatible with this, since it itself pulls the rendering elements into a new document, manipulates them, and then renders them back to the DOM. MathJax's APIs seem to expect a full document as input, so I see no way around this.
- Related to the above, we need to prevent any renderers with this requirement from running if we're in non-deferred mode. I figure that's the purpose the `canRenderInline` property on the renderers can serve.
- Given that this should only be used in specific LMS use cases, I've effectively made this behaviour opt-in via replacing the usual `template` with a `div` with a specific class.