### PR TITLE
US133950 - Keep temp elements connected to the DOM during rendering so MathJax can find style properties

### DIFF
--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -42,7 +42,7 @@
 
 		</script>
 		<script>
-			document.getElementsByTagName('html')[0].dataset.mathjaxContext = JSON.stringify({ renderLatex: window.location.search.indexOf('latex=true') !== -1 });
+			document.getElementsByTagName('html')[0].dataset.mathjaxContext = JSON.stringify({ outputScale: 1.1, renderLatex: window.location.search.indexOf('latex=true') !== -1 });
 		</script>
 	</head>
 	<body unresolved>

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -245,8 +245,10 @@ class HtmlBlock extends LitElement {
 			if (fragment) {
 
 				let temp = document.createElement('div');
+				temp.style.display = 'none';
 				temp.appendChild(fragment);
 
+				this._renderContainer.appendChild(temp);
 				temp = await this._processRenderers(temp);
 				this._renderContainer.innerHTML = temp.innerHTML;
 

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -113,8 +113,11 @@ describe('d2l-html-block', () => {
 
 	it('should not explode if no replacements', async() => {
 		const htmlBlock = await fixture(emptyReplacementFixture);
-		expect(htmlBlock.shadowRoot.querySelector('.d2l-html-block-rendered').innerHTML)
-			.to.equal('');
+		// Wait a frame for rendering to finish, since we temporarily add elements to the DOM
+		requestAnimationFrame(() => {
+			expect(htmlBlock.shadowRoot.querySelector('.d2l-html-block-rendered').innerHTML)
+				.to.equal('');
+		});
 	});
 
 	it('should do replacements', async() => {

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -32,9 +32,11 @@ export class HtmlBlockMathRenderer {
 		await loadMathJax(mathJaxConfig);
 
 		const temp = document.createElement('div');
+		temp.style.display = 'none';
 		temp.attachShadow({ mode: 'open' });
 		temp.shadowRoot.innerHTML = `<div><mjx-doc><mjx-head></mjx-head><mjx-body>${elem.innerHTML}</mjx-body></mjx-doc></div>`;
 
+		elem.appendChild(temp);
 		window.MathJax.typesetShadow(temp.shadowRoot);
 		return temp.shadowRoot.firstChild;
 	}


### PR DESCRIPTION
MathJax allows a global scale property to be attached to its output renderers that renders math at some fixed scale (perhaps unsurprisingly) larger or smaller than the surrounding text. This is configurable within the LMS, but it turns out it hasn't been functional in the component.

MathJax creates a test element within the document and tries to compute its style to figure out all of its base measurements (font-size, ex-height, etc.), which it then multiplies by the scaling factor. However, we use two layers of temp elements that aren't attached to the DOM, so `window.getComputedStyle` returns empty attributes when MathJax does this checking. Hence it ignores that scale factor entirely.

Proposed solution: Within the html-block component, attach the temp element to the render container and don't display it. Then in the math renderer, do something similar: attach our temporary shadowRoot to the existing element.