### PR TITLE
Revalidate inputs when a custom validator is attached

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -227,7 +227,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 
 	validationCustomConnected(custom) {
 		this._validationCustoms.add(custom);
-		if (validateOnInit) {
+		if (this.validateOnInit) {
 			this.requestValidate(true);
 		}
 	}

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -99,6 +99,11 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 			noValidate: { type: Boolean, attribute: 'novalidate' },
 			/**
 			 * @ignore
+			 * Perform validation immediately instead of waiting for the user to make changes.
+			 */
+			validateOnInit: { type: Boolean, attribute: 'validate-on-init' },
+			/**
+			 * @ignore
 			 */
 			validationError: { type: String, attribute: false },
 			/**
@@ -124,6 +129,8 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		this.invalid = false;
 		/** @ignore */
 		this.noValidate = false;
+		/** @ignore */
+		this.validateOnInit = false;
 		/** @ignore */
 		this.validationError = null;
 		/** @ignore */
@@ -153,6 +160,13 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		return this._validity;
 	}
 
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		if (this.validateOnInit) {
+			this.requestValidate(true);
+		}
+	}
+
 	updated(changedProperties) {
 		if (changedProperties.has('_errors') || changedProperties.has('childErrors')) {
 			let errors = this._errors;
@@ -170,6 +184,9 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 				/** @ignore */
 				this.dispatchEvent(new CustomEvent('invalid-change'));
 			}
+		}
+		if (this.validateOnInit && (changedProperties.has('noValidate') || changedProperties.has('validateOnInit'))) {
+			this.requestValidate(true);
 		}
 	}
 
@@ -210,7 +227,9 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 
 	validationCustomConnected(custom) {
 		this._validationCustoms.add(custom);
-		this.requestValidate(true);
+		if (validateOnInit) {
+			this.requestValidate(true);
+		}
 	}
 
 	validationCustomDisconnected(custom) {

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -160,13 +160,6 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		return this._validity;
 	}
 
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
-		if (this.validateOnInit) {
-			this.requestValidate(true);
-		}
-	}
-
 	updated(changedProperties) {
 		if (changedProperties.has('_errors') || changedProperties.has('childErrors')) {
 			let errors = this._errors;

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -210,6 +210,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 
 	validationCustomConnected(custom) {
 		this._validationCustoms.add(custom);
+		this.requestValidate(true);
 	}
 
 	validationCustomDisconnected(custom) {

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -33,7 +33,7 @@ const formTag = defineCE(
 	}
 );
 
-const formFixture = `<${formTag}></${formTag}`;
+const formFixture = `<${formTag}></${formTag}>`;
 
 describe('form-element', () => {
 
@@ -193,6 +193,24 @@ describe('form-element', () => {
 			await formElement.requestValidate(false);
 			expect(formElement.invalid).to.be.false;
 			expect(formElement.validationError).to.be.null;
+		});
+
+	});
+	
+	describe('validate-on-init', () => {
+		it('should not validate immediately if validate-on-init is not set', async() => {
+			form.isValidationCustomValid = false;
+			await formElement.performUpdate();
+			expect(formElement.invalid).to.be.false;
+			await formElement.validate();
+			expect(formElement.invalid).to.be.true;
+		});
+
+		it('should validate immediately if validate-on-init is set', async() => {
+			form.isValidationCustomValid = false;
+			formElement.validateOnInit = true;
+			await oneEvent(formElement, 'invalid-change');
+			expect(formElement.invalid).to.be.true;
 		});
 
 	});

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -196,7 +196,7 @@ describe('form-element', () => {
 		});
 
 	});
-	
+
 	describe('validate-on-init', () => {
 		it('should not validate immediately if validate-on-init is not set', async() => {
 			form.isValidationCustomValid = false;

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -1,6 +1,4 @@
 import '../input-number.js';
-import '../../form/form.js';
-import '../../validation/validation-custom.js';
 import { aTimeout, expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
@@ -14,18 +12,6 @@ const minFixture = html`<d2l-input-number label="label" min="5"></d2l-input-numb
 const minExclusiveFixture = html`<d2l-input-number label="label" min="5" min-exclusive></d2l-input-number>`;
 const maxFixture = html`<d2l-input-number label="label" max="10"></d2l-input-number>`;
 const maxExclusiveFixture = html`<d2l-input-number label="label" max="10" max-exclusive></d2l-input-number>`;
-const minMaxWithValueFeature = html`<d2l-input-number label="label" min="5" max="10" value="11"></d2l-input-number>`;
-const minMaxWithValueAndImmediateValidationFeature = html`<d2l-input-number label="label" validate-on-init min="5" max="10" value="11"></d2l-input-number>`;
-const customValidatorFixture = html`
-	<d2l-form>
-		<d2l-input-number validate-on-init id="input" label="label" value="11"></d2l-input-number>
-		<d2l-validation-custom
-			for="input"
-			failure-text="Test"
-			@d2l-validation-custom-validate=${e => e.detail.resolve(false)}
-		></d2l-validation-custom>
-	</d2l-form>
-`;
 
 function dispatchEvent(elem, eventType) {
 	const e = new Event(
@@ -647,24 +633,6 @@ describe('d2l-input-number', () => {
 				expect(elem.valueTrailingZeroes).to.equal(val);
 				expect(elem._formattedValue).to.equal(val);
 			});
-		});
-
-		it('should not validate immediately if validate-on-init is not set', async() => {
-			const elem = await fixture(minMaxWithValueFeature);
-			expect(!elem.hasAttribute('invalid'));
-			await elem.validate();
-			expect(elem.hasAttribute('hasAttribute'));
-		});
-
-		it('should validate immediately if validate-on-init is set', async() => {
-			const elem = await fixture(minMaxWithValueAndImmediateValidationFeature);
-			expect(elem.hasAttribute('invalid'));
-		});
-
-		it('should validate custom validators when attached if validate-on-init is set', async() => {
-			const elem = await fixture(customValidatorFixture);
-			await oneEvent(elem, 'd2l-form-element-errors-change');
-			expect(elem.hasAttribute('invalid'));
 		});
 
 	});

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -1,4 +1,6 @@
 import '../input-number.js';
+import '../../form/form.js';
+import '../../validation/validation-custom.js';
 import { aTimeout, expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
@@ -12,6 +14,18 @@ const minFixture = html`<d2l-input-number label="label" min="5"></d2l-input-numb
 const minExclusiveFixture = html`<d2l-input-number label="label" min="5" min-exclusive></d2l-input-number>`;
 const maxFixture = html`<d2l-input-number label="label" max="10"></d2l-input-number>`;
 const maxExclusiveFixture = html`<d2l-input-number label="label" max="10" max-exclusive></d2l-input-number>`;
+const minMaxWithValueFeature = html`<d2l-input-number label="label" min="5" max="10" value="11"></d2l-input-number>`;
+const minMaxWithValueAndImmediateValidationFeature = html`<d2l-input-number label="label" validate-on-init min="5" max="10" value="11"></d2l-input-number>`;
+const customValidatorFixture = html`
+	<d2l-form>
+		<d2l-input-number validate-on-init id="input" label="label" value="11"></d2l-input-number>
+		<d2l-validation-custom
+			for="input"
+			failure-text="Test"
+			@d2l-validation-custom-validate=${e => e.detail.resolve(false)}
+		></d2l-validation-custom>
+	</d2l-form>
+`;
 
 function dispatchEvent(elem, eventType) {
 	const e = new Event(
@@ -633,6 +647,24 @@ describe('d2l-input-number', () => {
 				expect(elem.valueTrailingZeroes).to.equal(val);
 				expect(elem._formattedValue).to.equal(val);
 			});
+		});
+
+		it('should not validate immediately if validate-on-init is not set', async() => {
+			const elem = await fixture(minMaxWithValueFeature);
+			expect(!elem.hasAttribute('invalid'));
+			await elem.validate();
+			expect(elem.hasAttribute('hasAttribute'));
+		});
+
+		it('should validate immediately if validate-on-init is set', async() => {
+			const elem = await fixture(minMaxWithValueAndImmediateValidationFeature);
+			expect(elem.hasAttribute('invalid'));
+		});
+
+		it('should validate custom validators when attached if validate-on-init is set', async() => {
+			const elem = await fixture(customValidatorFixture);
+			await oneEvent(elem, 'd2l-form-element-errors-change');
+			expect(elem.hasAttribute('invalid'));
 		});
 
 	});


### PR DESCRIPTION
Automatically call `requestValidate` when a custom validator is added to prevent race conditions when attempting to validate based on a custom validator.