### PR TITLE
US134386 - Add public filter functions needed by the applied filters lab component

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -212,6 +212,25 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		`;
 	}
 
+	focus() {
+		const opener = this.shadowRoot.querySelector('d2l-dropdown-button-subtle');
+		if (opener) opener.focus();
+	}
+
+	requestFilterClearAll() {
+		this._handleClearAll();
+	}
+
+	requestFilterValueClear(keyObject) {
+		const dimension = this._dimensions.find(dimension => dimension.key === keyObject.dimension);
+
+		switch (dimension.type) {
+			case 'd2l-filter-dimension-set':
+				this._performChangeSetDimension(dimension, keyObject.value, false);
+				break;
+		}
+	}
+
 	_buildDimension(dimension, singleDimension) {
 		let dimensionHTML;
 		switch (dimension.type) {
@@ -433,20 +452,9 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		const dimensionKey = e.target.id.slice(SET_DIMENSION_ID_PREFIX.length);
 		const dimension = this._dimensions.find(dimension => dimension.key === dimensionKey);
 		const valueKey = e.detail.key;
-		const value = dimension.values.find(value => value.key === valueKey);
 		const selected = e.detail.selected;
 
-		value.selected = selected;
-
-		if (selected) {
-			dimension.appliedCount++;
-			this._totalAppliedCount++;
-		} else {
-			dimension.appliedCount--;
-			this._totalAppliedCount--;
-		}
-
-		this._dispatchChangeEvent(dimension, { valueKey: valueKey, selected: selected });
+		this._performChangeSetDimension(dimension, valueKey, selected);
 	}
 
 	_handleClear() {
@@ -619,6 +627,22 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		}
 
 		return false;
+	}
+
+	_performChangeSetDimension(dimension, valueKey, selected) {
+		const value = dimension.values.find(value => value.key === valueKey);
+		if (value.selected === selected) return;
+		value.selected = selected;
+
+		if (selected) {
+			dimension.appliedCount++;
+			this._totalAppliedCount++;
+		} else {
+			dimension.appliedCount--;
+			this._totalAppliedCount--;
+		}
+
+		this._dispatchChangeEvent(dimension, { valueKey: valueKey, selected: selected });
 	}
 
 	_performDimensionClear(dimension) {

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -141,6 +141,39 @@ describe('d2l-filter', () => {
 			expect(elem._dimensions[1].appliedCount).to.equal(0);
 			expect(elem._totalAppliedCount).to.equal(0);
 		});
+
+		it('requestFilterValueClear clears the corresponding active filter value', async() => {
+			const elem = await fixture(multiDimensionFixture);
+			expect(elem._dimensions[2].values[1].selected).to.be.true;
+			expect(elem._dimensions[2].appliedCount).to.equal(1);
+			expect(elem._totalAppliedCount).to.equal(2);
+
+			elem.requestFilterValueClear({ dimension: '3', value: '2' });
+			expect(elem._dimensions[2].values[1].selected).to.be.false;
+			expect(elem._dimensions[2].appliedCount).to.equal(0);
+			expect(elem._totalAppliedCount).to.equal(1);
+			expect(elem._changeEventsToDispatch.size).to.equal(1);
+			const changeEventDim = elem._changeEventsToDispatch.get('3');
+			expect(changeEventDim.dimensionKey).to.equal('3');
+			expect(changeEventDim.cleared).to.be.false;
+			expect(changeEventDim.changes.size).to.equal(1);
+			const changeEvent = changeEventDim.changes.get('2');
+			expect(changeEvent.valueKey).to.equal('2');
+			expect(changeEvent.selected).to.be.false;
+		});
+
+		it('requestFilterValueClear does nothing if the filter value is already inactive', async() => {
+			const elem = await fixture(multiDimensionFixture);
+			expect(elem._dimensions[2].values[0].selected).to.be.false;
+			expect(elem._dimensions[2].appliedCount).to.equal(1);
+			expect(elem._totalAppliedCount).to.equal(2);
+
+			elem.requestFilterValueClear({ dimension: '3', value: '1' });
+			expect(elem._dimensions[2].values[0].selected).to.be.false;
+			expect(elem._dimensions[2].appliedCount).to.equal(1);
+			expect(elem._totalAppliedCount).to.equal(2);
+			expect(elem._changeEventsToDispatch.size).to.equal(0);
+		});
 	});
 
 	describe('searching', () => {


### PR DESCRIPTION
This was an easily separated piece.  These three functions will be needed by the applied filters lab component, who can request to clear an individual active filter (when the user removes a tag) or request to clear all active filters (by pressing the "clear filters" button).  When all filters are cleared, the component moves focus back to the filter (even if we don't want to keep that functionality in the final `core` version, having a `focus` function on the filter isn't a bad thing).