### PR TITLE
removing mocha dependency lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,3 @@ updates:
     ignore:
       - dependency-name: "@formatjs/intl-pluralrules"
       - dependency-name: "intl-messageformat"
-        # mocha needs to be < 8.1, may be fixed but waiting for release
-      - dependency-name: "mocha"


### PR DESCRIPTION
I don't really remember why we were locking Mocha to version 8, but 1) core doesn't have an explicit dependency on Mocha anymore and b) we're now successfully using Mocha 9 for visual-diff testing so any issues should be resolved.