### PR TITLE
explicitly ignoring dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,13 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "@formatjs/intl-pluralrules"
+      # Lit 2 upgrade
+      - dependency-name: "@open-wc/testing"
+        versions: ["3.x"]
       - dependency-name: "intl-messageformat"
+      # Lit 2 upgrade
+      - dependency-name: "lit-element"
+        versions: ["3.x"]
+      # Lit 2 upgrade
+      - dependency-name: "lit-html"
+        versions: ["2.x"]


### PR DESCRIPTION
While reviewing this I noticed we had ignored these upgrades through the PR workflow but should probably list them out explicitly here, along with the reason.

I'm going to make this change to the `npm init` generator too, otherwise new repos will suddenly get Dependabot PRs to upgrade Lit.