### PR TITLE
US134551 - Lit 2 Prep - Add shadowRoot checks

### DIFF
--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -108,7 +108,7 @@ export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin
 	}
 
 	focus() {
-		const button = this.shadowRoot.querySelector('button');
+		const button = this.shadowRoot ? this.shadowRoot.querySelector('button') : undefined;
 		if (button) button.focus();
 	}
 

--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -108,7 +108,7 @@ export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin
 	}
 
 	focus() {
-		const button = this.shadowRoot ? this.shadowRoot.querySelector('button') : undefined;
+		const button = this.shadowRoot && this.shadowRoot.querySelector('button');
 		if (button) button.focus();
 	}
 

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -557,7 +557,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			await this.updateComplete;
 			this._focusDateAddFocus();
 		} else {
-			const button = this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-icon') : undefined;
+			const button = this.shadowRoot && this.shadowRoot.querySelector('d2l-button-icon');
 			if (button) button.focus();
 		}
 	}
@@ -582,9 +582,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 	async _getDateElement(date) {
 		await this.updateComplete;
-		return this.shadowRoot ?
-			this.shadowRoot.querySelector(`td[data-date="${date.getDate()}"][data-month="${date.getMonth()}"][data-year="${date.getFullYear()}"]`)
-			: undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector(`td[data-date="${date.getDate()}"][data-month="${date.getMonth()}"][data-year="${date.getFullYear()}"]`);
 	}
 
 	_getInitialFocusDate() {
@@ -717,7 +715,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				if (!canUpdateFocusDate) this._focusDate = undefined;
 				if (this._focusDate) this._focusDateAddFocus();
 				else {
-					const buttons = this.shadowRoot ? this.shadowRoot.querySelectorAll('d2l-button-icon') : undefined;
+					const buttons = this.shadowRoot && this.shadowRoot.querySelectorAll('d2l-button-icon');
 					if (buttons && buttons.length > 0) buttons[0].focus();
 				}
 				preventDefault = true;
@@ -744,7 +742,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				if (!canUpdateFocusDate) this._focusDate = undefined;
 				if (this._focusDate) this._focusDateAddFocus();
 				else {
-					const buttons = this.shadowRoot ? this.shadowRoot.querySelectorAll('d2l-button-icon') : undefined;
+					const buttons = this.shadowRoot && this.shadowRoot.querySelectorAll('d2l-button-icon');
 					if (buttons && buttons.length > 1) buttons[1].focus();
 				}
 				preventDefault = true;

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -582,7 +582,9 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 	async _getDateElement(date) {
 		await this.updateComplete;
-		return this.shadowRoot.querySelector(`td[data-date="${date.getDate()}"][data-month="${date.getMonth()}"][data-year="${date.getFullYear()}"]`);
+		return this.shadowRoot ?
+			this.shadowRoot.querySelector(`td[data-date="${date.getDate()}"][data-month="${date.getMonth()}"][data-year="${date.getFullYear()}"]`)
+			: undefined;
 	}
 
 	_getInitialFocusDate() {
@@ -715,7 +717,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				if (!canUpdateFocusDate) this._focusDate = undefined;
 				if (this._focusDate) this._focusDateAddFocus();
 				else {
-					const buttons = this.shadowRoot.querySelectorAll('d2l-button-icon');
+					const buttons = this.shadowRoot ? this.shadowRoot.querySelectorAll('d2l-button-icon') : undefined;
 					if (buttons && buttons.length > 0) buttons[0].focus();
 				}
 				preventDefault = true;
@@ -742,7 +744,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				if (!canUpdateFocusDate) this._focusDate = undefined;
 				if (this._focusDate) this._focusDateAddFocus();
 				else {
-					const buttons = this.shadowRoot.querySelectorAll('d2l-button-icon');
+					const buttons = this.shadowRoot ? this.shadowRoot.querySelectorAll('d2l-button-icon') : undefined;
 					if (buttons && buttons.length > 1) buttons[1].focus();
 				}
 				preventDefault = true;
@@ -832,7 +834,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		}
 
 		await this.updateComplete; // for case of keyboard navigation where second month contains no enabled dates
-		if (this.shadowRoot.querySelector('.d2l-calendar-date:enabled')) {
+		if (this.shadowRoot && this.shadowRoot.querySelector('.d2l-calendar-date:enabled')) {
 			const validDates = this.shadowRoot.querySelectorAll('.d2l-calendar-date:enabled');
 			const focusDate = validDates[latestPossibleFocusDate ? (validDates.length - 1) : 0].parentNode;
 			const year = focusDate.getAttribute('data-year');

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -557,7 +557,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			await this.updateComplete;
 			this._focusDateAddFocus();
 		} else {
-			const button = this.shadowRoot.querySelector('d2l-button-icon');
+			const button = this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-icon') : undefined;
 			if (button) button.focus();
 		}
 	}

--- a/components/card/card-footer-link.js
+++ b/components/card/card-footer-link.js
@@ -149,11 +149,11 @@ class CardFooterLink extends RtlMixin(LitElement) {
 	}
 
 	_onBlur() {
-		this.shadowRoot.querySelector('d2l-count-badge-icon').forceFocusRing = false;
+		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-count-badge-icon').forceFocusRing = false;
 	}
 
 	_onFocus() {
-		this.shadowRoot.querySelector('d2l-count-badge-icon').forceFocusRing = true;
+		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-count-badge-icon').forceFocusRing = true;
 	}
 
 }

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -307,7 +307,7 @@ class Card extends RtlMixin(LitElement) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('a');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('a') : undefined;
 		if (!elem) return;
 		elem.focus();
 	}

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -307,7 +307,7 @@ class Card extends RtlMixin(LitElement) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('a') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('a');
 		if (!elem) return;
 		elem.focus();
 	}

--- a/components/count-badge/count-badge-mixin.js
+++ b/components/count-badge/count-badge-mixin.js
@@ -7,7 +7,7 @@ import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
-import { styleMap } from 'lit-html/directives/style-map.js';
+import { styleMap } from 'lit-html/directives/style-map';
 
 export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(SkeletonMixin(RtlMixin(superclass))) {
 

--- a/components/count-badge/count-badge-mixin.js
+++ b/components/count-badge/count-badge-mixin.js
@@ -7,7 +7,7 @@ import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
-import { styleMap } from 'lit-html/directives/style-map';
+import { styleMap } from 'lit-html/directives/style-map.js';
 
 export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(SkeletonMixin(RtlMixin(superclass))) {
 

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -52,7 +52,7 @@ class CodeView extends LitElement {
 	}
 
 	forceUpdate() {
-		this._updateCode(this.shadowRoot.querySelector('slot'));
+		if (this.shadowRoot) this._updateCode(this.shadowRoot.querySelector('slot'));
 	}
 
 	get _codeTemplate() {

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -36,7 +36,7 @@ class CodeView extends LitElement {
 			const path = `/node_modules/prismjs/components/prism-${language}.min.js`;
 			this._dependenciesPromise = import(path);
 		}
-		this._updateCode(this.shadowRoot.querySelector('slot'));
+		if (this.shadowRoot) this._updateCode(this.shadowRoot.querySelector('slot'));
 		super.attributeChangedCallback(name, oldval, newval);
 	}
 

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -105,18 +105,19 @@ class DemoSnippet extends LitElement {
 
 		changedProperties.forEach((_, prop) => {
 			if (prop === '_code') {
-				this.shadowRoot.querySelector('d2l-code-view').forceUpdate();
+				if (this.shadowRoot) this.shadowRoot.querySelector('d2l-code-view').forceUpdate();
 				this._updateHasSkeleton();
 			}
 		});
 	}
 
 	forceCodeUpdate() {
-		this._updateCode(this.shadowRoot.querySelector('slot:not([name="_demo"])'));
+		if (this.shadowRoot) this._updateCode(this.shadowRoot.querySelector('slot:not([name="_demo"])'));
 	}
 
 	_applyAttr(name, value, applyToShadowRoot) {
 		const query = this._isTemplate ? 'slot[name="_demo"]' : 'slot:not([name="_demo"])';
+		if (!this.shadowRoot) return;
 		const nodes = this.shadowRoot.querySelector(query).assignedNodes();
 		if (nodes.length === 0) return;
 		const doApply = (nodes, isRoot) => {
@@ -191,6 +192,7 @@ class DemoSnippet extends LitElement {
 	}
 
 	_removeImportedDemo() {
+		if (!this.shadowRoot) return;
 		const nodes = this.shadowRoot.querySelector('slot[name="_demo"]').assignedNodes();
 		for (let i = nodes.length - 1; i === 0; i--) {
 			nodes[i].parentNode.removeChild(nodes[i]);
@@ -231,6 +233,7 @@ class DemoSnippet extends LitElement {
 	_updateHasSkeleton() {
 
 		const query = this._isTemplate ? 'slot[name="_demo"]' : 'slot:not([name="_demo"])';
+		if (!this.shadowRoot) return;
 		const nodes = this.shadowRoot.querySelector(query).assignedNodes();
 
 		const doApply = (nodes) => {

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -81,6 +81,7 @@ class DialogConfirm extends DialogMixin(LitElement) {
 	}
 
 	_focusInitial() {
+		if (!this.shadowRoot) return;
 		const footer = this.shadowRoot.querySelector('.d2l-dialog-footer-slot');
 		const nodes = footer.assignedNodes();
 		for (let i = 0; i < nodes.length; i++) {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -129,7 +129,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 	_addHandlers() {
 		window.addEventListener('resize', this._updateSize);
-		this.shadowRoot.querySelector('.d2l-dialog-content').addEventListener('scroll', this._updateOverflow);
+		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-dialog-content').addEventListener('scroll', this._updateOverflow);
 	}
 
 	_close(action) {
@@ -139,6 +139,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		clearDismissible(this._dismissibleId);
 		this._dismissibleId = null;
 
+		if (!this.shadowRoot) return;
 		const dialog = this.shadowRoot.querySelector('.d2l-dialog-outer');
 
 		const doClose = () => {
@@ -161,6 +162,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	}
 
 	_focusFirst() {
+		if (!this.shadowRoot) return;
 		const content = this.shadowRoot.querySelector('.d2l-dialog-content');
 		if (content) {
 			const firstFocusable = getNextFocusable(content);
@@ -187,6 +189,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	}
 
 	_getHeight() {
+		if (!this.shadowRoot) return;
 
 		const availableHeight = this._ifrauContextInfo
 			? this._ifrauContextInfo.availableHeight - this._margin.top - this._margin.bottom
@@ -303,6 +306,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._action = undefined;
 		this._addHandlers();
 
+		if (!this.shadowRoot) return;
 		const dialog = this.shadowRoot.querySelector('.d2l-dialog-outer');
 
 		const animPromise = new Promise((resolve) => {
@@ -357,7 +361,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 	_removeHandlers() {
 		window.removeEventListener('resize', this._updateSize);
-		this.shadowRoot.querySelector('.d2l-dialog-content').removeEventListener('scroll', this._updateOverflow);
+		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-dialog-content').removeEventListener('scroll', this._updateOverflow);
 	}
 
 	_render(inner, info, iframeTopOverride) {
@@ -423,6 +427,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	}
 
 	_updateOverflow() {
+		if (!this.shadowRoot) return;
 		const content = this.shadowRoot.querySelector('.d2l-dialog-content');
 		this._overflowTop = (content.scrollTop > 0);
 		this._overflowBottom = (content.scrollHeight > content.scrollTop + content.clientHeight);

--- a/components/dropdown/dropdown-button-subtle.js
+++ b/components/dropdown/dropdown-button-subtle.js
@@ -41,7 +41,7 @@ class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 	 * @return {HTMLElement}
 	 */
 	getOpenerElement() {
-		return this.shadowRoot.querySelector('d2l-button-subtle');
+		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-subtle') : undefined;
 	}
 
 }

--- a/components/dropdown/dropdown-button-subtle.js
+++ b/components/dropdown/dropdown-button-subtle.js
@@ -41,7 +41,7 @@ class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 	 * @return {HTMLElement}
 	 */
 	getOpenerElement() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-subtle') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('d2l-button-subtle');
 	}
 
 }

--- a/components/dropdown/dropdown-button.js
+++ b/components/dropdown/dropdown-button.js
@@ -72,7 +72,7 @@ class DropdownButton extends DropdownOpenerMixin(RtlMixin(LitElement)) {
 	 * @return {HTMLElement}
 	 */
 	getOpenerElement() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-button') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('d2l-button');
 	}
 
 }

--- a/components/dropdown/dropdown-button.js
+++ b/components/dropdown/dropdown-button.js
@@ -72,7 +72,7 @@ class DropdownButton extends DropdownOpenerMixin(RtlMixin(LitElement)) {
 	 * @return {HTMLElement}
 	 */
 	getOpenerElement() {
-		return this.shadowRoot.querySelector('d2l-button');
+		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-button') : undefined;
 	}
 
 }

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -399,15 +399,15 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 	}
 
 	__getContentBottom() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-bottom') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('.d2l-dropdown-content-bottom');
 	}
 
 	__getContentContainer() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-container') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('.d2l-dropdown-content-container');
 	}
 
 	__getContentTop() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-top') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('.d2l-dropdown-content-top');
 	}
 
 	__getOpener() {
@@ -420,11 +420,11 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 	}
 
 	__getPositionContainer() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-position') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('.d2l-dropdown-content-position');
 	}
 
 	__getWidthContainer() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-width') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('.d2l-dropdown-content-width');
 	}
 
 	__handleFooterSlotChange(e) {

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -338,7 +338,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		};
 
 		if (!reduceMotion && this._useMobileStyling && this.mobileTray && isVisible(this)) {
-			this.shadowRoot.querySelector('.d2l-dropdown-content-width')
+			if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-dropdown-content-width')
 				.addEventListener('animationend', hide, { once: true });
 			this._closing = true;
 			this._showBackdrop = false;
@@ -399,15 +399,15 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 	}
 
 	__getContentBottom() {
-		return this.shadowRoot.querySelector('.d2l-dropdown-content-bottom');
+		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-bottom') : undefined;
 	}
 
 	__getContentContainer() {
-		return this.shadowRoot.querySelector('.d2l-dropdown-content-container');
+		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-container') : undefined;
 	}
 
 	__getContentTop() {
-		return this.shadowRoot.querySelector('.d2l-dropdown-content-top');
+		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-top') : undefined;
 	}
 
 	__getOpener() {
@@ -420,11 +420,11 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 	}
 
 	__getPositionContainer() {
-		return this.shadowRoot.querySelector('.d2l-dropdown-content-position');
+		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-position') : undefined;
 	}
 
 	__getWidthContainer() {
-		return this.shadowRoot.querySelector('.d2l-dropdown-content-width');
+		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-dropdown-content-width') : undefined;
 	}
 
 	__handleFooterSlotChange(e) {

--- a/components/dropdown/dropdown-context-menu.js
+++ b/components/dropdown/dropdown-context-menu.js
@@ -55,7 +55,7 @@ class DropdownContextMenu extends DropdownOpenerMixin(VisibleOnAncestorMixin(Lit
 	 * @return {HTMLElement}
 	 */
 	getOpenerElement() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-icon') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('d2l-button-icon');
 	}
 
 }

--- a/components/dropdown/dropdown-context-menu.js
+++ b/components/dropdown/dropdown-context-menu.js
@@ -55,7 +55,7 @@ class DropdownContextMenu extends DropdownOpenerMixin(VisibleOnAncestorMixin(Lit
 	 * @return {HTMLElement}
 	 */
 	getOpenerElement() {
-		return this.shadowRoot.querySelector('d2l-button-icon');
+		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-icon') : undefined;
 	}
 
 }

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -51,6 +51,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 	}
 
 	__getMenuElement() {
+		if (!this.shadowRoot) return undefined;
 		return this.shadowRoot.querySelector('.d2l-dropdown-content-slot')
 			.assignedNodes().filter(node => node.hasAttribute
 				&& (node.getAttribute('role') === 'menu' || node.getAttribute('role') === 'listbox'))[0];

--- a/components/dropdown/dropdown-more.js
+++ b/components/dropdown/dropdown-more.js
@@ -55,7 +55,7 @@ class DropdownMore extends DropdownOpenerMixin(VisibleOnAncestorMixin(LitElement
 	 * @return {HTMLElement}
 	 */
 	getOpenerElement() {
-		return this.shadowRoot.querySelector('d2l-button-icon');
+		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-icon') : undefined;
 	}
 
 }

--- a/components/dropdown/dropdown-more.js
+++ b/components/dropdown/dropdown-more.js
@@ -55,7 +55,7 @@ class DropdownMore extends DropdownOpenerMixin(VisibleOnAncestorMixin(LitElement
 	 * @return {HTMLElement}
 	 */
 	getOpenerElement() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-icon') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('d2l-button-icon');
 	}
 
 }

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -170,6 +170,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	}
 
 	__getContentElement() {
+		if (!this.shadowRoot) return undefined;
 		return this.shadowRoot.querySelector('slot:not([name])').assignedNodes()
 			.filter(node => node.hasAttribute && node.hasAttribute('dropdown-content'))[0];
 	}

--- a/components/dropdown/dropdown-tabs.js
+++ b/components/dropdown/dropdown-tabs.js
@@ -37,6 +37,7 @@ class DropdownTabs extends DropdownContentMixin(LitElement) {
 	}
 
 	_getTabsElement() {
+		if (!this.shadowRoot) return undefined;
 		return this.shadowRoot.querySelector('.d2l-dropdown-content-container > slot')
 			.assignedNodes()
 			.filter(node => node.hasAttribute && node.tagName === 'D2L-TABS')[0];

--- a/components/dropdown/dropdown.js
+++ b/components/dropdown/dropdown.js
@@ -21,6 +21,7 @@ class Dropdown extends DropdownOpenerMixin(LitElement) {
 	 * @return {HTMLElement}
 	 */
 	getOpenerElement() {
+		if (!this.shadowRoot) return undefined;
 		return this.shadowRoot.querySelector('slot')
 			.assignedNodes()
 			.filter(node => node.classList && node.classList.contains('d2l-dropdown-opener'))[0];

--- a/components/dropdown/test/dropdown-component.js
+++ b/components/dropdown/test/dropdown-component.js
@@ -27,7 +27,7 @@ class DropdownComponent extends LitElement {
 	}
 
 	toggleOpen() {
-		this.shadowRoot.querySelector('d2l-dropdown-content').toggleOpen();
+		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-dropdown-content').toggleOpen();
 	}
 
 }

--- a/components/expand-collapse/expand-collapse-content.js
+++ b/components/expand-collapse/expand-collapse-content.js
@@ -117,9 +117,7 @@ class ExpandCollapseContent extends LitElement {
 				await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
 				if (this._state === states.PREEXPANDING) {
 					this._state = states.EXPANDING;
-					const content = this.shadowRoot ?
-						this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner')
-						: undefined;
+					const content = this.shadowRoot && this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner');
 					if (content) this._height = `${content.scrollHeight}px`;
 				}
 			}
@@ -136,9 +134,7 @@ class ExpandCollapseContent extends LitElement {
 				this._eventPromiseResolve();
 			} else {
 				this._state = states.PRECOLLAPSING;
-				const content = this.shadowRoot ?
-					this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner')
-					: undefined;
+				const content = this.shadowRoot && this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner');
 				if (content) this._height = `${content.scrollHeight}px`;
 				await this.updateComplete;
 				await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));

--- a/components/expand-collapse/expand-collapse-content.js
+++ b/components/expand-collapse/expand-collapse-content.js
@@ -117,8 +117,10 @@ class ExpandCollapseContent extends LitElement {
 				await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
 				if (this._state === states.PREEXPANDING) {
 					this._state = states.EXPANDING;
-					const content = this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner');
-					this._height = `${content.scrollHeight}px`;
+					const content = this.shadowRoot ?
+						this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner')
+						: undefined;
+					if (content) this._height = `${content.scrollHeight}px`;
 				}
 			}
 		} else {
@@ -134,8 +136,10 @@ class ExpandCollapseContent extends LitElement {
 				this._eventPromiseResolve();
 			} else {
 				this._state = states.PRECOLLAPSING;
-				const content = this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner');
-				this._height = `${content.scrollHeight}px`;
+				const content = this.shadowRoot ?
+					this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner')
+					: undefined;
+				if (content) this._height = `${content.scrollHeight}px`;
 				await this.updateComplete;
 				await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
 				if (this._state === states.PRECOLLAPSING) {

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -213,7 +213,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	focus() {
-		const opener = this.shadowRoot ? this.shadowRoot.querySelector('d2l-dropdown-button-subtle') : undefined;
+		const opener = this.shadowRoot && this.shadowRoot.querySelector('d2l-dropdown-button-subtle');
 		if (opener) opener.focus();
 	}
 
@@ -538,9 +538,8 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	_handleDimensionShowComplete() {
-		const returnButton = this.shadowRoot ?
-			this.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]')
-			: undefined;
+		const returnButton = this.shadowRoot
+			&& this.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]');
 		if (returnButton) returnButton.focus();
 	}
 

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -523,7 +523,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	_handleDimensionHide() {
-		this.shadowRoot.querySelector(`d2l-hierarchical-view[data-key="${this._activeDimensionKey}"]`).hide();
+		if (this.shadowRoot) this.shadowRoot.querySelector(`d2l-hierarchical-view[data-key="${this._activeDimensionKey}"]`).hide();
 	}
 
 	_handleDimensionHideKeyPress(e) {
@@ -538,8 +538,10 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	_handleDimensionShowComplete() {
-		const returnButton = this.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]');
-		returnButton.focus();
+		const returnButton = this.shadowRoot ?
+			this.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]')
+			: undefined;
+		if (returnButton) returnButton.focus();
 	}
 
 	_handleDimensionShowStart(e) {

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -213,7 +213,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	focus() {
-		const opener = this.shadowRoot.querySelector('d2l-dropdown-button-subtle');
+		const opener = this.shadowRoot ? this.shadowRoot.querySelector('d2l-dropdown-button-subtle') : undefined;
 		if (opener) opener.focus();
 	}
 

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -56,7 +56,7 @@ class FocusTrap extends LitElement {
 	}
 
 	focus() {
-		const focusable = this.shadowRoot.querySelector('.d2l-focus-trap-start');
+		const focusable = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-focus-trap-start') : undefined;
 		if (focusable) focusable.focus();
 	}
 

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -61,13 +61,15 @@ class FocusTrap extends LitElement {
 	}
 
 	_focusFirst() {
-		const focusable = getNextFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-start'));
+		const focusable = this.shadowRoot ?
+			getNextFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-start'))
+			: undefined;
 		if (focusable) forceFocusVisible(focusable);
 		this.dispatchEvent(new CustomEvent('d2l-focus-trap-enter', { bubbles: true, composed: true }));
 	}
 
 	_getContainer() {
-		return this.shadowRoot.querySelector('.d2l-focus-trap-start').parentNode;
+		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-focus-trap-start').parentNode : undefined;
 	}
 
 	_handleBodyFocus(e) {
@@ -80,7 +82,7 @@ class FocusTrap extends LitElement {
 
 	_handleEndFocusIn(e) {
 		const container = this._getContainer();
-		if (isComposedAncestor(container, e.relatedTarget)) {
+		if (this.shadowRoot && isComposedAncestor(container, e.relatedTarget)) {
 			// user is exiting trap via forward tabbing...
 			const firstFocusable = getNextFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-start'));
 			if (firstFocusable) {
@@ -96,7 +98,7 @@ class FocusTrap extends LitElement {
 
 	_handleStartFocusIn(e) {
 		const container = this._getContainer();
-		if (isComposedAncestor(container, e.relatedTarget)) {
+		if (this.shadowRoot && isComposedAncestor(container, e.relatedTarget)) {
 			// user is exiting trap via back tabbing...
 			const lastFocusable = getPreviousFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-end'));
 			if (lastFocusable) {

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -56,20 +56,19 @@ class FocusTrap extends LitElement {
 	}
 
 	focus() {
-		const focusable = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-focus-trap-start') : undefined;
+		const focusable = this.shadowRoot && this.shadowRoot.querySelector('.d2l-focus-trap-start');
 		if (focusable) focusable.focus();
 	}
 
 	_focusFirst() {
-		const focusable = this.shadowRoot ?
-			getNextFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-start'))
-			: undefined;
+		const focusable = this.shadowRoot &&
+			getNextFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-start'));
 		if (focusable) forceFocusVisible(focusable);
 		this.dispatchEvent(new CustomEvent('d2l-focus-trap-enter', { bubbles: true, composed: true }));
 	}
 
 	_getContainer() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-focus-trap-start').parentNode : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('.d2l-focus-trap-start').parentNode;
 	}
 
 	_handleBodyFocus(e) {

--- a/components/form/demo/form-demo.js
+++ b/components/form/demo/form-demo.js
@@ -86,7 +86,7 @@ class FormNestedDemo extends LitElement {
 	}
 
 	_submit() {
-		this.shadowRoot.querySelector('#root').submit();
+		if (this.shadowRoot) this.shadowRoot.querySelector('#root').submit();
 	}
 
 	_validatePassword(e) {

--- a/components/form/demo/form-dialog-demo.js
+++ b/components/form/demo/form-dialog-demo.js
@@ -66,11 +66,11 @@ class FormDialogDemo extends LitElement {
 		e.stopPropagation();
 		// eslint-disable-next-line no-console
 		console.log(e.detail.formData);
-		this.shadowRoot.querySelector('#dialog').opened = false;
+		if (this.shadowRoot) this.shadowRoot.querySelector('#dialog').opened = false;
 	}
 
 	_onDialogSubmitClicked() {
-		this.shadowRoot.querySelector('#dialog-secondary-form').submit();
+		if (this.shadowRoot) this.shadowRoot.querySelector('#dialog-secondary-form').submit();
 	}
 
 	_onSubmit(e) {
@@ -79,11 +79,11 @@ class FormDialogDemo extends LitElement {
 	}
 
 	_onSubmitClicked() {
-		this.shadowRoot.querySelector('#dialog-main-form').submit();
+		if (this.shadowRoot) this.shadowRoot.querySelector('#dialog-main-form').submit();
 	}
 
 	_openDialog() {
-		this.shadowRoot.querySelector('#dialog').opened = true;
+		if (this.shadowRoot) this.shadowRoot.querySelector('#dialog').opened = true;
 	}
 
 	_validatePassword(e) {

--- a/components/form/demo/form-native-demo.js
+++ b/components/form/demo/form-native-demo.js
@@ -69,7 +69,7 @@ class FormNativeDemo extends LitElement {
 	}
 
 	_onClick(e) {
-		this.shadowRoot.querySelector('d2l-form-native').requestSubmit(e.target);
+		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-form-native').requestSubmit(e.target);
 	}
 
 	_validatePassword(e) {

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -136,9 +136,6 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		/** @ignore */
 		this.childErrors = new Map();
 		this._errors = [];
-
-		this.shadowRoot.addEventListener('d2l-validation-custom-connected', this._validationCustomConnected);
-		this.shadowRoot.addEventListener('d2l-form-element-errors-change', this._onFormElementErrorsChange);
 	}
 
 	/** @ignore */
@@ -158,6 +155,18 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 	/** @ignore */
 	get validity() {
 		return this._validity;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.shadowRoot.addEventListener('d2l-validation-custom-connected', this._validationCustomConnected);
+		this.shadowRoot.addEventListener('d2l-form-element-errors-change', this._onFormElementErrorsChange);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.shadowRoot.removeEventListener('d2l-validation-custom-connected', this._validationCustomConnected);
+		this.shadowRoot.removeEventListener('d2l-form-element-errors-change', this._onFormElementErrorsChange);
 	}
 
 	updated(changedProperties) {

--- a/components/form/form-errory-summary.js
+++ b/components/form/form-errory-summary.js
@@ -104,7 +104,7 @@ class FormErrorSummary extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		} else {
 			focusEleSelector = 'd2l-button-icon';
 		}
-		const focusEle = this.shadowRoot ? this.shadowRoot.querySelector(focusEleSelector) : undefined;
+		const focusEle = this.shadowRoot && this.shadowRoot.querySelector(focusEleSelector);
 		if (focusEle) focusEle.focus();
 	}
 

--- a/components/form/form-errory-summary.js
+++ b/components/form/form-errory-summary.js
@@ -104,8 +104,8 @@ class FormErrorSummary extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		} else {
 			focusEleSelector = 'd2l-button-icon';
 		}
-		const focusEle = this.shadowRoot.querySelector(focusEleSelector);
-		focusEle.focus();
+		const focusEle = this.shadowRoot ? this.shadowRoot.querySelector(focusEleSelector) : undefined;
+		if (focusEle) focusEle.focus();
 	}
 
 	_toggleExpandCollapse(e) {

--- a/components/form/form-native.js
+++ b/components/form/form-native.js
@@ -133,7 +133,7 @@ class FormNative extends FormMixin(LitElement) {
 			}
 		}
 		this._errors = errorMap;
-		if (errorMap.size > 0) {
+		if (this.shadowRoot && errorMap.size > 0) {
 			const errorSummary = this.shadowRoot.querySelector('d2l-form-error-summary');
 			this.updateComplete.then(() => errorSummary.focus());
 		}

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -100,7 +100,7 @@ class Form extends FormMixin(LitElement) {
 		const flattenedErrorMap = flattenMap(errorMap);
 		this._errors = errorMap;
 		if (errorMap.size > 0) {
-			const errorSummary = this.shadowRoot.querySelector('d2l-form-error-summary');
+			const errorSummary = this.shadowRoot ? this.shadowRoot.querySelector('d2l-form-error-summary') : undefined;
 			if (errorSummary) {
 				this.updateComplete.then(() => errorSummary.focus());
 			}

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -100,7 +100,7 @@ class Form extends FormMixin(LitElement) {
 		const flattenedErrorMap = flattenMap(errorMap);
 		this._errors = errorMap;
 		if (errorMap.size > 0) {
-			const errorSummary = this.shadowRoot ? this.shadowRoot.querySelector('d2l-form-error-summary') : undefined;
+			const errorSummary = this.shadowRoot && this.shadowRoot.querySelector('d2l-form-error-summary');
 			if (errorSummary) {
 				this.updateComplete.then(() => errorSummary.focus());
 			}

--- a/components/form/test/form-element.js
+++ b/components/form/test/form-element.js
@@ -30,7 +30,7 @@ class FormElement extends FormElementMixin(LitElement) {
 	}
 
 	get validity() {
-		const input = this.shadowRoot.querySelector('input');
+		const input = this.shadowRoot ? this.shadowRoot.querySelector('input') : undefined;
 		if (!input.validity.valid) {
 			return input.validity;
 		}

--- a/components/form/test/form-element.js
+++ b/components/form/test/form-element.js
@@ -30,7 +30,7 @@ class FormElement extends FormElementMixin(LitElement) {
 	}
 
 	get validity() {
-		const input = this.shadowRoot ? this.shadowRoot.querySelector('input') : undefined;
+		const input = this.shadowRoot && this.shadowRoot.querySelector('input');
 		if (!input.validity.valid) {
 			return input.validity;
 		}

--- a/components/form/test/nested-form.js
+++ b/components/form/test/nested-form.js
@@ -41,6 +41,7 @@ class NestedForm extends LitElement {
 	}
 
 	fill() {
+		if (!this.shadowRoot) return;
 		const firstName = this.shadowRoot.querySelector('#composed-nested-first-name');
 		firstName.value = 'John Doe';
 

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -496,9 +496,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 			/* deep link scenario */
 			this.show(e.detail.data, e.detail.sourceView);
 		}
-		const content = this.shadowRoot ?
-			this.shadowRoot.querySelector('.d2l-hierarchical-view-content')
-			: undefined;
+		const content = this.shadowRoot && this.shadowRoot.querySelector('.d2l-hierarchical-view-content');
 
 		if (this.shadowRoot && reduceMotion) {
 

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -222,7 +222,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	isActive() {
-		if (this.childView && !this.shown) {
+		if ((this.childView && !this.shown) || !this.shadowRoot) {
 			return false;
 		} else {
 			const content = this.shadowRoot.querySelector('.d2l-hierarchical-view-content');
@@ -325,6 +325,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 			view.resize();
 			return;
 		}
+		if (!this.shadowRoot) return;
 		const content = this.shadowRoot.querySelector('.d2l-hierarchical-view-content');
 		const contentRect = content.getBoundingClientRect();
 		if (contentRect.height < 1) return;
@@ -432,7 +433,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		if (rootTarget === this || !rootTarget.hierarchicalView) return;
 
 		const parentView = this.__getParentViewFromEvent(e);
-		if (parentView === this) {
+		if (this.shadowRoot && parentView === this) {
 			const content = this.shadowRoot.querySelector('.d2l-hierarchical-view-content');
 
 			const data = e.detail.data;
@@ -495,16 +496,18 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 			/* deep link scenario */
 			this.show(e.detail.data, e.detail.sourceView);
 		}
-		const content = this.shadowRoot.querySelector('.d2l-hierarchical-view-content');
+		const content = this.shadowRoot ?
+			this.shadowRoot.querySelector('.d2l-hierarchical-view-content')
+			: undefined;
 
-		if (reduceMotion) {
+		if (this.shadowRoot && reduceMotion) {
 
 			content.classList.add('d2l-child-view-show');
 			requestAnimationFrame(() => {
 				e.detail.sourceView.__dispatchShowComplete(e.detail.data, e.detail);
 			});
 
-		} else {
+		} else if (this.shadowRoot) {
 
 			if (e.detail.isSource && this.__getParentViewFromEvent(e) === this) {
 				const animationEnd = () => {

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -290,7 +290,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 			this.__isAutoSized = true;
 			let rect;
-			if (view === this) {
+			if (view === this && this.shadowRoot) {
 				rect = this.shadowRoot.querySelector('.d2l-hierarchical-view-content').getBoundingClientRect();
 			} else {
 				rect = view.getBoundingClientRect();

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -217,6 +217,7 @@ class HtmlBlock extends LitElement {
 	}
 
 	_findSlottedElement(tagName, slot) {
+		if (!this.shadowRoot) return;
 		if (!slot) slot = this.shadowRoot.querySelector('slot');
 		return slot.assignedNodes({ flatten: true })
 			.find(node => (node.nodeType === Node.ELEMENT_NODE && node.tagName === tagName.toUpperCase()));

--- a/components/inputs/demo/input-radio-solo-test.js
+++ b/components/inputs/demo/input-radio-solo-test.js
@@ -38,7 +38,7 @@ class TestInputRadioSolo extends LitElement {
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('input');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('input') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/demo/input-radio-solo-test.js
+++ b/components/inputs/demo/input-radio-solo-test.js
@@ -38,7 +38,7 @@ class TestInputRadioSolo extends LitElement {
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('input') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('input');
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/demo/input-radio-spacer-test.js
+++ b/components/inputs/demo/input-radio-spacer-test.js
@@ -19,7 +19,7 @@ class TestInputRadioSpacer extends LitElement {
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('input') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('input');
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/demo/input-radio-spacer-test.js
+++ b/components/inputs/demo/input-radio-spacer-test.js
@@ -19,7 +19,7 @@ class TestInputRadioSpacer extends LitElement {
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('input');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('input') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/demo/input-select-test.js
+++ b/components/inputs/demo/input-select-test.js
@@ -53,7 +53,7 @@ class TestInputSelect extends SkeletonMixin(RtlMixin(LitElement)) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('select') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('select');
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/demo/input-select-test.js
+++ b/components/inputs/demo/input-select-test.js
@@ -53,7 +53,7 @@ class TestInputSelect extends SkeletonMixin(RtlMixin(LitElement)) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('select');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('select') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -205,7 +205,7 @@ class InputCheckbox extends SkeletonMixin(RtlMixin(LitElement)) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('input.d2l-input-checkbox');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('input.d2l-input-checkbox') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -205,7 +205,7 @@ class InputCheckbox extends SkeletonMixin(RtlMixin(LitElement)) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('input.d2l-input-checkbox') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('input.d2l-input-checkbox');
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -163,8 +163,8 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	}
 
 	render() {
-		const startDateInput = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input-date-range-start') : undefined;
-		const endDateInput = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input-date-range-end') : undefined;
+		const startDateInput = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input-date-range-start');
+		const endDateInput = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input-date-range-end');
 		const tooltipStart = (this.validationError && !this.startOpened && !this.childErrors.has(startDateInput)) ? html`<d2l-tooltip align="start" announced for="${this._startInputId}" state="error">${this.validationError}</d2l-tooltip>` : null;
 		const tooltipEnd = (this.validationError && !this.endOpened && !this.childErrors.has(endDateInput)) ? html`<d2l-tooltip align="start" announced for="${this._endInputId}" state="error">${this.validationError}</d2l-tooltip>` : null;
 		return html`
@@ -252,7 +252,7 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	}
 
 	focus() {
-		const input = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-date') : undefined;
+		const input = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-date');
 		if (input) input.focus();
 	}
 

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -163,8 +163,8 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	}
 
 	render() {
-		const startDateInput = this.shadowRoot.querySelector('.d2l-input-date-range-start');
-		const endDateInput = this.shadowRoot.querySelector('.d2l-input-date-range-end');
+		const startDateInput = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input-date-range-start') : undefined;
+		const endDateInput = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input-date-range-end') : undefined;
 		const tooltipStart = (this.validationError && !this.startOpened && !this.childErrors.has(startDateInput)) ? html`<d2l-tooltip align="start" announced for="${this._startInputId}" state="error">${this.validationError}</d2l-tooltip>` : null;
 		const tooltipEnd = (this.validationError && !this.endOpened && !this.childErrors.has(endDateInput)) ? html`<d2l-tooltip align="start" announced for="${this._endInputId}" state="error">${this.validationError}</d2l-tooltip>` : null;
 		return html`
@@ -257,6 +257,7 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	}
 
 	async validate() {
+		if (!this.shadowRoot) return;
 		const startDateInput = this.shadowRoot.querySelector('.d2l-input-date-range-start');
 		const endDateInput = this.shadowRoot.querySelector('.d2l-input-date-range-end');
 		const errors = await Promise.all([startDateInput.validate(), endDateInput.validate(), super.validate()]);

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -252,7 +252,7 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	}
 
 	focus() {
-		const input = this.shadowRoot.querySelector('d2l-input-date');
+		const input = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-date') : undefined;
 		if (input) input.focus();
 	}
 

--- a/components/inputs/input-date-time-range-to.js
+++ b/components/inputs/input-date-time-range-to.js
@@ -179,7 +179,7 @@ class InputDateTimeRangeTo extends SkeletonMixin(LocalizeCoreElement(LitElement)
 	}
 
 	_startObserving() {
-		if (!this._parentNode) return;
+		if (!this.shadowRoot || !this._parentNode) return;
 
 		const leftElem = this.shadowRoot.querySelector('.d2l-input-date-time-range-start-container');
 		this._leftElemResizeObserver = this._leftElemResizeObserver || new ResizeObserver(() => {

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -308,7 +308,7 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 	}
 
 	focus() {
-		const input = this.shadowRoot.querySelector('d2l-input-date-time');
+		const input = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-date-time') : undefined;
 		if (input) input.focus();
 	}
 

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -209,12 +209,8 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 	}
 
 	render() {
-		const startDateTimeInput = this.shadowRoot ?
-			this.shadowRoot.querySelector('.d2l-input-date-time-range-start')
-			: undefined;
-		const endDateTimeInput = this.shadowRoot ?
-			this.shadowRoot.querySelector('.d2l-input-date-time-range-end')
-			: undefined;
+		const startDateTimeInput = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input-date-time-range-start');
+		const endDateTimeInput = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input-date-time-range-end');
 
 		const tooltipStart = (this.validationError && !this.startOpened && !this.childErrors.has(startDateTimeInput)) ? html`<d2l-tooltip align="start" announced for="${this._startInputId}" position="bottom" state="error">${this.validationError}</d2l-tooltip>` : null;
 		const tooltipEnd = (this.validationError && !this.endOpened && !this.childErrors.has(endDateTimeInput)) ? html`<d2l-tooltip align="start" announced for="${this._endInputId}" position="bottom" state="error">${this.validationError}</d2l-tooltip>` : null;
@@ -312,7 +308,7 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 	}
 
 	focus() {
-		const input = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-date-time') : undefined;
+		const input = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-date-time');
 		if (input) input.focus();
 	}
 

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -209,8 +209,12 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 	}
 
 	render() {
-		const startDateTimeInput = this.shadowRoot.querySelector('.d2l-input-date-time-range-start');
-		const endDateTimeInput = this.shadowRoot.querySelector('.d2l-input-date-time-range-end');
+		const startDateTimeInput = this.shadowRoot ?
+			this.shadowRoot.querySelector('.d2l-input-date-time-range-start')
+			: undefined;
+		const endDateTimeInput = this.shadowRoot ?
+			this.shadowRoot.querySelector('.d2l-input-date-time-range-end')
+			: undefined;
 
 		const tooltipStart = (this.validationError && !this.startOpened && !this.childErrors.has(startDateTimeInput)) ? html`<d2l-tooltip align="start" announced for="${this._startInputId}" position="bottom" state="error">${this.validationError}</d2l-tooltip>` : null;
 		const tooltipEnd = (this.validationError && !this.endOpened && !this.childErrors.has(endDateTimeInput)) ? html`<d2l-tooltip align="start" announced for="${this._endInputId}" position="bottom" state="error">${this.validationError}</d2l-tooltip>` : null;
@@ -313,6 +317,7 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 	}
 
 	async validate() {
+		if (!this.shadowRoot) return;
 		const startDateTimeInput = this.shadowRoot.querySelector('.d2l-input-date-time-range-start');
 		const endDateTimeInput = this.shadowRoot.querySelector('.d2l-input-date-time-range-end');
 		const errors = await Promise.all([startDateTimeInput.validate(), endDateTimeInput.validate(), super.validate()]);

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -296,7 +296,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-date') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-date');
 		if (elem) elem.focus();
 	}
 
@@ -320,7 +320,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 		if (!newDate) {
 			this.value = '';
 		} else {
-			const inputTime = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-time') : undefined;
+			const inputTime = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-time');
 			let time;
 			if (e.detail && e.detail.setToNow) time = _getFormattedDefaultTime('now');
 			else time = inputTime ? inputTime.value : _getFormattedDefaultTime(this.timeDefaultValue);
@@ -347,12 +347,12 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 	}
 
 	_handleInputTimeBlur() {
-		const tooltip = this.shadowRoot ? this.shadowRoot.querySelector('d2l-tooltip') : undefined;
+		const tooltip = this.shadowRoot && this.shadowRoot.querySelector('d2l-tooltip');
 		if (tooltip) tooltip.hide();
 	}
 
 	_handleInputTimeFocus() {
-		const tooltip = this.shadowRoot ? this.shadowRoot.querySelector('d2l-tooltip') : undefined;
+		const tooltip = this.shadowRoot && this.shadowRoot.querySelector('d2l-tooltip');
 		if (tooltip) tooltip.show();
 	}
 
@@ -361,7 +361,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 	}
 
 	async _handleTimeChange(e) {
-		const date = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-date').value : undefined;
+		const date = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-date').value;
 		const time = e.target.value;
 		this.value = this.localized ? _formatLocalDateTimeInISO(date, time) : getUTCDateTimeFromLocalDateTime(date, time);
 		this._dispatchChangeEvent();

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -301,6 +301,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 	}
 
 	async validate() {
+		if (!this.shadowRoot) return;
 		const dateInput = this.shadowRoot.querySelector('d2l-input-date');
 		const timeInput = this.shadowRoot.querySelector('d2l-input-time');
 		const errors = await Promise.all([dateInput.validate(), timeInput.validate(), super.validate()]);
@@ -319,7 +320,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 		if (!newDate) {
 			this.value = '';
 		} else {
-			const inputTime = this.shadowRoot.querySelector('d2l-input-time');
+			const inputTime = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-time') : undefined;
 			let time;
 			if (e.detail && e.detail.setToNow) time = _getFormattedDefaultTime('now');
 			else time = inputTime ? inputTime.value : _getFormattedDefaultTime(this.timeDefaultValue);
@@ -360,7 +361,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 	}
 
 	async _handleTimeChange(e) {
-		const date = this.shadowRoot.querySelector('d2l-input-date').value;
+		const date = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-date').value : undefined;
 		const time = e.target.value;
 		this.value = this.localized ? _formatLocalDateTimeInISO(date, time) : getUTCDateTimeFromLocalDateTime(date, time);
 		this._dispatchChangeEvent();

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -296,7 +296,7 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('d2l-input-date');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-date') : undefined;
 		if (elem) elem.focus();
 	}
 
@@ -346,12 +346,12 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 	}
 
 	_handleInputTimeBlur() {
-		const tooltip = this.shadowRoot.querySelector('d2l-tooltip');
+		const tooltip = this.shadowRoot ? this.shadowRoot.querySelector('d2l-tooltip') : undefined;
 		if (tooltip) tooltip.hide();
 	}
 
 	_handleInputTimeFocus() {
-		const tooltip = this.shadowRoot.querySelector('d2l-tooltip');
+		const tooltip = this.shadowRoot ? this.shadowRoot.querySelector('d2l-tooltip') : undefined;
 		if (tooltip) tooltip.show();
 	}
 

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -336,6 +336,7 @@ class InputDate extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCor
 	}
 
 	async validate() {
+		if (!this.shadowRoot) return;
 		const textInput = this.shadowRoot.querySelector('d2l-input-text');
 		const errors = await Promise.all([textInput.validate(), super.validate()]);
 		return [...errors[0], ...errors[1]];
@@ -407,6 +408,7 @@ class InputDate extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCor
 	}
 
 	_handleDropdownOpen() {
+		if (!this.shadowRoot) return;
 		const calendarOffset = this.shadowRoot.querySelector('d2l-calendar').getBoundingClientRect();
 		const fullCalendarVisible = calendarOffset.y + calendarOffset.height < window.innerHeight;
 		if (this._dropdown && !this._dropdown.openedAbove && !fullCalendarVisible) {
@@ -432,6 +434,7 @@ class InputDate extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCor
 	async _handleFirstDropdownOpen() {
 		this._dropdownFirstOpened = true;
 		await this.updateComplete;
+		if (!this.shadowRoot) return;
 		this._calendar = this.shadowRoot.querySelector('d2l-calendar');
 		this._dropdown = this.shadowRoot.querySelector('d2l-dropdown-content');
 		await this._calendar.updateComplete;

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -376,6 +376,7 @@ class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeC
 	}
 
 	async validate() {
+		if (!this.shadowRoot) return;
 		const inputTextElem = this.shadowRoot.querySelector('d2l-input-text');
 		await inputTextElem.updateComplete;
 		const childErrors = await inputTextElem.validate();

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -366,7 +366,7 @@ class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeC
 	}
 
 	async focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-text') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-text');
 		if (elem) {
 			elem.focus();
 		} else {

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -366,7 +366,7 @@ class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeC
 	}
 
 	async focus() {
-		const elem = this.shadowRoot.querySelector('d2l-input-text');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-text') : undefined;
 		if (elem) {
 			elem.focus();
 		} else {

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -132,7 +132,7 @@ class InputPercent extends LabelledMixin(SkeletonMixin(FormElementMixin(Localize
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('d2l-input-number');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-number') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -132,7 +132,7 @@ class InputPercent extends LabelledMixin(SkeletonMixin(FormElementMixin(Localize
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-number') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-number');
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -137,6 +137,7 @@ class InputPercent extends LabelledMixin(SkeletonMixin(FormElementMixin(Localize
 	}
 
 	async validate() {
+		if (!this.shadowRoot) return;
 		const inputNumberElem = this.shadowRoot.querySelector('d2l-input-number');
 		await inputNumberElem.updateComplete;
 		const childErrors = await inputNumberElem.validate();

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -132,7 +132,7 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		this._dispatchEvent();
 		if (!this.noClear && this.value.length > 0) {
 			this.updateComplete.then(() => {
-				this.shadowRoot.querySelector('d2l-button-icon').focus();
+				if (this.shadowRoot) this.shadowRoot.querySelector('d2l-button-icon').focus();
 			});
 		}
 	}
@@ -158,7 +158,7 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			this._setLastSearchValue('');
 			this._dispatchEvent();
 		}
-		this.shadowRoot.querySelector('d2l-input-text').focus();
+		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-input-text').focus();
 	}
 
 	_handleInput(e) {

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -123,7 +123,7 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('d2l-input-text');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-text') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -123,7 +123,7 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-text') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-text');
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -271,13 +271,13 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 
 	/** @ignore */
 	get selectionEnd() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
 		return elem ? elem.selectionEnd : 0;
 	}
 
 	/** @ignore */
 	get selectionStart() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
 		return elem ? elem.selectionStart : 0;
 	}
 
@@ -301,7 +301,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 
 	/** @ignore */
 	get validity() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
 		if (!elem.validity.valid) {
 			return elem.validity;
 		}
@@ -318,7 +318,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		if (this._intersectionObserver) this._intersectionObserver.disconnect();
-		const container = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input-text-container') : undefined;
+		const container = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input-text-container');
 		if (!container) return;
 		container.removeEventListener('blur', this._handleBlur, true);
 		container.removeEventListener('focus', this._handleFocus, true);
@@ -331,7 +331,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 
 		this._setValue(this.value, true);
 
-		const container = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input-text-container') : undefined;
+		const container = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input-text-container');
 		if (!container) return;
 		container.addEventListener('blur', this._handleBlur, true);
 		container.addEventListener('focus', this._handleFocus, true);
@@ -464,7 +464,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 	}
 
 	async focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
 		if (elem) {
 			elem.focus();
 		} else {
@@ -572,7 +572,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 		this._prevValue = (oldVal === undefined) ? '' : oldVal;
 		this._value = val;
 
-		const input = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
+		const input = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
 		if (!input) return;
 
 		this.setValidity({ tooShort: this.minlength && this.value.length > 0 && this.value.length < this.minlength });

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -271,13 +271,13 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 
 	/** @ignore */
 	get selectionEnd() {
-		const elem = this.shadowRoot.querySelector('.d2l-input');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
 		return elem ? elem.selectionEnd : 0;
 	}
 
 	/** @ignore */
 	get selectionStart() {
-		const elem = this.shadowRoot.querySelector('.d2l-input');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
 		return elem ? elem.selectionStart : 0;
 	}
 
@@ -301,7 +301,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 
 	/** @ignore */
 	get validity() {
-		const elem = this.shadowRoot.querySelector('.d2l-input');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
 		if (!elem.validity.valid) {
 			return elem.validity;
 		}
@@ -318,7 +318,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		if (this._intersectionObserver) this._intersectionObserver.disconnect();
-		const container = this.shadowRoot.querySelector('.d2l-input-text-container');
+		const container = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input-text-container') : undefined;
 		if (!container) return;
 		container.removeEventListener('blur', this._handleBlur, true);
 		container.removeEventListener('focus', this._handleFocus, true);
@@ -331,7 +331,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 
 		this._setValue(this.value, true);
 
-		const container = this.shadowRoot.querySelector('.d2l-input-text-container');
+		const container = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input-text-container') : undefined;
 		if (!container) return;
 		container.addEventListener('blur', this._handleBlur, true);
 		container.addEventListener('focus', this._handleFocus, true);
@@ -595,7 +595,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 	_updateInputLayout() {
 
 		// defer until we're visible
-		if (!this._isIntersecting) return;
+		if (!this.shadowRoot || !this._isIntersecting) return;
 
 		const firstContainer = this.shadowRoot.querySelector('.d2l-input-inside-before');
 		const firstSlotHasNodes = firstContainer.querySelector('slot').assignedNodes({ flatten: true }).length > 0

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -464,7 +464,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 	}
 
 	async focus() {
-		const elem = this.shadowRoot.querySelector('.d2l-input');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
 		if (elem) {
 			elem.focus();
 		} else {
@@ -572,7 +572,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 		this._prevValue = (oldVal === undefined) ? '' : oldVal;
 		this._value = val;
 
-		const input = this.shadowRoot.querySelector('.d2l-input');
+		const input = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
 		if (!input) return;
 
 		this.setValidity({ tooShort: this.minlength && this.value.length > 0 && this.value.length < this.minlength });

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -264,7 +264,7 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 	}
 
 	async focus() {
-		const elem = this.shadowRoot.querySelector('textarea');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('textarea') : undefined;
 		if (elem) {
 			elem.focus();
 		} else {

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -165,7 +165,7 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 	/** @ignore */
 	get textarea() {
 		// temporary until consumers are updated
-		return this.shadowRoot ? this.shadowRoot.querySelector('textarea') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('textarea');
 	}
 
 	/** @ignore */
@@ -178,7 +178,7 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 
 	/** @ignore */
 	get validity() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('textarea') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('textarea');
 		if (elem && !elem.validity.valid) {
 			return elem.validity;
 		}
@@ -264,7 +264,7 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 	}
 
 	async focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('textarea') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('textarea');
 		if (elem) {
 			elem.focus();
 		} else {
@@ -274,7 +274,7 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 	}
 
 	async select() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('textarea') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('textarea');
 		if (elem) {
 			elem.select();
 		} else {

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -165,7 +165,7 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 	/** @ignore */
 	get textarea() {
 		// temporary until consumers are updated
-		return this.shadowRoot.querySelector('textarea');
+		return this.shadowRoot ? this.shadowRoot.querySelector('textarea') : undefined;
 	}
 
 	/** @ignore */
@@ -178,8 +178,8 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 
 	/** @ignore */
 	get validity() {
-		const elem = this.shadowRoot.querySelector('textarea');
-		if (!elem.validity.valid) {
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('textarea') : undefined;
+		if (elem && !elem.validity.valid) {
 			return elem.validity;
 		}
 		return super.validity;
@@ -274,7 +274,7 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 	}
 
 	async select() {
-		const elem = this.shadowRoot.querySelector('textarea');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('textarea') : undefined;
 		if (elem) {
 			elem.select();
 		} else {

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -210,13 +210,8 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 		const startLabel = this.startLabel ? this.startLabel : this.localize('components.input-time-range.startTime');
 		const endLabel = this.endLabel ? this.endLabel : this.localize('components.input-time-range.endTime');
 
-		const startTimeInput = this.shadowRoot ?
-			this.shadowRoot.querySelector('.d2l-input-time-range-start')
-			: undefined;
-		const endTimeInput =  this.shadowRoot ?
-			this.shadowRoot.querySelector('.d2l-input-time-range-end')
-			: undefined;
-
+		const startTimeInput = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input-time-range-start');
+		const endTimeInput =  this.shadowRoot && this.shadowRoot.querySelector('.d2l-input-time-range-end');
 		/**
 		 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
 		 */
@@ -308,7 +303,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	}
 
 	focus() {
-		const input = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-time') : undefined;
+		const input = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-time');
 		if (input) input.focus();
 	}
 

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -210,8 +210,12 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 		const startLabel = this.startLabel ? this.startLabel : this.localize('components.input-time-range.startTime');
 		const endLabel = this.endLabel ? this.endLabel : this.localize('components.input-time-range.endTime');
 
-		const startTimeInput = this.shadowRoot.querySelector('.d2l-input-time-range-start');
-		const endTimeInput = this.shadowRoot.querySelector('.d2l-input-time-range-end');
+		const startTimeInput = this.shadowRoot ?
+			this.shadowRoot.querySelector('.d2l-input-time-range-start')
+			: undefined;
+		const endTimeInput =  this.shadowRoot ?
+			this.shadowRoot.querySelector('.d2l-input-time-range-end')
+			: undefined;
 
 		/**
 		 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
@@ -309,6 +313,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	}
 
 	async validate() {
+		if (!this.shadowRoot) return;
 		const startTimeInput = this.shadowRoot.querySelector('.d2l-input-time-range-start');
 		const endTimeInput = this.shadowRoot.querySelector('.d2l-input-time-range-end');
 		const errors = await Promise.all([startTimeInput.validate(), endTimeInput.validate(), super.validate()]);

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -304,7 +304,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	}
 
 	focus() {
-		const input = this.shadowRoot.querySelector('d2l-input-time');
+		const input = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-time') : undefined;
 		if (input) input.focus();
 	}
 

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -350,7 +350,7 @@ class InputTime extends LabelledMixin(SkeletonMixin(FormElementMixin(LitElement)
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('.d2l-input');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -350,7 +350,7 @@ class InputTime extends LabelledMixin(SkeletonMixin(FormElementMixin(LitElement)
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-input') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
 		if (elem) elem.focus();
 	}
 

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -118,7 +118,7 @@ class Link extends LitElement {
 	}
 
 	focus() {
-		const link = this.shadowRoot.querySelector('.d2l-link');
+		const link = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-link') : undefined;
 		if (link) link.focus();
 	}
 }

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -118,7 +118,7 @@ class Link extends LitElement {
 	}
 
 	focus() {
-		const link = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-link') : undefined;
+		const link = this.shadowRoot && this.shadowRoot.querySelector('.d2l-link');
 		if (link) link.focus();
 	}
 }

--- a/components/list/demo/list-drag-and-drop.js
+++ b/components/list/demo/list-drag-and-drop.js
@@ -163,7 +163,7 @@ class ListDemoDragAndDrop extends LitElement {
 			targetItems.splice(targetIndex, 0, dataToMove[i]);
 		}
 
-		await this.requestUpdate();
+		await this.updateComplete;
 
 		if (e.detail.keyboardActive) {
 			requestAnimationFrame(() => {

--- a/components/list/demo/list-drag-and-drop.js
+++ b/components/list/demo/list-drag-and-drop.js
@@ -163,7 +163,7 @@ class ListDemoDragAndDrop extends LitElement {
 			targetItems.splice(targetIndex, 0, dataToMove[i]);
 		}
 
-		await this.updateComplete;
+		await this.requestUpdate();
 
 		if (e.detail.keyboardActive) {
 			requestAnimationFrame(() => {

--- a/components/list/demo/list-drag-and-drop.js
+++ b/components/list/demo/list-drag-and-drop.js
@@ -167,6 +167,7 @@ class ListDemoDragAndDrop extends LitElement {
 
 		if (e.detail.keyboardActive) {
 			requestAnimationFrame(() => {
+				if (!this.shadowRoot) return;
 				const newItem = this.shadowRoot.querySelector('d2l-list').getListItemByKey(sourceListItems[0].key);
 				newItem.activateDragHandle();
 			});

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -119,7 +119,7 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(L
 		event.preventDefault();
 		if (this.disabled) return;
 		this.setSelected(!this.selected);
-		const checkbox = this.shadowRoot.querySelector(`#${this._checkboxId}`);
+		const checkbox = this.shadowRoot ? this.shadowRoot.querySelector(`#${this._checkboxId}`) : undefined;
 		if (checkbox) checkbox.focus();
 	}
 

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -119,7 +119,7 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(L
 		event.preventDefault();
 		if (this.disabled) return;
 		this.setSelected(!this.selected);
-		const checkbox = this.shadowRoot ? this.shadowRoot.querySelector(`#${this._checkboxId}`) : undefined;
+		const checkbox = this.shadowRoot && this.shadowRoot.querySelector(`#${this._checkboxId}`);
 		if (checkbox) checkbox.focus();
 	}
 

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -360,7 +360,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 	}
 
 	activateDragHandle() {
-		this.shadowRoot.querySelector(`#${this._itemDragId}`).activateKeyboardMode();
+		if (this.shadowRoot) this.shadowRoot.querySelector(`#${this._itemDragId}`).activateKeyboardMode();
 	}
 
 	_annoucePositionChange(dragTargetKey, dropTargetKey, dropLocation) {
@@ -550,8 +550,10 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 			e.dataTransfer.setData('text/plain', `${this.dropText}`);
 		}
 
-		const nodeImage = this.shadowRoot.querySelector('.d2l-list-item-drag-image') || this;
-		e.dataTransfer.setDragImage(nodeImage, 50, 50);
+		if (this.shadowRoot) {
+			const nodeImage = this.shadowRoot.querySelector('.d2l-list-item-drag-image') || this;
+			e.dataTransfer.setDragImage(nodeImage, 50, 50);
+		}
 
 		const rootList = this._getRootList(this);
 
@@ -583,6 +585,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 	}
 
 	_onDragTargetClick(e) {
+		if (!this.shadowRoot) return;
 		if (this._keyboardActiveOnNextClick) {
 			this.shadowRoot.querySelector(`#${this._itemDragId}`).activateKeyboardMode();
 		} else {
@@ -691,7 +694,8 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		const dropGrid = listItem.shadowRoot.querySelector('.d2l-list-item-drag-drop-grid');
 		if (dropGrid) dropGrid.dispatchEvent(createDragEvent('drop'));
 		// simulate dragend
-		this.shadowRoot.querySelector('.d2l-list-item-drag-area').dispatchEvent(createDragEvent('dragend'));
+		if (this.shadowRoot)
+			this.shadowRoot.querySelector('.d2l-list-item-drag-area').dispatchEvent(createDragEvent('dragend'));
 	}
 
 	/**
@@ -743,7 +747,8 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		// simulate dragstart for touch and hold
 		this._touchTimeoutId = setTimeout(() => {
 			this._touchStarted = true;
-			this.shadowRoot.querySelector('.d2l-list-item-drag-area').dispatchEvent(createDragEvent('dragstart'));
+			if (this.shadowRoot)
+				this.shadowRoot.querySelector('.d2l-list-item-drag-area').dispatchEvent(createDragEvent('dragstart'));
 		}, touchHoldDuration);
 	}
 

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -171,7 +171,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 	}
 
 	_focusCellItem(num, itemNum) {
-		const cell = this.shadowRoot ? this.shadowRoot.querySelector(`[data-cell-num="${num}"]`) : undefined;
+		const cell = this.shadowRoot && this.shadowRoot.querySelector(`[data-cell-num="${num}"]`);
 		if (!cell) return;
 
 		const firstFocusable = getFirstFocusableDescendant(cell);
@@ -197,7 +197,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 		let focusable = null;
 		let num = 1;
 		do {
-			cell = this.shadowRoot ? this.shadowRoot.querySelector(`[data-cell-num="${num++}"]`) : undefined;
+			cell = this.shadowRoot && this.shadowRoot.querySelector(`[data-cell-num="${num++}"]`);
 			if (cell) {
 				focusable = getLastFocusableDescendant(cell) || focusable;
 			}
@@ -220,7 +220,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 		let focusable = null;
 
 		do {
-			cell = this.shadowRoot ? this.shadowRoot.querySelector(`[data-cell-num="${num}"]`) : undefined;
+			cell = this.shadowRoot && this.shadowRoot.querySelector(`[data-cell-num="${num}"]`);
 			if (cell) {
 				focusable = forward ? getFirstFocusableDescendant(cell) : getLastFocusableDescendant(cell);
 			}
@@ -381,9 +381,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 	}
 
 	_getThisCell() {
-		return this.shadowRoot ?
-			this.shadowRoot.querySelector(`.d2l-cell[data-cell-num="${this._cellNum}"]`)
-			: undefined;
+		return this.shadowRoot &&
+			this.shadowRoot.querySelector(`.d2l-cell[data-cell-num="${this._cellNum}"]`);
 	}
 
 	_onKeydown(event) {

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -197,7 +197,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 		let focusable = null;
 		let num = 1;
 		do {
-			cell = this.shadowRoot.querySelector(`[data-cell-num="${num++}"]`);
+			cell = this.shadowRoot ? this.shadowRoot.querySelector(`[data-cell-num="${num++}"]`) : undefined;
 			if (cell) {
 				focusable = getLastFocusableDescendant(cell) || focusable;
 			}
@@ -220,7 +220,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 		let focusable = null;
 
 		do {
-			cell = this.shadowRoot.querySelector(`[data-cell-num="${num}"]`);
+			cell = this.shadowRoot ? this.shadowRoot.querySelector(`[data-cell-num="${num}"]`) : undefined;
 			if (cell) {
 				focusable = forward ? getFirstFocusableDescendant(cell) : getLastFocusableDescendant(cell);
 			}
@@ -381,7 +381,9 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 	}
 
 	_getThisCell() {
-		return this.shadowRoot.querySelector(`.d2l-cell[data-cell-num="${this._cellNum}"]`);
+		return this.shadowRoot ?
+			this.shadowRoot.querySelector(`.d2l-cell[data-cell-num="${this._cellNum}"]`)
+			: undefined;
 	}
 
 	_onKeydown(event) {

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -171,7 +171,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 	}
 
 	_focusCellItem(num, itemNum) {
-		const cell = this.shadowRoot.querySelector(`[data-cell-num="${num}"]`);
+		const cell = this.shadowRoot ? this.shadowRoot.querySelector(`[data-cell-num="${num}"]`) : undefined;
 		if (!cell) return;
 
 		const firstFocusable = getFirstFocusableDescendant(cell);

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -303,6 +303,7 @@ export const ListItemMixin = superclass => class extends ListItemDragDropMixin(L
 	}
 
 	_getNestedList() {
+		if (!this.shadowRoot) return;
 		const nestedSlot = this.shadowRoot.querySelector('slot[name="nested"]');
 		let nestedNodes = nestedSlot.assignedNodes();
 		if (nestedNodes.length === 0) {

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -101,6 +101,7 @@ class List extends SelectionMixin(LitElement) {
 	}
 
 	getItems() {
+		if (!this.shadowRoot) return;
 		const slot = this.shadowRoot.querySelector('slot:not([name])');
 		if (!slot) return [];
 		return slot.assignedNodes({ flatten: true }).filter((node) => {
@@ -157,6 +158,7 @@ class List extends SelectionMixin(LitElement) {
 	_handleKeyDown(e) {
 		if (!this.grid || this.slot === 'nested' || e.keyCode !== keyCodes.TAB) return;
 		e.preventDefault();
+		if (!this.shadowRoot) return;
 		const focusable = (e.shiftKey ? getPreviousFocusable(this.shadowRoot.querySelector('slot:not([name])'))
 			: getNextFocusable(this, false, true, true));
 		if (focusable) focusable.focus();

--- a/components/menu/demo/custom-view.js
+++ b/components/menu/demo/custom-view.js
@@ -48,7 +48,7 @@ class CustomView extends HierarchicalViewMixin(LitElement) {
 	}
 
 	focus() {
-		this.shadowRoot.querySelector('.d2l-custom-view-back-container > a').focus();
+		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-custom-view-back-container > a').focus();
 	}
 
 	_handleHide(e) {

--- a/components/menu/menu-item-link.js
+++ b/components/menu/menu-item-link.js
@@ -84,7 +84,7 @@ class MenuItemLink extends MenuItemMixin(LitElement) {
 	}
 
 	_onClick() {
-		this.shadowRoot.querySelector('a').dispatchEvent(new CustomEvent('click'));
+		if (this.shadowRoot) this.shadowRoot.querySelector('a').dispatchEvent(new CustomEvent('click'));
 	}
 
 	_onKeyDown(e) {

--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -109,7 +109,7 @@ export const MenuItemMixin = superclass => class extends FocusVisiblePolyfillMix
 	}
 
 	__initializeItem() {
-		const slot = this.shadowRoot.querySelector('slot:not([name])');
+		const slot = this.shadowRoot ? this.shadowRoot.querySelector('slot:not([name])') : undefined;
 		if (!slot) {
 			return;
 		}

--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -109,7 +109,7 @@ export const MenuItemMixin = superclass => class extends FocusVisiblePolyfillMix
 	}
 
 	__initializeItem() {
-		const slot = this.shadowRoot ? this.shadowRoot.querySelector('slot:not([name])') : undefined;
+		const slot = this.shadowRoot && this.shadowRoot.querySelector('slot:not([name])');
 		if (!slot) {
 			return;
 		}

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -221,11 +221,11 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(FocusVisiblePolyfillMixin(Li
 	}
 
 	_getMenuItemReturn() {
-		return this.shadowRoot.querySelector('d2l-menu-item-return');
+		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-menu-item-return') : undefined;
 	}
 
 	_getMenuItems() {
-		const slot = this.shadowRoot.querySelector('slot');
+		const slot = this.shadowRoot ? this.shadowRoot.querySelector('slot') : undefined;
 		if (!slot) return;
 		const items = slot.assignedNodes({ flatten: true }).filter((node) => node.nodeType === Node.ELEMENT_NODE);
 

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -221,11 +221,11 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(FocusVisiblePolyfillMixin(Li
 	}
 
 	_getMenuItemReturn() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('d2l-menu-item-return') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('d2l-menu-item-return');
 	}
 
 	_getMenuItems() {
-		const slot = this.shadowRoot ? this.shadowRoot.querySelector('slot') : undefined;
+		const slot = this.shadowRoot && this.shadowRoot.querySelector('slot');
 		if (!slot) return;
 		const items = slot.assignedNodes({ flatten: true }).filter((node) => node.nodeType === Node.ELEMENT_NODE);
 

--- a/components/menu/test/custom-view.js
+++ b/components/menu/test/custom-view.js
@@ -48,7 +48,7 @@ class CustomView extends HierarchicalViewMixin(LitElement) {
 	}
 
 	focus() {
-		this.shadowRoot.querySelector('.d2l-custom-view-back-container > a').focus();
+		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-custom-view-back-container > a').focus();
 	}
 
 	_handleHide(e) {

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -318,7 +318,7 @@ class OverflowGroup extends RtlMixin(LocalizeCoreElement(LitElement)) {
 	}
 
 	_chomp() {
-		if (!this._itemLayouts) return;
+		if (!this.shadowRoot || !this._itemLayouts) return;
 
 		this._overflowMenu = this.shadowRoot.querySelector('.d2l-overflow-dropdown');
 		this._overflowMenuMini = this.shadowRoot.querySelector('.d2l-overflow-dropdown-mini');

--- a/components/scroll-wrapper/demo/scroll-wrapper-test.js
+++ b/components/scroll-wrapper/demo/scroll-wrapper-test.js
@@ -53,7 +53,7 @@ class TestScrollWrapper extends RtlMixin(LitElement) {
 	}
 
 	focus() {
-		forceFocusVisible(this.shadowRoot.querySelector('d2l-scroll-wrapper')._container);
+		if (this.shadowRoot) forceFocusVisible(this.shadowRoot.querySelector('d2l-scroll-wrapper')._container);
 	}
 
 }

--- a/components/selection/selection-action.js
+++ b/components/selection/selection-action.js
@@ -79,7 +79,7 @@ class Action extends LocalizeCoreElement(SelectionObserverMixin(ButtonMixin(RtlM
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('d2l-button-subtle');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-subtle') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/selection/selection-action.js
+++ b/components/selection/selection-action.js
@@ -79,7 +79,7 @@ class Action extends LocalizeCoreElement(SelectionObserverMixin(ButtonMixin(RtlM
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-button-subtle') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-button-subtle');
 		if (elem) elem.focus();
 	}
 

--- a/components/selection/selection-input.js
+++ b/components/selection/selection-input.js
@@ -142,7 +142,7 @@ class Input extends SkeletonMixin(LabelledMixin(LitElement)) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.firstElementChild : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.firstElementChild;
 		if (elem) elem.focus();
 	}
 

--- a/components/selection/selection-input.js
+++ b/components/selection/selection-input.js
@@ -142,7 +142,7 @@ class Input extends SkeletonMixin(LabelledMixin(LitElement)) {
 	}
 
 	focus() {
-		const elem = this.shadowRoot.firstElementChild;
+		const elem = this.shadowRoot ? this.shadowRoot.firstElementChild : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/selection/selection-select-all.js
+++ b/components/selection/selection-select-all.js
@@ -57,7 +57,7 @@ class SelectAll extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) 
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('d2l-input-checkbox');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-checkbox') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/selection/selection-select-all.js
+++ b/components/selection/selection-select-all.js
@@ -57,7 +57,7 @@ class SelectAll extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) 
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('d2l-input-checkbox') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-checkbox');
 		if (elem) elem.focus();
 	}
 

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -213,7 +213,7 @@ export const SwitchMixin = superclass => class extends RtlMixin(FocusVisiblePoly
 	}
 
 	focus() {
-		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-switch-container') : undefined;
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-switch-container');
 		if (elem) elem.focus();
 	}
 

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -213,7 +213,7 @@ export const SwitchMixin = superclass => class extends RtlMixin(FocusVisiblePoly
 	}
 
 	focus() {
-		const elem = this.shadowRoot.querySelector('.d2l-switch-container');
+		const elem = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-switch-container') : undefined;
 		if (elem) elem.focus();
 	}
 

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -71,7 +71,7 @@ export class TableColSortButton extends LitElement {
 	}
 
 	focus() {
-		const button = this.shadowRoot ? this.shadowRoot.querySelector('button') : undefined;
+		const button = this.shadowRoot && this.shadowRoot.querySelector('button');
 		if (button) button.focus();
 	}
 

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -71,7 +71,7 @@ export class TableColSortButton extends LitElement {
 	}
 
 	focus() {
-		const button = this.shadowRoot.querySelector('button');
+		const button = this.shadowRoot ? this.shadowRoot.querySelector('button') : undefined;
 		if (button) button.focus();
 	}
 

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -488,7 +488,9 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	async _focusSelected() {
-		const selectedTab = this.shadowRoot.querySelector('d2l-tab-internal[aria-selected="true"]');
+		const selectedTab = this.shadowRoot ?
+			this.shadowRoot.querySelector('d2l-tab-internal[aria-selected="true"]')
+			: undefined;
 		if (!selectedTab) return;
 
 		const selectedTabInfo = this._getTabInfo(selectedTab.controlsPanel);

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -379,9 +379,8 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	_animateTabAddition(tabInfo) {
-		const tab = this.shadowRoot ?
-			this.shadowRoot.querySelector(`d2l-tab-internal[controls-panel="${cssEscape(tabInfo.id)}"]`)
-			: undefined;
+		const tab = this.shadowRoot
+			&& this.shadowRoot.querySelector(`d2l-tab-internal[controls-panel="${cssEscape(tabInfo.id)}"]`);
 		return new Promise((resolve) => {
 			const handleTransitionEnd = (e) => {
 				if (e.propertyName !== 'max-width') return;
@@ -395,9 +394,8 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	_animateTabRemoval(tabInfo) {
-		const tab = this.shadowRoot ?
-			this.shadowRoot.querySelector(`d2l-tab-internal[controls-panel="${cssEscape(tabInfo.id)}"]`)
-			: undefined;
+		const tab = this.shadowRoot &&
+			this.shadowRoot.querySelector(`d2l-tab-internal[controls-panel="${cssEscape(tabInfo.id)}"]`);
 		return new Promise((resolve) => {
 			const handleTransitionEnd = (e) => {
 				if (e.propertyName !== 'max-width') return;
@@ -493,9 +491,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	async _focusSelected() {
-		const selectedTab = this.shadowRoot ?
-			this.shadowRoot.querySelector('d2l-tab-internal[aria-selected="true"]')
-			: undefined;
+		const selectedTab = this.shadowRoot && this.shadowRoot.querySelector('d2l-tab-internal[aria-selected="true"]');
 		if (!selectedTab) return;
 
 		const selectedTabInfo = this._getTabInfo(selectedTab.controlsPanel);
@@ -813,7 +809,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 			expandedPromise = this.updateComplete;
 		} else {
 			expandedPromise = new Promise((resolve) => {
-				const tabsContainer = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-tabs-container') : undefined;
+				const tabsContainer = this.shadowRoot && this.shadowRoot.querySelector('.d2l-tabs-container');
 				const handleTransitionEnd = (e) => {
 					if (e.propertyName !== 'max-width') return;
 					if (tabsContainer) tabsContainer.removeEventListener('transitionend', handleTransitionEnd);

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -374,34 +374,39 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	getTabListRect() {
+		if (!this.shadowRoot) return undefined;
 		return this.shadowRoot.querySelector('.d2l-tabs-container-list').getBoundingClientRect();
 	}
 
 	_animateTabAddition(tabInfo) {
-		const tab = this.shadowRoot.querySelector(`d2l-tab-internal[controls-panel="${cssEscape(tabInfo.id)}"]`);
+		const tab = this.shadowRoot ?
+			this.shadowRoot.querySelector(`d2l-tab-internal[controls-panel="${cssEscape(tabInfo.id)}"]`)
+			: undefined;
 		return new Promise((resolve) => {
 			const handleTransitionEnd = (e) => {
 				if (e.propertyName !== 'max-width') return;
-				tab.removeEventListener('transitionend', handleTransitionEnd);
+				if (tab) tab.removeEventListener('transitionend', handleTransitionEnd);
 				resolve();
 			};
-			tab.addEventListener('transitionend', handleTransitionEnd);
+			if (tab) tab.addEventListener('transitionend', handleTransitionEnd);
 			tabInfo.state = '';
 			this.requestUpdate();
 		});
 	}
 
 	_animateTabRemoval(tabInfo) {
-		const tab = this.shadowRoot.querySelector(`d2l-tab-internal[controls-panel="${cssEscape(tabInfo.id)}"]`);
+		const tab = this.shadowRoot ?
+			this.shadowRoot.querySelector(`d2l-tab-internal[controls-panel="${cssEscape(tabInfo.id)}"]`)
+			: undefined;
 		return new Promise((resolve) => {
 			const handleTransitionEnd = (e) => {
 				if (e.propertyName !== 'max-width') return;
-				tab.removeEventListener('transitionend', handleTransitionEnd);
+				if (tab) tab.removeEventListener('transitionend', handleTransitionEnd);
 				this._tabInfos.splice(this._tabInfos.findIndex(info => info.id === tabInfo.id), 1);
 				this.requestUpdate();
 				resolve();
 			};
-			tab.addEventListener('transitionend', handleTransitionEnd);
+			if (tab) tab.addEventListener('transitionend', handleTransitionEnd);
 		});
 	}
 
@@ -519,6 +524,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	_getPanel(id) {
+		if (!this.shadowRoot) return;
 		// use simple selector for slot (Edge)
 		const slot = this.shadowRoot.querySelector('.d2l-panels-container').querySelector('slot');
 		const panels = this._getPanels(slot);
@@ -704,7 +710,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 		await this._scrollToPosition(newTranslationValue);
 		await this._updateScrollVisibility(newMeasures);
 
-		if (!isOverflowingNext) {
+		if (!isOverflowingNext && this.shadowRoot) {
 			this.shadowRoot.querySelector('.d2l-tabs-scroll-previous-container button').focus();
 		}
 
@@ -737,7 +743,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 		await this._scrollToPosition(newTranslationValue);
 		await this._updateScrollVisibility(newMeasures);
 
-		if (!isOverflowingPrevious) {
+		if (!isOverflowingPrevious && this.shadowRoot) {
 			this.shadowRoot.querySelector('.d2l-tabs-scroll-next-container button').focus();
 		}
 
@@ -779,7 +785,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 		}
 
 		this._translationValue = translationValue;
-		if (reduceMotion) return this.updateComplete;
+		if (!this.shadowRoot || reduceMotion) return this.updateComplete;
 
 		return new Promise((resolve) => {
 			const tabList = this.shadowRoot.querySelector('.d2l-tabs-container-list');
@@ -807,13 +813,13 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 			expandedPromise = this.updateComplete;
 		} else {
 			expandedPromise = new Promise((resolve) => {
-				const tabsContainer = this.shadowRoot.querySelector('.d2l-tabs-container');
+				const tabsContainer = this.shadowRoot ? this.shadowRoot.querySelector('.d2l-tabs-container') : undefined;
 				const handleTransitionEnd = (e) => {
 					if (e.propertyName !== 'max-width') return;
-					tabsContainer.removeEventListener('transitionend', handleTransitionEnd);
+					if (tabsContainer) tabsContainer.removeEventListener('transitionend', handleTransitionEnd);
 					resolve();
 				};
-				tabsContainer.addEventListener('transitionend', handleTransitionEnd);
+				if (tabsContainer) tabsContainer.addEventListener('transitionend', handleTransitionEnd);
 				this._scrollCollapsed = false;
 				this._maxWidth = measures.totalTabsWidth + 50;
 			});
@@ -830,7 +836,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 			if (!this._allowScrollPrevious) {
 				this._focusSelected();
 			} else {
-				this.shadowRoot.querySelector('.d2l-tabs-scroll-previous-container button').focus();
+				if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-tabs-scroll-previous-container button').focus();
 			}
 		}
 
@@ -840,6 +846,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 
 	_updateMeasures() {
 		let totalTabsWidth = 0;
+		if (!this.shadowRoot) return;
 		const tabs = [...this.shadowRoot.querySelectorAll('d2l-tab-internal')];
 
 		const tabRects = tabs.map((tab) => {
@@ -896,7 +903,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 			// don't animate the tabs list visibility if it's the inital render
 			if (reduceMotion || !this._initialized) {
 				this._state = 'hidden';
-			} else {
+			} else if (this.shadowRoot) {
 				const layout = this.shadowRoot.querySelector('.d2l-tabs-layout');
 				const handleTransitionEnd = (e) => {
 					if (e.propertyName !== 'max-height') return;

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -715,7 +715,7 @@ class Tooltip extends RtlMixin(LitElement) {
 	}
 
 	_getContent() {
-		return this.shadowRoot.querySelector('.d2l-tooltip-content');
+		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-tooltip-content') : undefined;
 	}
 
 	_isAboveOrBelow() {

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -715,7 +715,7 @@ class Tooltip extends RtlMixin(LitElement) {
 	}
 
 	_getContent() {
-		return this.shadowRoot ? this.shadowRoot.querySelector('.d2l-tooltip-content') : undefined;
+		return this.shadowRoot && this.shadowRoot.querySelector('.d2l-tooltip-content');
 	}
 
 	_isAboveOrBelow() {

--- a/controllers/attributeObserver/test/htmlAttributeObserverController.test.js
+++ b/controllers/attributeObserver/test/htmlAttributeObserverController.test.js
@@ -39,7 +39,7 @@ const testHost = listeningAttributes => defineCE(
 			return this._controller.values.get(attr);
 		}
 		getRenderedVal(attr) {
-			const elem = this.shadowRoot.querySelector(`#${attr}`);
+			const elem = this.shadowRoot ? this.shadowRoot.querySelector(`#${attr}`) : undefined;
 			return (elem && elem.textContent) || undefined;
 		}
 		_hasChanged() {

--- a/controllers/attributeObserver/test/htmlAttributeObserverController.test.js
+++ b/controllers/attributeObserver/test/htmlAttributeObserverController.test.js
@@ -39,7 +39,7 @@ const testHost = listeningAttributes => defineCE(
 			return this._controller.values.get(attr);
 		}
 		getRenderedVal(attr) {
-			const elem = this.shadowRoot ? this.shadowRoot.querySelector(`#${attr}`) : undefined;
+			const elem = this.shadowRoot && this.shadowRoot.querySelector(`#${attr}`);
 			return (elem && elem.textContent) || undefined;
 		}
 		_hasChanged() {

--- a/directives/animate/test/animate.test.js
+++ b/directives/animate/test/animate.test.js
@@ -20,11 +20,11 @@ class FocusTestElem extends LitElement {
 	}
 
 	focus() {
-		this.shadowRoot.querySelector('#first').focus();
+		if (this.shadowRoot) this.shadowRoot.querySelector('#first').focus();
 	}
 
 	forceFocusVisible() {
-		forceFocusVisible(this.shadowRoot.querySelector('#first'));
+		if (this.shadowRoot) forceFocusVisible(this.shadowRoot.querySelector('#first'));
 	}
 
 	_dispatchEvent() {

--- a/helpers/demo/announce-test.js
+++ b/helpers/demo/announce-test.js
@@ -25,6 +25,7 @@ class AnnounceTest extends LitElement {
 	}
 
 	_handleAnnounce() {
+		if (!this.shadowRoot) return;
 		const value1 = this.shadowRoot.querySelector('#msg1').value;
 		if (value1.length > 0) announce(value1);
 		const value2 = this.shadowRoot.querySelector('#msg2').value;

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -18,7 +18,7 @@ const testElemTag = defineCE(
 			return html`<div id="container"><slot id="slot1"></slot></div>`;
 		}
 		getContainer() {
-			return this.shadowRoot ? this.shadowRoot.querySelector('#container') : undefined;
+			return this.shadowRoot && this.shadowRoot.querySelector('#container');
 		}
 	},
 );

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -18,7 +18,7 @@ const testElemTag = defineCE(
 			return html`<div id="container"><slot id="slot1"></slot></div>`;
 		}
 		getContainer() {
-			return this.shadowRoot.querySelector('#container');
+			return this.shadowRoot ? this.shadowRoot.querySelector('#container') : undefined;
 		}
 	},
 );

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -23,13 +23,13 @@ const testElemTag = defineCE(
 			`;
 		}
 		getContent() {
-			return this.shadowRoot ? this.shadowRoot.querySelector('#content') : undefined;
+			return this.shadowRoot && this.shadowRoot.querySelector('#content');
 		}
 		getShadow1() {
-			return this.shadowRoot ? this.shadowRoot.querySelector('#shadow1') : undefined;
+			return this.shadowRoot && this.shadowRoot.querySelector('#shadow1');
 		}
 		getShadow2() {
-			return this.shadowRoot ? this.shadowRoot.querySelector('#shadow2') : undefined;
+			return this.shadowRoot && this.shadowRoot.querySelector('#shadow2');
 		}
 	},
 );

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -23,13 +23,13 @@ const testElemTag = defineCE(
 			`;
 		}
 		getContent() {
-			return this.shadowRoot.querySelector('#content');
+			return this.shadowRoot ? this.shadowRoot.querySelector('#content') : undefined;
 		}
 		getShadow1() {
-			return this.shadowRoot.querySelector('#shadow1');
+			return this.shadowRoot ? this.shadowRoot.querySelector('#shadow1') : undefined;
 		}
 		getShadow2() {
-			return this.shadowRoot.querySelector('#shadow2');
+			return this.shadowRoot ? this.shadowRoot.querySelector('#shadow2') : undefined;
 		}
 	},
 );

--- a/mixins/arrow-keys-mixin.js
+++ b/mixins/arrow-keys-mixin.js
@@ -37,7 +37,9 @@ export const ArrowKeysMixin = superclass => class extends superclass {
 	}
 
 	async arrowKeysFocusablesProvider() {
-		return [...this.shadowRoot.querySelectorAll('.d2l-arrowkeys-focusable')];
+		return this.shadowRoot ?
+			[...this.shadowRoot.querySelectorAll('.d2l-arrowkeys-focusable')]
+			: [];
 	}
 
 	async _focus(elem) {

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -1014,6 +1014,7 @@ class TemplatePrimarySecondary extends FocusVisiblePolyfillMixin(RtlMixin(Locali
 	}
 
 	_computeContentBounds(contentRect) {
+		if (!this.shadowRoot) return;
 		const divider = this.shadowRoot.querySelector('.d2l-template-primary-secondary-divider');
 		const desktopDividerSize = divider.offsetWidth;
 		const mobileDividerSize = divider.offsetHeight;
@@ -1057,7 +1058,7 @@ class TemplatePrimarySecondary extends FocusVisiblePolyfillMixin(RtlMixin(Locali
 			} else {
 				if (this._isMobile) {
 					this._size = this._contentBounds.minHeight;
-				} else {
+				} else if (this.shadowRoot) {
 					const divider = this.shadowRoot.querySelector('.d2l-template-primary-secondary-divider');
 					const desktopDividerSize = contentRect.width - divider.offsetWidth;
 					this._size = Math.max(desktopMinSize, desktopDividerSize * (1 / 3));


### PR DESCRIPTION
This PR adds a guardrail to all of our shadowRoot calls to actually check it exists before querying the shadowRoot. It will not be guaranteed that the shadowRoot is in place if a method is called very early (before firstUpdated). As a precaution, I've added these checks to all the shadowRoot accesses, with the exception of those in the updated()/firstUpdated() calls. It may be a bit overkill, but it will not affect most of the code.  

Another PR will be coming after this one for more Lit 2 prep changes. Figured this PR was big enough on its own 😆 