### PR TITLE
US134551 - Lit 2 Prep - Non-breaking Compatibility changes for lit 2

### DIFF
--- a/components/count-badge/count-badge-mixin.js
+++ b/components/count-badge/count-badge-mixin.js
@@ -7,7 +7,7 @@ import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
-import { styleMap } from 'lit-html/directives/style-map';
+import { styleMap } from 'lit-html/directives/style-map.js';
 
 export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(SkeletonMixin(RtlMixin(superclass))) {
 

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -36,7 +36,7 @@ class CodeView extends LitElement {
 			const path = `/node_modules/prismjs/components/prism-${language}.min.js`;
 			this._dependenciesPromise = import(path);
 		}
-		this._updateCode(this.shadowRoot.querySelector('slot'));
+		if (this.shadowRoot) this._updateCode(this.shadowRoot.querySelector('slot'));
 		super.attributeChangedCallback(name, oldval, newval);
 	}
 
@@ -56,7 +56,8 @@ class CodeView extends LitElement {
 	}
 
 	get _codeTemplate() {
-		return html`<pre class="language-${this.language}"><code class="language-${this.language}">${unsafeHTML(this._code)}</code></pre>`;
+		const code = this._code !== undefined ? unsafeHTML(this._code) : '';
+		return html`<pre class="language-${this.language}"><code class="language-${this.language}">${code}</code></pre>`;
 	}
 
 	_formatCode(text) {

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -389,7 +389,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 					<d2l-list-item
 						?hidden="${item.hidden}"
 						key="${item.key}"
-						label="${item.text}"
+						label="${item.text ? item.text : 'placeholder'}"
 						selectable
 						?selected="${item.selected}"
 						slim>

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -389,7 +389,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 					<d2l-list-item
 						?hidden="${item.hidden}"
 						key="${item.key}"
-						label="${item.text ? item.text : 'placeholder'}"
+						label="${item.text}"
 						selectable
 						?selected="${item.selected}"
 						slim>

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -743,7 +743,7 @@ describe('d2l-filter', () => {
 			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			expect(elem._dimensions[1].text).to.equal('Test');
 			expect(elem._dimensions[1].loading).to.be.true;
-			expect(updateStub).to.be.called;
+			expect(updateStub).to.be.calledOnce;
 			expect(recountSpy).to.be.not.be.called;
 			expect(searchSpy).to.be.not.be.called;
 		});
@@ -755,7 +755,7 @@ describe('d2l-filter', () => {
 
 			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			expect(elem._dimensions[1].values[0].text).to.equal('Test');
-			expect(updateStub).to.be.called;
+			expect(updateStub).to.be.calledOnce;
 			expect(recountSpy).to.be.not.be.called;
 			expect(searchSpy).to.be.not.be.called;
 		});
@@ -805,7 +805,7 @@ describe('d2l-filter', () => {
 			expect(elem._dimensions[1].values[0].selected).to.be.true;
 			expect(elem._dimensions[1].appliedCount).to.equal(1);
 			expect(elem._totalAppliedCount).to.equal(3);
-			expect(updateStub).to.be.calledOnce;
+			expect(updateStub).to.be.called;
 			expect(recountSpy).to.be.not.be.called;
 			expect(searchSpy).to.be.not.be.called;
 		});
@@ -825,7 +825,7 @@ describe('d2l-filter', () => {
 			expect(elem._dimensions[1].values[1].selected).to.be.true;
 			expect(elem._dimensions[1].appliedCount).to.equal(1);
 			expect(elem._totalAppliedCount).to.equal(3);
-			expect(updateStub).to.be.calledOnce;
+			expect(updateStub).to.be.called;
 			expect(recountSpy).to.be.calledOnce;
 			expect(recountSpy).to.have.been.calledWith(elem._dimensions[1]);
 			expect(searchSpy).to.be.not.be.called;

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -549,6 +549,7 @@ describe('d2l-filter', () => {
 	describe('filter counts', () => {
 		it('single set dimension is counted correctly', async() => {
 			const elem = await fixture('<d2l-filter></d2l-filter>');
+			stub(elem, 'requestUpdate'); // Do not create actual DOM nodes for this test, missing text info for labels
 			elem._dimensions = [{
 				key: 'dim',
 				type: 'd2l-filter-dimension-set',
@@ -564,6 +565,7 @@ describe('d2l-filter', () => {
 
 		it('multiple dimensions are counted correctly', async() => {
 			const elem = await fixture('<d2l-filter></d2l-filter>');
+			stub(elem, 'requestUpdate'); // Do not create actual DOM nodes for this test, missing text info for labels
 			elem._dimensions = [{
 				key: '1',
 				type: 'd2l-filter-dimension-set',

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -743,7 +743,7 @@ describe('d2l-filter', () => {
 			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			expect(elem._dimensions[1].text).to.equal('Test');
 			expect(elem._dimensions[1].loading).to.be.true;
-			expect(updateStub).to.be.calledOnce;
+			expect(updateStub).to.be.called;
 			expect(recountSpy).to.be.not.be.called;
 			expect(searchSpy).to.be.not.be.called;
 		});
@@ -755,7 +755,7 @@ describe('d2l-filter', () => {
 
 			await oneEvent(elem, 'd2l-filter-dimension-data-change');
 			expect(elem._dimensions[1].values[0].text).to.equal('Test');
-			expect(updateStub).to.be.calledOnce;
+			expect(updateStub).to.be.called;
 			expect(recountSpy).to.be.not.be.called;
 			expect(searchSpy).to.be.not.be.called;
 		});
@@ -772,7 +772,7 @@ describe('d2l-filter', () => {
 			});
 			expect(elem._dimensions[1].values[0].text).to.equal('Test');
 			expect(elem._dimensions[1].values[0].selected).to.be.true;
-			expect(updateStub).to.be.calledOnce;
+			expect(updateStub).to.be.called;
 			expect(recountSpy).to.be.not.be.called;
 			expect(searchSpy).to.be.not.be.called;
 		});

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -136,9 +136,6 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		/** @ignore */
 		this.childErrors = new Map();
 		this._errors = [];
-
-		this.shadowRoot.addEventListener('d2l-validation-custom-connected', this._validationCustomConnected);
-		this.shadowRoot.addEventListener('d2l-form-element-errors-change', this._onFormElementErrorsChange);
 	}
 
 	/** @ignore */
@@ -158,6 +155,18 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 	/** @ignore */
 	get validity() {
 		return this._validity;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.shadowRoot.addEventListener('d2l-validation-custom-connected', this._validationCustomConnected);
+		this.shadowRoot.addEventListener('d2l-form-element-errors-change', this._onFormElementErrorsChange);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.shadowRoot.removeEventListener('d2l-validation-custom-connected', this._validationCustomConnected);
+		this.shadowRoot.removeEventListener('d2l-form-element-errors-change', this._onFormElementErrorsChange);
 	}
 
 	updated(changedProperties) {

--- a/components/list/demo/list-drag-and-drop.js
+++ b/components/list/demo/list-drag-and-drop.js
@@ -163,7 +163,8 @@ class ListDemoDragAndDrop extends LitElement {
 			targetItems.splice(targetIndex, 0, dataToMove[i]);
 		}
 
-		await this.requestUpdate();
+		this.requestUpdate();
+		await this.updateComplete;
 
 		if (e.detail.keyboardActive) {
 			requestAnimationFrame(() => {


### PR DESCRIPTION
This PR, in combination with https://github.com/BrightspaceUI/core/pull/1945, allows core to transition to lit 2 with changes to the package-lock only.  I am following the changes outlined in https://lit.dev/docs/releases/upgrade/. 

I also had to make changes to the filter unit tests due to some issues with sinon stubs and internal lit changes.