### PR TITLE
Fix Filter tests in Lit 2

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -389,7 +389,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 					<d2l-list-item
 						?hidden="${item.hidden}"
 						key="${item.key}"
-						label="${item.text ? item.text : 'placeholder'}"
+						label="${item.text}"
 						selectable
 						?selected="${item.selected}"
 						slim>

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -549,6 +549,7 @@ describe('d2l-filter', () => {
 	describe('filter counts', () => {
 		it('single set dimension is counted correctly', async() => {
 			const elem = await fixture('<d2l-filter></d2l-filter>');
+			stub(elem, 'requestUpdate'); // Do not create actual DOM nodes for this test, missing text info for labels
 			elem._dimensions = [{
 				key: 'dim',
 				type: 'd2l-filter-dimension-set',
@@ -564,6 +565,7 @@ describe('d2l-filter', () => {
 
 		it('multiple dimensions are counted correctly', async() => {
 			const elem = await fixture('<d2l-filter></d2l-filter>');
+			stub(elem, 'requestUpdate'); // Do not create actual DOM nodes for this test, missing text info for labels
 			elem._dimensions = [{
 				key: '1',
 				type: 'd2l-filter-dimension-set',


### PR DESCRIPTION
For the filter count tests I just want to check the count logic, I don't actually check the DOM nodes being rendered. So here I'm stubbing out `requestUpdate` so that setting `_totalAppliedCount` in `_setFilterCounts` doesn't cause a render.  This will avoid errors around missing labels.  I could also add `text` info to the data, but I don't need the DOM nodes anyways so figured this was more performant.

The `LabelledMixin` could also be enhanced to not warn about missing labels of disconnected nodes, but it will get this for free when/if we move it to the new [`idSubscriberController`](https://github.com/BrightspaceUI/core/blob/main/controllers/subscriber/subscriberControllers.js#L98).