### PR TITLE
Make sure MathJax loads even if only a single non-deferred html-block is loaded on the page

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -225,14 +225,17 @@ class HtmlBlock extends LitElement {
 
 	async _processRenderers(elem) {
 		for (const renderer of getRenderers()) {
-			if (this.noDeferredRendering && !renderer.canRenderInline) continue;
-
 			if (this._contextObserverController && renderer.contextAttributes) {
 				const contextValues = new Map();
 				renderer.contextAttributes.forEach(attr => contextValues.set(attr, this._contextObserverController.values.get(attr)));
-				elem = await renderer.render(elem, contextValues);
+				elem = await renderer.render(elem, {
+					contextValues: contextValues,
+					noDeferredRendering: this.noDeferredRendering
+				});
 			} else {
-				elem = await renderer.render(elem);
+				elem = await renderer.render(elem, {
+					noDeferredRendering: this.noDeferredRendering
+				});
 			}
 		}
 

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -4,10 +4,6 @@ import { provideInstance } from '../../../mixins/provider-mixin.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 class TestRenderer {
-	get canRenderInline() {
-		return true;
-	}
-
 	async render(elem) {
 		const elemsToReplace = elem.querySelectorAll('[data-replace-id]');
 		if (elemsToReplace.length === 0) return elem;
@@ -28,10 +24,6 @@ class TestRenderer {
 }
 
 class TestAsyncRenderer {
-	get canRenderInline() {
-		return true;
-	}
-
 	async render(elem) {
 		const elemsToReplace = elem.querySelectorAll('[data-async-replace-id]');
 		if (elemsToReplace.length === 0) return elem;
@@ -59,11 +51,9 @@ class TestAsyncRenderer {
 }
 
 class TestNoInlineRenderer {
-	get canRenderInline() {
-		return false;
-	}
-
-	async render(elem) {
+	async render(elem, options) {
+		if (options.noDeferredRendering) return;
+		
 		const elemsToReplace = elem.querySelectorAll('[data-no-inline-replace-id]');
 		if (elemsToReplace.length === 0) return elem;
 

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -53,7 +53,7 @@ class TestAsyncRenderer {
 class TestNoInlineRenderer {
 	async render(elem, options) {
 		if (options.noDeferredRendering) return;
-		
+
 		const elemsToReplace = elem.querySelectorAll('[data-no-inline-replace-id]');
 		if (elemsToReplace.length === 0) return elem;
 

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -4,19 +4,13 @@ let mathJaxLoaded;
 
 export class HtmlBlockMathRenderer {
 
-	get canRenderInline() {
-		// The custom MathJax ShadowAdaptor creates a new document and renders
-		// its contents to the DOM.
-		return false;
-	}
-
 	get contextAttributes() {
 		return [mathjaxContextAttribute];
 	}
 
-	async render(elem, contextValues) {
-		if (!contextValues) return elem;
-		const contextVal = contextValues.get(mathjaxContextAttribute);
+	async render(elem, options) {
+		if (!options.contextValues) return elem;
+		const contextVal = options.contextValues.get(mathjaxContextAttribute);
 		if (contextVal === undefined) return elem;
 
 		const context = JSON.parse(contextVal) || {};
@@ -30,6 +24,10 @@ export class HtmlBlockMathRenderer {
 		};
 
 		await loadMathJax(mathJaxConfig);
+
+		// If we're opting out of deferred rendering, we need to rely
+		// on the global MathJax install for rendering.
+		if (options.noDeferredRendering) return elem;
 
 		const temp = document.createElement('div');
 		temp.style.display = 'none';


### PR DESCRIPTION
The problem with not bothering to render math at all when `noDeferredRendering` is set is that we're still reliant on MathJax's global rendering in that case... But if we don't run the renderer we never load MathJax!

So I'm not tied to this solution necessarily, but it feels like the cleanest... Pass `noDeferredRendering` to the renderers as an option and let them figure out how they should support it. The math renderer can still load MathJax if needed and then bail before doing any inline replacements. Other renderers can, in theory, do something entirely different.