### PR TITLE
Ignore broken analyzer warning and fix other easy warnings

### DIFF
--- a/components/button/test/button-icon.perf.js
+++ b/components/button/test/button-icon.perf.js
@@ -5,7 +5,7 @@ import { expect } from '@open-wc/testing';
 describe('d2l-button-icon', () => {
 
 	it('normal', async() => {
-		const element = html`<d2l-button-icon label="Age" value="18"></d2l-button-icon>`;
+		const element = html`<d2l-button-icon icon="tier1:gear" text="Icon Button"></d2l-button-icon>`;
 		const result = await testRenderTime(element, { iterations: 1000 });
 		expect(result.duration).to.be.below(2500);
 	});

--- a/components/card/test/card-footer-link.axe.js
+++ b/components/card/test/card-footer-link.axe.js
@@ -9,12 +9,12 @@ describe('d2l-card-footer-link', () => {
 	});
 
 	it('secondary notification text', async() => {
-		const elem = await fixture(html`<d2l-card-footer-link href="https://www.d2l.com" icon="tier1:assignments" text="Assignments" secondary-text="3" secondary-text-type="notification"></d2l-card-footer-link>`);
+		const elem = await fixture(html`<d2l-card-footer-link href="https://www.d2l.com" icon="tier1:assignments" text="Assignments" secondary-count="3" secondary-count-type="notification"></d2l-card-footer-link>`);
 		await expect(elem).to.be.accessible();
 	});
 
 	it('secondary count text', async() => {
-		const elem = await fixture(html`<d2l-card-footer-link href="https://www.d2l.com" icon="tier1:assignments" text="Assignments" secondary-text="3" secondary-text-type="count"></d2l-card-footer-link>`);
+		const elem = await fixture(html`<d2l-card-footer-link href="https://www.d2l.com" icon="tier1:assignments" text="Assignments" secondary-count="3" secondary-count-type="count"></d2l-card-footer-link>`);
 		await expect(elem).to.be.accessible();
 	});
 

--- a/components/dialog/test/dialog-confirm.test.js
+++ b/components/dialog/test/dialog-confirm.test.js
@@ -1,3 +1,4 @@
+import '../../button/button.js';
 import '../dialog-confirm.js';
 import { expect, fixture, oneEvent } from '@open-wc/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
@@ -19,8 +20,8 @@ describe('d2l-dialog-confirm', () => {
 		it('should focus on first non-primary button', async() => {
 			const el = await fixture(html`
 				<d2l-dialog-confirm opened>
-					<button slot="footer" primary>Yes</button>
-					<button slot="footer">No</button>
+					<d2l-button slot="footer" primary>Yes</d2l-button>
+					<d2l-button slot="footer">No</d2l-button>
 				</d2l-dialog-confirm>
 			`);
 			await oneEvent(el, 'd2l-dialog-open');
@@ -30,7 +31,7 @@ describe('d2l-dialog-confirm', () => {
 		it('should focus on primary button if no others', async() => {
 			const el = await fixture(html`
 				<d2l-dialog-confirm opened>
-					<button slot="footer" primary>Yes</button>
+					<d2l-button slot="footer" primary>Yes</d2l-button>
 				</d2l-dialog-confirm>
 			`);
 			await oneEvent(el, 'd2l-dialog-open');

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -159,7 +159,8 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 				attribute: 'no-pointer'
 			},
 			/**
-			 * @ignore
+			 * Whether the dropdown is open or not
+			 * @type {boolean}
 			 */
 			opened: {
 				type: Boolean,

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -88,7 +88,6 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 			 */
 			invalid: { type: Boolean, reflect: true },
 			/**
-			 * @ignore
 			 * Name of the form control. Submitted with the form as part of a name/value pair.
 			 * @type {string}
 			 */

--- a/components/inputs/test/input-number.perf.js
+++ b/components/inputs/test/input-number.perf.js
@@ -30,7 +30,7 @@ describe('d2l-input-number', () => {
 	it('after-slot', async() => {
 		const element =
 			html`<d2l-input-number label="Help Text">
-				<span>Some text</span>
+				<span slot="after">Some text</span>
 			</d2l-input-number>`;
 		const result = await testRenderTime(element, { iterations: 1000 });
 		expect(result.duration).to.be.below(2000);

--- a/components/list/demo/list-item-custom.js
+++ b/components/list/demo/list-item-custom.js
@@ -1,3 +1,4 @@
+import '../list.js';
 import '../list-item-content.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { ListItemMixin } from '../list-item-mixin.js';

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -31,6 +31,7 @@ const keyCodes = {
  * @slot content - Content of the list item, such as that in a list-item-content component.
  * @slot content-action - Action associated with the content, such as a navigation link
  * @slot actions - Other actions for the list item on the far right, such as a context menu
+ * @slot nested - Optional `d2l-list` for creating nested lists
  */
 class ListItemGenericLayout extends RtlMixin(LitElement) {
 

--- a/components/menu/menu-item.js
+++ b/components/menu/menu-item.js
@@ -6,6 +6,7 @@ import { menuItemStyles } from './menu-item-styles.js';
 /**
  * A menu item component used with JS handlers.
  * @slot - Default content placed inside of the component
+ * @slot supporting - Allows supporting information to be displayed on the right-most side of the menu item
  */
 class MenuItem extends MenuItemMixin(LitElement) {
 

--- a/helpers/demo/announce-test.js
+++ b/helpers/demo/announce-test.js
@@ -21,7 +21,7 @@ class AnnounceTest extends LitElement {
 		return html`
 			<d2l-input-text id="msg1" type="text" value="I like cookies but I also like donuts and many other really yummy things." aria-label="first message to announce"></d2l-input-text>
 			<d2l-input-text id="msg2" type="text" value="I also like cake." aria-label="second message to announce"></d2l-input-text>
-			<d2l-button @click=${this._handleAnnounce} type="button">Announce</d2l-button>`;
+			<d2l-button @click=${this._handleAnnounce}>Announce</d2l-button>`;
 	}
 
 	_handleAnnounce() {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "npm run build:clean && npm run build:icons && npm run build:sass",
     "lint": "npm run lint:eslint && npm run lint:style && npm run lint:lit",
     "lint:eslint": "eslint . --ext .js,.html",
-    "lint:lit": "lit-analyzer \"{components,controllers,directives,helpers,mixins,templates,test,tools}/**/*.js\" --strict",
+    "lint:lit": "lit-analyzer \"{components,controllers,directives,helpers,mixins,templates,test,tools}/**/*.js\" --strict --rules.no-unknown-tag-name off",
     "lint:style": "stylelint \"**/*.{js,html}\"",
     "start": "web-dev-server --node-resolve --watch --open",
     "test": "npm run lint && npm run test:headless && npm run test:axe",


### PR DESCRIPTION
This PR ignores the `no-unknown-tag-name` warnings because we know these are broken ([more info here](https://github.com/runem/lit-analyzer/issues/34)).  It also tries to fix a number of real warnings, getting our total down from 99 to 66.

These are the remaining warnings we'd need to fix to get rid of all analyzer warnings:
- `animate` directive:
  - Unknown property `animate` (will go away with Lit 2)
- `FormElementMixin`:
  - `forceInvalid` is ignored
  - `invalid` is ignored
  - `noValidate` is ignored
- `d2l-input-date`:
  - `has-now` is ignored
  - `novalidateminmax` is ignored
- `d2l-input-number`:
  - `trailing-zeroes` is ignored
  - `value-trailing-zeroes` is ignored
- `d2l-selection-input`:
  - `hovering` is ignored
  - `_indeterminate` is ignored
- `d2l-table`:
  - Placing `selected` on `tr`s
  - Placing `sticky` `th`s
  - Placing `no-column-border` on `table`

These values are all hidden for a reason so we would need to develop a new way of hiding them from the Daylight site, but not the analyzer.  And switching the table over to classes or data attributes may be time consuming and tricky.