### PR TITLE
fix: moving checkbox description

### DIFF
--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -199,8 +199,9 @@ class InputCheckbox extends SkeletonMixin(RtlMixin(LitElement)) {
 					name="${ifDefined(this.name)}"
 					tabindex="${ifDefined(tabindex)}"
 					type="checkbox"
-					.value="${this.value}"></span><span class="${classMap(textClasses)}">${offscreenContainer}<slot></slot></span>
+					.value="${this.value}"></span><span class="${classMap(textClasses)}"><slot></slot></span>
 			</label>
+			${offscreenContainer}
 		`;
 	}
 


### PR DESCRIPTION
When the offscreen description is inside the `<label>`, assistive technology like NVDA reads it twice since technically it's also part of the primary label.

This change moves it outside to solve that. Confirmed that this solves the issue.