### PR TITLE
Add update-package-lock workflow

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -1,0 +1,22 @@
+name: Update package-lock.json
+on:
+  schedule:
+    - cron: "30 12 * * 1-5" # Mon-Fri 8:30AM EDT. 7:30AM EST.
+  workflow_dispatch: # manual trigger
+jobs:
+  update:
+    name: Update
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Brightspace/third-party-actions@actions/checkout
+      - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
+          cache: 'npm'
+      - name: Update package-lock.json
+        uses: BrightspaceUI/actions/update-package-lock@main
+        with:
+          APPROVAL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTO_MERGE_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 *       @BrightspaceUI/gaudi-dev
 helpers/getLocalizeResources.js @BrightspaceUI/team-usa-devs @BrightspaceUI/team-usa-senior-devs
 golden/
+package-lock.json


### PR DESCRIPTION
Have it set to run every morning and to auto-approve and auto-merge.  To do that, I need to undo the code reviewers approval requirement for `package-lock.json` and I'll turn on the auto-merge functionality in this repo.

Once merged, I'll manually trigger it to make sure everything works properly