### PR TITLE
DE45955: change all count badge plus langterms to "{number}+"

### DIFF
--- a/lang/es.js
+++ b/lang/es.js
@@ -6,7 +6,7 @@ export default {
 	"components.calendar.notSelected": "No seleccionado.",
 	"components.calendar.selected": "Seleccionado.",
 	"components.calendar.show": "Mostrar {month}",
-	"components.count-badge.plus" : "Más de {number}",
+	"components.count-badge.plus" : "{number}+",
 	"components.dialog.close": "Cerrar este cuadro de diálogo",
 	"components.dropdown.close": "Cerrar",
 	"components.filter.clear": "Borrar",

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -6,7 +6,7 @@ export default {
 	"components.calendar.notSelected": "Non sélectionné.",
 	"components.calendar.selected": "Sélectionné.",
 	"components.calendar.show": "Afficher {month}",
-	"components.count-badge.plus" : "Plus de {number}",
+	"components.count-badge.plus" : "{number}+",
 	"components.dialog.close": "Fermer cette boîte de dialogue",
 	"components.dropdown.close": "Fermer",
 	"components.filter.clear": "Effacer",

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -6,7 +6,7 @@ export default {
 	"components.calendar.notSelected": "選択されていません。",
 	"components.calendar.selected": "選択されています。",
 	"components.calendar.show": "{month} を表示",
-	"components.count-badge.plus" : "{number} 以上",
+	"components.count-badge.plus" : "{number}+",
 	"components.dialog.close": "このダイアログを閉じる",
 	"components.dropdown.close": "閉じる",
 	"components.filter.clear": "クリア",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -6,7 +6,7 @@ export default {
 	"components.calendar.notSelected": "Niet geselecteerd.",
 	"components.calendar.selected": "Geselecteerd.",
 	"components.calendar.show": "{month} weergeven",
-	"components.count-badge.plus" : "{number} +",
+	"components.count-badge.plus" : "{number}+",
 	"components.dialog.close": "Dit dialoogvenster sluiten",
 	"components.dropdown.close": "Sluiten",
 	"components.filter.clear": "Wissen",

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -6,7 +6,7 @@ export default {
 	"components.calendar.notSelected": "未选择。",
 	"components.calendar.selected": "已选择。",
 	"components.calendar.show": "显示 {month}",
-	"components.count-badge.plus" : "{number} +",
+	"components.count-badge.plus" : "{number}+",
 	"components.dialog.close": "关闭此对话框",
 	"components.dropdown.close": "关闭",
 	"components.filter.clear": "清除",


### PR DESCRIPTION
Changing all the count badge langterms back to using "{number}+" rather than multi-word langterms. We never heard back from localization, so we are keeping with our decision to not localize the term.