### PR TITLE
fix: dismissing on keydown so Esc on native elements like selects works

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -282,9 +282,11 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	_handleKeyDown(e) {
 		if (!this.opened) return;
 		if (e.keyCode === 27) {
-			// escape (note: prevent native dialog close so we can: animate it; use setDismissible)
+			// escape (note: prevent native dialog close so we can: animate it;)
 			e.stopPropagation();
 			e.preventDefault();
+			if (!this.opened) return;
+			this._close(abortAction);
 		}
 	}
 

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -282,11 +282,8 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	_handleKeyDown(e) {
 		if (!this.opened) return;
 		if (e.keyCode === 27) {
-			// escape (note: prevent native dialog close so we can: animate it;)
-			e.stopPropagation();
+			// escape (note: prevent native dialog close so we can: animate it; use setDismissible)
 			e.preventDefault();
-			if (!this.opened) return;
-			this._close(abortAction);
 		}
 	}
 

--- a/components/dialog/test/dialog-mixin.visual-diff.js
+++ b/components/dialog/test/dialog-mixin.visual-diff.js
@@ -63,7 +63,7 @@ describe('d2l-dialog-mixin', () => {
 					invoked when using puppeteer's keyboard api for the escape key for the
 					custom dialog impl even though it gets dispatched. use custom event instead. */
 					page.$eval('#dialog', (dialog) => {
-						const event = new CustomEvent('keyup', {
+						const event = new CustomEvent('keydown', {
 							bubbles: true,
 							cancelable: true,
 							composed: true

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -228,7 +228,7 @@ describe('d2l-dropdown', () => {
 			await aTimeout(0);
 
 			const eventObj = document.createEvent('Events');
-			eventObj.initEvent('keyup', true, true);
+			eventObj.initEvent('keydown', true, true);
 			eventObj.keyCode = 27;
 
 			setTimeout(() => document.dispatchEvent(eventObj));
@@ -642,7 +642,7 @@ describe('d2l-dropdown', () => {
 				await aTimeout(0);
 
 				const eventObj = document.createEvent('Events');
-				eventObj.initEvent('keyup', true, true);
+				eventObj.initEvent('keydown', true, true);
 				eventObj.keyCode = 27;
 
 				setTimeout(() => document.dispatchEvent(eventObj));

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -268,7 +268,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				@d2l-hierarchical-view-hide-start="${this._handleDimensionHideStart}"
 				@d2l-hierarchical-view-show-complete="${this._handleDimensionShowComplete}"
 				@d2l-hierarchical-view-show-start="${this._handleDimensionShowStart}"
-				@keyup="${this._handleDimensionHideKeyPress}"
+				@keydown="${this._handleDimensionHideKeyDown}"
 				data-key="${dimension.key}">
 				${dimensionHTML}
 			</d2l-hierarchical-view>
@@ -357,7 +357,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		`;
 
 		return html`
-			<div slot="header" @keyup="${this._handleDimensionHideKeyPress}">
+			<div slot="header" @keydown="${this._handleDimensionHideKeyDown}">
 				${header}
 				${actions}
 			</div>
@@ -551,7 +551,7 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		if (this.shadowRoot) this.shadowRoot.querySelector(`d2l-hierarchical-view[data-key="${this._activeDimensionKey}"]`).hide();
 	}
 
-	_handleDimensionHideKeyPress(e) {
+	_handleDimensionHideKeyDown(e) {
 		if (this._activeDimensionKey && (e.keyCode === ARROWLEFT_KEY_CODE || e.keyCode === ESCAPE_KEY_CODE)) {
 			e.stopPropagation();
 			this._handleDimensionHide();

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -895,7 +895,7 @@ describe('d2l-filter', () => {
 			await oneEvent(dropdown, 'd2l-dropdown-open');
 			expect(dropdownContent.opened).to.be.true;
 
-			const event = new CustomEvent('keyup', {
+			const event = new CustomEvent('keydown', {
 				detail: 0,
 				bubbles: true,
 				cancelable: true,
@@ -927,7 +927,7 @@ describe('d2l-filter', () => {
 				await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
 				expect(elem._activeDimensionKey).to.not.be.null;
 
-				const event = new CustomEvent('keyup', {
+				const event = new CustomEvent('keydown', {
 					detail: 0,
 					bubbles: true,
 					cancelable: true,
@@ -960,7 +960,7 @@ describe('d2l-filter', () => {
 				await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
 				expect(elem._activeDimensionKey).to.not.be.null;
 
-				const event = new CustomEvent('keyup', {
+				const event = new CustomEvent('keydown', {
 					detail: 0,
 					bubbles: true,
 					cancelable: true,

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -154,7 +154,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
-		this.addEventListener('keyup', this.__onKeyUp);
+		this.addEventListener('keydown', this.__onKeyDown);
 		this.addEventListener('d2l-hierarchical-view-hide-start', this.__onHideStart);
 		this.addEventListener('d2l-hierarchical-view-show-start', this.__onShowStart);
 		this.addEventListener('d2l-hierarchical-view-resize', this.__onViewResize);
@@ -477,7 +477,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 	}
 
-	__onKeyUp(e) {
+	__onKeyDown(e) {
 		if (this.childView && e.keyCode === escapeKeyCode) {
 			e.stopPropagation();
 			this.hide();

--- a/components/hierarchical-view/test/hierarchical-view.test.js
+++ b/components/hierarchical-view/test/hierarchical-view.test.js
@@ -114,7 +114,7 @@ describe('d2l-hierarchical-view', () => {
 		await oneEvent(view1, 'd2l-hierarchical-view-show-complete');
 		const view2_content = document.getElementById('view2_content');
 		const eventObj = document.createEvent('Events');
-		eventObj.initEvent('keyup', true, true);
+		eventObj.initEvent('keydown', true, true);
 		eventObj.keyCode = 27;
 		setTimeout(() => view2_content.dispatchEvent(eventObj));
 		await oneEvent(view1, 'd2l-hierarchical-view-hide-complete');

--- a/components/inputs/test/input-date.visual-diff.js
+++ b/components/inputs/test/input-date.visual-diff.js
@@ -498,7 +498,7 @@ describe('d2l-input-date', () => {
 				await openKey(page, '#value');
 				await page.$eval('#value', (elem) => {
 					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keyup', true, true);
+					eventObj.initEvent('keydown', true, true);
 					eventObj.keyCode = 27;
 					elem.dispatchEvent(eventObj);
 				});

--- a/components/menu/test/menu.test.js
+++ b/components/menu/test/menu.test.js
@@ -207,7 +207,7 @@ describe('d2l-menu', () => {
 			setTimeout(() => elem.querySelector('#b1').click());
 			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
 			const eventObj = document.createEvent('Events');
-			eventObj.initEvent('keyup', true, true);
+			eventObj.initEvent('keydown', true, true);
 			eventObj.keyCode = 27;
 			setTimeout(() => elem.querySelector('#b2').dispatchEvent(eventObj));
 			await oneEvent(elem, 'd2l-hierarchical-view-hide-complete');

--- a/components/menu/test/menu.visual-diff.js
+++ b/components/menu/test/menu.visual-diff.js
@@ -148,7 +148,7 @@ describe('d2l-menu', () => {
 				return new Promise((resolve) => {
 					item.addEventListener('d2l-hierarchical-view-hide-complete', resolve, { once: true });
 					const eventObj = document.createEvent('Events');
-					eventObj.initEvent('keyup', true, true);
+					eventObj.initEvent('keydown', true, true);
 					eventObj.keyCode = 27;
 					item.querySelector('#b2').dispatchEvent(eventObj);
 				});

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -169,7 +169,7 @@ describe('d2l-tooltip', () => {
 				await aTimeout();
 
 				const eventObj = document.createEvent('Events');
-				eventObj.initEvent('keyup', true, true);
+				eventObj.initEvent('keydown', true, true);
 				eventObj.keyCode = 27;
 
 				setTimeout(() => document.dispatchEvent(eventObj));
@@ -244,7 +244,7 @@ describe('d2l-tooltip', () => {
 		it('should not hide when ESC key is pressed ', async() => {
 
 			const eventObj = document.createEvent('Events');
-			eventObj.initEvent('keyup', true, true);
+			eventObj.initEvent('keydown', true, true);
 			eventObj.keyCode = 27;
 			document.dispatchEvent(eventObj);
 			await aTimeout(100);

--- a/helpers/dismissible.js
+++ b/helpers/dismissible.js
@@ -4,7 +4,7 @@ const stack = [];
 
 function cleanup() {
 	if (eventListener && stack.length === 0) {
-		document.removeEventListener('keyup', eventListener);
+		document.removeEventListener('keydown', eventListener);
 		eventListener = null;
 	}
 }
@@ -23,7 +23,7 @@ function init() {
 		}
 		cleanup();
 	};
-	document.addEventListener('keyup', eventListener);
+	document.addEventListener('keydown', eventListener);
 }
 
 export function clearDismissible(id) {

--- a/helpers/test/dismissible.test.js
+++ b/helpers/test/dismissible.test.js
@@ -3,7 +3,7 @@ import { clearDismissible, setDismissible } from '../dismissible.js';
 import { spy } from 'sinon';
 
 function pressEscape() {
-	const event = new CustomEvent('keyup', {
+	const event = new CustomEvent('keydown', {
 		detail: 0,
 		bubbles: true,
 		cancelable: true,


### PR DESCRIPTION
Native/OS elements like `<select>` and `<dialog>` dismiss when Escape is pressed on `keydown`. But because our dismiss code is listening for `keyup`, in these scenarios we execute a second dismiss action.

For example, a dialog or dropdown which has a `<select>` in it -- if the user opens the `<select>` and then presses Escape, the OS/browser will dismiss it and prevent default on that `keydown` event. But a `keyup` event still fires, which hits our dismissible code and closes the dialog or dropdown. Not what we want.

By listening to the `keydown` event instead, the `preventDefault` works and our code doesn't run in this scenario.

🎩 -tip to @jguann for raising this and @jorge-ramirez-arredondo for your help with the solution!