### PR TITLE
added h-align property to dropdown-button-subtle

### DIFF
--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -126,6 +126,7 @@ If the dropdown is initially empty when it's opened, the dropdown pointer will n
 | `disabled` | Boolean, default: `false` | Disables the dropdown opener |
 | `no-auto-open` | Boolean, default: `false` | Prevents the dropdown from automatically on click or on key press |
 | `open-on-hover` | Boolean, default: `false` | Optionally open dropdown on click or hover action |
+| `h-align` | String | Possible values are undefined (default) or text. If text, aligns the button content to the leading edge of text |
 <!-- docs: end hidden content -->
 
 ### Accessibility Properties

--- a/components/dropdown/dropdown-button-subtle.js
+++ b/components/dropdown/dropdown-button-subtle.js
@@ -17,6 +17,13 @@ class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 			 * @type {string}
 			 */
 			description: { type: String },
+
+			/**
+			 * Aligns the leading edge of text if value is set to "text"
+			 * @type {'text'|''}
+			 */
+			 hAlign: { type: String, reflect: true, attribute: 'h-align' },
+
 			/**
 			 * REQUIRED: Text for the button
 			 * @type {string}
@@ -31,7 +38,7 @@ class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 
 	render() {
 		return html`
-			<d2l-button-subtle description="${ifDefined(this.description)}" text=${this.text} icon="tier1:chevron-down" icon-right ?disabled=${this.disabled}></d2l-button-subtle>
+			<d2l-button-subtle description="${ifDefined(this.description)}" h-align="${ifDefined(this.hAlign)}" text=${this.text} icon="tier1:chevron-down" icon-right ?disabled=${this.disabled}></d2l-button-subtle>
 			<slot></slot>
 		`;
 	}

--- a/components/dropdown/dropdown-button-subtle.js
+++ b/components/dropdown/dropdown-button-subtle.js
@@ -19,10 +19,10 @@ class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 			description: { type: String },
 
 			/**
-			 * Aligns the leading edge of text if value is set to "text"
-			 * @type {'text'|''}
-			 */
-			 hAlign: { type: String, reflect: true, attribute: 'h-align' },
+			* Aligns the leading edge of text if value is set to "text"
+			* @type {'text'|''}
+			*/
+			hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
 			/**
 			 * REQUIRED: Text for the button


### PR DESCRIPTION
h-align property was present for `d2l-button-subtle` but not `d2l-dropdown-button-subtl`e component. 

This PR adds the h-align property to the `d2l-dropdown-button-subtle` component