### PR TITLE
fix: Windows-friendly way to get __dirname

### DIFF
--- a/cli/clean.js
+++ b/cli/clean.js
@@ -1,8 +1,9 @@
 import chalk from 'chalk';
 import { cleanDir } from './cleanDir.js';
+import { fileURLToPath } from 'url';
 import path from 'path';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const outputRoot = path.join(__dirname, '../generated');
 
 try {

--- a/cli/icon-generator.js
+++ b/cli/icon-generator.js
@@ -1,9 +1,10 @@
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import chalk from 'chalk';
 import { cleanDir } from './cleanDir.js';
+import { fileURLToPath } from 'url';
 import path from 'path';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const imagePath = path.join(__dirname, '../components/icons/images');
 const outputRoot = path.join(__dirname, '../generated');
 const outputPath = path.join(outputRoot, 'icons');


### PR DESCRIPTION
@emsandrews noticed that on Windows, our icon generation step in `npm run build` was failing. This started happening when I converted core to ESM, which no longer exposes `__dirname` as a global.

While what we had here is [often recommended](https://techsparx.com/nodejs/esnext/dirname-es-modules.html) as an equivalent way to get `__dirname` in ESM-land, [this StackOverflow](https://stackoverflow.com/a/50052194) recommends using `fileURLToPath`, which indeed works. There are even comments talking about the Windows issues with the original solution.