### PR TITLE
RTL fix for count-badge-icon

### DIFF
--- a/components/count-badge/count-badge-icon.js
+++ b/components/count-badge/count-badge-icon.js
@@ -89,14 +89,14 @@ class CountBadgeIcon extends CountBadgeMixin(LitElement) {
 			const xPadding = 'var(--d2l-count-badge-icon-padding)';
 			numberStyles = {
 				... numberStyles,
-				transform: this._dir === 'rtl'
+				transform: this.dir === 'rtl'
 					? `translateY(-50%) translateX(calc(0px - ${xPadding}))`
 					: `translateY(-50%) translateX(${xPadding})`
 			};
 		} else {
 			numberStyles = {
 				... numberStyles,
-				[this._dir === 'rtl' ? 'left' : 'right'] : '-0.1rem',
+				[this.dir === 'rtl' ? 'left' : 'right'] : '-0.1rem',
 				transform: 'translateY(-50%)'
 			};
 		}

--- a/components/count-badge/count-badge-icon.js
+++ b/components/count-badge/count-badge-icon.js
@@ -89,14 +89,14 @@ class CountBadgeIcon extends CountBadgeMixin(LitElement) {
 			const xPadding = 'var(--d2l-count-badge-icon-padding)';
 			numberStyles = {
 				... numberStyles,
-				transform: this.dir === 'rtl'
+				transform: this._dir === 'rtl'
 					? `translateY(-50%) translateX(calc(0px - ${xPadding}))`
 					: `translateY(-50%) translateX(${xPadding})`
 			};
 		} else {
 			numberStyles = {
 				... numberStyles,
-				[this.dir === 'rtl' ? 'left' : 'right'] : '-0.1rem',
+				[this._dir === 'rtl' ? 'left' : 'right'] : '-0.1rem',
 				transform: 'translateY(-50%)'
 			};
 		}

--- a/components/scroll-wrapper/scroll-wrapper.js
+++ b/components/scroll-wrapper/scroll-wrapper.js
@@ -184,7 +184,7 @@ class ScrollWrapper extends FocusVisiblePolyfillMixin(RtlMixin(LitElement)) {
 
 	scrollDistance(distance, smooth) {
 		if (!this._container) return;
-		if (this._dir === 'rtl') distance = distance * RTL_MULTIPLIER;
+		if (this.dir === 'rtl') distance = distance * RTL_MULTIPLIER;
 		if (this._container.scrollBy) {
 			this._container.scrollBy({ left: distance, behavior: smooth ? 'smooth' : 'auto' });
 		} else {

--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -138,13 +138,13 @@ export const SelectionMixin = superclass => class extends RtlMixin(superclass) {
 		if (currentIndex === -1) currentIndex = 0;
 		let newIndex;
 
-		if ((this._dir !== 'rtl' && e.keyCode === keyCodes.RIGHT)
-			|| (this._dir === 'rtl' && e.keyCode === keyCodes.LEFT)
+		if ((this.dir !== 'rtl' && e.keyCode === keyCodes.RIGHT)
+			|| (this.dir === 'rtl' && e.keyCode === keyCodes.LEFT)
 			|| e.keyCode === keyCodes.DOWN) {
 			if (currentIndex === selectables.length - 1) newIndex = 0;
 			else newIndex = currentIndex + 1;
-		} else if ((this._dir !== 'rtl' && e.keyCode === keyCodes.LEFT)
-			|| (this._dir === 'rtl' && e.keyCode === keyCodes.RIGHT)
+		} else if ((this.dir !== 'rtl' && e.keyCode === keyCodes.LEFT)
+			|| (this.dir === 'rtl' && e.keyCode === keyCodes.RIGHT)
 			|| e.keyCode === keyCodes.UP) {
 			if (currentIndex === 0) newIndex = selectables.length - 1;
 			else newIndex = currentIndex - 1;

--- a/mixins/rtl-mixin.js
+++ b/mixins/rtl-mixin.js
@@ -2,12 +2,18 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 export const RtlMixin = dedupeMixin(superclass => class extends superclass {
 
+	static get properties() {
+		return {
+			dir: { type: String, reflect: true }
+		};
+	}
+
 	constructor() {
 		super();
 		const dir = document.documentElement.getAttribute('dir');
 		// avoid reflecting "ltr" for better performance
 		if (dir && dir !== 'ltr') {
-			this.setAttribute('dir', 'rtl');
+			this.dir = dir;
 		}
 	}
 

--- a/mixins/rtl-mixin.js
+++ b/mixins/rtl-mixin.js
@@ -2,12 +2,6 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 export const RtlMixin = dedupeMixin(superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			_dir: { type: String, reflect: true, attribute: 'dir' }
-		};
-	}
-
 	constructor() {
 		super();
 		const dir = document.documentElement.getAttribute('dir');

--- a/mixins/rtl-mixin.js
+++ b/mixins/rtl-mixin.js
@@ -13,7 +13,7 @@ export const RtlMixin = dedupeMixin(superclass => class extends superclass {
 		const dir = document.documentElement.getAttribute('dir');
 		// avoid reflecting "ltr" for better performance
 		if (dir && dir !== 'ltr') {
-			this._dir = dir;
+			this.setAttribute('dir', 'rtl');
 		}
 	}
 


### PR DESCRIPTION
Currently, the count bubble is appearing on the incorrect side for RTL languages, until the badge is re-rendered (only on focus, which does not always happen). This leads to the bubbles swapping sides as you tab through the badges.

I was able to narrow down the issue to the RTL mixin not adding the dir="rtl" attribute until the count badge has already rendered. To fix this we can call the mixin's private property, _dir, which does get updated in its constructor. A bunch of places are already doing so (I assume because of similar timing issues?), see https://search.d2l.dev/search?full=%22this._dir%22&defs=&refs=&path=&hist=&type=&xrd=&nn=7&si=full&searchall=true&si=full. I don't think this is a great solution as we shouldn't be touching the mixin's private properties 😞 

An alternative solution I thought of was to update the RTLMixin constructor to forcibly set the dir attribute in its constructor, rather than relying on the requestUpdate call that isn't updating the attributes list in time. That way this.getAttribute('dir') will return the correct direction every time. I _think_ it should be fine, but it will require some more testing. 