### PR TITLE
Alternate RTL fix: add mutationObserver to count-badge-icon to re-render on dir attribute

### DIFF
--- a/components/count-badge/count-badge-icon.js
+++ b/components/count-badge/count-badge-icon.js
@@ -77,17 +77,9 @@ class CountBadgeIcon extends CountBadgeMixin(LitElement) {
 
 	connectedCallback() {
 		super.connectedCallback();
-		const self = this;
-		this._mutationObserver = new MutationObserver(mutations => {
-			mutations.forEach(mutation => {
-				if (mutation.type === 'attributes'
-					&& mutation.attributeName === 'dir') {
-					// re-render when dir attribute is added to reposition for RTL
-					self.requestUpdate();
-				}
-			});
-		});
-		this._mutationObserver.observe(this, { attributes: true });
+		// re-render when dir attribute is added to reposition for RTL
+		this._mutationObserver = new MutationObserver(() => this.requestUpdate());
+		this._mutationObserver.observe(this, { attributeFilter: ['dir'] });
 	}
 
 	disconnectedCallback() {

--- a/components/count-badge/count-badge-icon.js
+++ b/components/count-badge/count-badge-icon.js
@@ -75,6 +75,26 @@ class CountBadgeIcon extends CountBadgeMixin(LitElement) {
 		this._badgeId = getUniqueId();
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		const self = this;
+		this._mutationObserver = new MutationObserver(mutations => {
+			mutations.forEach(mutation => {
+				if (mutation.type === 'attributes'
+					&& mutation.attributeName === 'dir') {
+					// re-render when dir attribute is added to reposition for RTL
+					self.requestUpdate();
+				}
+			});
+		});
+		this._mutationObserver.observe(this, { attributes: true });
+	}
+
+	disconnectedCallback() {
+		this._mutationObserver.disconnect();
+		super.disconnectedCallback();
+	}
+
 	render() {
 		let numberStyles = {
 			border: '2px solid white',


### PR DESCRIPTION
This is an alternate fix for the RTL issues in the count badge. I think this is a pretty clean solution that we can suggest to others that will face this issue in the future. It avoids the issues we had with the attribute setting in the RTL mixin, and the performance impact is minimal since we only re-render for the dir attribute change. 