### PR TITLE
fix: Ignore dir in documentation

### DIFF
--- a/mixins/rtl-mixin.js
+++ b/mixins/rtl-mixin.js
@@ -4,6 +4,10 @@ export const RtlMixin = dedupeMixin(superclass => class extends superclass {
 
 	static get properties() {
 		return {
+			/**
+			 * The directionality of the text of the document
+			 * @type {'ltr'|'rtl'}
+			 */
 			dir: { type: String, reflect: true }
 		};
 	}

--- a/mixins/rtl-mixin.js
+++ b/mixins/rtl-mixin.js
@@ -5,8 +5,7 @@ export const RtlMixin = dedupeMixin(superclass => class extends superclass {
 	static get properties() {
 		return {
 			/**
-			 * The directionality of the text of the document
-			 * @type {'ltr'|'rtl'}
+			 * @ignore
 			 */
 			dir: { type: String, reflect: true }
 		};


### PR DESCRIPTION
Previously in the Daylight site `_dir` wasn't exposed because we filter out properties that start with underscores. The recent change to make `dir` public added this property to the properties tables for components that use `RtlMixin`.

This change just adds a description and values to `dir`, which does end up providing an easy to way to test RTL functionality in components that have it.