### PR TITLE
DE46715 added ariaDescribeContent property for a11y

### DIFF
--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -83,6 +83,12 @@ The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary 
 - `d2l-dialog-close`: dispatched with the action value when the dialog is closed for any reason
 <!-- docs: end hidden content -->
 
+### Accessibility Properties
+
+| Attribute | Description |
+|--|--|
+| `describe-content` | When set to 'true' reads the dialog content on open. |
+
 ### Methods
 
 - `resize`: resizes the dialog based on specified `width` and measured content height

--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -87,7 +87,7 @@ The `d2l-dialog` element is a generic dialog that provides a slot for arbitrary 
 
 | Attribute | Description |
 |--|--|
-| `describe-content` | When set to 'true' reads the dialog content on open. |
+| `describe-content` | When set, screen readers will announce the contents when opened. |
 
 ### Methods
 

--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -28,7 +28,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-button id="open">Show Dialog</d2l-button>
-					<d2l-dialog id="dialog" title-text="Dialog Title">
+					<d2l-dialog id="dialog" title-text="Dialog Title" describe-content>
 						<div>
 							<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
 							<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>

--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -28,7 +28,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-button id="open">Show Dialog</d2l-button>
-					<d2l-dialog id="dialog" title-text="Dialog Title" describe-content>
+					<d2l-dialog id="dialog" title-text="Dialog Title">
 						<div>
 							<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
 							<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -24,13 +24,14 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 	static get properties() {
 		return {
 			/**
-			 * Whether to read the contents of the dialog on open
-			 */
-			describeContent: { type: Boolean, attribute: 'describe-content' },
-			/**
 			 * Whether to render a loading-spinner and wait for state changes via AsyncContainerMixin
 			 */
 			async: { type: Boolean },
+
+			/**
+			 * Whether to read the contents of the dialog on open
+			 */
+			describeContent: { type: Boolean, attribute: 'describe-content' },
 
 			/**
 			 * The preferred width (unit-less) for the dialog
@@ -105,10 +106,10 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 	constructor() {
 		super();
 		this.async = false;
+		this.describeContent = false;
 		this.width = 600;
 		this._handleResize = this._handleResize.bind(this);
 		this._handleResize();
-		this.describeContent = false;
 	}
 
 	get asyncContainerCustom() {

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -23,6 +23,10 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 	static get properties() {
 		return {
 			/**
+			 * Whether to read the contents of the dialog on open
+			 */
+			ariaDescribeContent: { type: Boolean, attribute: 'aria-describe-content' },
+			/**
 			 * Whether to render a loading-spinner and wait for state changes via AsyncContainerMixin
 			 */
 			async: { type: Boolean },
@@ -32,6 +36,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			 */
 			width: { type: Number },
 			_hasFooterContent: { type: Boolean, attribute: false }
+
 		};
 	}
 
@@ -151,9 +156,11 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			'd2l-footer-no-content': !this._hasFooterContent
 		};
 
+		if (!this._textId) this._textId = getUniqueId();
+
 		const content = html`
 			${loading}
-			<div style=${styleMap(slotStyles)}><slot></slot></div>
+			<div id="${this._textId}" aria-describe-content="${this.ariaDescribeContent}" style=${styleMap(slotStyles)}><slot></slot></div>
 		`;
 
 		if (!this._titleId) this._titleId = getUniqueId();
@@ -171,9 +178,11 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 				</div>
 			</div>
 		`;
+
+		const descId = (this.ariaDescribeContent) ? this._textId : undefined;
 		return this._render(
 			inner,
-			{ labelId: this._titleId, role: 'dialog' },
+			{ labelId: this._titleId, descId: descId, role: 'dialog' },
 			topOverride
 		);
 	}

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -160,7 +160,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 
 		const content = html`
 			${loading}
-			<div id="${this._textId}" aria-describe-content="${this.ariaDescribeContent}" style=${styleMap(slotStyles)}><slot></slot></div>
+			<div id="${this._textId}" style=${styleMap(slotStyles)}><slot></slot></div>
 		`;
 
 		if (!this._titleId) this._titleId = getUniqueId();

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -8,6 +8,7 @@ import { DialogMixin } from './dialog-mixin.js';
 import { dialogStyles } from './dialog-styles.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { heading3Styles } from '../typography/styles.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
@@ -25,7 +26,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			/**
 			 * Whether to read the contents of the dialog on open
 			 */
-			ariaDescribeContent: { type: Boolean, attribute: 'aria-describe-content' },
+			describeContent: { type: Boolean, attribute: 'describe-content' },
 			/**
 			 * Whether to render a loading-spinner and wait for state changes via AsyncContainerMixin
 			 */
@@ -36,7 +37,6 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			 */
 			width: { type: Number },
 			_hasFooterContent: { type: Boolean, attribute: false }
-
 		};
 	}
 
@@ -108,6 +108,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		this.width = 600;
 		this._handleResize = this._handleResize.bind(this);
 		this._handleResize();
+		this.describeContent = false;
 	}
 
 	get asyncContainerCustom() {
@@ -156,11 +157,10 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			'd2l-footer-no-content': !this._hasFooterContent
 		};
 
-		if (!this._textId) this._textId = getUniqueId();
-
+		if (!this._textId && this.describeContent) this._textId = getUniqueId();
 		const content = html`
 			${loading}
-			<div id="${this._textId}" style=${styleMap(slotStyles)}><slot></slot></div>
+			<div id="${ifDefined(this._textId)}" style=${styleMap(slotStyles)}><slot></slot></div>
 		`;
 
 		if (!this._titleId) this._titleId = getUniqueId();
@@ -179,7 +179,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 			</div>
 		`;
 
-		const descId = (this.ariaDescribeContent) ? this._textId : undefined;
+		const descId = (this.describeContent) ? this._textId : undefined;
 		return this._render(
 			inner,
 			{ labelId: this._titleId, descId: descId, role: 'dialog' },


### PR DESCRIPTION
Original Rally Story: 
[DE46715](https://rally1.rallydev.com/#/?detail=/defect/622118312995&fdp=true): [A11y] Update all FACE help dialogs focus to be on the close (x) button instead of the okay button
 
In FACE quiz accessibility reviews it was pointed out that when the user opens the help dialog with the screen reader, the focus goes directly to the footer making it difficult for non-sighted users to access the dialog content. 

The original suggestion was to have the focus land on the close button at the top so users could navigate to the content text more easily, but based on my conversation with Dave B this would require larger changes to the dialog component. 

This is an alternative solution where there is an optional property added to the dialog that allows the content to be read out automatically on opening the dialog by using the aria-describedby property in the dialog-mixin. 

If aria-describe-content="true" the dialog content will be read when the dialog is opened. 

