### PR TITLE
Non-breaking changes for Lit 2

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -332,7 +332,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 		requestAnimationFrame(async() => {
 
-			this.shadowRoot.querySelector('.d2l-dialog-content').scrollTop = 0;
+			if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-dialog-content').scrollTop = 0;
 			// scrollbar is kept hidden while we update the scroll position to avoid scrollbar flash
 			setTimeout(() => {
 				this._scroll = true;

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -555,7 +555,9 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		const selectionInfo = rootList.getSelectionInfo(rootList.dragMultiple);
 
 		if (rootList.dragMultiple && selectionInfo.keys.length > 1) {
-			let dragImage = this.shadowRoot && this.shadowRoot.querySelector('d2l-list-item-drag-image');
+			let dragImage = this.shadowRoot
+				? this.shadowRoot.querySelector('d2l-list-item-drag-image')
+				: undefined;
 			if (!dragImage) {
 				dragImage = document.createElement('d2l-list-item-drag-image');
 				this.shadowRoot.appendChild(dragImage);

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -555,7 +555,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		const selectionInfo = rootList.getSelectionInfo(rootList.dragMultiple);
 
 		if (rootList.dragMultiple && selectionInfo.keys.length > 1) {
-			let dragImage = this.shadowRoot.querySelector('d2l-list-item-drag-image');
+			let dragImage = this.shadowRoot && this.shadowRoot.querySelector('d2l-list-item-drag-image');
 			if (!dragImage) {
 				dragImage = document.createElement('d2l-list-item-drag-image');
 				this.shadowRoot.appendChild(dragImage);


### PR DESCRIPTION
This PR makes backwards-compatible changes to prepare this repo for a Lit 2 upgrade. Since the changes are backwards compatible, it can be merged right away.

Non-breaking change checklist:
- [x] Add missing `.js` extensions for lit-html or lit-element imports
- [x] `await requestUpdate` -> `await elem.updateComplete`
- [x] add non-null checks to shadowRoot accesses (not including test files)
- [x] ensure `undefined` is not passed into unsafeHTML calls
- [x] remove dynamic code from inside  `<template>` tags (Lit files only)
- [x] remove any dependencies on old Lit versions
- [x] audit `ifDefined` usages for null parameters

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.