### PR TITLE
fix: Daylight: List items: documentation changes

### DIFF
--- a/components/list/list-header.js
+++ b/components/list/list-header.js
@@ -14,6 +14,7 @@ class ListHeader extends RtlMixin(LocalizeCoreElement(LitElement)) {
 	static get properties() {
 		return {
 			/**
+			 * @ignore
 			 * Whether to render a header with reduced whitespace
 			 * TODO: Remove
 			 * @type {boolean}
@@ -21,8 +22,7 @@ class ListHeader extends RtlMixin(LocalizeCoreElement(LitElement)) {
 			slim: { reflect: true, type: Boolean },
 			/**
 			 * How much padding to render list items with
-			 * One of 'normal'|'slim', defaults to 'normal'
-			 * @type {string}
+			 * @type {'normal'|'slim'}
 			 */
 			paddingType: { type: String, attribute: 'padding-type' },
 		};

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -60,11 +60,11 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 			dragTargetHandleOnly: { type: Boolean, attribute: 'drag-target-handle-only' },
 			/**
 			 * How much padding to render list items with
-			 * One of 'normal'|'slim'|'none', defaults to 'normal'
-			 * @type {string}
+			 * @type {'normal'|'slim'|'none'}
 			 */
 			paddingType: { type: String, attribute: 'padding-type' },
 			/**
+			 * @ignore
 			 * Whether to render the list-item with reduced whitespace.
 			 * TODO: Remove in favor of padding-type="slim"
 			 * @type {boolean}


### PR DESCRIPTION
Changes in order for the latest list item changes to be properly reflected in the Daylight site:
- Added `@ignore` to `slim` since it sounds like we wouldn't want that appearing in Daylight if we are planning to remove it
- Changed `@type` for `padding-type` to contain the possible options