### PR TITLE
fix: format using Intl API to avoid scientific notation

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -264,14 +264,13 @@ class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeC
 			countDecimalDigits(this._valueTrailingZeroes, false),
 			this.maxFractionDigits
 		);
-		let valueTrailingZeroes = this.value.toString();
-		const decimalDiff = (numDecimals - countDecimalDigits(valueTrailingZeroes, false));
-		if (decimalDiff > 0) {
-			if (decimalDiff === numDecimals) {
-				valueTrailingZeroes += '.';
+		const valueTrailingZeroes = new Intl.NumberFormat(
+			'en-US',
+			{
+				minimumFractionDigits: numDecimals,
+				useGrouping: false
 			}
-			valueTrailingZeroes = valueTrailingZeroes.padEnd(valueTrailingZeroes.length + decimalDiff, '0');
-		}
+		).format(this.value);
 		return valueTrailingZeroes;
 	}
 	set valueTrailingZeroes(val) {

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -622,6 +622,13 @@ describe('d2l-input-number', () => {
 			expect(elem._formattedValue).to.equal('2001,00');
 		});
 
+		it('should handle 7 decimals (which in JS use scientific notation)', async() => {
+			const elem = await fixture(html`<d2l-input-number label="label" trailing-zeroes value-trailing-zeroes="0.0000005" max-fraction-digits="7"></d2l-input-number>`);
+			expect(elem.value).to.equal(0.0000005);
+			expect(elem.valueTrailingZeroes).to.equal('0.0000005');
+			expect(elem._formattedValue).to.equal('0.0000005');
+		});
+
 		[
 			'12', '12.1', '12.10', '12.0', '12.00000',
 			'1', '1.1', '1.10', '1.0', '1.00000',


### PR DESCRIPTION
This is related to DS12459, which is being investigated by @tylergee and Team Borg. I'm going to backport it to `20.22.2` and `20.22.1`.

Little known fact (by me at least):
> If number is longer than 21 digits, JavaScript uses exponential (aka scientific) notation. JavaScript also uses exponential notation if number starts with “0.” followed by more than five zeros.

It's that second case of a number starting with zero and then having more than five zeroes that comes up in the defect. It results in `0.0000005` being saved as `5e-7.0000000` which then causes our .NET parsing code to explode.

The solution is to leverage the `Intl.NumberFormat` API to do all the heavy lifting for us.