### PR TITLE
Push MathJax font styles to document head to allow them to download

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -1,4 +1,29 @@
 const mathjaxContextAttribute = 'data-mathjax-context';
+const mathjaxBaseUrl = 'https://s.brightspace.com/lib/mathjax/3.1.2';
+
+const mathjaxFontMappings = new Map([
+	['MJXTEX', 'MathJax_Main-Regular'],
+	['MJXTEX-B', 'MathJax_Main-Bold'],
+	['MJXTEX-I', 'MathJax_Math-Italic'],
+	['MJXTEX-MI', 'MathJax_Main-Italic'],
+	['MJXTEX-BI', 'MathJax_Math-BoldItalic'],
+	['MJXTEX-S1', 'MathJax_Size1-Regular'],
+	['MJXTEX-S2', 'MathJax_Size2-Regular'],
+	['MJXTEX-S3', 'MathJax_Size3-Regular'],
+	['MJXTEX-S4', 'MathJax_Size4-Regular'],
+	['MJXTEX-A', 'MathJax_AMS-Regular'],
+	['MJXTEX-C', 'MathJax_Calligraphic-Regular'],
+	['MJXTEX-CB', 'MathJax_Calligraphic-Bold'],
+	['MJXTEX-FR', 'MathJax_Fraktur-Regular'],
+	['MJXTEX-FRB', 'MathJax_Fraktur-Bold'],
+	['MJXTEX-SS', 'MathJax_SansSerif-Regular'],
+	['MJXTEX-SSB', 'MathJax_SansSerif-Bold'],
+	['MJXTEX-SSI',  'MathJax_SansSerif-Italic'],
+	['MJXTEX-SC', 'MathJax_Script-Regular'],
+	['MJXTEX-T', 'MathJax_Typewriter-Regular'],
+	['MJXTEX-V', 'MathJax_Vector-Regular'],
+	['MJXTEX-VB', 'MathJax_Vector-Bold']
+]);
 
 let mathJaxLoaded;
 
@@ -158,6 +183,23 @@ export function loadMathJax(mathJaxConfig) {
 		}
 	};
 
+	if (mathJaxConfig && mathJaxConfig.deferTypeset && !document.head.querySelector('#d2l-mathjax-fonts') && !document.head.querySelector('#MJX-CHTML-styles')) {
+		const styleElem = document.createElement('style');
+		styleElem.id = 'd2l-mathjax-fonts';
+
+		let fontImportStyles = '';
+		mathjaxFontMappings.forEach((font, family) => {
+			fontImportStyles +=
+				`\n@font-face {
+					font-family: ${family};
+					src: url("${mathjaxBaseUrl}/output/chtml/fonts/woff-v2/${font}.woff") format("woff");
+				}`;
+		});
+
+		styleElem.textContent = fontImportStyles;
+		document.head.appendChild(styleElem);
+	}
+
 	mathJaxLoaded = new Promise(resolve => {
 		const script = document.createElement('script');
 		script.async = 'async';
@@ -167,7 +209,7 @@ export function loadMathJax(mathJaxConfig) {
 			? 'tex-mml-chtml'
 			: 'mml-chtml';
 
-		script.src = `https://s.brightspace.com/lib/mathjax/3.1.2/${component}.js`;
+		script.src = `${mathjaxBaseUrl}/${component}.js`;
 		document.head.appendChild(script);
 	});
 


### PR DESCRIPTION
So... It turns out that MathJax fonts aren't loading properly within the html-block control when rendering is deferred; specifically because MathJax sprouts its font at-rules in a style element in whatever document context you give it. It turns out that within a component's shadowDOM, these fonts are just never downloaded.

My proposed solution is to mimic what MathJax does with its styles when rendering isn't deferred: sprout the font at-rules in the document head. This allows them to download as one would expect.

As usual, I'm entirely open to other ideas here. :)