### PR TITLE
Added icon-right property to selection-action

### DIFF
--- a/components/selection/selection-action.js
+++ b/components/selection/selection-action.js
@@ -27,7 +27,7 @@ class Action extends LocalizeCoreElement(SelectionActionMixin(ButtonMixin(RtlMix
 			 * Indicates that the icon should be rendered on right
 			 * @type {boolean}
 			 */
-			 iconRight: { type: Boolean, reflect: true, attribute: 'icon-right' },
+			iconRight: { type: Boolean, reflect: true, attribute: 'icon-right' },
 			/**
 			 * REQUIRED: The text for the action
 			 * @type {string}

--- a/components/selection/selection-action.js
+++ b/components/selection/selection-action.js
@@ -24,6 +24,11 @@ class Action extends LocalizeCoreElement(SelectionActionMixin(ButtonMixin(RtlMix
 			 */
 			icon: { type: String, reflect: true },
 			/**
+			 * Indicates that the icon should be rendered on right
+			 * @type {boolean}
+			 */
+			 iconRight: { type: Boolean, reflect: true, attribute: 'icon-right' },
+			/**
 			 * REQUIRED: The text for the action
 			 * @type {string}
 			 */
@@ -59,7 +64,8 @@ class Action extends LocalizeCoreElement(SelectionActionMixin(ButtonMixin(RtlMix
 				?disabled="${this.disabled}"
 				disabled-tooltip="${ifDefined(this.disabled ? this.localize('components.selection.action-hint') : undefined)}"
 				icon="${ifDefined(this.icon)}"
-				text="${this.text}">
+				text="${this.text}"
+				?icon-right="${this.iconRight}">
 			</d2l-button-subtle>
 		`;
 	}


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F622114101391

Need right icon option for a "Move To" button in FACE quizzing but could be useful in other cases too.