### PR TITLE
fix: switch to use dynamic mixin

### DIFF
--- a/lang/localize-core-element.js
+++ b/lang/localize-core-element.js
@@ -1,74 +1,11 @@
-import { LocalizeMixin } from '../mixins/localize-mixin.js';
+import { LocalizeDynamicMixin } from '../mixins/localize-dynamic-mixin.js';
 
-export const LocalizeCoreElement = superclass => class extends LocalizeMixin(superclass) {
+export const LocalizeCoreElement = superclass => class extends LocalizeDynamicMixin(superclass) {
 
-	static async getLocalizeResources(langs) {
-		let translations;
-		for await (const lang of langs) {
-			switch (lang) {
-				case 'ar':
-					translations = await import('./ar.js');
-					break;
-				case 'cy':
-					translations = await import('./cy.js');
-					break;
-				case 'da':
-					translations = await import('./da.js');
-					break;
-				case 'de':
-					translations = await import('./de.js');
-					break;
-				case 'en':
-					translations = await import('./en.js');
-					break;
-				case 'es-es':
-					translations = await import('./es-es.js');
-					break;
-				case 'es':
-					translations = await import('./es.js');
-					break;
-				case 'fr-fr':
-					translations = await import('./fr-fr.js');
-					break;
-				case 'fr':
-					translations = await import('./fr.js');
-					break;
-				case 'ja':
-					translations = await import('./ja.js');
-					break;
-				case 'ko':
-					translations = await import('./ko.js');
-					break;
-				case 'nl':
-					translations = await import('./nl.js');
-					break;
-				case 'pt':
-					translations = await import('./pt.js');
-					break;
-				case 'sv':
-					translations = await import('./sv.js');
-					break;
-				case 'tr':
-					translations = await import('./tr.js');
-					break;
-				case 'zh-tw':
-					translations = await import('./zh-tw.js');
-					break;
-				case 'zh':
-					translations = await import('./zh.js');
-					break;
-			}
-			if (translations && translations.default) {
-				return {
-					language: lang,
-					resources: translations.default
-				};
-			}
-		}
-		translations = await import('./en.js');
+	static get localizeConfig() {
 		return {
-			language: 'en',
-			resources: translations.default
+			importFunc: async lang => (await import(`./${lang}.js`)).default
 		};
 	}
+
 };


### PR DESCRIPTION
The use of `for await` here was causing [esbuild to complain](https://github.com/evanw/esbuild/issues/1930) (it's used by `@web/dev-server`) in Firefox.

Since the languages passed into this function are a static list, I don't actually think `for await` was required. Either way, switching this to use the newer `LocalizeDynamicMixin` also resolves this.

There are [a bunch of places](https://search.d2l.dev/search?project=Brightspace&project=BrightspaceHypermediaComponents&project=BrightspaceUI&project=BrightspaceUILabs&project=lms&full=%22getLocalizeResources%22+%22for+await%22&defs=&refs=&path=&hist=&type=&xrd=&nn=5&si=full&si=full) that copied this though, so they may also need to be updated.