### PR TITLE
fix: Daylight: Minor documentation tweaks to table, input-search, and selection-action-dropdown

### DIFF
--- a/components/inputs/docs/input-search.md
+++ b/components/inputs/docs/input-search.md
@@ -80,7 +80,7 @@ search.addEventListener('d2l-input-search-searched', (e) => {
 When the input is cleared, the same event will be fired with an empty value.
 <!-- docs: end hidden content -->
 
-### Accessibility
+### Accessibility Properties
 
 To make your usage of `d2l-input-search` accessible, use the following property when applicable:
 

--- a/components/selection/selection-action-dropdown.js
+++ b/components/selection/selection-action-dropdown.js
@@ -9,6 +9,7 @@ import { SelectionActionMixin } from './selection-action-mixin.js';
 /**
  * A dropdown opener associated with a selection component.
  * @slot - Dropdown content (e.g., "d2l-dropdown-content", "d2l-dropdown-menu" or "d2l-dropdown-tabs")
+ * @fires d2l-selection-observer-subscribe - Internal event
  */
 class ActionDropdown extends LocalizeCoreElement(SelectionActionMixin(DropdownOpenerMixin(LitElement))) {
 

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -114,7 +114,7 @@ The `d2l-table-wrapper` element can be combined with table styles to apply defau
 <!-- docs: start hidden content -->
 ### Properties
 
-| Property | Type | Description |
+| Property | Type | Description | Default Value |
 |---|---|---|---|
 | `no-column-border` | boolean | Hides the column borders on "default" table type | false |
 | `sticky-headers` | boolean | Whether to make the header row sticky | false |

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -115,7 +115,7 @@ The `d2l-table-wrapper` element can be combined with table styles to apply defau
 ### Properties
 
 | Property | Type | Description |
-|---|---|---|
+|---|---|---|---|
 | `no-column-border` | boolean | Hides the column borders on "default" table type | false |
 | `sticky-headers` | boolean | Whether to make the header row sticky | false |
 | `type` | string | Type of the table style. Can be one of  `default`, `light`. | 'default' |
@@ -242,7 +242,7 @@ When tabular data can be sorted, the `<d2l-table-col-sort-button>` can be used t
 ### Properties
 
 | Property | Type | Description | Default Value |
-|---|---|---|
+|---|---|---|---|
 | `desc` | boolean | Whether sort direction is descending | false |
 | `nosort` | boolean | Column is not currently sorted. Hides the ascending/descending sort icon. | false |
 

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -116,9 +116,9 @@ The `d2l-table-wrapper` element can be combined with table styles to apply defau
 
 | Property | Type | Description |
 |---|---|---|
-| `no-column-border` | Boolean, default: `false` | Hides the column borders on "default" table type |
-| `sticky-headers` | Boolean, default: `false` | Whether to make the header row sticky |
-| `type` | String, default: `'default'` | Type of the table style. Can be one of  `default`, `light`. |
+| `no-column-border` | boolean | Hides the column borders on "default" table type | false |
+| `sticky-headers` | boolean | Whether to make the header row sticky | false |
+| `type` | string | Type of the table style. Can be one of  `default`, `light`. | 'default' |
 
 ## Light Type
 
@@ -241,10 +241,10 @@ When tabular data can be sorted, the `<d2l-table-col-sort-button>` can be used t
 
 ### Properties
 
-| Property | Type | Description |
+| Property | Type | Description | Default Value |
 |---|---|---|
-| `desc` | Boolean, default: `false` | Whether sort direction is descending |
-| `nosort` | Booealn, default: `false` | Column is not currently sorted. Hides the ascending/descending sort icon. |
+| `desc` | boolean | Whether sort direction is descending | false |
+| `nosort` | boolean | Column is not currently sorted. Hides the ascending/descending sort icon. | false |
 
 ## Selection
 


### PR DESCRIPTION
Changes:
- search: make h3 title consistent with other components
- selection-action-dropdown: the other selection components hide this event with the `Internal event` description so this change does the same
- table: the second properties table is shown in Daylight so this makes the format of the tables on this page consistent with the generated properties tables