### PR TITLE
Add support for newline characters in d2l-dialog-confirm text.

### DIFF
--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -184,7 +184,7 @@ The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting t
 
 | Property | Type | Description |
 |--|--|--|
-| `text` | String, required | The required text content for the confirmation dialog |
+| `text` | String, required | The text content for the confirmation dialog. Newline characters (`&#10;` in HTML or `\n` in JavaScript) will result in multiple paragraphs. |
 | `opened` | Boolean | Whether or not the dialog is open |
 | `title-text` | String | The optional title for the confirmation dialog |
 

--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -184,7 +184,7 @@ The `d2l-dialog-confirm` element is a simple confirmation dialog for prompting t
 
 | Property | Type | Description |
 |--|--|--|
-| `text` | String, required | The text content for the confirmation dialog. Newline characters (`&#10;` in HTML or `\n` in JavaScript) will result in multiple paragraphs. |
+| `text` | String, required | The text content for the confirmation dialog. Newline characters (`&#10;` in HTML or `\n` in JavaScript) will render as multiple paragraphs. |
 | `opened` | Boolean | Whether or not the dialog is open |
 | `title-text` | String | The optional title for the confirmation dialog |
 

--- a/components/dialog/demo/dialog-confirm.html
+++ b/components/dialog/demo/dialog-confirm.html
@@ -37,6 +37,26 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Confirm Dialog (Multi Paragraph)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-button id="openConfirmMultiParagraph">Show Confirm</d2l-button>
+					<d2l-dialog-confirm id="confirmMultiParagraph" title-text="Confirm Title" text="Are you sure you want more cookies?&#10;Are you sure you want more donuts?">
+						<d2l-button slot="footer" primary data-dialog-action="ok">Yes</d2l-button>
+						<d2l-button slot="footer" data-dialog-action>No</d2l-button>
+					</d2l-dialog-confirm>
+					<script>
+						document.querySelector('#openConfirmMultiParagraph').addEventListener('click', () => {
+							document.querySelector('#confirmMultiParagraph').opened = true;
+						});
+						document.querySelector('#confirmMultiParagraph').addEventListener('d2l-dialog-close', (e) => {
+							console.log('confirm action:', e.detail.action);
+						});
+					</script>
+				</template>
+			</d2l-demo-snippet>
+
 			<h2>Confirm Dialog (No Title)</h2>
 
 			<d2l-demo-snippet>

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -14,7 +14,7 @@ class DialogConfirm extends DialogMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * REQUIRED: The text content for the confirmation dialog. Newline characters (`&#10;` in HTML or `\n` in JavaScript) will result in multiple paragraphs.
+			 * REQUIRED: The text content for the confirmation dialog. Newline characters (`&#10;` in HTML or `\n` in JavaScript) will render as multiple paragraphs.
 			 * @type {string}
 			 */
 			text: { type: String }

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -14,7 +14,7 @@ class DialogConfirm extends DialogMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * REQUIRED: The text content for the confirmation dialog
+			 * REQUIRED: The text content for the confirmation dialog. Newline characters (`&#10;` in HTML or `\n` in JavaScript) will result in multiple paragraphs.
 			 * @type {string}
 			 */
 			text: { type: String }
@@ -34,6 +34,18 @@ class DialogConfirm extends DialogMixin(LitElement) {
 
 			.d2l-dialog-header + .d2l-dialog-content > div {
 				padding-top: 0;
+			}
+
+			.d2l-dialog-content p {
+				margin: 1rem 0;
+			}
+
+			.d2l-dialog-content p:first-child {
+				margin-top: 0;
+			}
+
+			.d2l-dialog-content p:last-child {
+				margin-bottom: 0;
 			}
 
 			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
@@ -65,7 +77,7 @@ class DialogConfirm extends DialogMixin(LitElement) {
 						<div><h2 id="${this._titleId}" class="d2l-heading-3">${this.titleText}</h2></div>
 					</div>` : null}
 				<div id="${this._textId}" class="d2l-dialog-content">
-					<div>${this.text}</div>
+					<div>${this.text ? this.text.split('\n').map(line => html`<p>${line}</p>`) : null}</div>
 				</div>
 				<div class="d2l-dialog-footer">
 					<slot name="footer" class="d2l-dialog-footer-slot"></slot>

--- a/components/dialog/test/dialog-confirm.visual-diff.html
+++ b/components/dialog/test/dialog-confirm.visual-diff.html
@@ -48,5 +48,10 @@
 		<d2l-button slot="footer" id="cancel">No</d2l-button>
 	</d2l-dialog-confirm>
 
+	<d2l-dialog-confirm id="confirmMultiParagraph" title-text="Title" text="Paragraph 1&#10;Paragraph 2">
+		<d2l-button slot="footer" primary>Yes</d2l-button>
+		<d2l-button slot="footer" id="cancel">No</d2l-button>
+	</d2l-dialog-confirm>
+
 </body>
 </html>

--- a/components/dialog/test/dialog-confirm.visual-diff.js
+++ b/components/dialog/test/dialog-confirm.visual-diff.js
@@ -31,6 +31,7 @@ describe('d2l-dialog-confirm', () => {
 				await reset(page, '#confirmNoTitle');
 				await reset(page, '#confirmLongText');
 				await reset(page, '#confirmRtl');
+				await reset(page, '#confirmMultiParagraph');
 			});
 
 			[
@@ -69,7 +70,8 @@ describe('d2l-dialog-confirm', () => {
 					{ name: 'long title', selector: '#confirmLongTitle' },
 					{ name: 'no title', selector: '#confirmNoTitle' },
 					{ name: 'long text', selector: '#confirmLongText' },
-					{ name: 'long buttons', selector: '#confirmLongButtons' }
+					{ name: 'long buttons', selector: '#confirmLongButtons' },
+					{ name: 'multiple paragraphs', selector: '#confirmMultiParagraph' }
 				].forEach((info) => {
 
 					it(info.name, async function() {


### PR DESCRIPTION
This PR adds support for newline characters in `d2l-dialog-confirm` `text`.  One paragraph will be rendered for each line of text provided.  Consumers will need to construct their text in HTML using `&#10;` or in JavaScript using `\n`.

In the future we may pull this out and combine it with other simple formatting if we ever support some type of SML in our components. 