### PR TITLE
fix: Dialog: Height calculation could be slightly off because of rounding

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -197,7 +197,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		let preferredHeight = 0;
 
 		const header = this.shadowRoot.querySelector('.d2l-dialog-header');
-		if (header) preferredHeight += header.getBoundingClientRect().height;
+		if (header) preferredHeight += Math.ceil(header.getBoundingClientRect().height);
 
 		const contentOuter = this.shadowRoot.querySelector('.d2l-dialog-content');
 		const content = this.shadowRoot.querySelector('.d2l-dialog-content > div');
@@ -210,7 +210,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		}
 
 		const footer = this.shadowRoot.querySelector('.d2l-dialog-footer');
-		if (footer) preferredHeight += footer.getBoundingClientRect().height;
+		if (footer) preferredHeight += Math.ceil(footer.getBoundingClientRect().height);
 
 		const height = (preferredHeight < availableHeight ? preferredHeight : availableHeight);
 		return height;

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -197,7 +197,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		let preferredHeight = 0;
 
 		const header = this.shadowRoot.querySelector('.d2l-dialog-header');
-		if (header) preferredHeight += header.scrollHeight;
+		if (header) preferredHeight += header.getBoundingClientRect().height;
 
 		const contentOuter = this.shadowRoot.querySelector('.d2l-dialog-content');
 		const content = this.shadowRoot.querySelector('.d2l-dialog-content > div');
@@ -210,7 +210,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		}
 
 		const footer = this.shadowRoot.querySelector('.d2l-dialog-footer');
-		if (footer) preferredHeight += footer.scrollHeight;
+		if (footer) preferredHeight += footer.getBoundingClientRect().height;
 
 		const height = (preferredHeight < availableHeight ? preferredHeight : availableHeight);
 		return height;


### PR DESCRIPTION
An issue was reported in #web-platform about a scrollbar appearing for the confirm dialog at large font sizes. Digging into the height calculation, the footer had a height of 110.39 but that was being rounded down, causing the height to be slightly off and the scrollbar to appear. Using `getBoundingClientRect().height` instead of `scrollHeight` allow for us to get the demo value.

~I'm going to run this through visual diff before opening it for reviews in order to check if this breaks anything.~ Tests passed