### PR TITLE
fix: Primary-secondary template: Remove -webkit-overflow-scrolling: cert fix

### DIFF
--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -542,7 +542,6 @@ class TemplatePrimarySecondary extends FocusVisiblePolyfillMixin(RtlMixin(Locali
 
 			main {
 				flex: 2 0 0;
-				-webkit-overflow-scrolling: touch;
 				overflow-x: hidden;
 				transition: none;
 			}
@@ -570,7 +569,6 @@ class TemplatePrimarySecondary extends FocusVisiblePolyfillMixin(RtlMixin(Locali
 			aside {
 				height: 100%;
 				min-width: ${desktopMinSize}px;
-				-webkit-overflow-scrolling: touch;
 				overflow-x: hidden;
 				overflow-y: scroll;
 			}


### PR DESCRIPTION
Cert fix of https://github.com/BrightspaceUI/core/pull/2120

The 20.22.3 release of core was `1.231.1` (https://github.com/Brightspace/brightspace-integration/blob/20.22.3/package-lock.json#L1571). I had done a fix release after that so there is a `1.231.2`. The changes between the two are here https://github.com/BrightspaceUI/core/compare/v1.231.1...v1.231.2 . The changes I had made were documentation ones, so the riskiest ones that aren't in already would be the package-lock changes, but those seem like they'd be fine.