### PR TITLE
Dropdown menu: Use no-auto-focus

### DIFF
--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -12,19 +12,27 @@ import { ThemeMixin } from '../../mixins/theme-mixin.js';
  */
 class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
+	static get properties() {
+		return {
+			_noAutoFocus: { type: Boolean }
+		};
+	}
+
 	static get styles() {
 		return dropdownContentStyles;
 	}
 
 	constructor() {
 		super();
-		this.noAutoFocus = true;
 		this.noPadding = true;
 		this._maxHeightNonTray = this.maxHeight;
 	}
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
+
+		if (this.noAutoFocus) this._noAutoFocus = true;
+		this.noAutoFocus = true;
 
 		this._maxHeightNonTray = this.maxHeight;
 		if (this._useMobileStyling && this.mobileTray) {
@@ -114,7 +122,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 		menu.resize();
 
-		menu.focus();
+		if (!this._noAutoFocus) menu.focus();
 	}
 
 	_onSelect(e) {


### PR DESCRIPTION
In Daylight we want to use `no-auto-focus` on dropdown contents in order to not have the page move around with auto-opening dropdowns. I noticed that `noAutoFocus` isn't actually respected with `dropdown-menu`. This seems to be because `dropdown-menu` shouldn't use the `DropdownContentMixin` auto focusing behaviour, and instead uses the menu focus behaviour.

If we don't actually want this, I can remove the auto-opening on the dropdown menu demo in Daylight.