### PR TITLE
Backport fix to list-items z-index to allow for embedded fullscreen html-editor

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -73,6 +73,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 			_breakpoint: { type: Number },
 			_displayKeyboardTooltip: { type: Boolean },
 			_dropdownOpen: { type: Boolean, attribute: '_dropdown-open', reflect: true },
+			_fullscreenWithin: { type: Boolean, attribute: '_fullscreen-within', reflect: true },
 			_hoveringPrimaryAction: { type: Boolean },
 			_focusing: { type: Boolean },
 			_focusingPrimaryAction: { type: Boolean },
@@ -92,7 +93,8 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				display: none;
 			}
 			:host([_tooltip-showing]),
-			:host([_dropdown-open]) {
+			:host([_dropdown-open]),
+			:host([_fullscreen-within]) {
 				z-index: 10;
 			}
 			:host(:first-child) d2l-list-item-generic-layout[data-separators="between"] {
@@ -275,6 +277,10 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				width: 100%;
 				z-index: 5;
 			}
+			:host([_fullscreen-within]) .d2l-list-item-active-border,
+			:host([_fullscreen-within]) d2l-list-item-generic-layout.d2l-focusing + .d2l-list-item-active-border {
+				display: none;
+			}
 			d2l-tooltip > div {
 				font-weight: 700;
 			}
@@ -298,6 +304,9 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 		this._breakpoint = 0;
 		this._contentId = getUniqueId();
 		this._displayKeyboardTooltip = false;
+		this._fullscreenWithin = false;
+		this._fullscreenWithinCount = 0;
+
 	}
 
 	get breakpoints() {
@@ -421,6 +430,12 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 		this._focusingPrimaryAction = false;
 	}
 
+	_onFullscreenWithin(e) {
+		if (e.detail.state) this._fullscreenWithinCount += 1;
+		else this._fullscreenWithinCount -= 1;
+		this._fullscreenWithin = (this._fullscreenWithinCount > 0);
+	}
+
 	_onMouseEnter() {
 		this._hovering = true;
 	}
@@ -460,6 +475,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 			<d2l-list-item-generic-layout
 				@focusin="${this._onFocusIn}"
 				@focusout="${this._onFocusOut}"
+				@d2l-fullscreen-within="${this._onFullscreenWithin}"
 				class="${classMap(classes)}"
 				data-breakpoint="${this._breakpoint}"
 				data-separators="${ifDefined(this._separators)}"


### PR DESCRIPTION
This PR back-ports https://github.com/BrightspaceUI/core/commit/4dd515ca301048c36aca289a2ad042344e874dc3 to `v1.231`.