### PR TITLE
fix: Daylight: Add "Advanced" to more advanced properties

### DIFF
--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -35,7 +35,7 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	static get properties() {
 		return {
 			/**
-			 * Automatically shifts end date when start date changes to keep same range
+			 * ADVANCED: Automatically shifts end date when start date changes to keep same range
 			 * @type {boolean}
 			 */
 			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
@@ -56,7 +56,7 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			endLabel: { attribute: 'end-label', reflect: true, type: String },
 			/**
-			 * Indicates if the end calendar dropdown is open
+			 * ADVANCED: Indicates if the end calendar dropdown is open
 			 * @type {boolean}
 			 */
 			endOpened: { attribute: 'end-opened', type: Boolean },
@@ -102,7 +102,7 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },
 			/**
-			 * Indicates if the start calendar dropdown is open
+			 * ADVANCED: Indicates if the start calendar dropdown is open
 			 * @type {boolean}
 			 */
 			startOpened: { attribute: 'start-opened', type: Boolean },

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -68,7 +68,7 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 	static get properties() {
 		return {
 			/**
-			 * Automatically shifts end date when start date changes to keep same range. If start and end date are equal, automatically shifts end time when start time changes.
+			 * ADVANCED: Automatically shifts end date when start date changes to keep same range. If start and end date are equal, automatically shifts end time when start time changes.
 			 * @type {boolean}
 			 */
 			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
@@ -89,7 +89,7 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 			 */
 			endLabel: { attribute: 'end-label', reflect: true, type: String },
 			/**
-			 * Indicates if the end date or time dropdown is open
+			 * ADVANCED: Indicates if the end date or time dropdown is open
 			 * @type {boolean}
 			 */
 			endOpened: { attribute: 'end-opened', type: Boolean },
@@ -140,7 +140,7 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },
 			/**
-			 * Indicates if the start date or time dropdown is open
+			 * ADVANCED: Indicates if the start date or time dropdown is open
 			 * @type {boolean}
 			 */
 			startOpened: { attribute: 'start-opened', type: Boolean },

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -37,7 +37,7 @@ class InputDate extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCor
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * Text that appears as a placeholder in the input to reassure users that they can choose not to provide a value (usually not necessary)
+			 * ADVANCED: Text that appears as a placeholder in the input to reassure users that they can choose not to provide a value (usually not necessary)
 			 * @type {string}
 			 */
 			emptyText: { type: String, attribute: 'empty-text' },

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -78,7 +78,7 @@ class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeC
 			 */
 			autocomplete: { type: String },
 			/**
-			 * When set, will automatically place focus on the input
+			 * ADVANCED: When set, will automatically place focus on the input
 			 * @type {boolean}
 			 */
 			autofocus: { type: Boolean },
@@ -88,7 +88,7 @@ class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeC
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * Hide the alert icon when input is invalid
+			 * ADVANCED: Hide the alert icon when input is invalid
 			 * @type {boolean}
 			 */
 			hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -27,17 +27,17 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 	static get properties() {
 		return {
 			/**
-			 * Indicates that the input has a popup menu
+			 * ADVANCED: Indicates that the input has a popup menu
 			 * @type {string}
 			 */
 			ariaHaspopup: { type: String, attribute: 'aria-haspopup' },
 			/**
-			 * Indicates that the input value is invalid
+			 * ADVANCED: Indicates that the input value is invalid
 			 * @type {string}
 			 */
 			ariaInvalid: { type: String, attribute: 'aria-invalid' },
 			/**
-			 * Specifies whether or not the screen reader should always present changes to the live region as a whole.
+			 * ADVANCED: Specifies whether or not the screen reader should always present changes to the live region as a whole.
 			 * This only applies if live is set to polite or assertive.
 			 * @type {string}
 			 */
@@ -63,7 +63,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Hide the alert icon when input is invalid
+			 * ADVANCED: Hide the alert icon when input is invalid
 			 * @type {boolean}
 			 */
 			hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
@@ -78,7 +78,7 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
 			/**
-			 * Set the priority with which screen readers should treat updates to the input's live text region
+			 * ADVANCED: Set the priority with which screen readers should treat updates to the input's live text region
 			 * @type {string}
 			 */
 			live: { type: String },

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -22,7 +22,7 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 	static get properties() {
 		return {
 			/**
-			 * Indicates that the input value is invalid
+			 * ADVANCED: Indicates that the input value is invalid
 			 * @type {string}
 			 */
 			ariaInvalid: { type: String, attribute: 'aria-invalid' },

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -43,7 +43,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 	static get properties() {
 		return {
 			/**
-			 * Automatically shifts end time when start time changes to keep same range
+			 * ADVANCED: Automatically shifts end time when start time changes to keep same range
 			 * @type {boolean}
 			 */
 			autoShiftTimes: { attribute: 'auto-shift-times', reflect: true, type: Boolean },
@@ -64,7 +64,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			endLabel: { attribute: 'end-label', reflect: true, type: String },
 			/**
-			 * Indicates if the end dropdown is open
+			 * ADVANCED: Indicates if the end dropdown is open
 			 * @type {boolean}
 			 */
 			endOpened: { attribute: 'end-opened', type: Boolean },
@@ -105,7 +105,7 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			 */
 			startLabel: { attribute: 'start-label', reflect: true, type: String },
 			/**
-			 * Indicates if the start dropdown is open
+			 * ADVANCED: Indicates if the start dropdown is open
 			 * @type {boolean}
 			 */
 			startOpened: { attribute: 'start-opened', type: Boolean },


### PR DESCRIPTION
This will hide them under the "show advanced properties" part of the properties table. 

This was a best guess and I leaned more towards show too many than show less. Let me know if there's others I missed or if any of these should probably be shown by default.