### PR TITLE
Update padding for list-item actions when extend-separators is turned on.

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -193,6 +193,13 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 			.d2l-list-item-actions-container {
 				padding: 0.55rem 0;
 			}
+			.d2l-list-item-content-extend-separators .d2l-list-item-actions-container {
+				padding-right: 0.7rem;
+			}
+			:host([dir="rtl"]) .d2l-list-item-content-extend-separators .d2l-list-item-actions-container {
+				padding-left: 0.7rem;
+				padding-right: 0;
+			}
 			::slotted([slot="actions"]),
 			.d2l-list-item-actions * {
 				display: grid;

--- a/components/list/test/list.visual-diff.html
+++ b/components/list/test/list.visual-diff.html
@@ -77,40 +77,11 @@
 		</div>
 
 		<div style="width: 400px;">
-			<div class="visual-diff" id="actions">
-				<d2l-list>
-					<d2l-list-item>
-						<div>Item 1</div>
-						<div slot="actions">
-							<d2l-link href="http://www.d2l.com">Action 1</d2l-link>
-							<d2l-button-icon text="Action 2" icon="tier1:preview"></d2l-button-icon>
-						</div>
-					</d2l-list-item>
-				</d2l-list>
-			</div>
-		</div>
-
-		<div style="width: 400px;">
 			<div class="visual-diff" id="illustration">
 				<d2l-list>
 					<d2l-list-item>
 						<div>Item 1</div>
 						<div slot="illustration" style="background-color: blue; height: 400px; width: 400px;"></div>
-					</d2l-list-item>
-				</d2l-list>
-			</div>
-		</div>
-
-		<div style="width: 400px;">
-			<div class="visual-diff" id="rtl" dir="rtl">
-				<d2l-list dir="rtl">
-					<d2l-list-item dir="rtl">
-						<div slot="illustration" style="background-color: blue; height: 400px; width: 400px;"></div>
-						<div>Item 1</div>
-						<div slot="actions">
-							<d2l-button-icon text="Action 1" icon="tier1:preview"></d2l-button-icon>
-							<d2l-button-icon text="Action 2" icon="tier1:more"></d2l-button-icon>
-						</div>
 					</d2l-list-item>
 				</d2l-list>
 			</div>
@@ -152,6 +123,49 @@
 					<d2l-list-item>Item 1</d2l-list-item>
 					<d2l-list-item>Item 2</d2l-list-item>
 					<d2l-list-item>Item 3</d2l-list-item>
+				</d2l-list>
+			</div>
+		</div>
+
+		<div style="width: 400px;">
+			<div class="visual-diff" id="actions">
+				<d2l-list>
+					<d2l-list-item>
+						<div>Item 1</div>
+						<div slot="actions">
+							<d2l-link href="http://www.d2l.com">Action 1</d2l-link>
+							<d2l-button-icon text="Action 2" icon="tier1:preview"></d2l-button-icon>
+						</div>
+					</d2l-list-item>
+				</d2l-list>
+			</div>
+		</div>
+
+		<div style="width: 400px;">
+			<div class="visual-diff" id="actionsSeparatorsExtended">
+				<d2l-list extend-separators>
+					<d2l-list-item>
+						<div>Item 1</div>
+						<div slot="actions">
+							<d2l-link href="http://www.d2l.com">Action 1</d2l-link>
+							<d2l-button-icon text="Action 2" icon="tier1:preview"></d2l-button-icon>
+						</div>
+					</d2l-list-item>
+				</d2l-list>
+			</div>
+		</div>
+
+		<div style="width: 400px;">
+			<div class="visual-diff" id="actionsRtl" dir="rtl">
+				<d2l-list dir="rtl">
+					<d2l-list-item dir="rtl">
+						<div slot="illustration" style="background-color: blue; height: 400px; width: 400px;"></div>
+						<div>Item 1</div>
+						<div slot="actions">
+							<d2l-button-icon text="Action 1" icon="tier1:preview"></d2l-button-icon>
+							<d2l-button-icon text="Action 2" icon="tier1:more"></d2l-button-icon>
+						</div>
+					</d2l-list-item>
 				</d2l-list>
 			</div>
 		</div>

--- a/components/list/test/list.visual-diff.js
+++ b/components/list/test/list.visual-diff.js
@@ -79,12 +79,10 @@ describe('d2l-list', () => {
 		{ category: 'general', tests: [
 			{ name: 'simple', selector: '#simple' },
 			{ name: 'slim', selector: '#slim' },
-			{ name: 'no padding', selector: '#noPadding' },
-			{ name: 'actions', selector: '#actions' },
-			{ name: 'rtl', selector: '#rtl' },
+			{ name: 'no padding', selector: '#noPadding' }
 		] },
 		{ category: 'illustration', tests: [
-			{ name: 'default', selector: '#illustration' },
+			{ name: 'default', selector: '#illustration' }
 		] },
 		{ category: 'separators', tests: [
 			{ name: 'default', selector: '#simple' },
@@ -92,6 +90,11 @@ describe('d2l-list', () => {
 			{ name: 'all', selector: '#separatorsAll' },
 			{ name: 'between', selector: '#separatorsBetween' },
 			{ name: 'extended', selector: '#separatorsExtended' }
+		] },
+		{ category: 'actions', tests: [
+			{ name: 'default', selector: '#actions' },
+			{ name: 'extended separators', selector: '#actionsSeparatorsExtended' },
+			{ name: 'rtl', selector: '#actionsRtl' }
 		] },
 		{ category: 'item-content', tests: [
 			{ name: 'all', selector: '#itemContent' },


### PR DESCRIPTION
This PR fixes the layout for list-item actions for the case when `extend-separators` is turned on.  Previously, the last action would be jammed up against the edge of the container.

Updated:
![image](https://user-images.githubusercontent.com/9042472/156604456-e378d8af-0c17-46a4-866c-3de185e1a985.png)
