### PR TITLE
HTML block component should respect document dir

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -3,6 +3,7 @@ import { css, LitElement } from 'lit-element/lit-element.js';
 import { HtmlAttributeObserverController } from '../../controllers/attributeObserver/htmlAttributeObserverController.js';
 import { HtmlBlockMathRenderer } from '../../helpers/mathjax.js';
 import { requestInstance } from '../../mixins/provider-mixin.js';
+import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 export const htmlBlockContentStyles = css`
 	.d2l-html-block-compact {
@@ -120,7 +121,7 @@ const getRenderers = () => {
  * A component for displaying user-authored HTML.
  * @slot - Provide your user-authored HTML
  */
-class HtmlBlock extends LitElement {
+class HtmlBlock extends RtlMixin(LitElement) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
There's CSS in the html-block component that applies when `dir="rtl"` so it seems likely to me that we want this mixin applied. The only thing I'm unsure about is if we're unsure about applying this blindly to user-provided HTML, but the HTML control implicitly does this so I suspect it's still what we want.