### PR TITLE
feat: implemented FocusMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ npm install @brightspace-ui/core
 * Mixins
   * [ArrowKeysMixin](mixins/arrow-keys-mixin.md): manage focus with arrow keys
   * [AsyncContainerMixin](mixins/async-container/): manage collective async state
+  * [FocusMixin](mixins/focus-mixin.md): delegate focus to a nested element when `focus()` is called
   * [FocusVisiblePolyfillMixin](mixins/focus-visible-polyfill-mixin.md): components can use the `:focus-visible` pseudo-class polyfill
   * [FormElementMixin](components/form/docs/form-element-mixin.md): allow components to participate in forms and validation
   * [LabelledMixin](mixins/labelled-mixin.md): label custom elements by referencing elements across DOM scopes

--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -1,6 +1,7 @@
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FocusVisiblePolyfillMixin } from '../../mixins/focus-visible-polyfill-mixin.js';
 
-export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin(superclass) {
+export const ButtonMixin = superclass => class extends FocusMixin(FocusVisiblePolyfillMixin(superclass)) {
 
 	static get properties() {
 		return {
@@ -65,6 +66,8 @@ export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin
 		};
 	}
 
+	static focusElementSelector = 'button';
+
 	constructor() {
 		super();
 		this.disabled = false;
@@ -105,11 +108,6 @@ export const ButtonMixin = superclass => class extends FocusVisiblePolyfillMixin
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.removeEventListener('click', this._handleClick, true);
-	}
-
-	focus() {
-		const button = this.shadowRoot && this.shadowRoot.querySelector('button');
-		if (button) button.focus();
 	}
 
 	/** @internal */

--- a/components/button/test/button-icon.axe.js
+++ b/components/button/test/button-icon.axe.js
@@ -20,7 +20,7 @@ describe('d2l-button-icon', () => {
 
 	it('focused', async() => {
 		const el = await fixture(html`<d2l-button-icon icon="tier1:gear" text="Icon Button"></d2l-button-icon>`);
-		setTimeout(() => el.shadowRoot.querySelector('button').focus());
+		setTimeout(() => el.focus());
 		await oneEvent(el, 'focus');
 		await expect(el).to.be.accessible();
 	});

--- a/components/button/test/button-mixin.test.js
+++ b/components/button/test/button-mixin.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture } from '@open-wc/testing';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { ButtonMixin } from '../button-mixin.js';
 
@@ -46,17 +46,6 @@ describe('ButtonMixin', () => {
 		it('should stop propagation of click events if button is disabled with disabled-tooltip', async() => {
 			const el = await fixture(`<${tagName} disabled disabled-tooltip="tooltip text"></${tagName}`);
 			expect(() => el.click()).to.not.throw();
-		});
-
-	});
-
-	describe('focus management', () => {
-
-		it('should delegate focus to button', async() => {
-			const el = await fixture(`<${tagName}></${tagName}`);
-			const buttonEl = el.shadowRoot.querySelector('button');
-			setTimeout(() => el.focus());
-			await oneEvent(buttonEl, 'focus');
 		});
 
 	});

--- a/components/button/test/button-subtle.axe.js
+++ b/components/button/test/button-subtle.axe.js
@@ -20,7 +20,7 @@ describe('d2l-button-subtle', () => {
 
 	it('normal + focused', async() => {
 		const el = await fixture(html`<d2l-button-subtle text="Subtle Button"></d2l-button-subtle>`);
-		setTimeout(() => el.shadowRoot.querySelector('button').focus());
+		setTimeout(() => el.focus());
 		await oneEvent(el, 'focus');
 		await expect(el).to.be.accessible();
 	});
@@ -37,7 +37,7 @@ describe('d2l-button-subtle', () => {
 
 	it('icon + focused', async() => {
 		const el = await fixture(html`<d2l-button-subtle text="Subtle Button with Icon" icon="tier1:gear"></d2l-button-subtle>`);
-		setTimeout(() => el.shadowRoot.querySelector('button').focus());
+		setTimeout(() => el.focus());
 		await oneEvent(el, 'focus');
 		await expect(el).to.be.accessible();
 	});

--- a/components/button/test/button.axe.js
+++ b/components/button/test/button.axe.js
@@ -23,7 +23,7 @@ describe('d2l-button', () => {
 
 	it('normal + focused', async() => {
 		const el = await fixture(normalFixture);
-		setTimeout(() => el.shadowRoot.querySelector('button').focus());
+		setTimeout(() => el.focus());
 		await oneEvent(el, 'focus');
 		await expect(el).to.be.accessible();
 	});
@@ -40,7 +40,7 @@ describe('d2l-button', () => {
 
 	it('primary + focused', async() => {
 		const el = await fixture(primaryFixture);
-		setTimeout(() => el.shadowRoot.querySelector('button').focus());
+		setTimeout(() => el.focus());
 		await oneEvent(el, 'focus');
 		await expect(el).to.be.accessible();
 	});

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -1,6 +1,7 @@
 import '../colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
@@ -15,7 +16,7 @@ import { styleMap } from 'lit-html/directives/style-map.js';
  * @slot footer - Slot for footer content, such secondary actions
  * @slot header - Slot for header content, such as course image (no actionable elements)
  */
-class Card extends RtlMixin(LitElement) {
+class Card extends FocusMixin(RtlMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -234,6 +235,8 @@ class Card extends RtlMixin(LitElement) {
 		`];
 	}
 
+	static focusElementSelector = 'a';
+
 	constructor() {
 		super();
 		this.alignCenter = false;
@@ -304,12 +307,6 @@ class Card extends RtlMixin(LitElement) {
 				<div class="${classMap(footerClass)}"><slot name="footer"></slot></div>
 			</div>
 		`;
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('a');
-		if (!elem) return;
-		elem.focus();
 	}
 
 	_onBadgeResize(entries) {

--- a/components/card/test/card.axe.js
+++ b/components/card/test/card.axe.js
@@ -1,5 +1,5 @@
 import '../card.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 
 describe('d2l-card', () => {
 
@@ -20,7 +20,8 @@ describe('d2l-card', () => {
 
 	it('default link + focused', async() => {
 		const elem = await fixture(html`<d2l-card text="Link Text" href="https://d2l.com"><div slot="content">Content</div></d2l-card>`);
-		elem.focus();
+		setTimeout(() => elem.focus());
+		await oneEvent(elem, 'focus');
 		await expect(elem).to.be.accessible();
 	});
 
@@ -31,7 +32,8 @@ describe('d2l-card', () => {
 
 	it('subtle link + focused', async() => {
 		const elem = await fixture(html`<d2l-card subtle text="Link Text" href="https://d2l.com"><div slot="content">Content</div></d2l-card>`);
-		elem.focus();
+		setTimeout(() => elem.focus());
+		await oneEvent(elem, 'focus');
 		await expect(elem).to.be.accessible();
 	});
 

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -19,6 +19,7 @@ import { bodyCompactStyles, bodySmallStyles, bodyStandardStyles } from '../typog
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { announce } from '../../helpers/announce.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
@@ -37,7 +38,7 @@ const SET_DIMENSION_ID_PREFIX = 'list-';
  * @fires d2l-filter-dimension-first-open - Dispatched when a dimension is opened for the first time
  * @fires d2l-filter-dimension-search - Dispatched when a dimension that supports searching and has the "manual" search-type is searched
  */
-class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
+class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -136,6 +137,8 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		`];
 	}
 
+	static focusElementSelector = 'd2l-dropdown-button-subtle';
+
 	constructor() {
 		super();
 		this.disabled = false;
@@ -227,11 +230,6 @@ class Filter extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			</d2l-dropdown-button-subtle>
 			<slot @slotchange="${this._handleSlotChange}"></slot>
 		`;
-	}
-
-	focus() {
-		const opener = this.shadowRoot && this.shadowRoot.querySelector('d2l-dropdown-button-subtle');
-		if (opener) opener.focus();
 	}
 
 	getSubscriberController() {

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { forceFocusVisible, getNextFocusable, getPreviousFocusable } from '../../helpers/focus.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { isComposedAncestor } from '../../helpers/dom.js';
 
@@ -7,7 +8,7 @@ import { isComposedAncestor } from '../../helpers/dom.js';
  * A generic container component to trap user focus.
  * @fires d2l-focus-trap-enter - Dispatched when focus enters the trap. May be used to override initial focus placement when focus enters the trap.
  */
-class FocusTrap extends LitElement {
+class FocusTrap extends FocusMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -29,6 +30,8 @@ class FocusTrap extends LitElement {
 			}
 		`;
 	}
+
+	static focusElementSelector = '.d2l-focus-trap-start';
 
 	constructor() {
 		super();
@@ -53,11 +56,6 @@ class FocusTrap extends LitElement {
 			<slot></slot>
 			<span class="d2l-focus-trap-end" @focusin="${this._handleEndFocusIn}" tabindex="${ifDefined(tabindex)}"></span>
 		`;
-	}
-
-	focus() {
-		const focusable = this.shadowRoot && this.shadowRoot.querySelector('.d2l-focus-trap-start');
-		if (focusable) focusable.focus();
 	}
 
 	_focusFirst() {

--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -1,6 +1,7 @@
 import '../colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
@@ -56,7 +57,7 @@ export const checkboxStyles = css`
  * @slot - Checkbox information (e.g., text)
  * @fires change - Dispatched when the checkbox's state changes
  */
-class InputCheckbox extends SkeletonMixin(RtlMixin(LitElement)) {
+class InputCheckbox extends FocusMixin(SkeletonMixin(RtlMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -163,6 +164,8 @@ class InputCheckbox extends SkeletonMixin(RtlMixin(LitElement)) {
 		];
 	}
 
+	static focusElementSelector = 'input.d2l-input-checkbox';
+
 	constructor() {
 		super();
 		this.checked = false;
@@ -203,11 +206,6 @@ class InputCheckbox extends SkeletonMixin(RtlMixin(LitElement)) {
 			</label>
 			${offscreenContainer}
 		`;
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('input.d2l-input-checkbox');
-		if (elem) elem.focus();
 	}
 
 	simulateClick() {

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -4,6 +4,7 @@ import './input-fieldset.js';
 import '../tooltip/tooltip.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { formatDateTimeInISO, getDateFromISODate, parseISODateTime } from '../../helpers/dateTime.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -30,7 +31,7 @@ export function getShiftedEndDate(startValue, endValue, prevStartValue, inclusiv
  * A component consisting of two input-date components - one for start of range and one for end of range. Values specified for these components (through start-value and/or end-value attributes) should be localized to the user's timezone if applicable and must be in ISO 8601 calendar date format ("YYYY-MM-DD").
  * @fires change - Dispatched when there is a change to selected start date or selected end date. `start-value` and `end-value` correspond to the selected values and are formatted in ISO 8601 calendar date format (`YYYY-MM-DD`).
  */
-class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement)))) {
+class InputDateRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -127,6 +128,8 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			}
 		`];
 	}
+
+	static focusElementSelector = 'd2l-input-date';
 
 	constructor() {
 		super();
@@ -249,11 +252,6 @@ class InputDateRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 				this.requestValidate(true);
 			}
 		});
-	}
-
-	focus() {
-		const input = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-date');
-		if (input) input.focus();
 	}
 
 	async validate() {

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -5,6 +5,7 @@ import '../tooltip/tooltip.js';
 import { convertLocalToUTCDateTime, convertUTCToLocalDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { formatDateTimeInISO, getAdjustedTime, getDateFromISODateTime, getDateNoConversion, parseISODateTime } from '../../helpers/dateTime.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -63,7 +64,7 @@ export function getShiftedEndDateTime(startValue, endValue, prevStartValue, incl
  * @slot end - Optional content that would appear below the end input-date-time
  * @fires change - Dispatched when there is a change to selected start date-time or selected end date-time. `start-value` and `end-value` correspond to the selected values and are formatted in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`).
  */
-class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement)))) {
+class InputDateTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -170,6 +171,8 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 
 		`];
 	}
+
+	static focusElementSelector = 'd2l-input-date-time';
 
 	constructor() {
 		super();
@@ -305,11 +308,6 @@ class InputDateTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(Localiz
 				this.requestValidate(true);
 			}
 		});
-	}
-
-	focus() {
-		const input = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-date-time');
-		if (input) input.focus();
 	}
 
 	async validate() {

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -13,6 +13,7 @@ import { formatDateInISO,
 	parseISODate,
 	parseISODateTime,
 	parseISOTime } from '../../helpers/dateTime.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getDefaultTime } from './input-time.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
@@ -40,7 +41,7 @@ function _getFormattedDefaultTime(defaultValue) {
  * A component that consists of a "<d2l-input-date>" and a "<d2l-input-time>" component. The time input only appears once a date is selected. This component displays the "value" if one is specified, and reflects the selected value when one is selected or entered.
  * @fires change - Dispatched when there is a change to selected date or selected time. `value` corresponds to the selected value and is formatted in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`).
  */
-class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement))))) {
+class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement)))))) {
 
 	static get properties() {
 		return {
@@ -111,6 +112,8 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 			}
 		`];
 	}
+
+	static focusElementSelector = 'd2l-input-date';
 
 	constructor() {
 		super();
@@ -293,11 +296,6 @@ class InputDateTime extends LabelledMixin(SkeletonMixin(FormElementMixin(Localiz
 				this._preventDefaultValidation = true;
 			}
 		});
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-date');
-		if (elem) elem.focus();
 	}
 
 	async validate() {

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -8,6 +8,7 @@ import './input-text.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { formatDate, parseDate } from '@brightspace-ui/intl/lib/dateTime.js';
 import { formatDateInISO, getDateFromISODate, getDateTimeDescriptorShared, getToday } from '../../helpers/dateTime.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -27,7 +28,7 @@ export function formatISODateInUserCalDescriptor(val) {
  * A component that consists of a text input field for typing a date and an attached calendar (d2l-calendar) dropdown. It displays the "value" if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the calendar or entered in the text input.
  * @fires change - Dispatched when there is a change to selected date. `value` corresponds to the selected value and is formatted in ISO 8601 calendar date format (`YYYY-MM-DD`).
  */
-class InputDate extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement)))) {
+class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -136,6 +137,8 @@ class InputDate extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCor
 			}
 		`];
 	}
+
+	static focusElementSelector = 'd2l-input-text';
 
 	constructor() {
 		super();
@@ -329,10 +332,6 @@ class InputDate extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCor
 				if (this.opened) this._open();
 			}
 		});
-	}
-
-	focus() {
-		if (this._textInput) this._textInput.focus();
 	}
 
 	async validate() {

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -1,6 +1,7 @@
 import './input-text.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { formatNumber, getNumberDescriptor, parseNumber } from '@brightspace-ui/intl/lib/number.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -68,7 +69,7 @@ function roundPrecisely(val, maxFractionDigits) {
  * @slot right - Slot within the input on the right side. Useful for an "icon" or "button-icon".
  * @fires change - Dispatched when an alteration to the value is committed (typically after focus is lost) by the user. The `value` attribute reflects a JavaScript Number which is parsed from the formatted input value.
  */
-class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement)))) {
+class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -184,6 +185,8 @@ class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeC
 			`
 		];
 	}
+
+	static focusElementSelector = 'd2l-input-text';
 
 	constructor() {
 		super();
@@ -362,16 +365,6 @@ class InputNumber extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeC
 				this.requestValidate(true);
 			}
 		});
-	}
-
-	async focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-text');
-		if (elem) {
-			elem.focus();
-		} else {
-			await this.updateComplete;
-			this.focus();
-		}
 	}
 
 	async validate() {

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -1,5 +1,6 @@
 import './input-number.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LabelledMixin } from '../../mixins/labelled-mixin.js';
@@ -12,7 +13,7 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  * @slot after - Slot beside the input on the right side. Useful for an "icon" or "button-icon".
  * @fires change - Dispatched when an alteration to the value is committed (typically after focus is lost) by the user. The `value` attribute reflects a JavaScript Number which is parsed from the formatted input value.
  */
-class InputPercent extends LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement))))) {
+class InputPercent extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(RtlMixin(LitElement)))))) {
 
 	static get properties() {
 		return {
@@ -85,6 +86,8 @@ class InputPercent extends LabelledMixin(SkeletonMixin(FormElementMixin(Localize
 		];
 	}
 
+	static focusElementSelector = 'd2l-input-number';
+
 	constructor() {
 		super();
 		this.autofocus = false;
@@ -129,11 +132,6 @@ class InputPercent extends LabelledMixin(SkeletonMixin(FormElementMixin(Localize
 					<slot slot="after" name="after"></slot>
 			</d2l-input-number>
 		`;
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-number');
-		if (elem) elem.focus();
 	}
 
 	async validate() {

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -2,6 +2,7 @@ import '../button/button-icon.js';
 import '../colors/colors.js';
 import './input-text.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputStyles } from './input-styles.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
@@ -11,7 +12,7 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
  * This component wraps the native "<input type="search">"" element and is for text searching.
  * @fires d2l-input-search-searched - Dispatched when a search is performed. When the input is cleared, this will be fired with an empty value.
  */
-class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
+class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -73,6 +74,8 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		];
 	}
 
+	static focusElementSelector = 'd2l-input-text';
+
 	constructor() {
 		super();
 		this._lastSearchValue = '';
@@ -120,11 +123,6 @@ class InputSearch extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				${search}
 			</d2l-input-text>
 		`;
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-text');
-		if (elem) elem.focus();
 	}
 
 	search() {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -1,6 +1,7 @@
 import '../tooltip/tooltip.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { formatNumber } from '@brightspace-ui/intl/lib/number.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
@@ -22,7 +23,7 @@ import { styleMap } from 'lit-html/directives/style-map.js';
  * @fires change - Dispatched when an alteration to the value is committed (typically after focus is lost) by the user
  * @fires input - Dispatched immediately after changes by the user
  */
-class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(LitElement)))) {
+class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -233,6 +234,8 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 			`
 		];
 	}
+
+	static focusElementSelector = '.d2l-input';
 
 	constructor() {
 		super();
@@ -461,16 +464,6 @@ class InputText extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(Li
 				}
 			}
 		});
-	}
-
-	async focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
-		if (elem) {
-			elem.focus();
-		} else {
-			await this.updateComplete;
-			this.focus();
-		}
 	}
 
 	_getAriaLabel() {

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -1,5 +1,6 @@
 import '../tooltip/tooltip.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { formatNumber } from '@brightspace-ui/intl/lib/number.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
@@ -17,7 +18,7 @@ import { styleMap } from 'lit-html/directives/style-map.js';
  * @fires change - Dispatched when an alteration to the value is committed (typically after focus is lost) by the user
  * @fires input - Dispatched immediately after changes by the user
  */
-class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(LitElement)))) {
+class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -149,6 +150,8 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 		`];
 	}
 
+	static focusElementSelector = 'textarea';
+
 	constructor() {
 		super();
 		this.disabled = false;
@@ -261,16 +264,6 @@ class InputTextArea extends LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixi
 				}
 			}
 		});
-	}
-
-	async focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('textarea');
-		if (elem) {
-			elem.focus();
-		} else {
-			await this.updateComplete;
-			this.focus();
-		}
 	}
 
 	async select() {

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -4,6 +4,7 @@ import '../tooltip/tooltip.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { formatDateInISOTime, formatTimeInISO, getAdjustedTime, getDateFromISOTime, isValidTime, parseISOTime } from '../../helpers/dateTime.js';
 import { getDefaultTime, getIntervalNumber, getTimeAtInterval } from './input-time.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -38,7 +39,7 @@ function getValidISOTimeAtInterval(val, timeInterval) {
  * @fires change - Dispatched when there is a change to selected start time or selected end time. `start-value` and `end-value` correspond to the selected values and are formatted in ISO 8601 calendar time format (`hh:mm:ss`).
  */
 
-class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement)))) {
+class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCoreElement(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -135,6 +136,8 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 			}
 		`];
 	}
+
+	static focusElementSelector = 'd2l-input-time';
 
 	constructor() {
 		super();
@@ -300,11 +303,6 @@ class InputTimeRange extends SkeletonMixin(FormElementMixin(RtlMixin(LocalizeCor
 				this.requestValidate(true);
 			}
 		});
-	}
-
-	focus() {
-		const input = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-time');
-		if (input) input.focus();
 	}
 
 	async validate() {

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -7,6 +7,7 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { formatDateInISOTime, getDateFromISOTime, getToday } from '../../helpers/dateTime.js';
 import { formatTime, parseTime } from '@brightspace-ui/intl/lib/dateTime.js';
 import { bodySmallStyles } from '../typography/styles.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -116,7 +117,7 @@ function initIntervals(size, enforceTimeIntervals) {
  * A component that consists of a text input field for typing a time and an attached dropdown for time selection. It displays the "value" if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
  * @fires change - Dispatched when there is a change to selected time. `value` corresponds to the selected value and is formatted in ISO 8601 time format (`hh:mm:ss`).
  */
-class InputTime extends LabelledMixin(SkeletonMixin(FormElementMixin(LitElement))) {
+class InputTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -213,6 +214,8 @@ class InputTime extends LabelledMixin(SkeletonMixin(FormElementMixin(LitElement)
 			`
 		];
 	}
+
+	static focusElementSelector = '.d2l-input';
 
 	constructor() {
 		super();
@@ -347,11 +350,6 @@ class InputTime extends LabelledMixin(SkeletonMixin(FormElementMixin(LitElement)
 		changedProperties.forEach((oldVal, prop) => {
 			if (prop === 'value') this.setFormValue(this.value);
 		});
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
-		if (elem) elem.focus();
 	}
 
 	getTime() {

--- a/components/inputs/test/input-percent.axe.js
+++ b/components/inputs/test/input-percent.axe.js
@@ -1,5 +1,5 @@
 import '../input-percent.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 
 describe('d2l-input-percent', () => {
 	it('normal', async() => {
@@ -42,7 +42,8 @@ describe('d2l-input-percent', () => {
 
 	it('focused', async() => {
 		const elem = await fixture(html`<d2l-input-percent label="label"></d2l-input-percent>`);
-		elem.focus();
+		setTimeout(() => elem.focus());
+		await oneEvent(elem, 'focus');
 		await expect(elem).to.be.accessible();
 	});
 });

--- a/components/inputs/test/input-search.axe.js
+++ b/components/inputs/test/input-search.axe.js
@@ -1,5 +1,5 @@
 import '../input-search.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 
 describe('d2l-input-search', () => {
 
@@ -25,7 +25,8 @@ describe('d2l-input-search', () => {
 
 	it('focused', async() => {
 		const elem = await fixture(html`<d2l-input-search label="search"></d2l-input-search>`);
-		elem.focus();
+		setTimeout(() => elem.focus());
+		await oneEvent(elem, 'focus');
 		await expect(elem).to.be.accessible();
 	});
 

--- a/components/inputs/test/input-text.axe.js
+++ b/components/inputs/test/input-text.axe.js
@@ -1,5 +1,5 @@
 import '../input-text.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 
 describe('d2l-input-text', () => {
 
@@ -25,7 +25,8 @@ describe('d2l-input-text', () => {
 
 	it('focused', async() => {
 		const elem = await fixture(html`<d2l-input-text label="label"></d2l-input-text>`);
-		elem.focus();
+		setTimeout(() => elem.focus());
+		await oneEvent(elem, 'focus');
 		await expect(elem).to.be.accessible();
 	});
 

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -1,6 +1,5 @@
 import '../input-text.js';
 import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
-import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-text label="label"></d2l-input-text>`;
@@ -94,27 +93,6 @@ describe('d2l-input-text', () => {
 		it('should default unrecognized "type" to "text"', () => {
 			elem.setAttribute('type', 'silly');
 			expect(getInput(elem).type).to.equal('text');
-		});
-
-	});
-
-	describe('focus management', () => {
-
-		it('should delegate focus to underlying input', async() => {
-			const elem = await fixture(normalFixture);
-			elem.focus();
-			const activeElement = getComposedActiveElement();
-			expect(activeElement).to.equal(getInput(elem));
-		});
-
-		it('should focus even if component has not rendered', async() => {
-			const container = await fixture(html`<div></div>`);
-			const newInput = document.createElement('d2l-input-text');
-			newInput.setAttribute('label', 'label');
-			container.appendChild(newInput);
-			await newInput.focus();
-			const activeElement = getComposedActiveElement();
-			expect(activeElement).to.equal(getInput(newInput));
 		});
 
 	});

--- a/components/inputs/test/input-textarea.axe.js
+++ b/components/inputs/test/input-textarea.axe.js
@@ -1,5 +1,5 @@
 import '../input-textarea.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 
 describe('d2l-input-textarea', () => {
 
@@ -25,7 +25,8 @@ describe('d2l-input-textarea', () => {
 
 	it('focused', async() => {
 		const elem = await fixture(html`<d2l-input-textarea label="label"></d2l-input-textarea>`);
-		elem.focus();
+		setTimeout(() => elem.focus());
+		await oneEvent(elem, 'focus');
 		await expect(elem).to.be.accessible();
 	});
 

--- a/components/inputs/test/input-time.axe.js
+++ b/components/inputs/test/input-time.axe.js
@@ -28,7 +28,7 @@ describe('d2l-input-time', () => {
 
 	it('focused', async() => {
 		const elem = await fixture(html`<d2l-input-time label="label text" time-interval="sixty"></d2l-input-time>`);
-		setTimeout(() => elem.shadowRoot.querySelector('.d2l-input').focus());
+		setTimeout(() => elem.focus());
 		await oneEvent(elem, 'focus');
 		await expect(elem).to.be.accessible();
 	});

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -1,6 +1,7 @@
 import '../colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 export const linkStyles = css`
@@ -41,7 +42,7 @@ export const linkStyles = css`
  * This component can be used just like the native anchor tag.
  * @slot - The content (e.g., text) that when selected causes navigation
  */
-class Link extends LitElement {
+class Link extends FocusMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -96,6 +97,8 @@ class Link extends LitElement {
 		];
 	}
 
+	static focusElementSelector = '.d2l-link';
+
 	constructor() {
 		super();
 		this.download = false;
@@ -117,9 +120,5 @@ class Link extends LitElement {
 				target="${ifDefined(this.target)}"><slot></slot></a>`;
 	}
 
-	focus() {
-		const link = this.shadowRoot && this.shadowRoot.querySelector('.d2l-link');
-		if (link) link.focus();
-	}
 }
 customElements.define('d2l-link', Link);

--- a/components/link/test/link.axe.js
+++ b/components/link/test/link.axe.js
@@ -20,7 +20,7 @@ describe('d2l-link', () => {
 
 	it('focused', async() => {
 		const elem = await fixture(html`<d2l-link href="https://www.d2l.com">Link Test</d2l-link>`);
-		setTimeout(() => elem.shadowRoot.querySelector('a').focus());
+		setTimeout(() => elem.focus());
 		await oneEvent(elem, 'focus');
 		await expect(elem).to.be.accessible();
 	});

--- a/components/link/test/link.test.js
+++ b/components/link/test/link.test.js
@@ -1,6 +1,5 @@
 import '../link.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
-import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-link href="https://www.d2l.com">Link Test</d2l-link>`;
@@ -89,17 +88,6 @@ describe('d2l-link', () => {
 			setTimeout(() => getAnchor(elem).click());
 			const { target } = await oneEvent(elem, 'click');
 			expect(target).to.equal(elem);
-		});
-
-	});
-
-	describe('focus management', () => {
-
-		it('should delegate focus to underlying anchor', async() => {
-			const elem = await fixture(normalFixture);
-			elem.focus();
-			const activeElement = getComposedActiveElement();
-			expect(activeElement).to.equal(getAnchor(elem));
 		});
 
 	});

--- a/components/selection/selection-action-dropdown.js
+++ b/components/selection/selection-action-dropdown.js
@@ -2,6 +2,7 @@ import '../button/button-subtle.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { DropdownOpenerMixin } from '../dropdown/dropdown-opener-mixin.js';
 import { dropdownOpenerStyles } from '../dropdown/dropdown-opener-styles.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { SelectionActionMixin } from './selection-action-mixin.js';
@@ -11,7 +12,7 @@ import { SelectionActionMixin } from './selection-action-mixin.js';
  * @slot - Dropdown content (e.g., "d2l-dropdown-content", "d2l-dropdown-menu" or "d2l-dropdown-tabs")
  * @fires d2l-selection-observer-subscribe - Internal event
  */
-class ActionDropdown extends LocalizeCoreElement(SelectionActionMixin(DropdownOpenerMixin(LitElement))) {
+class ActionDropdown extends FocusMixin(LocalizeCoreElement(SelectionActionMixin(DropdownOpenerMixin(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -27,6 +28,8 @@ class ActionDropdown extends LocalizeCoreElement(SelectionActionMixin(DropdownOp
 		return dropdownOpenerStyles;
 	}
 
+	static focusElementSelector = 'd2l-button-subtle';
+
 	render() {
 		return html`
 			<d2l-button-subtle
@@ -37,11 +40,6 @@ class ActionDropdown extends LocalizeCoreElement(SelectionActionMixin(DropdownOp
 				text=${this.text}></d2l-button-subtle>
 			<slot></slot>
 		`;
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-button-subtle');
-		if (elem) elem.focus();
 	}
 
 	/**

--- a/components/selection/selection-action.js
+++ b/components/selection/selection-action.js
@@ -1,6 +1,7 @@
 import '../button/button-subtle.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ButtonMixin } from '../button/button-mixin.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { SelectionActionMixin } from './selection-action-mixin.js';
@@ -11,7 +12,7 @@ import { SelectionInfo } from './selection-mixin.js';
  * @fires d2l-selection-action-click - Dispatched when the user clicks the action button. The `SelectionInfo` is provided as the event `detail`. If `requires-selection` was specified then the event will only be dispatched if items are selected.
  * @fires d2l-selection-observer-subscribe - Internal event
  */
-class Action extends LocalizeCoreElement(SelectionActionMixin(ButtonMixin(LitElement))) {
+class Action extends FocusMixin(LocalizeCoreElement(SelectionActionMixin(ButtonMixin(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -39,6 +40,8 @@ class Action extends LocalizeCoreElement(SelectionActionMixin(ButtonMixin(LitEle
 		`;
 	}
 
+	static focusElementSelector = 'd2l-button-subtle';
+
 	connectedCallback() {
 		super.connectedCallback();
 		this.addEventListener('d2l-button-ghost-click', this._handleActionClick);
@@ -59,11 +62,6 @@ class Action extends LocalizeCoreElement(SelectionActionMixin(ButtonMixin(LitEle
 				text="${this.text}">
 			</d2l-button-subtle>
 		`;
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-button-subtle');
-		if (elem) elem.focus();
 	}
 
 	_handleActionClick(e) {

--- a/components/selection/selection-select-all-pages.js
+++ b/components/selection/selection-select-all-pages.js
@@ -1,5 +1,6 @@
 import '../button/button-subtle.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { SelectionInfo } from './selection-mixin.js';
 import { SelectionObserverMixin } from './selection-observer-mixin.js';
@@ -8,7 +9,7 @@ import { SelectionObserverMixin } from './selection-observer-mixin.js';
  * A subtle button that selects all items for all pages.
  * @fires d2l-selection-observer-subscribe - Internal event
  */
-class SelectAllPages extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) {
+class SelectAllPages extends FocusMixin(LocalizeCoreElement(SelectionObserverMixin(LitElement))) {
 
 	static get styles() {
 		return css`
@@ -21,6 +22,8 @@ class SelectAllPages extends LocalizeCoreElement(SelectionObserverMixin(LitEleme
 		`;
 	}
 
+	static focusElementSelector = 'd2l-button-subtle';
+
 	render() {
 		if (!this._provider) return;
 		if (!this._provider.itemCount) return;
@@ -32,11 +35,6 @@ class SelectAllPages extends LocalizeCoreElement(SelectionObserverMixin(LitEleme
 				@click="${this._handleClick}"
 				text="${this.localize('components.selection.select-all-items', 'count', this._provider.itemCount)}">
 			</d2l-button-subtle>`;
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-button-subtle');
-		if (elem) elem.focus();
 	}
 
 	_handleClick() {

--- a/components/selection/selection-select-all.js
+++ b/components/selection/selection-select-all.js
@@ -1,5 +1,6 @@
 import '../inputs/input-checkbox.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../lang/localize-core-element.js';
 import { SelectionInfo } from './selection-mixin.js';
@@ -9,7 +10,7 @@ import { SelectionObserverMixin } from './selection-observer-mixin.js';
  * A checkbox that provides select-all behavior for selection components such as tables and lists.
  * @fires d2l-selection-observer-subscribe - Internal event
  */
-class SelectAll extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) {
+class SelectAll extends FocusMixin(LocalizeCoreElement(SelectionObserverMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -33,6 +34,8 @@ class SelectAll extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) 
 		`;
 	}
 
+	static focusElementSelector = 'd2l-input-checkbox';
+
 	constructor() {
 		super();
 		this.disabled = false;
@@ -54,11 +57,6 @@ class SelectAll extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) 
 				?indeterminate="${this.selectionInfo.state === SelectionInfo.states.some}">
 			</d2l-input-checkbox>
 		`;
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-checkbox');
-		if (elem) elem.focus();
 	}
 
 	_handleCheckboxChange(e) {

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -1,12 +1,13 @@
 import '../colors/colors.js';
 import '../tooltip/tooltip.js';
 import { css, html } from 'lit-element/lit-element.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FocusVisiblePolyfillMixin } from '../../mixins/focus-visible-polyfill-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
-export const SwitchMixin = superclass => class extends RtlMixin(FocusVisiblePolyfillMixin(superclass)) {
+export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(FocusVisiblePolyfillMixin(superclass))) {
 
 	static get properties() {
 		return {
@@ -165,6 +166,8 @@ export const SwitchMixin = superclass => class extends RtlMixin(FocusVisiblePoly
 		`;
 	}
 
+	static focusElementSelector = '.d2l-switch-container';
+
 	constructor() {
 		super();
 		this.disabled = false;
@@ -210,11 +213,6 @@ export const SwitchMixin = superclass => class extends RtlMixin(FocusVisiblePoly
 			${tooltip}
 			${textPosition === 'end' ? text : ''}
 		`;
-	}
-
-	focus() {
-		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-switch-container');
-		if (elem) elem.focus();
 	}
 
 	_handleClick() {

--- a/components/switch/test/switch.test.js
+++ b/components/switch/test/switch.test.js
@@ -29,7 +29,8 @@ describe('d2l-switch', () => {
 
 	it('delegates focus to underlying focusable', async() => {
 		const elem = await fixture(html`<d2l-switch text="some text"></d2l-switch>`);
-		elem.focus();
+		setTimeout(() => elem.focus());
+		await oneEvent(elem, 'focus');
 		const activeElement = getComposedActiveElement();
 		expect(activeElement).to.equal(elem.shadowRoot.querySelector('[role="switch"]'));
 	});

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -1,11 +1,12 @@
 import '../icons/icon.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 
 /**
  * Button for sorting a table column in ascending/descending order.
  * @slot - Text of the sort button
  */
-export class TableColSortButton extends LitElement {
+export class TableColSortButton extends FocusMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -57,6 +58,8 @@ export class TableColSortButton extends LitElement {
 		`;
 	}
 
+	static focusElementSelector = 'button';
+
 	constructor() {
 		super();
 		this.nosort = false;
@@ -68,11 +71,6 @@ export class TableColSortButton extends LitElement {
 			html`<d2l-icon icon="${this.desc ? 'tier1:arrow-toggle-down' : 'tier1:arrow-toggle-up'}"></d2l-icon>` :
 			null;
 		return html`<button type="button"><slot></slot>${iconView}</button>`;
-	}
-
-	focus() {
-		const button = this.shadowRoot && this.shadowRoot.querySelector('button');
-		if (button) button.focus();
 	}
 
 }

--- a/mixins/focus-mixin.js
+++ b/mixins/focus-mixin.js
@@ -1,0 +1,41 @@
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
+
+export const FocusMixin = dedupeMixin(superclass => class extends superclass {
+
+	static focusElementSelector = null;
+
+	constructor() {
+		super();
+		this._focusOnFirstRender = false;
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		if (this._focusOnFirstRender) {
+			this._focusOnFirstRender = false;
+			this.focus();
+		}
+	}
+
+	focus() {
+
+		const selector = this.constructor.focusElementSelector;
+		if (!selector) {
+			throw new Error(`FocusMixin: no static focusElementSelector provided for "${this.tagName}"`);
+		}
+
+		if (!this.hasUpdated) {
+			this._focusOnFirstRender = true;
+			return;
+		}
+
+		const elem = this.shadowRoot.querySelector(selector);
+		if (!elem) {
+			throw new Error(`FocusMixin: selector "${selector}" yielded no element for "${this.tagName}"`);
+		}
+
+		elem.focus();
+
+	}
+
+});

--- a/mixins/focus-mixin.md
+++ b/mixins/focus-mixin.md
@@ -1,0 +1,24 @@
+# FocusMixin
+
+The `FocusMixin` can be used to delegate focus to an element within a component's shadow root when its `focus()` method is called.
+
+If the component has yet to render, focus will automatically be applied after `firstUpdated`.
+
+## Usage
+
+Apply the mixin and set the static `focusElementSelector` to a CSS query selector which will match the element to which focus should be delegated.
+
+```js
+import { FocusMixin } from '@brightspace-ui/core/mixins/focus-mixin.js';
+
+class MyComponent extends FocusMixin(LitElement) {
+  
+  // delegate focus to the underlying input
+  static focusElementSelector = 'input';
+
+  render() {
+	  return html`<input type="text">`;
+  }
+
+}
+```

--- a/mixins/test/focus-mixin.test.js
+++ b/mixins/test/focus-mixin.test.js
@@ -1,0 +1,61 @@
+
+import { defineCE, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { FocusMixin } from '../focus-mixin.js';
+import { getComposedActiveElement } from '../../../helpers/focus.js';
+import { LitElement } from 'lit-element/lit-element.js';
+
+const mixinTag = defineCE(
+	class extends FocusMixin(LitElement) {
+		static focusElementSelector = 'input';
+		render() {
+			return html`<input type="text">`;
+		}
+	}
+);
+
+const mixinNoSelectorTag = defineCE(
+	class extends FocusMixin(LitElement) {}
+);
+
+const mixinNoElemTag = defineCE(
+	class extends FocusMixin(LitElement) {
+		static focusElementSelector = 'div';
+		render() {
+			return html`<input type="text">`;
+		}
+	}
+);
+
+describe('FocusMixin', () => {
+
+	it('should delegate focus to underlying input', async() => {
+		const elem = await fixture(`<${mixinTag}></${mixinTag}>`);
+		setTimeout(() => elem.focus());
+		await oneEvent(elem, 'focus');
+		const activeElement = getComposedActiveElement();
+		expect(activeElement).to.equal(elem.shadowRoot.querySelector('input'));
+	});
+
+	it('should focus even if component has not rendered', async() => {
+		const container = await fixture(html`<div></div>`);
+		const elem = document.createElement(mixinTag);
+		container.appendChild(elem);
+		setTimeout(() => elem.focus());
+		await oneEvent(elem, 'focus');
+		const activeElement = getComposedActiveElement();
+		expect(activeElement).to.equal(elem.shadowRoot.querySelector('input'));
+	});
+
+	it('should throw if no selector is provided', async() => {
+		const elem = await fixture(`<${mixinNoSelectorTag}></${mixinNoSelectorTag}>`);
+		expect(() => elem.focus())
+			.to.throw(`FocusMixin: no static focusElementSelector provided for "${mixinNoSelectorTag.toUpperCase()}"`);
+	});
+
+	it('should throw if no selector yields no element', async() => {
+		const elem = await fixture(`<${mixinNoElemTag}></${mixinNoElemTag}>`);
+		expect(() => elem.focus())
+			.to.throw(`FocusMixin: selector "div" yielded no element for "${mixinNoElemTag.toUpperCase()}"`);
+	});
+
+});


### PR DESCRIPTION
The need for this arose from #2165, where if the component hadn't initially rendered when `focus()` was called, the focus wouldn't happen.

This mixin is pretty simple -- the consumer provides it with a CSS selector and it implements the `focus()` method. Inside there, if the component hasn't yet rendered, it remembers that and when it _does_ render, will the use the selector to focus.