### PR TITLE
Fix update-package-lock workflow credentials

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          persist-credentials: false
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
           node-version: '14'


### PR DESCRIPTION
Thanks to @devpow112 for the callout (https://github.com/BrightspaceUI/core/pull/2129#pullrequestreview-887226110)!  Previously, additional commits added to an open `package-lock.json` update PR wouldn't trigger ci (found during the BSI migration).  I [fixed the action](https://github.com/BrightspaceUI/actions/pull/55/files) and [updated the README instructions](https://github.com/BrightspaceUI/actions/pull/56/files), but didn't add the fix to `core`.  Doing that here!