### PR TITLE
Zero out margins when fullscreen-within so fixed positioned elements position at the top of the viewport

### DIFF
--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -130,6 +130,7 @@ export const dialogStyles = css`
 		border-radius: 0;
 		box-shadow: none;
 		height: 100% !important;
+		margin: 0;
 		max-height: initial; /* required to override Chrome native positioning */
 		max-width: initial; /* required to override Chrome native positioning */
 		top: 0;


### PR DESCRIPTION
Because the fullscreen dialog applies a transform to its outer div, fixed position elements in fullscreen mode have their origin set 1.5rem below the top of the viewport. To fix this, we can just zero out the margins when `d2l-fullscreen-within` is set.