### PR TITLE
Update list-item to be absolute positioned when fullscreen within for Safari.

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -99,6 +99,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				z-index: 10; /* must be greater than adjacent selected items */
 			}
 			:host([_fullscreen-within]) {
+				position: absolute; /* required for Safari */
 				z-index: 1000; /* must be greater than floating workflow buttons */
 			}
 			:host(:first-child) d2l-list-item-generic-layout[data-separators="between"] {


### PR DESCRIPTION
This PR fixes an issue in Safari where the fullscreen html-editor (`position: fixed;`) within the list-item is not stacked properly.  I only observe this issue at larger viewport heights - resizing the browser to be shorter can cause the editor to suddenly appear.  Oddly, it can also appear by adjusting the editor's `z-index` to be smaller in the dev console, which is also counter to what one would expect.  This seems like a buggy behaviour with Safari.  Changing the positioning of the list-item when an element within is fullscreen addresses the issue.

Screenshot showing the incorrect behaviour:
![image](https://user-images.githubusercontent.com/9042472/157329400-05cd8926-a061-4c6a-9e56-c11fc5e1507a.png)

Screenshot showing the corrected behaviour:
![image](https://user-images.githubusercontent.com/9042472/157329590-edb9af93-e048-49ab-b186-9a6796cfc901.png)
