### PR TITLE
feat: adding id-list attribute manipulation helpers

### DIFF
--- a/components/tooltip/demo/tooltip.html
+++ b/components/tooltip/demo/tooltip.html
@@ -52,7 +52,7 @@
 		<h2>Tooltip (error)</h2>
 		<d2l-demo-snippet>
 			<template>
-				<d2l-input-text placeholder="Hover for Error" id="tooltip-error" aria-invalid="true"></d2l-input-text>
+				<d2l-input-text placeholder="Hover for Error" id="tooltip-error" aria-invalid="true" label="label"></d2l-input-text>
 				<d2l-tooltip for="tooltip-error" state="error" align="start" offset="10">
 					Your error message will display here
 				</d2l-tooltip>

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -1,6 +1,6 @@
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { cssEscape, getBoundingAncestor, getOffsetParent } from '../../helpers/dom.js';
+import { cssEscape, elemIdListAdd, getBoundingAncestor, getOffsetParent } from '../../helpers/dom.js';
 import { announce } from '../../helpers/announce.js';
 import { bodySmallStyles } from '../typography/styles.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
@@ -844,9 +844,9 @@ class Tooltip extends RtlMixin(LitElement) {
 			this.id = this.id || getUniqueId();
 			this.setAttribute('role', 'tooltip');
 			if (this.forType === 'label') {
-				this._target.setAttribute('aria-labelledby', this.id);
+				elemIdListAdd(this._target, 'aria-labelledby', this.id);
 			} else if (!this.announced || isInteractive) {
-				this._target.setAttribute('aria-describedby', this.id);
+				elemIdListAdd(this._target, 'aria-describedby', this.id);
 			}
 			if (logAccessibilityWarning && !isInteractive && !this.announced) {
 				console.warn(

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -76,6 +76,12 @@ DOM helper functions to make your life easier.
 ```js
 import { ... } from '@brightspace-ui/core/helpers/dom.js';
 
+// adds a value to an id-list attribute (e.g. aria-labelledby)
+elemIdListAdd(node, attrName, value);
+
+// removes a value from an id-list attribute (e.g. aria-labelledby)
+elemIdListRemoves(node, attrName, value);
+
 // returns null or the closest ancestor that fulfills the specified predicate fxn
 findComposedAncestor(node, predicate);
 

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -7,6 +7,53 @@ export function cssEscape(val) {
 	return val;
 }
 
+export function elemIdListAdd(elem, attrName, value) {
+
+	if (elem === undefined || elem === null || !elem.getAttribute || !elem.setAttribute) {
+		throw new TypeError('elemIdListAdd: "elem" must be a valid DOM Element');
+	}
+	if (typeof(attrName) !== 'string') {
+		throw new TypeError('elemIdListAdd: "attrName" must be a valid string');
+	}
+	if (typeof(value) !== 'string') {
+		throw new TypeError('elemIdListAdd: "value" must be a valid ID string');
+	}
+
+	const parts = elem.hasAttribute(attrName) ? elem.getAttribute(attrName).split(' ') : [];
+	if (parts.indexOf(value) > -1) return;
+
+	parts.push(value);
+	elem.setAttribute(attrName, parts.join(' '));
+
+}
+
+export function elemIdListRemove(elem, attrName, value) {
+
+	if (elem === undefined || elem === null || !elem.getAttribute || !elem.setAttribute) {
+		throw new TypeError('elemIdListRemove: "elem" must be a valid DOM Element');
+	}
+	if (typeof(attrName) !== 'string') {
+		throw new TypeError('elemIdListRemove: "attrName" must be a valid string');
+	}
+	if (typeof(value) !== 'string') {
+		throw new TypeError('elemIdListRemove: "value" must be a valid ID string');
+	}
+
+	const existingValue = elem.getAttribute(attrName) || '';
+
+	const parts = existingValue.split(' ');
+	const index = parts.indexOf(value);
+	if (index === -1) return;
+
+	parts.splice(index, 1);
+	if (parts.length === 0) {
+		elem.removeAttribute(attrName);
+	} else {
+		elem.setAttribute(attrName, parts.join(' '));
+	}
+
+}
+
 export function findComposedAncestor(node, predicate) {
 	while (node) {
 		if (predicate(node) === true) {

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -45,10 +45,10 @@ export function elemIdListRemove(elem, attrName, value) {
 	const index = parts.indexOf(value);
 	if (index === -1) return;
 
-	parts.splice(index, 1);
-	if (parts.length === 0) {
+	if (parts.length === 1) {
 		elem.removeAttribute(attrName);
 	} else {
+		parts.splice(index, 1);
 		elem.setAttribute(attrName, parts.join(' '));
 	}
 

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -1,6 +1,8 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import {
 	cssEscape,
+	elemIdListAdd,
+	elemIdListRemove,
 	findComposedAncestor,
 	getBoundingAncestor,
 	getComposedChildren,
@@ -118,6 +120,108 @@ describe('dom', () => {
 		it('should escape $ using polyfill', () => {
 			const val = cssEscape('foo$bar$blah');
 			expect(val).to.equal('foo\\$bar\\$blah');
+		});
+
+	});
+
+	describe('elemIdList', () => {
+
+		describe('add', () => {
+
+			[
+				undefined,
+				null,
+				{}
+			].forEach((input) => {
+				it(`should throw TypeError for "${input}" elem`, () => {
+					expect(() => {
+						elemIdListAdd(input, 'foo', 'bar');
+					}).to.throw(TypeError, 'elemIdListAdd: "elem" must be a valid DOM Element');
+				});
+				it(`should throw TypeError for "${input}" attrName`, async() => {
+					const elem = await fixture(html`<div></div>`);
+					expect(() => {
+						elemIdListAdd(elem, input, 'bar');
+					}).to.throw(TypeError, 'elemIdListAdd: "attrName" must be a valid string');
+				});
+				it(`should throw TypeError for "${input}" value`, async() => {
+					const elem = await fixture(html`<div></div>`);
+					expect(() => {
+						elemIdListAdd(elem, 'foo', input);
+					}).to.throw(TypeError, 'elemIdListAdd: "value" must be a valid ID string');
+				});
+			});
+
+			it('should add to an empty attribute', async() => {
+				const elem = await fixture(html`<div></div>`);
+				elemIdListAdd(elem, 'aria-labelledby', 'one');
+				expect(elem.getAttribute('aria-labelledby')).to.equal('one');
+			});
+
+			it('should add to an existing attribute', async() => {
+				const elem = await fixture(html`<div aria-labelledby="one"></div>`);
+				elemIdListAdd(elem, 'aria-labelledby', 'two');
+				expect(elem.getAttribute('aria-labelledby')).to.equal('one two');
+			});
+
+			it('should do nothing if value already exists', async() => {
+				const elem = await fixture(html`<div aria-labelledby="one"></div>`);
+				elemIdListAdd(elem, 'aria-labelledby', 'one');
+				expect(elem.getAttribute('aria-labelledby')).to.equal('one');
+			});
+
+		});
+
+		describe('remove', () => {
+
+			[
+				undefined,
+				null,
+				{}
+			].forEach((input) => {
+				it(`should throw TypeError for "${input}" elem`, () => {
+					expect(() => {
+						elemIdListRemove(input, 'foo', 'bar');
+					}).to.throw(TypeError, 'elemIdListRemove: "elem" must be a valid DOM Element');
+				});
+				it(`should throw TypeError for "${input}" attrName`, async() => {
+					const elem = await fixture(html`<div></div>`);
+					expect(() => {
+						elemIdListRemove(elem, input, 'bar');
+					}).to.throw(TypeError, 'elemIdListRemove: "attrName" must be a valid string');
+				});
+				it(`should throw TypeError for "${input}" value`, async() => {
+					const elem = await fixture(html`<div></div>`);
+					expect(() => {
+						elemIdListRemove(elem, 'foo', input);
+					}).to.throw(TypeError, 'elemIdListRemove: "value" must be a valid ID string');
+				});
+			});
+
+			it('should do nothing to an empty attribute', async() => {
+				const elem = await fixture(html`<div></div>`);
+				elemIdListRemove(elem, 'aria-labelledby', 'one');
+				expect(elem.hasAttribute('aria-labelledby')).to.be.false;
+			});
+
+			it('should remove from an existing attribute with multiple values', async() => {
+				const elem = await fixture(html`<div aria-labelledby="one two"></div>`);
+				elemIdListRemove(elem, 'aria-labelledby', 'two');
+				expect(elem.getAttribute('aria-labelledby')).to.equal('one');
+			});
+
+			it('should remove attribute if last value', async() => {
+				const elem = await fixture(html`<div aria-labelledby="one"></div>`);
+				elemIdListRemove(elem, 'aria-labelledby', 'one');
+				expect(elem.hasAttribute('aria-labelledby')).to.be.false;
+			});
+
+			it('should do nothing if value does not exist', async() => {
+				const elem = await fixture(html`<div aria-labelledby="one"></div>`);
+				elemIdListRemove(elem, 'aria-labelledby', 'two');
+				expect(elem.getAttribute('aria-labelledby')).to.equal('one');
+			});
+
 		});
 
 	});


### PR DESCRIPTION
Before we can change our button-like components to leverage `aria-describedby` for their `description` attributes, we need to fix `<d2l-tooltip>` (which also uses `aria-labelledby` and `aria-describedby`) so that it doesn't clobber any existing values in those attributes.

To solve that, I created two DOM helpers which can be used to manipulate space-separated ID-list attributes. I switched tooltip to use them.