### PR TITLE
Attempt 2 for fixing stacking issue with fullscreen editor in list items.

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -99,7 +99,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				z-index: 10; /* must be greater than adjacent selected items */
 			}
 			:host([_fullscreen-within]) {
-				position: absolute; /* required for Safari */
+				position: fixed; /* required for Safari */
 				z-index: 1000; /* must be greater than floating workflow buttons */
 			}
 			:host(:first-child) d2l-list-item-generic-layout[data-separators="between"] {


### PR DESCRIPTION
This PR is the 2nd attempt to work around some buggy behaviour in Safari.  The stacking context is messed up - the fullscreen editor should be on top.  This scenario is more complex (fullscreen editor in list-item in scroll-wrapper in fullscreen dialog) than the previous scenario, though it is not clear why Safari is messing up.

Before the fix:
![image](https://user-images.githubusercontent.com/9042472/157526488-48214684-5c21-4946-80e7-65d1a5979413.png)

After the fix:
![image](https://user-images.githubusercontent.com/9042472/157526618-a03b6f8a-fd64-4d70-963b-82c881716c10.png)
