### PR TITLE
Visual-diff: Input-time: Use timeout to fix flakiness

### DIFF
--- a/components/inputs/test/input-helper.js
+++ b/components/inputs/test/input-helper.js
@@ -2,14 +2,12 @@
 export async function open(page, selector) {
 	const openEvent = page.$eval(selector, (elem) => {
 		return new Promise((resolve) => {
-			elem.shadowRoot.querySelector('d2l-dropdown').addEventListener('d2l-dropdown-open', resolve, { once: true });
+			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
+			dropdown.addEventListener('d2l-dropdown-open', resolve, { once: true });
+			dropdown.toggleOpen();
 		});
 	});
 
-	await page.$eval(selector, (elem) => {
-		const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
-		dropdown.toggleOpen();
-	});
 	return openEvent;
 }
 

--- a/components/inputs/test/input-time.visual-diff.js
+++ b/components/inputs/test/input-time.visual-diff.js
@@ -133,6 +133,7 @@ describe('d2l-input-time', () => {
 
 		it('dropdown open top', async function() {
 			await open(page, '#dropdown');
+			await page.waitForTimeout(100);
 			const rect = await getRect(page, '#dropdown');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 		});
@@ -166,6 +167,7 @@ describe('d2l-input-time', () => {
 		it('dropdown open enforce-time-intervals', async function() {
 			await page.$eval('#enforce', (elem) => elem.skeleton = false);
 			await open(page, '#enforce');
+			await page.waitForTimeout(100);
 			const rect = await getRect(page, '#enforce');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 			await reset(page, '#enforce'); // Make sure the dropdown is closed before the next test


### PR DESCRIPTION
Ran several times locally and with this pattern I didn't see flake. I'll try several times here too and we'll see.