### PR TITLE
Added a drag group id to disable dragging if the groups have different ids

### DIFF
--- a/components/list/demo/list-drag-and-drop-position.js
+++ b/components/list/demo/list-drag-and-drop-position.js
@@ -13,7 +13,8 @@ class ListDemoDragAndDropPosition extends LitElement {
 			// below are for demonstration only
 			grid: { type: Boolean },
 			hrefs: { type: Boolean },
-			selectable: { type: Boolean }
+			selectable: { type: Boolean },
+			dragGroupId: { type: String, attribute: 'drag-group-id' }
 		};
 	}
 
@@ -67,7 +68,7 @@ class ListDemoDragAndDropPosition extends LitElement {
 
 	render() {
 		return html`
-			<d2l-list ?grid="${this.grid}" @d2l-list-item-position-change="${this._moveItems}">
+			<d2l-list ?grid="${this.grid}" drag-group-id="${ifDefined(this.dragGroupId)}" @d2l-list-item-position-change="${this._moveItems}">
 				${repeat(this.list, (item) => item.key, (item) => html`
 					<d2l-list-item
 						key="${ifDefined(item.key)}"

--- a/components/list/demo/list-drag-and-drop.html
+++ b/components/list/demo/list-drag-and-drop.html
@@ -30,6 +30,31 @@
 			</template>
 		</d2l-demo-snippet>
 
+		<h2>Drag Between Lists</h2>
+
+
+		<p>Can Darg Between These Two</p>
+
+		<d2l-demo-snippet>
+			<template>
+				<d2l-demo-list-drag-and-drop-position grid selectable hrefs drag-group-id="id-1"></d2l-demo-list-drag-and-drop-position>
+			</template>
+		</d2l-demo-snippet>
+
+		<d2l-demo-snippet>
+			<template>
+				<d2l-demo-list-drag-and-drop-position grid selectable hrefs drag-group-id="id-1"></d2l-demo-list-drag-and-drop-position>
+			</template>
+		</d2l-demo-snippet>
+
+		<p>Can't Drag To This One</p>
+
+		<d2l-demo-snippet>
+			<template>
+				<d2l-demo-list-drag-and-drop-position grid selectable hrefs drag-group-id="id-2"></d2l-demo-list-drag-and-drop-position>
+			</template>
+		</d2l-demo-snippet>
+
 
 	</d2l-demo-page>
 

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -765,7 +765,11 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 	}
 
 	_renderBottomPlacementMarker(renderTemplate) {
-		return this._dropLocation === dropLocation.below ? html`<div class="d2l-list-item-drag-bottom-marker">${renderTemplate}</div>` : null;
+		const dragState = getDragState();
+		const sourceGroupId = dragState.dragTargets[0]?._getRootList().attributes['drag-group-id']?.nodeValue;
+		const targetGroupId = this._getRootList().attributes['drag-group-id']?.nodeValue;
+		const shouldRenderMarker = sourceGroupId === targetGroupId && this._dropLocation === dropLocation.below;
+		return shouldRenderMarker ? html`<div class="d2l-list-item-drag-bottom-marker">${renderTemplate}</div>` : null;
 	}
 
 	_renderDragHandle(templateMethod) {
@@ -821,6 +825,10 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 	}
 
 	_renderTopPlacementMarker(renderTemplate) {
-		return this._dropLocation === dropLocation.above ? html`<div class="d2l-list-item-drag-top-marker">${renderTemplate}</div>` : null;
+		const dragState = getDragState();
+		const sourceGroupId = dragState.dragTargets[0]?._getRootList().attributes['drag-group-id']?.nodeValue;
+		const targetGroupId = this._getRootList().attributes['drag-group-id']?.nodeValue;
+		const shouldRenderMarker = sourceGroupId === targetGroupId && this._dropLocation === dropLocation.above;
+		return shouldRenderMarker ? html`<div class="d2l-list-item-drag-top-marker">${renderTemplate}</div>` : null;
 	}
 };


### PR DESCRIPTION
This addresses https://github.com/BrightspaceUI/core/issues/2095

Adds a single property `drag-group-id` to specify a drag group for inter list dragging. 

This approach allows for a lot of customization. For example if you have four lists on a page and you want to allow dragging between 1 and 2 and 3 and 4 but not with each other you would be able to accomplish it by giving 1,2 the same `drag-group-id` and 3,4 the same `drag-group-id`.

This fixes the issue with rubric issue while leaving a multi list drag possible to implement in the future. 

![temp4](https://user-images.githubusercontent.com/30714020/158222547-ad279f96-dbd7-446c-9497-3ed857d50c84.gif)
