### PR TITLE
fix: going back to a polymer-cli friendly static getter

### DIFF
--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -66,8 +66,6 @@ export const ButtonMixin = superclass => class extends FocusMixin(FocusVisiblePo
 		};
 	}
 
-	static focusElementSelector = 'button';
-
 	constructor() {
 		super();
 		this.disabled = false;
@@ -98,6 +96,10 @@ export const ButtonMixin = superclass => class extends FocusMixin(FocusVisiblePo
 		const oldValue = this._disabledTooltip;
 		this._disabledTooltip = value;
 		this.requestUpdate('disabledTooltip', oldValue);
+	}
+
+	static get focusElementSelector() {
+		return 'button';
 	}
 
 	connectedCallback() {

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -235,8 +235,6 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 		`];
 	}
 
-	static focusElementSelector = 'a';
-
 	constructor() {
 		super();
 		this.alignCenter = false;
@@ -249,6 +247,10 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 		this._tooltipShowing = false;
 		this._onBadgeResize = this._onBadgeResize.bind(this);
 		this._onFooterResize = this._onFooterResize.bind(this);
+	}
+
+	static get focusElementSelector() {
+		return 'a';
 	}
 
 	firstUpdated(changedProperties) {

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -137,8 +137,6 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		`];
 	}
 
-	static focusElementSelector = 'd2l-dropdown-button-subtle';
-
 	constructor() {
 		super();
 		this.disabled = false;
@@ -153,6 +151,10 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 			{ onSubscribe: this._updateActiveFiltersSubscriber.bind(this), updateSubscribers: this._updateActiveFiltersSubscribers.bind(this) },
 			{}
 		);
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-dropdown-button-subtle';
 	}
 
 	connectedCallback() {

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -31,12 +31,14 @@ class FocusTrap extends FocusMixin(LitElement) {
 		`;
 	}
 
-	static focusElementSelector = '.d2l-focus-trap-start';
-
 	constructor() {
 		super();
 		this.trap = false;
 		this._handleBodyFocus = this._handleBodyFocus.bind(this);
+	}
+
+	static get focusElementSelector() {
+		return '.d2l-focus-trap-start';
 	}
 
 	connectedCallback() {

--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -164,8 +164,6 @@ class InputCheckbox extends FocusMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		];
 	}
 
-	static focusElementSelector = 'input.d2l-input-checkbox';
-
 	constructor() {
 		super();
 		this.checked = false;
@@ -175,6 +173,10 @@ class InputCheckbox extends FocusMixin(SkeletonMixin(RtlMixin(LitElement))) {
 		this.notTabbable = false;
 		this.value = 'on';
 		this._descriptionId = getUniqueId();
+	}
+
+	static get focusElementSelector() {
+		return 'input.d2l-input-checkbox';
 	}
 
 	render() {

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -129,8 +129,6 @@ class InputDateRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 		`];
 	}
 
-	static focusElementSelector = 'd2l-input-date';
-
 	constructor() {
 		super();
 
@@ -145,6 +143,10 @@ class InputDateRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 
 		this._startInputId = getUniqueId();
 		this._endInputId = getUniqueId();
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-input-date';
 	}
 
 	/** @ignore */

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -172,8 +172,6 @@ class InputDateTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMi
 		`];
 	}
 
-	static focusElementSelector = 'd2l-input-date-time';
-
 	constructor() {
 		super();
 
@@ -191,6 +189,10 @@ class InputDateTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMi
 		this._endInputId = getUniqueId();
 
 		this._slotOccupied = false;
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-input-date-time';
 	}
 
 	/** @ignore */

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -113,8 +113,6 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 		`];
 	}
 
-	static focusElementSelector = 'd2l-input-date';
-
 	constructor() {
 		super();
 		this.disabled = false;
@@ -177,6 +175,10 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 			}
 		}
 		this.requestUpdate('value', oldValue);
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-input-date';
 	}
 
 	/** @ignore */

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -138,8 +138,6 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 		`];
 	}
 
-	static focusElementSelector = 'd2l-input-text';
-
 	constructor() {
 		super();
 
@@ -168,6 +166,10 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 		this._shownValue = '';
 
 		this._dateTimeDescriptor = getDateTimeDescriptorShared();
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-input-text';
 	}
 
 	/** @ignore */

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -192,8 +192,6 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 		];
 	}
 
-	static focusElementSelector = 'd2l-input-text';
-
 	constructor() {
 		super();
 		this.autofocus = false;
@@ -286,6 +284,10 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 		this.value = parseFloat(val);
 		this._valueTrailingZeroes = this.value === undefined ? '' : val;
 		this._updateFormattedValue();
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-input-text';
 	}
 
 	/** @ignore */

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -86,8 +86,6 @@ class InputPercent extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMix
 		];
 	}
 
-	static focusElementSelector = 'd2l-input-number';
-
 	constructor() {
 		super();
 		this.autofocus = false;
@@ -103,6 +101,10 @@ class InputPercent extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMix
 		else if (val > 100) val = 100;
 		this._value = val;
 		this.requestUpdate('value', oldValue);
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-input-number';
 	}
 
 	render() {

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -74,8 +74,6 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 		];
 	}
 
-	static focusElementSelector = 'd2l-input-text';
-
 	constructor() {
 		super();
 		this._lastSearchValue = '';
@@ -87,6 +85,10 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 	/** @ignore */
 	get lastSearchValue() { return this._lastSearchValue; }
 	set lastSearchValue(val) {}
+
+	static get focusElementSelector() {
+		return 'd2l-input-text';
+	}
 
 	connectedCallback() {
 		super.connectedCallback();

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -235,8 +235,6 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		];
 	}
 
-	static focusElementSelector = '.d2l-input';
-
 	constructor() {
 		super();
 		this.autofocus = false;
@@ -270,6 +268,10 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 	get value() { return this._value; }
 	set value(val) {
 		this._setValue(val, true);
+	}
+
+	static get focusElementSelector() {
+		return '.d2l-input';
 	}
 
 	/** @ignore */

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -150,8 +150,6 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 		`];
 	}
 
-	static focusElementSelector = 'textarea';
-
 	constructor() {
 		super();
 		this.disabled = false;
@@ -163,6 +161,10 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 
 		this._descriptionId = getUniqueId();
 		this._textareaId = getUniqueId();
+	}
+
+	static get focusElementSelector() {
+		return 'textarea';
 	}
 
 	/** @ignore */

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -137,8 +137,6 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 		`];
 	}
 
-	static focusElementSelector = 'd2l-input-time';
-
 	constructor() {
 		super();
 
@@ -176,6 +174,10 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 		if (isValidTime(val)) this._startValue = (this.enforceTimeIntervals && !this._initialValues) ? getValidISOTimeAtInterval(val, this.timeInterval) : val;
 		else this._startValue = formatDateInISOTime(getDefaultTime(undefined, this.enforceTimeIntervals, this.timeInterval));
 		this.requestUpdate('startValue', oldValue);
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-input-time';
 	}
 
 	/** @ignore */

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -215,8 +215,6 @@ class InputTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 		];
 	}
 
-	static focusElementSelector = '.d2l-input';
-
 	constructor() {
 		super();
 		this.disabled = false;
@@ -252,6 +250,10 @@ class InputTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 		this._value = formatDateInISOTime(time);
 		this._formattedValue = formatTime(time);
 		this.requestUpdate('value', oldValue);
+	}
+
+	static get focusElementSelector() {
+		return '.d2l-input';
 	}
 
 	disconnectedCallback() {

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -97,13 +97,15 @@ class Link extends FocusMixin(LitElement) {
 		];
 	}
 
-	static focusElementSelector = '.d2l-link';
-
 	constructor() {
 		super();
 		this.download = false;
 		this.main = false;
 		this.small = false;
+	}
+
+	static get focusElementSelector() {
+		return '.d2l-link';
 	}
 
 	render() {

--- a/components/selection/selection-action-dropdown.js
+++ b/components/selection/selection-action-dropdown.js
@@ -28,7 +28,9 @@ class ActionDropdown extends FocusMixin(LocalizeCoreElement(SelectionActionMixin
 		return dropdownOpenerStyles;
 	}
 
-	static focusElementSelector = 'd2l-button-subtle';
+	static get focusElementSelector() {
+		return 'd2l-button-subtle';
+	}
 
 	render() {
 		return html`

--- a/components/selection/selection-action.js
+++ b/components/selection/selection-action.js
@@ -40,7 +40,9 @@ class Action extends FocusMixin(LocalizeCoreElement(SelectionActionMixin(ButtonM
 		`;
 	}
 
-	static focusElementSelector = 'd2l-button-subtle';
+	static get focusElementSelector() {
+		return 'd2l-button-subtle';
+	}
 
 	connectedCallback() {
 		super.connectedCallback();

--- a/components/selection/selection-select-all-pages.js
+++ b/components/selection/selection-select-all-pages.js
@@ -22,7 +22,9 @@ class SelectAllPages extends FocusMixin(LocalizeCoreElement(SelectionObserverMix
 		`;
 	}
 
-	static focusElementSelector = 'd2l-button-subtle';
+	static get focusElementSelector() {
+		return 'd2l-button-subtle';
+	}
 
 	render() {
 		if (!this._provider) return;

--- a/components/selection/selection-select-all.js
+++ b/components/selection/selection-select-all.js
@@ -34,11 +34,13 @@ class SelectAll extends FocusMixin(LocalizeCoreElement(SelectionObserverMixin(Li
 		`;
 	}
 
-	static focusElementSelector = 'd2l-input-checkbox';
-
 	constructor() {
 		super();
 		this.disabled = false;
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-input-checkbox';
 	}
 
 	render() {

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -166,8 +166,6 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 		`;
 	}
 
-	static focusElementSelector = '.d2l-switch-container';
-
 	constructor() {
 		super();
 		this.disabled = false;
@@ -176,6 +174,10 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 		this.textPosition = 'end';
 		this._switchId = getUniqueId();
 		this._textId = getUniqueId();
+	}
+
+	static get focusElementSelector() {
+		return '.d2l-switch-container';
 	}
 
 	firstUpdated(changedProperties) {

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -58,12 +58,14 @@ export class TableColSortButton extends FocusMixin(LitElement) {
 		`;
 	}
 
-	static focusElementSelector = 'button';
-
 	constructor() {
 		super();
 		this.nosort = false;
 		this.desc = false;
+	}
+
+	static get focusElementSelector() {
+		return 'button';
 	}
 
 	render() {

--- a/mixins/focus-mixin.js
+++ b/mixins/focus-mixin.js
@@ -2,11 +2,13 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 export const FocusMixin = dedupeMixin(superclass => class extends superclass {
 
-	static focusElementSelector = null;
-
 	constructor() {
 		super();
 		this._focusOnFirstRender = false;
+	}
+
+	static get focusElementSelector() {
+		return null;
 	}
 
 	firstUpdated(changedProperties) {

--- a/mixins/focus-mixin.md
+++ b/mixins/focus-mixin.md
@@ -14,7 +14,8 @@ import { FocusMixin } from '@brightspace-ui/core/mixins/focus-mixin.js';
 class MyComponent extends FocusMixin(LitElement) {
   
   // delegate focus to the underlying input
-  static focusElementSelector = 'input';
+  static get focusElementSelector() {
+		return 'input';
 
   render() {
 	  return html`<input type="text">`;

--- a/mixins/test/focus-mixin.test.js
+++ b/mixins/test/focus-mixin.test.js
@@ -6,7 +6,9 @@ import { LitElement } from 'lit-element/lit-element.js';
 
 const mixinTag = defineCE(
 	class extends FocusMixin(LitElement) {
-		static focusElementSelector = 'input';
+		static get focusElementSelector() {
+			return 'input';
+		}
 		render() {
 			return html`<input type="text">`;
 		}
@@ -19,7 +21,9 @@ const mixinNoSelectorTag = defineCE(
 
 const mixinNoElemTag = defineCE(
 	class extends FocusMixin(LitElement) {
-		static focusElementSelector = 'div';
+		static get focusElementSelector() {
+			return 'div';
+		}
 		render() {
 			return html`<input type="text">`;
 		}


### PR DESCRIPTION
Like optional chaining, `polymer-cli` hates the new-style static getters. While this is a great opportunity to force repos to switch to `@web/test-runner` and remove `polymer-cli` entirely, it could slow down the Lit 2 upgrade. So for now, I'm putting this back to use the old syntax.