### PR TITLE
DE47655 Remove word "group" from start/end date widget in screen readers

### DIFF
--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -236,6 +236,8 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 		const dateOpened = this.opened && !this._timeOpened && !this.disabled && !this.skeleton;
 		const parsedValue = this.value ? (this.localized ? this.value : getLocalDateTimeFromUTCDateTime(this.value)) : '';
 		const tooltip = (this.validationError && !this.opened && this.childErrors.size === 0) ? html`<d2l-tooltip align="start" announced for="${this._inputId}" state="error">${this.validationError}</d2l-tooltip>` : null;
+		const dateLabel = this.localize('components.input-date-time.date');
+		const timeLabel = this.localize('components.input-date-time.time');
 		const inputTime = !timeHidden ? html`<d2l-input-time
 				?novalidate="${this.noValidate}"
 				@blur="${this._handleInputTimeBlur}"
@@ -247,7 +249,7 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 				.forceInvalid=${this.invalid}
 				@mouseout="${this._handleInputTimeBlur}"
 				@mouseover="${this._handleInputTimeFocus}"
-				label="${this.localize('components.input-date-time.time')}"
+				label="${ifDefined(this.suppressGroup && this.label ? `${this.label}, ${timeLabel}` : timeLabel)}"
 				label-hidden
 				.labelRequired="${false}"
 				max-height="430"
@@ -274,7 +276,7 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 						?disabled="${this.disabled}"
 						.forceInvalid=${this.invalid}
 						id="${this._inputId}"
-						label="${ifDefined(this.suppressGroup ? this.label : this.localize('components.input-date-time.date'))}"
+						label="${ifDefined(this.suppressGroup && this.label ? `${this.label}, ${dateLabel}` : dateLabel)}"
 						label-hidden
 						.labelRequired="${false}"
 						max-value="${ifDefined(this._maxValueLocalized)}"

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -84,7 +84,7 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 			 * Suppresses the screenreader term "group" on the contained fieldset
 			 * @type {boolean}
 			 */
-			 suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean },
+			suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean },
 			/**
 			 * Default value of time input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
 			 * @type {string}

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -81,6 +81,11 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
+			 * Suppresses the screenreader term "group" on the contained fieldset
+			 * @type {boolean}
+			 */
+			 suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean },
+			/**
 			 * Default value of time input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
 			 * @type {string}
 			 */
@@ -257,7 +262,8 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 				label="${ifDefined(this.label)}"
 				?label-hidden="${this.labelHidden || this.labelledBy}"
 				?required="${this.required}"
-				?skeleton="${this.skeleton}">
+				?skeleton="${this.skeleton}"
+				?suppress-group="${this.suppressGroup}">
 				<div class="d2l-input-date-time-container">
 					<d2l-input-date
 						?novalidate="${this.noValidate}"

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -274,7 +274,7 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 						?disabled="${this.disabled}"
 						.forceInvalid=${this.invalid}
 						id="${this._inputId}"
-						label="${this.localize('components.input-date-time.date')}"
+						label="${ifDefined(this.suppressGroup ? this.label : this.localize('components.input-date-time.date'))}"
 						label-hidden
 						.labelRequired="${false}"
 						max-value="${ifDefined(this._maxValueLocalized)}"

--- a/components/inputs/input-fieldset.js
+++ b/components/inputs/input-fieldset.js
@@ -27,7 +27,12 @@ class InputFieldset extends SkeletonMixin(RtlMixin(LitElement)) {
 			 * Indicates that a value is required for inputs in the fieldset
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true }
+			required: { type: Boolean, reflect: true },
+			/**
+			 * Suppresses the screenreader term "group" on the contained fieldset
+			 * @type {boolean}
+			 */
+			 suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean }
 		};
 	}
 
@@ -56,7 +61,17 @@ class InputFieldset extends SkeletonMixin(RtlMixin(LitElement)) {
 			'd2l-offscreen': this.labelHidden,
 			'd2l-skeletize': true
 		};
-		return html`
+		return this.suppressGroup ?
+		html`
+			<fieldset
+				class="d2l-input-label-fieldset"
+				aria-description="${this.label}"
+				role="label">
+				<p class="${classMap(legendClasses)}">${this.label}</p>
+				<slot></slot>
+			</fieldset>
+		` :
+		html`
 			<fieldset class="d2l-input-label-fieldset">
 				<legend class="${classMap(legendClasses)}">${this.label}</legend>
 				<slot></slot>

--- a/components/inputs/input-fieldset.js
+++ b/components/inputs/input-fieldset.js
@@ -32,7 +32,7 @@ class InputFieldset extends SkeletonMixin(RtlMixin(LitElement)) {
 			 * Suppresses the screenreader term "group" on the contained fieldset
 			 * @type {boolean}
 			 */
-			suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean }
+			 suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean }
 		};
 	}
 
@@ -61,22 +61,14 @@ class InputFieldset extends SkeletonMixin(RtlMixin(LitElement)) {
 			'd2l-offscreen': this.labelHidden,
 			'd2l-skeletize': true
 		};
-		return this.suppressGroup ?
-			html`
-				<fieldset
-					class="d2l-input-label-fieldset"
-					aria-description="${this.label}"
-					role="label">
-					<p class="${classMap(legendClasses)}">${this.label}</p>
-					<slot></slot>
-				</fieldset>
-			` :
-			html`
-				<fieldset class="d2l-input-label-fieldset">
-					<legend class="${classMap(legendClasses)}">${this.label}</legend>
-					<slot></slot>
-				</fieldset>
-			`;
+		return html`
+			<fieldset
+				class="d2l-input-label-fieldset"
+				role="${this.suppressGroup ? 'presentation' : 'group'}">
+				<legend class="${classMap(legendClasses)}">${this.label}</legend>
+				<slot></slot>
+			</fieldset>
+		`;
 	}
 
 }

--- a/components/inputs/input-fieldset.js
+++ b/components/inputs/input-fieldset.js
@@ -32,7 +32,7 @@ class InputFieldset extends SkeletonMixin(RtlMixin(LitElement)) {
 			 * Suppresses the screenreader term "group" on the contained fieldset
 			 * @type {boolean}
 			 */
-			 suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean }
+			suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean }
 		};
 	}
 
@@ -62,21 +62,21 @@ class InputFieldset extends SkeletonMixin(RtlMixin(LitElement)) {
 			'd2l-skeletize': true
 		};
 		return this.suppressGroup ?
-		html`
-			<fieldset
-				class="d2l-input-label-fieldset"
-				aria-description="${this.label}"
-				role="label">
-				<p class="${classMap(legendClasses)}">${this.label}</p>
-				<slot></slot>
-			</fieldset>
-		` :
-		html`
-			<fieldset class="d2l-input-label-fieldset">
-				<legend class="${classMap(legendClasses)}">${this.label}</legend>
-				<slot></slot>
-			</fieldset>
-		`;
+			html`
+				<fieldset
+					class="d2l-input-label-fieldset"
+					aria-description="${this.label}"
+					role="label">
+					<p class="${classMap(legendClasses)}">${this.label}</p>
+					<slot></slot>
+				</fieldset>
+			` :
+			html`
+				<fieldset class="d2l-input-label-fieldset">
+					<legend class="${classMap(legendClasses)}">${this.label}</legend>
+					<slot></slot>
+				</fieldset>
+			`;
 	}
 
 }

--- a/components/inputs/input-fieldset.js
+++ b/components/inputs/input-fieldset.js
@@ -32,7 +32,7 @@ class InputFieldset extends SkeletonMixin(RtlMixin(LitElement)) {
 			 * Suppresses the screenreader term "group" on the contained fieldset
 			 * @type {boolean}
 			 */
-			 suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean }
+			suppressGroup: { attribute: 'suppress-group', reflect: true, type: Boolean }
 		};
 	}
 


### PR DESCRIPTION
## Relevant Rally Links

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F628618321793


## Description

> Problem - Actual Behaviour:
>
> Navigating to the Due/Start/End date fields using a screenreader announces the label + selector group. Audio is "Group Start Date" or "Group Due Date" which is confusing as a group is an actual concept within Brightspace, but does not apply here. 
>
>
> Expected Behaviour:
>
> The component group should not be announced through the screenreader and only read out the actual label for Start Date and then the date selector.


## Goal/Solution

### Problem Location

[The "group" keyword is associated with the fieldset tag in JAWS](https://freedomscientific.github.io/VFO-standards-support/html.html#toc-f).

The fieldset in question is found in [`d2l-input-fieldset`](https://github.com/BrightspaceUI/core/blob/main/components/inputs/input-fieldset.js), which is a core UI component within another core UI component, [`d2l-input-date-time`](https://github.com/BrightspaceUI/core/blob/main/components/inputs/input-date-time.js).

The problem occurs twice in [`d2l-activity-availability-dates-editor`](https://github.com/BrightspaceHypermediaComponents/activities/blob/master/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js), once for the start date and end date each, and once in the [`d2l-activity-due-date-editor`](https://github.com/BrightspaceHypermediaComponents/activities/blob/master/components/d2l-activity-editor/d2l-activity-due-date-editor.js).

As the `d2l-input-date-time` component may be used elsewhere, the fix should be toggled off by default to maintain behaviour for other uses.

### Fix

The fix involves adding `role="presentation"` to the fieldset in `<d2l-input-fieldset>`, as well as making the "date/time" label in `<d2l-input-date>` and `<d2l-input-time>` more verbose.  The presentation role tells screen readers that the fieldset should not be read aloud, while allowing labels to be read for contained elements (unlike `aria-hidden="true"`).  These changes will only take place if the **suppress-group** property is true.

In JAWS, this removes the word "group".  In NVDA, this removes the word "grouping".
The text formerly read out by the fieldset's legend is now the label on the input date and time components themselves, preserving the information served while avoiding the term "group".

When **suppress-group** is not present, the components behave as they did without the changes.

### Screen Reader Results

#### JAWS

Before change/with fix toggled off:

> Edit-activity dash course dash google chrome, complimentary region, **start date group**, date edit has pop-up, m slash d slash yyyy, type and text, use date format m slash d slash yyyy, Arrow down or press enter to access mini-calendar

After change:

> Edit-activity dash course dash google chrome, complimentary region, **start date**, date edit has pop-up, m slash d slash yyyy, type and text, use date format m slash d slash yyyy, Arrow down or press enter to access mini-calendar


#### NVDA

Before change/with fix toggled off:

> Complimentary landmark, **start date grouping**, date edit submenu m slash d slash yyyy blank, use date format m slash d slash yyyy, Arrow down or press enter to access mini-calendar

After change:

> Complimentary landmark, **start date**, date edit submenu m slash d slash yyyy blank, use date format m slash d slash yyyy, Arrow down or press enter to access mini-calendar


## Video/Screenshots

Testing revealed the "group" keyword was associated with the fieldset tag, seen here within the `d2l-input-label-fieldset` class:

![A11y Pre-Fix 3](https://user-images.githubusercontent.com/89945180/158880140-3957afd6-2688-407f-8c45-a8e74f1653fb.PNG)

With the changes described above:

![A11y Fix 3](https://user-images.githubusercontent.com/89945180/158878376-457ed68d-9fed-429f-a42e-54df6afee339.PNG)

Note that when the optional fix is toggled, NVDA's element list becomes more navigable with the full labels.

Without `suppress-group`:

![NVDA Pre-Fix](https://user-images.githubusercontent.com/89945180/158881253-4f4025e8-79cd-4d88-82c6-d4d19864884d.PNG)

With `suppress-group`:

![NVDA Fix 2](https://user-images.githubusercontent.com/89945180/158892163-ce9bf075-b758-4f60-b821-264c01a97924.PNG)


## Related PRs

- Activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/2466


## Remaining Work

- [ ] Dev Testing: another developer will test this code on their machine
