### PR TITLE
fix: demo import

### DIFF
--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -30,11 +30,7 @@ class CodeView extends LitElement {
 		if (Prism.languages[language]) {
 			this._dependenciesPromise = Promise.resolve();
 		} else {
-			/* Current, non-relative imports don't appear to work with Polymer dev server
-			for FF, Edge, IE11.  Use of non-default languages is limited to dev with this approach.
-			https://github.com/Polymer/tools/issues/3402 */
-			const path = `/node_modules/prismjs/components/prism-${language}.min.js`;
-			this._dependenciesPromise = import(path);
+			this._dependenciesPromise = import(`./node_modules/prismjs/components/prism-${language}.min.js`);
 		}
 		if (this.shadowRoot) this._updateCode(this.shadowRoot.querySelector('slot'));
 		super.attributeChangedCallback(name, oldval, newval);


### PR DESCRIPTION
I'm trying to get a demo working for a client and to show how to build our components with Rollup, but the `rollup-plugin-dynamic-import-variables` plugin that we use to fix our dynamic import language files doesn't allow arbitrary variables in imports.

Regardless, I don't think this hack is needed anymore as Polymer CLI should be abandoned easily enough, IE11/Edge are gone and I tested this in Firefox and it was fine.