### PR TITLE
fix: handling text change in updated

### DIFF
--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -51,17 +51,6 @@ export const TabPanelMixin = superclass => class extends superclass {
 		this.selected = false;
 	}
 
-	async attributeChangedCallback(name, oldval, newval) {
-		super.attributeChangedCallback(name, oldval, newval);
-		if (name === 'text') {
-			this.setAttribute('aria-label', this.text);
-			/** Dispatched when the text attribute is changed */
-			this.dispatchEvent(new CustomEvent(
-				'd2l-tab-panel-text-changed', { bubbles: true, composed: true, detail: { text: this.text } }
-			));
-		}
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 		if (this.id.length === 0) this.id = getUniqueId();
@@ -80,6 +69,11 @@ export const TabPanelMixin = superclass => class extends superclass {
 						));
 					});
 				}
+			} else if (prop === 'text') {
+				this.setAttribute('aria-label', this.text);
+				this.dispatchEvent(new CustomEvent(
+					'd2l-tab-panel-text-changed', { bubbles: true, composed: true, detail: { text: this.text } }
+				));
 			}
 		});
 	}


### PR DESCRIPTION
This was noticed [in my-courses](https://github.com/Brightspace/d2l-my-courses-ui/pull/922/). Tab panels were relying on the `attributeChangedCallback` to update the `aria-label` and fire the `d2l-tab-panel-text-changed` event -- which `<d2l-tabs>` uses to keep the actual tab label updated.

But `attributeChangedCallback` isn't called when properties are set directly. This switches to using `updated()`. I've tested this in my-courses and it addresses the issue.