### PR TITLE
fix: Fix event race condition in filter

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -506,7 +506,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		const changes = e.detail.changes;
 		const dimension = this._dimensions.find(dimension => dimension.key === e.detail.dimensionKey);
 		const value = e.detail.valueKey && dimension.values.find(value => value.key === e.detail.valueKey);
-		const toUpdate = value ? value : dimension;
+		const toUpdate = e.detail.valueKey ? value : dimension;
 
 		if (!toUpdate) return;
 


### PR DESCRIPTION
There seems to be a potential race condition when adding a new `d2l-filter-dimension-set-value`, where the element is attached and fires an event to the dimension saying its text has been changed, before the dimension has fired its event to tell the filter about the new value.  This isn't a problem (the first event can just be safely ignored), but the check here wasn't accounting for the fact that it might not be able to find a value for a value event.