### PR TITLE
feat: US136317- Add slim attribute to d2l-button-subtle

### DIFF
--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -41,6 +41,12 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 			iconRight: { type: Boolean, reflect: true, attribute: 'icon-right' },
 
 			/**
+			 * Whether to render the slimmer version of the button
+			 * @type {boolean}
+			 */
+			slim: { type: Boolean, reflect: true },
+
+			/**
 			 * REQUIRED: Text for the button
 			 * @type {string}
 			 */
@@ -59,19 +65,41 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 				}
 
 				button {
+					--d2l-button-subtle-padding-left: 0.6rem;
+					--d2l-button-subtle-padding-right: 0.6rem;
 					background-color: transparent;
 					border-color: transparent;
 					font-family: inherit;
-					padding: 0.55rem 0.6rem;
+					padding: 0 var(--d2l-button-subtle-padding-right) 0 var(--d2l-button-subtle-padding-left);
 					position: relative;
 				}
 
+				:host([dir="rtl"]) button {
+					padding: 0 var(--d2l-button-subtle-padding-left) 0 var(--d2l-button-subtle-padding-right);
+				}
+
+				:host([slim]) button {
+					--d2l-button-subtle-padding-left: 0.5rem;
+					--d2l-button-subtle-padding-right: 0.5rem;
+					min-height: 1.5rem;
+				}
+
+				:host([slim][icon]) button {
+					--d2l-button-subtle-padding-left: 0.4rem;
+					--d2l-button-subtle-padding-right: 0.5rem;
+				}
+
+				:host([slim][icon][icon-right]) button {
+					--d2l-button-subtle-padding-left: 0.5rem;
+					--d2l-button-subtle-padding-right: 0.4rem;
+				}
+
 				:host([h-align="text"]) button {
-					left: -0.6rem;
+					left: calc(var(--d2l-button-subtle-padding-left)*-1);
 				}
 				:host([dir="rtl"][h-align="text"]) button {
 					left: 0;
-					right: -0.6rem;
+					right: calc(var(--d2l-button-subtle-padding-left)*-1);
 				}
 
 				/* Firefox includes a hidden border which messes up button dimensions */
@@ -98,22 +126,15 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 				:host([active]:not([disabled])) button .d2l-button-subtle-content {
 					color: var(--d2l-color-celestine-minus-1);
 				}
-				:host([icon]) .d2l-button-subtle-content {
-					padding-left: 1.2rem;
-				}
-				:host([icon][icon-right]) .d2l-button-subtle-content {
-					padding-left: 0;
-					padding-right: 1.2rem;
-				}
-
-				:host([dir="rtl"][icon]) .d2l-button-subtle-content {
-					padding-left: 0;
-					padding-right: 1.2rem;
-				}
-
+				:host([icon]) .d2l-button-subtle-content,
 				:host([dir="rtl"][icon][icon-right]) .d2l-button-subtle-content {
 					padding-left: 1.2rem;
 					padding-right: 0;
+				}
+				:host([dir="rtl"][icon]) .d2l-button-subtle-content,
+				:host([icon][icon-right]) .d2l-button-subtle-content {
+					padding-left: 0;
+					padding-right: 1.2rem;
 				}
 
 				d2l-icon.d2l-button-subtle-icon {
@@ -125,19 +146,21 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 					transform: translateY(-50%);
 					width: 0.9rem;
 				}
+
 				button:hover:not([disabled]) d2l-icon.d2l-button-subtle-icon,
 				button:focus:not([disabled]) d2l-icon.d2l-button-subtle-icon,
 				:host([active]:not([disabled])) button d2l-icon.d2l-button-subtle-icon {
 					color: var(--d2l-color-celestine-minus-1);
 				}
+
 				:host([icon]) d2l-icon.d2l-button-subtle-icon {
 					display: inline-block;
 				}
 				:host([icon][icon-right]) d2l-icon.d2l-button-subtle-icon {
-					right: 0.6rem;
+					right: var(--d2l-button-subtle-padding-right);
 				}
 				:host([dir="rtl"][icon][icon-right]) d2l-icon.d2l-button-subtle-icon {
-					left: 0.6rem;
+					left: var(--d2l-button-subtle-padding-right);
 					right: auto;
 				}
 
@@ -152,6 +175,7 @@ class ButtonSubtle extends ButtonMixin(RtlMixin(LitElement)) {
 	constructor() {
 		super();
 		this.iconRight = false;
+		this.slim = false;
 
 		/** @internal */
 		this._buttonId = getUniqueId();

--- a/components/button/demo/button-subtle.html
+++ b/components/button/demo/button-subtle.html
@@ -18,6 +18,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-button-subtle id="normal" text="Subtle Button"></d2l-button-subtle>
+					<d2l-button-subtle slim id="normal" text="Slim Subtle Button"></d2l-button-subtle>
 				</template>
 			</d2l-demo-snippet>
 
@@ -26,6 +27,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-button-subtle id="disabled" text="Subtle Button" disabled></d2l-button-subtle>
+					<d2l-button-subtle slim id="disabled" text="Slim Subtle Button" disabled></d2l-button-subtle>
 				</template>
 			</d2l-demo-snippet>
 
@@ -34,6 +36,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-button-subtle id="disabled" text="Subtle Button" disabled disabled-tooltip="Optional disabled tooltip"></d2l-button-subtle>
+					<d2l-button-subtle slim id="disabled" text="Slim Subtle Button" disabled disabled-tooltip="Optional disabled tooltip"></d2l-button-subtle>
 				</template>
 			</d2l-demo-snippet>
 
@@ -42,6 +45,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-button-subtle id="with-icon" icon="tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
+					<d2l-button-subtle slim id="with-icon" icon="tier1:bookmark-hollow" text="Slim Subtle Button"></d2l-button-subtle>
 				</template>
 			</d2l-demo-snippet>
 
@@ -50,6 +54,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-button-subtle id="icon-right" icon="tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
+					<d2l-button-subtle slim id="icon-right" icon="tier1:chevron-down" text="Slim Subtle Button" icon-right></d2l-button-subtle>
 				</template>
 			</d2l-demo-snippet>
 
@@ -60,6 +65,12 @@
 					<d2l-button-subtle icon="tier1:gear" text="Button Edge Aligned (default)"></d2l-button-subtle>
 					<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
 					<d2l-button-subtle icon="tier1:gear" text="Button Content Aligned" h-align="text"></d2l-button-subtle>
+					<br>
+					<d2l-button-subtle slim icon="tier1:gear" text="Slim Button Content Aligned" h-align="text"></d2l-button-subtle>
+					<br>
+					<d2l-button-subtle id="icon-right" icon="tier1:chevron-down" text="Subtle Button" icon-right h-align="text"></d2l-button-subtle>
+					<br>
+					<d2l-button-subtle slim id="icon-right" icon="tier1:chevron-down" text="Slim Subtle Button" icon-right h-align="text"></d2l-button-subtle>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/button/test/button-subtle.visual-diff.html
+++ b/components/button/test/button-subtle.visual-diff.html
@@ -14,22 +14,53 @@
 </head>
 <body class="d2l-typography">
 	<div class="visual-diff">
-		<d2l-button-subtle id="normal" text="Subtle Button"></d2l-button-subtle>
+		<d2l-button-subtle id="default-normal" text="Subtle Button"></d2l-button-subtle>
 	</div>
 	<div class="visual-diff">
-		<d2l-button-subtle id="disabled" text="Subtle Button" disabled></d2l-button-subtle>
+		<d2l-button-subtle id="default-disabled" text="Subtle Button" disabled></d2l-button-subtle>
 	</div>
 	<div class="visual-diff">
-		<d2l-button-subtle id="with-icon" icon="tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
+		<d2l-button-subtle id="default-with-icon" icon="tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
 	</div>
 	<div class="visual-diff">
-		<d2l-button-subtle id="icon-right" icon="tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
+		<d2l-button-subtle id="default-icon-right" icon="tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
 	</div>
 	<div class="visual-diff">
-		<d2l-button-subtle id="with-icon-rtl" dir="rtl" icon="tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
+		<d2l-button-subtle id="default-with-icon-rtl" dir="rtl" icon="tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
 	</div>
 	<div class="visual-diff">
-		<d2l-button-subtle id="icon-right-rtl" dir="rtl" icon="tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
+		<d2l-button-subtle id="default-icon-right-rtl" dir="rtl" icon="tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
+	</div>
+	<div class="visual-diff">
+		<d2l-button-subtle slim id="slim-normal" text="Subtle Button"></d2l-button-subtle>
+	</div>
+	<div class="visual-diff">
+		<d2l-button-subtle slim id="slim-disabled" text="Subtle Button" disabled></d2l-button-subtle>
+	</div>
+	<div class="visual-diff">
+		<d2l-button-subtle slim id="slim-with-icon" icon="tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
+	</div>
+	<div class="visual-diff">
+		<d2l-button-subtle slim id="slim-icon-right" icon="tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
+	</div>
+	<div class="visual-diff">
+		<d2l-button-subtle slim id="slim-with-icon-rtl" dir="rtl" icon="tier1:bookmark-hollow" text="Subtle Button"></d2l-button-subtle>
+	</div>
+	<div class="visual-diff">
+		<d2l-button-subtle slim id="slim-icon-right-rtl" dir="rtl" icon="tier1:chevron-down" text="Subtle Button" icon-right></d2l-button-subtle>
+	</div>
+	<div class="visual-diff">
+		<div id="h-align">
+			<d2l-button-subtle icon="tier1:gear" text="Button Edge Aligned (default)"></d2l-button-subtle>
+			<div>Lorem ipsum dolor sit amet, consectetur adipiscing elit</div>
+			<d2l-button-subtle icon="tier1:gear" text="Button Content Aligned" h-align="text"></d2l-button-subtle>
+			<br>
+			<d2l-button-subtle slim icon="tier1:gear" text="Slim Button Content Aligned" h-align="text"></d2l-button-subtle>
+			<br>
+			<d2l-button-subtle id="icon-right" icon="tier1:chevron-down" text="Subtle Button" icon-right h-align="text"></d2l-button-subtle>
+			<br>
+			<d2l-button-subtle slim id="icon-right" icon="tier1:chevron-down" text="Slim Subtle Button" icon-right h-align="text"></d2l-button-subtle>
+		</div>
 	</div>
 </body>
 </html>

--- a/components/button/test/button-subtle.visual-diff.js
+++ b/components/button/test/button-subtle.visual-diff.js
@@ -22,30 +22,43 @@ describe('d2l-button-subtle', () => {
 	after(async() => await browser.close());
 
 	[
-		{ category: 'normal', tests: ['normal', 'hover', 'focus', 'click', 'disabled'] },
-		{ category: 'icon', tests: ['with-icon', 'with-icon-rtl', 'icon-right', 'icon-right-rtl'] },
+		'default',
+		'slim'
+	].forEach((type) => {
+		describe(type, () => {
+			[
+				{ category: 'normal', tests: ['normal', 'hover', 'focus', 'click', 'disabled'] },
+				{ category: 'icon', tests: ['with-icon', 'with-icon-rtl', 'icon-right', 'icon-right-rtl'] }
 
-	].forEach((entry) => {
-		describe(entry.category, () => {
-			entry.tests.forEach((name) => {
-				it(name, async function() {
+			].forEach((entry) => {
+				describe(entry.category, () => {
+					entry.tests.forEach((name) => {
+						it(name, async function() {
 
-					const selector = `#${entry.category}`;
-					if (name === 'hover') {
-						await page.hover(selector);
-					} else if (name === 'focus') {
-						await page.$eval(selector, (elem) => forceFocusVisible(elem));
-					} else if (name === 'click') {
-						await page.$eval(selector, (elem) => elem.focus());
-					}
+							const selector = `#${type}-${entry.category}`;
+							if (name === 'hover') {
+								await page.hover(selector);
+							} else if (name === 'focus') {
+								await page.$eval(selector, (elem) => forceFocusVisible(elem));
+							} else if (name === 'click') {
+								await page.$eval(selector, (elem) => elem.focus());
+							}
 
-					const rectId = (name.indexOf('disabled') !== -1 || name.indexOf('icon') !== -1) ? name : entry.category;
-					const rect = await visualDiff.getRect(page, `#${rectId}`);
-					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+							const rectId = `${type}-${(name.indexOf('disabled') !== -1 || name.indexOf('icon') !== -1) ? name : entry.category}`;
+							const rect = await visualDiff.getRect(page, `#${rectId}`);
+							await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 
+						});
+					});
 				});
 			});
 		});
+	});
+
+	it('h-align', async function() {
+		const rect = await visualDiff.getRect(page, '#h-align');
+		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+
 	});
 
 });


### PR DESCRIPTION
Add `slim` attribute to `d2l-button-subtle` and update demo pages and visual-diff tests.

Design details:
- Height should be `1.5rem` (`30px`)
- Side padding should reduce to `0.5rem` (`10px`)
- When there is a button, that side's padding should reduce to `0.4rem` (`8px`)

![image](https://user-images.githubusercontent.com/13419300/160210156-3b05a91a-4ac9-4ce8-bfa9-2278e1b54bee.png)
