### PR TITLE
fix: List: Safari: selectable items are not always selectable

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -121,6 +121,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			}
 			::slotted([slot="control-action"]) {
 				grid-column: control-start / end;
+				height: 100%;
+				width: 100%;
 				z-index: 2;
 			}
 			::slotted([slot="content-action"]) {


### PR DESCRIPTION
This was showing itself in Daylight and possibly within another team's feature.

The `control-action` slot div that wraps this https://github.com/BrightspaceUI/core/blob/main/components/list/list-item-checkbox-mixin.js#L164 (which is what triggers the click workflow to select/unselect) sometimes had no height/width resulting in no clickable area. Actually specifying a 100% height and width, which seems to be what it ends up with by default when working properly, seems to fix this.

I have done some quick testing in Safari and Chrome on Mac on the demo page and on Daylight (list and filter pages). If the visual-diffs pass and this solution seems good I'll do some more cross-browser/device testing as well.