### PR TITLE
US136319 - Add ability for tooltip to only show when an element is truncating

### DIFF
--- a/components/tooltip/demo/tooltip.html
+++ b/components/tooltip/demo/tooltip.html
@@ -32,6 +32,26 @@
 			padding: 20px;
 			width: 200px;
 		}
+
+		.truncated {
+			border: 1px solid #cdd5dc;
+			border-radius: 6px;
+			height: 200px;
+			padding: 20px;
+			width: 200px;
+		}
+
+		.truncated d2l-button {
+			margin-bottom: 20px;
+			max-width: 100%;
+		}
+
+		.truncated d2l-button span {
+			display: block;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
 	</style>
 </head>
 
@@ -109,6 +129,22 @@
 					<d2l-button id="tooltip-bounded">Bounded Tooltip</d2l-button>
 					<d2l-tooltip for="tooltip-bounded">
 						A bounded tooltip message that will wrap to more than one line.
+					</d2l-tooltip>
+				</div>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Tooltip (only show if truncating)</h2>
+		<d2l-demo-snippet>
+			<template>
+				<div class="truncated">
+					<d2l-button id="tooltip-short"><span>Short Tooltip</span></d2l-button>
+					<d2l-tooltip for="tooltip-short" only-show-if-truncating>
+						This tooltip will not show.
+					</d2l-tooltip>
+					<d2l-button id="tooltip-long"><span>Very Very Very Very Long Tooltip</span></d2l-button>
+					<d2l-tooltip for="tooltip-long" only-show-if-truncating>
+						Very Very Very Very Long Tooltip - this tooltip will show because the text is truncating.
 					</d2l-tooltip>
 				</div>
 			</template>

--- a/components/tooltip/test/tooltip-helper.js
+++ b/components/tooltip/test/tooltip-helper.js
@@ -11,3 +11,30 @@ export async function show(page, selector) {
 	page.$eval(`${selector} d2l-tooltip`, tooltip => tooltip.show());
 	return openEvent;
 }
+
+export function getRect(page, selector) {
+	return page.$eval(selector, elem => {
+		let x, y, width, height;
+		const openerRect = elem.getBoundingClientRect();
+		const content = elem.querySelector('d2l-tooltip');
+		if (!content.showing) {
+			x = openerRect.x;
+			y = openerRect.y;
+			width = openerRect.right - x;
+			height = openerRect.bottom - y;
+		} else {
+			const contentWidth = content.shadowRoot.querySelector('.d2l-tooltip-content');
+			const contentRect = contentWidth.getBoundingClientRect();
+			x = Math.min(openerRect.x, contentRect.x);
+			y = Math.min(openerRect.y, contentRect.y);
+			width = Math.max(openerRect.right, contentRect.right) - x;
+			height = Math.max(openerRect.bottom, contentRect.bottom) - y;
+		}
+		return {
+			x: x - 10,
+			y: y - 10,
+			width: width + 20,
+			height: height + 20
+		};
+	});
+}

--- a/components/tooltip/test/tooltip-truncating.visual-diff.html
+++ b/components/tooltip/test/tooltip-truncating.visual-diff.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
+	<script type="module">
+		import '../../../test/typography-preload.js';
+		import '../../button/button.js';
+		import '../../link/link.js';
+		import '../../list/list.js';
+		import '../../list/list-item-button.js';
+		import '../tooltip.js';
+	</script>
+	<title>d2l-tooltip with truncating</title>
+	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1.0">
+	<meta charset="UTF-8">
+	<style>
+		.truncated {
+			border: 1px solid #cdd5dc;
+			border-radius: 6px;
+			height: 400px;
+			padding: 20px;
+			width: 200px;
+		}
+
+		.truncated > div {
+			display: flex;
+			margin-bottom: 30px;
+		}
+
+		.truncated d2l-button {
+			max-width: 100%;
+		}
+
+		.truncated d2l-list {
+			width: 100%;
+		}
+
+		.truncated d2l-button span,
+		.truncated d2l-link,
+		.truncated d2l-list-item-content {
+			display: block;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	</style>
+</head>
+<body class="d2l-typography">
+	<div class="visual-diff">
+
+		<div class="truncated">
+			<div id="button-not-truncating">
+				<d2l-button id="button-short"><span>Short Text</span></d2l-button>
+				<d2l-tooltip for="button-short" only-show-if-truncating>
+					This tooltip will not show.
+				</d2l-tooltip>
+			</div>
+			<div id="button-truncating">
+				<d2l-button id="button-long"><span>Very Very Very Very Long Text</span></d2l-button>
+				<d2l-tooltip for="button-long" only-show-if-truncating>
+					Very Very Very Very Long Text - this tooltip will show because the text is truncating.
+				</d2l-tooltip>
+			</div>
+			<div id="link-not-truncating">
+				<d2l-link id="link-short" href="https://www.d2l.com">Short Text</d2l-link>
+				<d2l-tooltip for="link-short" only-show-if-truncating>
+					This tooltip will not show.
+				</d2l-tooltip>
+			</div>
+			<div id="link-truncating">
+				<d2l-link id="link-long" href="https://www.d2l.com">Very Very Very Very Long Text</d2l-link>
+				<d2l-tooltip for="link-long" only-show-if-truncating>
+					Very Very Very Very Long Text - this tooltip will show because the text is truncating.
+				</d2l-tooltip>
+			</div>
+			<div>
+				<d2l-list>
+					<d2l-list-item-button id="list-item-not-truncating">
+						<d2l-list-item-content id="list-item-short">Short Text</d2l-list-item-content>
+						<d2l-tooltip only-show-if-truncating="list-item-short">
+							This tooltip will not show.
+						</d2l-tooltip>	
+					</d2l-list-item-button>
+					<d2l-list-item-button id="list-item-truncating">
+						<d2l-list-item-content id="list-item-long">Very Very Very Very Long Text</d2l-list-item-content>
+						<d2l-tooltip only-show-if-truncating="list-item-long">
+							Very Very Very Very Long Text - this tooltip will show because the text is truncating.
+						</d2l-tooltip>	
+					</d2l-list-item-button>
+				</d2l-list>
+			</div>
+		</div>
+
+	</div>
+</body>
+</html>

--- a/components/tooltip/test/tooltip-truncating.visual-diff.js
+++ b/components/tooltip/test/tooltip-truncating.visual-diff.js
@@ -1,0 +1,44 @@
+import { getRect } from './tooltip-helper.js';
+import puppeteer from 'puppeteer';
+import VisualDiff from '@brightspace-ui/visual-diff';
+
+describe('d2l-tooltip truncating', () => {
+
+	const visualDiff = new VisualDiff('tooltip-truncating', import.meta.url);
+
+	let browser, page;
+
+	before(async() => {
+		browser = await puppeteer.launch();
+		page = await visualDiff.createPage(browser, { viewport: { width: 400, height: 400 } });
+		await page.goto(`${visualDiff.getBaseUrl()}/components/tooltip/test/tooltip-truncating.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
+		await page.bringToFront();
+	});
+
+	afterEach(async() => {
+		await page.reload();
+	});
+
+	after(async() => await browser.close());
+
+	[
+		{ name: 'button-not-truncating', focus: ' :first-child' },
+		{ name: 'button-truncating', focus: ' :first-child' },
+		{ name: 'link-not-truncating', focus: ' :first-child' },
+		{ name: 'link-truncating', focus: ' :first-child' },
+		{ name: 'list-item-not-truncating', focus: '' },
+		{ name: 'list-item-truncating', focus: '' }
+	].forEach((testCase) => {
+
+		it(testCase, async function() {
+			const selector = `#${testCase.name}`;
+			await page.$eval(`${selector}${testCase.focus}`, (content) => {
+				content.focus();
+			});
+			const rect = await getRect(page, selector);
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+	});
+
+});


### PR DESCRIPTION
Just putting up what I have for early feedback and handover, but I don't love the way the attribute works.  It's basically a combination of a boolean and a string.  If the attribute is not set at all, it'll be `undefined` and none of the new code runs.  If it's set _like_ a boolean (meaning the value is an empty string), we use the tooltip's target element.  This is how many use cases will use it, and how I originally had it always working.  But through testing I found more complicated use cases where the tooltip is not pointing to the element that's truncating (like in the `list` visual-diff example).