### PR TITLE
Fix input-text to include the unit in the aria-label.

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -469,11 +469,12 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 	}
 
 	_getAriaLabel() {
-		if (this.label && (this.labelHidden || this.labelledBy)) {
-			return this.label;
-		}
-		if (this.hasAttribute('aria-label')) {
-			return this.getAttribute('aria-label');
+		let label;
+		if (this.label && (this.labelHidden || this.labelledBy)) label = this.label;
+		if (this.hasAttribute('aria-label')) label = this.getAttribute('aria-label');
+		if (label) {
+			const unitLabel = this.unit ? ` ${this.unit}` : '';
+			return `${label}${unitLabel}`;
 		}
 		return undefined;
 	}

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -470,8 +470,11 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 
 	_getAriaLabel() {
 		let label;
-		if (this.label && (this.labelHidden || this.labelledBy)) label = this.label;
-		if (this.hasAttribute('aria-label')) label = this.getAttribute('aria-label');
+		if (this.label && (this.labelHidden || this.labelledBy)) {
+			label = this.label;
+		} else if (this.hasAttribute('aria-label')) {
+			label = this.getAttribute('aria-label');
+		}
 		if (label) {
 			const unitLabel = this.unit ? ` ${this.unit}` : '';
 			return `${label}${unitLabel}`;


### PR DESCRIPTION
This PR updates the `aria-label` to include the `unit`.  Previously, when the label was hidden, an accessible `unit` would not be rendered or announced because it is rendered as part of the `label`.  I also played around with rendering the unit as part of the aria description, but appending to the label provided the best announcement, and also keeps it consistent with how it's announced when the label is visible.