### PR TITLE
Add support for dropdowns to have opener in a slot

### DIFF
--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -39,6 +39,14 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 				type: Boolean,
 				attribute: 'open-on-hover'
 			},
+			/**
+			 * Optionally enclose opener in a slot with name "opener"
+			 * @type {boolean}
+			 */
+			slottedOpener: {
+				type: Boolean,
+				attribute: 'slotted-opener'
+			},
 			_isHovering: { type: Boolean },
 			_isOpen: { type: Boolean },
 			_isOpenedViaClick: { type: Boolean },
@@ -52,6 +60,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.noAutoOpen = false;
 		this.openOnHover = false;
 		this.disabled = false;
+		this.slottedOpener = false;
 
 		// hover option
 		this._dismissTimerId = getUniqueId();

--- a/components/dropdown/dropdown.js
+++ b/components/dropdown/dropdown.js
@@ -22,8 +22,20 @@ class Dropdown extends DropdownOpenerMixin(LitElement) {
 	 */
 	getOpenerElement() {
 		if (!this.shadowRoot) return undefined;
+		if (this.slottedOpener) return this.getSlottedOpener();
 		return this.shadowRoot.querySelector('slot')
 			.assignedNodes()
+			.filter(node => node.classList && node.classList.contains('d2l-dropdown-opener'))[0];
+	}
+
+	/**
+	 * Gets the slotted opener element with class "d2l-dropdown-opener" (required by dropdown-opener-mixin).
+	 * @return {HTMLElement}
+	 */
+	getSlottedOpener() {
+		if (!this.shadowRoot) return undefined;
+		return this.querySelector('slot[name="opener"]')
+			.assignedNodes({ flatten: true })
 			.filter(node => node.classList && node.classList.contains('d2l-dropdown-opener'))[0];
 	}
 


### PR DESCRIPTION
Currently, we only support direct children of `d2l-dropdown` to act as openers. Adding a `slotted-opener` attribute allows us to optionally check a `name="opener"` slot to see if any openers exist. This will catch both the default slot AND any slot overrides. 

This will be used by the user profile card. I would like to add tests, but since this is a no-op for all other dropdowns, I'll add more tests in a separate PR. 