### PR TITLE
DE47878 - Switch list to acting on keydown events instead of keyup

### DIFF
--- a/components/list/demo/list-drag-and-drop.js
+++ b/components/list/demo/list-drag-and-drop.js
@@ -167,7 +167,7 @@ class ListDemoDragAndDrop extends LitElement {
 		await this.updateComplete;
 
 		if (e.detail.keyboardActive) {
-			requestAnimationFrame(() => {
+			setTimeout(() => {
 				if (!this.shadowRoot) return;
 				const newItem = this.shadowRoot.querySelector('d2l-list').getListItemByKey(sourceListItems[0].key);
 				newItem.activateDragHandle();

--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -262,23 +262,12 @@ class ListItemDragHandle extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		}
 	}
 
-	_onInactiveKeyDown(e) {
-		if (e.type === 'click' || e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) {
-			e.preventDefault();
-		}
-	}
-
-	_onPreventDefault(e) {
-		e.preventDefault();
-	}
-
 	_renderDragger() {
 		return html`
 			<button
 				class="d2l-list-item-drag-handle-dragger-button"
 				@click="${this._onInactiveKeyboard}"
-				@keyup="${this._onInactiveKeyboard}"
-				@keydown="${this._onInactiveKeyDown}"
+				@keydown="${this._onInactiveKeyboard}"
 				aria-label="${this._defaultLabel}"
 				?disabled="${this.disabled}">
 				<d2l-icon icon="tier1:dragger" class="d2l-button-icon"></d2l-icon>
@@ -295,8 +284,7 @@ class ListItemDragHandle extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				@focusin="${this._onFocusInKeyboardButton}"
 				@focusout="${this._onFocusOutKeyboardButton}"
 				id="${this._buttonId}"
-				@keydown="${this._onPreventDefault}"
-				@keyup="${this._onActiveKeyboard}">
+				@keydown="${this._onActiveKeyboard}">
 				<d2l-icon icon="tier1:arrow-toggle-up" @click="${this._dispatchActionUp}" class="d2l-button-icon"></d2l-icon>
 				<d2l-icon icon="tier1:arrow-toggle-down" @click="${this._dispatchActionDown}" class="d2l-button-icon"></d2l-icon>
 			</button>

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -172,7 +172,6 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 	firstUpdated() {
 		this.addEventListener('keydown', this._onKeydown.bind(this));
-		this.addEventListener('keyup', this._onKeyup.bind(this));
 		this.addEventListener('focusin', this._setFocusInfo.bind(this));
 	}
 
@@ -408,30 +407,6 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 	}
 
 	_onKeydown(event) {
-		if (!this.gridActive) return;
-		let preventDefault = true;
-		switch (event.keyCode) {
-			case keyCodes.ENTER:
-			case keyCodes.SPACE:
-			case keyCodes.RIGHT:
-			case keyCodes.LEFT:
-			case keyCodes.UP:
-			case keyCodes.DOWN:
-			case keyCodes.HOME:
-			case keyCodes.END:
-			case keyCodes.PAGEUP:
-			case keyCodes.PAGEDOWN:
-				break;
-			default:
-				preventDefault = false;
-		}
-		if (preventDefault) {
-			event.preventDefault();
-			event.stopPropagation();
-		}
-	}
-
-	_onKeyup(event) {
 		if (!this.gridActive) return;
 		let node = null;
 		let preventDefault = true;

--- a/components/list/test/list-item-drag-handle.test.js
+++ b/components/list/test/list-item-drag-handle.test.js
@@ -49,7 +49,7 @@ describe('ListItemDragHandle', () => {
 				element.addEventListener('d2l-list-item-drag-handle-action', (e) => action = e.detail.action);
 				const actionArea = element.shadowRoot.querySelector('button');
 				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress.code));
-				await oneEvent(actionArea, 'keyup');
+				await oneEvent(actionArea, 'keydown');
 
 				expect(action).to.equal(dragActions.active);
 			});
@@ -86,7 +86,7 @@ describe('ListItemDragHandle', () => {
 				element.addEventListener('d2l-list-item-drag-handle-action', (e) => action = e.detail.action);
 				const actionArea = element.shadowRoot.querySelector('button');
 				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress.code, !!testCase.shift));
-				await oneEvent(actionArea, 'keyup');
+				await oneEvent(actionArea, 'keydown');
 
 				expect(action).to.equal(testCase.result);
 			});
@@ -107,7 +107,7 @@ describe('ListItemDragHandle', () => {
 
 	function dispatchKeyEvent(el, key, shiftKey = false) {
 		const eventObj = document.createEvent('Events');
-		eventObj.initEvent('keyup', true, true);
+		eventObj.initEvent('keydown', true, true);
 		eventObj.which = key;
 		eventObj.keyCode = key;
 		eventObj.shiftKey = shiftKey;

--- a/components/list/test/list-item-generic-layout.test.js
+++ b/components/list/test/list-item-generic-layout.test.js
@@ -117,7 +117,7 @@ describe('d2l-list-item-generic-layout', () => {
 
 	function dispatchKeyEvent(el, { code, ctrl }) {
 		const eventObj = document.createEvent('Events');
-		eventObj.initEvent('keyup', true, true);
+		eventObj.initEvent('keydown', true, true);
 		eventObj.which = code;
 		eventObj.keyCode = code;
 		eventObj.ctrlKey = ctrl;
@@ -380,7 +380,7 @@ describe('d2l-list-item-generic-layout', () => {
 			});
 			layout.querySelector('d2l-selection-input').focus();
 			setTimeout(() => dispatchKeyEvent(layout, { code: keyCodes.TAB }));
-			const event = await oneEvent(layout, 'keyup');
+			const event = await oneEvent(layout, 'keydown');
 			expect(event.preventDefault).to.not.have.been.called;
 		});
 


### PR DESCRIPTION
`DE47878` refers to the the first list option being selected when the filter is opened using the enter key.  This is an issue with `d2l-list` listening to `keyup` events instead of `keydown`, mixed with moving `focus` into the dropdown on open.

This PR switches everything that happens on `keyup` to instead happen on `keydown`, and removes the code that was previously suppressing all the corresponding `keydown` events.