### PR TITLE
fix: tag-list: Update example, _lines property

### DIFF
--- a/components/tag-list/README.md
+++ b/components/tag-list/README.md
@@ -1,6 +1,5 @@
-
 # Tag List
-*This component is in progress and the api is not yet stable.*
+*This component is in progress. The API is generally stable but the ability to clear tags is currently a WIP.*
 
 Tag lists are used to present a list of compact, discrete pieces of information.
 
@@ -12,9 +11,14 @@ Tag lists are used to present a list of compact, discrete pieces of information.
 </script>
 
 <d2l-tag-list description="Example Tags">
-  <d2l-tag-list-item text="Tag"></d2l-tag-list-item>
-  <d2l-tag-list-item text="Another Tag"></d2l-tag-list-item>
-  <d2l-tag-list-item text="A Third Very Very Very Long Tag"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Lorem ipsum dolor"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Reprehenderit in voluptate velit esse"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Sit amet"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Duis aute irure"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Excepteur sint"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Cillum"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Saunt in culpa"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Laboris nisi"></d2l-tag-list-item>
 </d2l-tag-list>
 ```
 
@@ -30,9 +34,10 @@ The `d2l-tag-list` element can take a combination of any type of `d2l-tag-list-i
 </script>
 
 <d2l-tag-list description="Example Tags">
-  <d2l-tag-list-item text="Tag"></d2l-tag-list-item>
-  <d2l-tag-list-item text="Another Tag"></d2l-tag-list-item>
-  <d2l-tag-list-item text="A Third Very Very Very Long Tag"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Lorem ipsum dolor"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Reprehenderit in voluptate velit esse"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Sit amet"></d2l-tag-list-item>
+  <d2l-tag-list-item text="Duis aute irure"></d2l-tag-list-item>
 </d2l-tag-list>
 ```
 

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -26,6 +26,7 @@ class TagList extends LocalizeCoreElement(ArrowKeysMixin(LitElement)) {
 			 */
 			description: { type: String },
 			_chompIndex: { type: Number },
+			_lines: { type: Number },
 			_showHiddenTags: { type: Boolean }
 		};
 	}
@@ -122,7 +123,7 @@ class TagList extends LocalizeCoreElement(ArrowKeysMixin(LitElement)) {
 		`;
 
 		const outerContainerStyles = {
-			maxHeight: this._showHiddenTags ? undefined : `${(this._itemHeight + MARGIN_TOP_HEIGHT) * this._lines}px`
+			maxHeight: (this._showHiddenTags || !this._lines) ? undefined : `${(this._itemHeight + MARGIN_TOP_HEIGHT) * this._lines}px`
 		};
 
 		return html`


### PR DESCRIPTION
The tag-list example has been updated to show off the line clamping/hiding.

`_lines` changing should also trigger a re-render.