### PR TITLE
Add mathjax test context

### DIFF
--- a/tools/mathjax-test-context.js
+++ b/tools/mathjax-test-context.js
@@ -1,0 +1,4 @@
+document.documentElement.dataset.mathjaxContext = JSON.stringify({
+	outputScale: 1.1,
+	renderLatex: true
+});


### PR DESCRIPTION
We are currently using this is rubrics vdiff, tests and demo pages to auto setup the mathjax context. I'd like to include it with the core (similar to https://github.com/BrightspaceUI/core/blob/main/tools/resize-observer-test-error-handler.js) so that we can use it from this component across multiple repos in testing scenarios (similar to https://github.com/BrightspaceUI/core/blob/main/web-test-runner.config.js#L31-L37).