### PR TITLE
Use mathjax context in demos

### DIFF
--- a/components/html-block/README.md
+++ b/components/html-block/README.md
@@ -100,7 +100,7 @@ Examples are provided to display how user-authored math can be embedded within y
 </d2l-html-block>
 ```
 
-**LaTeX:** Rendering LaTeX requires the `mathjax` context to be set correctly. For testing and or demo pages you can do the following.
+**LaTeX:** Rendering LaTeX requires the `mathjax` context to be set correctly. For testing and/or demo pages you can do the following.
 
 <!-- docs: demo code -->
 ```html
@@ -117,7 +117,7 @@ Examples are provided to display how user-authored math can be embedded within y
 
 ### Add Context Automatically to Demos and Tests
 
-You can automatically set-up the `mathjax` context for demo pages and unit tests when using `@web/dev-server` and `@web/test-runner` by adding the following plugin to your configuration
+You can automatically set-up the `mathjax` context for demo pages and unit tests when using `@web/dev-server` and `@web/test-runner` by adding the following plugin to your configuration.
 
 ```javascript
 export default {

--- a/components/html-block/README.md
+++ b/components/html-block/README.md
@@ -67,6 +67,7 @@ To use `d2l-html-block` within another Lit component, use the [unsafeHTML](https
 ```
 
 ### Rendering MathML and LaTeX
+
 Examples are provided to display how user-authored math can be embedded within your webpage.
 
 **MathML:**
@@ -99,29 +100,41 @@ Examples are provided to display how user-authored math can be embedded within y
 </d2l-html-block>
 ```
 
-**LaTeX:** Rendering LaTeX requires the `us125413-mathjax-render-latex` feature flag to be enabled.
+**LaTeX:** Rendering LaTeX requires the `mathjax` context to be set correctly. For testing and or demo pages you can do the following.
 
 <!-- docs: demo code -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/html-block/html-block.js';
-
-  window.D2L = {};
-  D2L.LP = {};
-  D2L.LP.Web = {};
-  D2L.LP.Web.UI = {};
-  D2L.LP.Web.UI.Flags = {
-    Flag: (feature, defaultValue) => {
-      if (feature === 'us125413-mathjax-render-latex') return true;
-      else return defaultValue;
-    }
-  };
-  <!-- docs: start hidden content -->
-  document.getElementsByTagName('html')[0].dataset.mathjaxContext = JSON.stringify({ renderLatex: true });<!-- docs: end hidden content -->
+  import '@brightspace-ui/core/tools/mathjax-test-context.js';
 </script>
 <d2l-html-block>
   <div class="latex-container">
     $$ f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x $$ $$ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} $$
   </div>
 </d2l-html-block>
+```
+
+### Add Context Automatically to Demos and Tests
+
+You can automatically set-up the `mathjax` context for demo pages and unit tests when using `@web/dev-server` and `@web/test-runner` by adding the following plugin to your configuration
+
+```javascript
+export default {
+  ...
+  plugins: [{
+    name: 'setup-mathjax-context',
+    transform(context) {
+      if (context.response.is('html')) {
+        const newBody = context.body.replace(
+          /<head>/,
+          '<head><script src="/node_modules/@brightspace-ui/core/tools/mathjax-test-context.js"></script>'
+        );
+
+        return { body: newBody };
+      }
+    }
+  }],
+  ...
+}
 ```

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -7,6 +7,7 @@
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../html-block.js';
+
 			import { provideInstance } from '../../../mixins/provider-mixin.js';
 
 			class DemoReplacementRenderer {
@@ -41,8 +42,8 @@
 			provideInstance(document, 'html-block-renderers', [ new DemoReplacementRenderer() ]);
 
 		</script>
-		<script>
-			document.getElementsByTagName('html')[0].dataset.mathjaxContext = JSON.stringify({ outputScale: 1.1, renderLatex: window.location.search.indexOf('latex=true') !== -1 });
+		<script type="module">
+			import '../../../tools/mathjax-test-context.js';
 		</script>
 	</head>
 	<body unresolved>

--- a/index.html
+++ b/index.html
@@ -85,8 +85,8 @@
 		<li>
 			HtmlBlock
 			<ul>
-				<li><a href="components/html-block/demo/html-block.html">d2l-html-block</a></li>
-				<li><a href="components/html-block/demo/html-block.html?latex=true">d2l-html-block (with LaTeX rendering)</a></li>
+				<li><a href="components/html-block/demo/html-block.html?latex=false">d2l-html-block</a></li>
+				<li><a href="components/html-block/demo/html-block.html">d2l-html-block (with LaTeX rendering)</a></li>
 			</ul>
 		</li>
 		<li><a href="components/icons/demo/icon.html">d2l-icon</a></li>

--- a/tools/mathjax-test-context.js
+++ b/tools/mathjax-test-context.js
@@ -1,4 +1,6 @@
-document.documentElement.dataset.mathjaxContext = JSON.stringify({
+const disabled = window.location.search.indexOf('latex=false') !== -1;
+
+document.getElementsByTagName('html')[0].dataset.mathjaxContext = JSON.stringify({
 	outputScale: 1.1,
-	renderLatex: true
+	renderLatex: !disabled
 });


### PR DESCRIPTION
Also update documentation. Should have done this with my other PR but didn't. This expands on #2288 and switches `core` demos to use the new file. Required a bit of re-work since didn't realize we had a demo page that disabled it. This should work, you need to explicitly set `latex=false` on a URL for a demo page or test to disable the test context render latex property, otherwise it's enabled.