### PR TITLE
fix: add mathjax test context warning message

### DIFF
--- a/tools/mathjax-test-context.js
+++ b/tools/mathjax-test-context.js
@@ -1,3 +1,5 @@
+console.warn('Using mathjax test context, this is intended for demo pages and tests only');
+
 const disabled = window.location.search.indexOf('latex=false') !== -1;
 
 document.getElementsByTagName('html')[0].dataset.mathjaxContext = JSON.stringify({


### PR DESCRIPTION
Adding warning so if this accidently get's used incorrectly within a component we can see this message. Add on to #2289.