### PR TITLE
List-item layout fixes.

### DIFF
--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -25,16 +25,20 @@ class ListItemContent extends LitElement {
 			.d2l-list-item-content-text-secondary {
 				color: var(--d2l-list-item-content-text-secondary-color, var(--d2l-color-tungsten));
 				margin: 0;
-				margin-top: 0.15rem;
 				overflow: hidden;
 			}
 
 			.d2l-list-item-content-text-supporting-info {
 				color: var(--d2l-color-ferrite);
 				margin: 0;
-				margin-top: 0.15rem;
 				overflow: hidden;
 			}
+
+			.d2l-list-item-content-text-secondary ::slotted(*),
+			.d2l-list-item-content-text-supporting-info ::slotted(*) {
+				margin-top: 0.15rem;
+			}
+
 
 		`];
 	}

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -96,12 +96,12 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			}
 			::slotted([slot="outside-control"]) {
 				grid-column: outside-control-start / outside-control-end;
-				width: 2.1rem;
+				width: 2.2rem;
 			}
 
 			::slotted([slot="control"]) {
 				grid-column: control-start / control-end;
-				width: 2.1rem;
+				width: 2.2rem;
 			}
 
 			::slotted([slot="content"]) {

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -118,9 +118,8 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 			[slot="control-container"]::after {
 				border-top: 1px solid var(--d2l-color-mica);
 				content: "";
-				left: 4px;
 				position: absolute;
-				width: calc(100% - 8px);
+				width: 100%;
 			}
 			:host(:first-of-type) [slot="control-container"]::before {
 				top: 0;

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -161,9 +161,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				padding-left: 0.9rem;
 				padding-right: 0;
 			}
-			.d2l-list-item-content ::slotted(*) {
-				margin-top: 0.05rem;
-			}
+
 			:host([_hovering-primary-action]) .d2l-list-item-content,
 			:host([_focusing-primary-action]) .d2l-list-item-content {
 				--d2l-list-item-content-text-color: var(--d2l-color-celestine);
@@ -185,11 +183,11 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				padding-right: 0;
 			}
 			:host([slim]) [slot="content"] { /* TODO, remove */
-				padding-bottom: 0.35rem;
+				padding-bottom: 0.4rem;
 				padding-top: 0.4rem;
 			}
 			:host([padding-type="slim"]) [slot="content"] {
-				padding-bottom: 0.35rem;
+				padding-bottom: 0.4rem;
 				padding-top: 0.4rem;
 			}
 			:host([padding-type="none"]) [slot="content"] {
@@ -202,7 +200,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				border-radius: 6px;
 				flex-grow: 0;
 				flex-shrink: 0;
-				margin: 0.15rem 0.9rem 0.15rem 0;
+				margin-right: 0.9rem;
 				max-height: 2.6rem;
 				max-width: 4.5rem;
 				overflow: hidden;
@@ -228,7 +226,6 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				gap: 0.3rem;
 				grid-auto-columns: 1fr;
 				grid-auto-flow: column;
-				margin: 0.15rem 0;
 			}
 
 			.d2l-list-item-content-extend-separators ::slotted([slot="actions"]),
@@ -275,21 +272,21 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				margin-right: 0;
 			}
 			d2l-selection-input {
-				margin: 1.15rem 0.9rem 1.15rem 0;
+				margin: 0.55rem 0.9rem 0.55rem 0;
 			}
 			.d2l-list-item-content-extend-separators d2l-selection-input {
 				margin-left: 0.9rem;
 			}
 			:host([slim]) d2l-selection-input { /* TODO, remove */
-				margin-bottom: 0.55rem;
-				margin-top: 0.55rem;
+				margin-bottom: 0.4rem;
+				margin-top: 0.4rem;
 			}
 			:host([padding-type="slim"]) d2l-selection-input {
-				margin-bottom: 0.55rem;
-				margin-top: 0.55rem;
+				margin-bottom: 0.4rem;
+				margin-top: 0.4rem;
 			}
 			d2l-list-item-drag-handle {
-				margin: 0.8rem 0 0.8rem 0.4rem;
+				margin: 0.25rem 0 0.25rem 0.4rem;
 			}
 			:host([dir="rtl"]) d2l-selection-input {
 				margin-left: 0.9rem;

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -305,6 +305,8 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				margin: 0 -12px;
 			}
 			.d2l-list-item-content-extend-separators [slot="outside-control-container"] {
+				border-left: none;
+				border-right: none;
 				border-radius: 0;
 			}
 			:host([draggable]) [slot="outside-control-container"],


### PR DESCRIPTION
This PR makes a few changes to update the layout of list-items.  Key things are:

* Update `d2l-list-item-content` margins so they are only rendered for secondary and supporting content when content is assigned to the slots.
* Update the size of the control containers (drag handle & selection checkbox) to be 44px wide for a11y.
* Update the separator width to be 100% - previously this was reduced to avoid funky rendering along with the border radius, which is no longer an issue because the outside container is being extended.
* Update to not show left/right borders when extending separators, since it is expected that the list is being placed in a container that provides a border (we don't want double borders at edges)
* Update margins so that checkbox is aligned with top of text.