### PR TITLE
Fix so that NVDA doesn't announce list items 3 times when moving them up with keyboard.

### DIFF
--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -279,7 +279,6 @@ class ListItemDragHandle extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		return html`
 			<button
 				aria-label="${this._defaultLabel}"
-				aria-live="assertive"
 				class="d2l-list-item-drag-handle-keyboard-button"
 				@focusin="${this._onFocusInKeyboardButton}"
 				@focusout="${this._onFocusOutKeyboardButton}"


### PR DESCRIPTION
This PR fixes an issue where NVDA announces the position and instruction for keyboard "move" button three times when moving an item up. (it would announce once as expected when moving down). Removing the `aria-live` fixes the issue, and the position & instruction are announced once as expected, moving up or down. Checked behaviour with both NVDA and VoiceOver.