### PR TITLE
Ignore focus events coming from inside tag items to prevent focus looping

### DIFF
--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -72,7 +72,10 @@ export const TagListItemMixin = superclass => class extends superclass {
 		super.firstUpdated(changedProperties);
 
 		const container = this.shadowRoot.querySelector('.tag-list-item-container');
-		this.addEventListener('focus', () => container.focus());
+		this.addEventListener('focus', (e) => {
+			// ignore focus events coming from inside the tag content
+			if (e.composedPath()[0] === this) container.focus();
+		});
 		this.addEventListener('blur', () => container.blur());
 	}
 


### PR DESCRIPTION
If the focus is coming directly from the tag list item host (such as the case where the arrowKeysMixin moves the focus), then the container should be focused. 

If the focus bubbles up from an item inside the tag (ie. profile tags contain the profile card dropdown inside them), then do not force focus on the container.