### PR TITLE
fix: removing the redundant prepare translations step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
         run: npm run build
       - name: Create custom-elements.json
         run: npx wca analyze \"{components,templates}/**/*.js\" --format json --outFile custom-elements.json
-      - name: Prepare Translations for NPM
-        uses: BrightspaceUI/actions/prepare-translations-for-npm@main
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:


### PR DESCRIPTION
This action was blowing up on the new comments in our translations as it was treating the JS files as JSON. It's also completely redundant since the translations would fail validation in CI if any language files were missing entries.

Since the action is only used in core and htmleditor, I'm removing it from both and will delete the action itself after.