### PR TITLE
fix: Dialog: Move location of documentation of d2l-dialog-before-close

### DIFF
--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -7,6 +7,7 @@ import { heading3Styles } from '../typography/styles.js';
 
 /**
  * A simple confirmation dialog for prompting the user. Apply the "data-dialog-action" attribute to workflow buttons to automatically close the confirm dialog with the action value.
+ * @fires d2l-dialog-before-close - Dispatched with the action value before the dialog is closed for any reason, providing an opportunity to prevent the dialog from closing
  * @slot footer - Slot for footer content such as workflow buttons
  */
 class DialogConfirm extends DialogMixin(LitElement) {

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -14,6 +14,7 @@ const mediaQueryList = window.matchMedia('(max-width: 615px), (max-height: 420px
 
 /**
  * A generic fullscreen dialog that provides a slot for arbitrary content and a "footer" slot for workflow buttons. Apply the "data-dialog-action" attribute to workflow buttons to automatically close the dialog with the action value.
+ * @fires d2l-dialog-before-close - Dispatched with the action value before the dialog is closed for any reason, providing an opportunity to prevent the dialog from closing
  * @slot - Default slot for content inside dialog
  * @slot footer - Slot for footer content such as workflow buttons
  */

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -304,8 +304,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	}
 
 	_isCloseAborted() {
-
-		/** Dispatched with the action value before the dialog is closed for any reason, providing an opportunity to prevent the dialog from closing */
 		const abortEvent = new CustomEvent('d2l-dialog-before-close', {
 			cancelable: true,
 			detail: {

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -16,6 +16,7 @@ const mediaQueryList = window.matchMedia('(max-width: 615px), (max-height: 420px
 
 /**
  * A generic dialog that provides a slot for arbitrary content and a "footer" slot for workflow buttons. Apply the "data-dialog-action" attribute to workflow buttons to automatically close the dialog with the action value.
+ * @fires d2l-dialog-before-close - Dispatched with the action value before the dialog is closed for any reason, providing an opportunity to prevent the dialog from closing
  * @slot - Default slot for content inside dialog
  * @slot footer - Slot for footer content such as workflow buttons
  */


### PR DESCRIPTION
The comment documentation of `d2l-dialog-before-close` doesn't work as expected (description ends up empty) because it needs to be above the `dispatchEvent`, which also needs to contain the event name (e.g., the actual contents of `abortEvent` would need to be within `this.dispatchEvent`). This is a bit complicated in this case because of the function returning `abortEvent.defaultPrevented` and so in this case it makes sense to document in each case that is using the `DialogMixin`.