### PR TITLE
Add comment indicating importance of d2l-html-block-rendered class

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -203,6 +203,8 @@ class HtmlBlock extends RtlMixin(LitElement) {
 		super.firstUpdated(changedProperties);
 
 		if (this._renderContainer) return;
+
+		// The d2l-html-block-rendered class is used to apply CSS outside of the html-block component. Do not change lightly.
 		this.shadowRoot.innerHTML += '<div class="d2l-html-block-rendered'
 			+ `${this.compact ? ' d2l-html-block-compact' : ''}`
 			+ '"></div><slot'


### PR DESCRIPTION
The `d2l-html-block-rendered` class will soon be used to target CSS on things outside of the html-block component, so we should be sure it doesn't get changed lightly.

Alternatively, if we want to switch up the CSS to target and use a different class, that's also fine... Though the same caveat applies in that case.