### PR TITLE
InteractiveMixin A11y Fixes

### DIFF
--- a/components/tag-list/demo/tag-list.html
+++ b/components/tag-list/demo/tag-list.html
@@ -73,7 +73,7 @@
 
 			<h2>Tag List with Interactive</h2>
 			<d2l-demo-snippet fullscreen>
-				<div role="grid">
+				<div grid>
 					<d2l-tag-list description="A bunch of example tags" clearable>
 						<d2l-tag-list-item text="Example Tag"></d2l-tag-list-item>
 						<d2l-tag-list-item text="Longer Example Tag - much much much much much longer"></d2l-tag-list-item>

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -49,7 +49,7 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 	}
 
 	static get styles() {
-		return [super.styles, css`
+		return [...super.styles, css`
 			:host {
 				display: block;
 			}

--- a/mixins/interactive-mixin.js
+++ b/mixins/interactive-mixin.js
@@ -42,7 +42,7 @@ export const InteractiveMixin = superclass => class extends LocalizeCoreElement(
 		super.connectedCallback();
 
 		const parentGrid = findComposedAncestor(this.parentNode, node => {
-			return ((node.tagName === 'D2L-LIST' && node.grid) || (node.nodeType === Node.ELEMENT_NODE && node.getAttribute('role') === 'grid'));
+			return (node.nodeType === Node.ELEMENT_NODE && (node.hasAttribute('grid') || node.getAttribute('role') === 'grid'));
 		});
 		this._hasInteractiveAncestor = (parentGrid !== null);
 	}
@@ -71,13 +71,12 @@ export const InteractiveMixin = superclass => class extends LocalizeCoreElement(
 		return html`
 			<div class="${classMap(classes)}" @keydown="${this._handleInteractiveKeyDown}">
 					<button
-						aria-description="${this.localize('components.interactive.instructions')}"
 						class="interactive-toggle d2l-offscreen"
 						@blur="${this._handleInteractiveToggleBlur}"
 						@click="${this._handleInteractiveToggleClick}"
 						@focus="${this._handleInteractiveToggleFocus}"
 						tabindex="${ifDefined(this._hasInteractiveAncestor && !this._interactive ? '0' : '-1')}">
-							${label}
+						${`${label}, ${this.localize('components.interactive.instructions')}`}
 					</button>
 					<span class="interactive-trap-start" @focus="${this._handleInteractiveTrapStartFocus}" tabindex="${ifDefined(this._hasInteractiveAncestor ? '0' : undefined)}"></span>
 					<div class="interactive-container-content" @focusin="${this._handleInteractiveContentFocusIn}" @focusout="${this._handleInteractiveContentFocusOut}">${inner}</div>

--- a/mixins/test/interactive-mixin.test.js
+++ b/mixins/test/interactive-mixin.test.js
@@ -8,9 +8,9 @@ const mixinTag = defineCE(
 	class extends InteractiveMixin(LitElement) {
 		render() {
 			return this.renderInteractiveContainer(
-				html`<div><button>interactive</button></div>`,
+				html`<div><button class="content-button">interactive</button></div>`,
 				'interactive label',
-				() => this.shadowRoot.querySelector('button').focus()
+				() => this.shadowRoot.querySelector('.content-button').focus()
 			);
 		}
 	}
@@ -35,37 +35,36 @@ describe('InteractiveMixin', () => {
 			fixtureElem = await fixture(`<div role="grid"><span id="before" tabindex="0"></span><${mixinTag}></${mixinTag}><span id="after" tabindex="0"></div>`);
 			elem = fixtureElem.querySelector(mixinTag);
 			await elem.updateComplete;
-			toggle = elem.shadowRoot.querySelector('.interactive-container');
+			toggle = elem.shadowRoot.querySelector('.interactive-toggle');
 		});
 
 		it('should render interactive container if a descendant of a grid', async() => {
 			expect(toggle).not.be.null;
 			expect(toggle.tabIndex).to.equal(0);
-			expect(toggle.getAttribute('role')).to.equal('button');
-			expect(toggle.getAttribute('aria-label')).to.equal('interactive label');
+			expect(toggle.textContent).to.contain('interactive label');
 		});
 
 		it('should toggle to interactive mode when Enter pressed', async() => {
 			toggle.focus();
-			keyDown(toggle, 13);
+			toggle.click();
 			await new Promise(resolve => setTimeout(resolve, 0));
 			const activeElement = getComposedActiveElement();
 			expect(toggle.tabIndex).to.equal(-1);
-			expect(activeElement).to.equal(elem.shadowRoot.querySelector('button'));
+			expect(activeElement).to.equal(elem.shadowRoot.querySelector('.content-button'));
 		});
 
 		it('should toggle to non-interactive mode when Escape pressed', async() => {
 			toggle.focus();
-			keyDown(toggle, 13);
+			toggle.click();
 			await new Promise(resolve => setTimeout(resolve, 0));
-			expect(getComposedActiveElement()).to.equal(elem.shadowRoot.querySelector('button'));
+			expect(getComposedActiveElement()).to.equal(elem.shadowRoot.querySelector('.content-button'));
 			keyDown(toggle, 27);
 			await new Promise(resolve => setTimeout(resolve, 0));
 			expect(getComposedActiveElement()).to.equal(toggle);
 		});
 
 		it('should toggle to interactive mode when focus moves into interactive contents', async() => {
-			elem.shadowRoot.querySelector('button').focus();
+			elem.shadowRoot.querySelector('.content-button').focus();
 			await elem.updateComplete;
 			expect(toggle.tabIndex).to.equal(-1);
 		});
@@ -85,7 +84,7 @@ describe('InteractiveMixin', () => {
 		});
 
 		it('should move focus to toggle if moving focus backwards to outside from within focusable contents', async() => {
-			elem.shadowRoot.querySelector('button').focus();
+			elem.shadowRoot.querySelector('.content-button').focus();
 			await elem.updateComplete;
 			elem.shadowRoot.querySelector('.interactive-trap-start').focus();
 			await new Promise(resolve => setTimeout(resolve, 0));
@@ -93,7 +92,7 @@ describe('InteractiveMixin', () => {
 		});
 
 		it('should move focus to toggle if moving focus forwards to outside from within focusable contents', async() => {
-			elem.shadowRoot.querySelector('button').focus();
+			elem.shadowRoot.querySelector('.content-button').focus();
 			await elem.updateComplete;
 			elem.shadowRoot.querySelector('.interactive-trap-end').focus();
 			await new Promise(resolve => setTimeout(resolve, 0));


### PR DESCRIPTION
This PR addresses two a11y issues with the `InteractiveMixin`:

1. VoiceOver + Safari: reads the label, not the description/instructions when tabbing to the interactive wrapper. Pressing `Enter` does move focus into the tag list but nothing is announced about the tags
2. NVDA + Firefox: reads the label and the description/instructions but it prevents the user from toggling when pressing `Enter` (without NVDA on the keyboard interactions work fine)

The solution to the above issues is to change the rendering so that the toggle is an offscreen `button` (keyboard access only) that is sibling to the interactive contents, instead of nesting the contents within a toggle `div`.  Seemingly, screen readers do not like it when focusables are nested within other focusables.