### PR TITLE
Shift htmlBlockStyles text-align style back into component

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -111,9 +111,6 @@ export const htmlBlockContentStyles = css`
 	mjx-assistive-mml math {
 		position: absolute;
 	}
-	:host([dir="rtl"]) {
-		text-align: right;
-	}
 `;
 
 let renderers;
@@ -163,6 +160,9 @@ class HtmlBlock extends RtlMixin(LitElement) {
 			}
 			:host([no-deferred-rendering]) div.d2l-html-block-rendered {
 				display: none;
+			}
+			:host([dir="rtl"]) {
+				text-align: right;
 			}
 		`];
 	}


### PR DESCRIPTION
Noticed this when I was doing something else, but I think this was just a miss from when I originally broke these styles out into a separate export. The intent was to leave `:host`-specific selectors in the component proper because it's not clear that they're always going to be applicable to an arbitrary consumer.