### PR TITLE
fix: temporary fix to not use native dialogs in Safari

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -14,7 +14,8 @@ import { tryGetIfrauBackdropService } from '../../helpers/ifrauBackdropService.j
 window.D2L = window.D2L || {};
 window.D2L.DialogMixin = window.D2L.DialogMixin || {};
 
-window.D2L.DialogMixin.hasNative = (window.HTMLDialogElement !== undefined);
+window.D2L.DialogMixin.hasNative = (window.HTMLDialogElement !== undefined)
+	&& (navigator.vendor && navigator.vendor.toLowerCase().indexOf('apple') === -1);
 if (window.D2L.DialogMixin.preferNative === undefined) {
 	window.D2L.DialogMixin.preferNative = true;
 }


### PR DESCRIPTION
Safari shipped native `<dialog>`s in version 15.4 and our fullscreen dialog in mobile viewports is very broken. I'm also seeing focus-trap issues when the native `<dialog>` is used.

Since this is affecting production and we need to cert & hotfix it quickly, this is a temporary fix that will just cause Safari to fall back to the non-native dialog solution that it's been using previously. That'll buy us time to address this properly.