### PR TITLE
Update list-items to support interactive element in list-item content.

### DIFF
--- a/components/list/README.md
+++ b/components/list/README.md
@@ -363,6 +363,7 @@ The `d2l-list-item` provides the appropriate `listitem` semantics for children w
 | `key` | String | Value to identify item if selectable or draggable |
 | `label` | String | Explicitly defined label for the element |
 | `labelled-by` | String | The id of element that provides the label for this element |
+| `no-primary-action` | Boolean | Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive. |
 | `padding-type` | String | List item whitespace (`normal` (default), `none`)|
 | `selectable` | Boolean | Indicates an input should be rendered for selecting the item |
 | `selected` | Boolean | Whether the item is selected |

--- a/components/list/demo/list.html
+++ b/components/list/demo/list.html
@@ -272,7 +272,7 @@
 								</d2l-dropdown-more>
 							</div>
 						</d2l-list-item>
-						<d2l-list-item href="http://www.d2l.com" selectable key="2" selected label="Engineering Materials for Energy Systems">
+						<d2l-list-item no-primary-action selectable key="2" selected label="Engineering Materials for Energy Systems">
 							<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
 							<div>
 								<d2l-list-item-content>
@@ -296,7 +296,7 @@
 								</d2l-dropdown-more>
 							</div>
 						</d2l-list-item>
-						<d2l-list-item href="http://www.d2l.com" selectable key="3" label="Geomorphology and GIS">
+						<d2l-list-item no-primary-action selectable key="3" label="Geomorphology and GIS">
 							<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
 							<div>
 								<d2l-list-item-content>

--- a/components/list/demo/list.html
+++ b/components/list/demo/list.html
@@ -20,11 +20,16 @@
 			import '../list-item-content.js';
 			import '../list-item.js';
 			import '../list.js';
+			import '../../tag-list/tag-list.js';
+			import '../../tag-list/tag-list-item.js';
 		</script>
 		<style>
 			img {
 				height: 500px;
 				object-fit: cover;
+			}
+			d2l-tag-list {
+				margin-top: 0.3rem;
 			}
 		</style>
 	</head>
@@ -220,6 +225,89 @@
 								<div>Geomorphology and GIS</div>
 								<div slot="supporting-info">This course explores the geological processes of the Earth's interior and surface. These include volcanism, earthquakes, mountain...</div>
 							</d2l-list-item-content>
+							<div slot="actions">
+								<d2l-button-icon id="tooltip-btn-1" text="My Button" icon="tier1:preview"></d2l-button-icon>
+								<d2l-tooltip for="tooltip-btn-1">Preview</d2l-tooltip>
+								<d2l-dropdown-more text="Open!">
+									<d2l-dropdown-menu>
+										<d2l-menu label="Astronomy">
+											<d2l-menu-item text="Introduction"></d2l-menu-item>
+											<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+										</d2l-menu>
+									</d2l-dropdown-menu>
+								</d2l-dropdown-more>
+							</div>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>List with Interactive Content</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list grid>
+						<d2l-list-item no-primary-action selectable key="1" label="Introductory Earth Sciences">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
+							<div>
+								<d2l-list-item-content>
+									<div>Introductory Earth Sciences</div>
+								</d2l-list-item-content>
+								<d2l-tag-list description="Tags for this course">
+									<d2l-tag-list-item text="Science"></d2l-tag-list-item>
+									<d2l-tag-list-item text="Environment"></d2l-tag-list-item>
+									<d2l-tag-list-item text="Earth"></d2l-tag-list-item>
+								</d2l-tag-list>
+							</div>
+							<div slot="actions">
+								<d2l-button-icon id="tooltip-btn-1" text="My Button" icon="tier1:preview"></d2l-button-icon>
+								<d2l-tooltip for="tooltip-btn-1">Preview</d2l-tooltip>
+								<d2l-dropdown-more text="Open!">
+									<d2l-dropdown-menu>
+										<d2l-menu label="Astronomy">
+											<d2l-menu-item text="Introduction"></d2l-menu-item>
+											<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+										</d2l-menu>
+									</d2l-dropdown-menu>
+								</d2l-dropdown-more>
+							</div>
+						</d2l-list-item>
+						<d2l-list-item href="http://www.d2l.com" selectable key="2" selected label="Engineering Materials for Energy Systems">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/e5fd575a-bc14-4a80-89e1-46f349a76178/tile-high-density-max-size.jpg"></img>
+							<div>
+								<d2l-list-item-content>
+									<div>Engineering Materials for Energy Systems</div>
+								</d2l-list-item-content>
+								<d2l-tag-list description="Tags for this course">
+									<d2l-tag-list-item text="Engineering"></d2l-tag-list-item>
+									<d2l-tag-list-item text="Energy Systems"></d2l-tag-list-item>
+								</d2l-tag-list>
+							</div>
+							<div slot="actions">
+								<d2l-button-icon id="tooltip-btn-1" text="My Button" icon="tier1:preview"></d2l-button-icon>
+								<d2l-tooltip for="tooltip-btn-1">Preview</d2l-tooltip>
+								<d2l-dropdown-more text="Open!">
+									<d2l-dropdown-menu>
+										<d2l-menu label="Astronomy">
+											<d2l-menu-item text="Introduction"></d2l-menu-item>
+											<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+										</d2l-menu>
+									</d2l-dropdown-menu>
+								</d2l-dropdown-more>
+							</div>
+						</d2l-list-item>
+						<d2l-list-item href="http://www.d2l.com" selectable key="3" label="Geomorphology and GIS">
+							<img slot="illustration" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-high-density-max-size.jpg"></img>
+							<div>
+								<d2l-list-item-content>
+									<div>Geomorphology and GIS</div>
+								</d2l-list-item-content>
+								<d2l-tag-list description="Tags for this course">
+									<d2l-tag-list-item text="Geology"></d2l-tag-list-item>
+									<d2l-tag-list-item text="GIS"></d2l-tag-list-item>
+									<d2l-tag-list-item text="Earth Sciences"></d2l-tag-list-item>
+								</d2l-tag-list>
+							</div>
 							<div slot="actions">
 								<d2l-button-icon id="tooltip-btn-1" text="My Button" icon="tier1:preview"></d2l-button-icon>
 								<d2l-tooltip for="tooltip-btn-1">Preview</d2l-tooltip>

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -43,7 +43,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			 * Whether to constrain actions so they do not fill the item. Required if slotted content is interactive.
 			 * @type {boolean}
 			 */
-			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
+			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action', reflect: true },
 			/**
 			 * @ignore
 			 */

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -198,7 +198,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			<slot name="control-action" class="d2l-cell" data-cell-num="3"></slot>
 			<slot name="control" class="d2l-cell" data-cell-num="4"></slot>
 			<slot name="actions" class="d2l-cell" data-cell-num="6"></slot>
-			<slot name="content" class="d2l-cell" data-cell-num="7" @focus="${this._preventFocus}"></slot>
+			<slot name="content" class="d2l-cell" data-cell-num="7" @focus="${!this.noPrimaryAction ? this._preventFocus : null}"></slot>
 			<slot name="nested"></slot>
 		`;
 	}

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -1,10 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { findComposedAncestor, getNextAncestorSibling, getPreviousAncestorSibling, isComposedAncestor } from '../../helpers/dom.js';
-import {
-	getComposedActiveElement,
-	getFirstFocusableDescendant,
-	getLastFocusableDescendant,
-	isFocusable } from '../../helpers/focus.js';
+import { getComposedActiveElement, getFirstFocusableDescendant, getLastFocusableDescendant, isFocusable } from '../../helpers/focus.js';
+import { isInteractiveDescendant } from '../../mixins/interactive-mixin.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 const keyCodes = {
@@ -42,6 +39,11 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			 * @type {'content'|'control'}
 			 */
 			alignNested: { type: String, reflect: true, attribute: 'align-nested' },
+			/**
+			 * Whether to constrain actions so they do not fill the item. Required if slotted content is interactive.
+			 * @type {boolean}
+			 */
+			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
 			/**
 			 * @ignore
 			 */
@@ -127,15 +129,24 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 				grid-column: start / end;
 				z-index: 1;
 			}
+			:host([no-primary-action]) ::slotted([slot="outside-control-action"]) {
+				grid-column: start / outside-control-end;
+			}
 			::slotted([slot="control-action"]) {
 				grid-column: control-start / end;
 				height: 100%;
 				width: 100%;
 				z-index: 2;
 			}
+			:host([no-primary-action]) ::slotted([slot="control-action"]) {
+				grid-column: control-start / control-end;
+			}
 			::slotted([slot="content-action"]) {
 				grid-column: content-start / end;
 				z-index: 3;
+			}
+			:host([no-primary-action]) ::slotted([slot="content-action"]) {
+				display: none;
 			}
 
 			::slotted([slot="outside-control-container"]) {
@@ -152,6 +163,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 	constructor() {
 		super();
 		this.alignNested = 'content';
+		this.noPrimaryAction = false;
 		this._preventFocus = {
 			handleEvent(event) {
 				// target content slot only for now - can add others later
@@ -186,7 +198,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			<slot name="control-action" class="d2l-cell" data-cell-num="3"></slot>
 			<slot name="control" class="d2l-cell" data-cell-num="4"></slot>
 			<slot name="actions" class="d2l-cell" data-cell-num="6"></slot>
-			<slot name="content" @focus="${this._preventFocus}"></slot>
+			<slot name="content" class="d2l-cell" data-cell-num="7" @focus="${this._preventFocus}"></slot>
 			<slot name="nested"></slot>
 		`;
 	}
@@ -276,14 +288,18 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 	}
 
 	_focusNextWithinCell(node, num = 1) {
+
 		if (!node || (node.assignedSlot && node.assignedSlot === this._getThisCell())) return null;
 		let focusable = null;
 		let siblingNum = 1;
 		while (!focusable || siblingNum < num) {
 			node = this._getNextSiblingInCell(node);
+
 			if (!node) break;
 			++siblingNum;
+
 			focusable = isFocusable(node, true) ? node : getFirstFocusableDescendant(node);
+			if (isInteractiveDescendant(focusable)) focusable = null;
 		}
 
 		if (focusable) focusable.focus();

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -58,6 +58,11 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 			 */
 			dragTargetHandleOnly: { type: Boolean, attribute: 'drag-target-handle-only' },
 			/**
+			 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
+			 * @type {boolean}
+			 */
+			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
+			/**
 			 * How much padding to render list items with
 			 * @type {'normal'|'none'}
 			 */
@@ -106,6 +111,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 
 			[slot="control-container"] {
 				position: relative;
+				z-index: -1; /* must allow for interactive content to be accessible with mouse */
 			}
 			:host(:first-of-type) [slot="control-container"]::before,
 			[slot="control-container"]::after {
@@ -343,6 +349,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 	constructor() {
 		super();
 		this.breakpoints = defaultBreakpoints;
+		this.noPrimaryAction = false;
 		this.paddingType = 'normal';
 		this._breakpoint = 0;
 		this._contentId = getUniqueId();
@@ -531,7 +538,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 			'd2l-dragging-over': this._draggingOver
 		};
 
-		const primaryAction = this._renderPrimaryAction ? this._renderPrimaryAction(this._contentId) : null;
+		const primaryAction = ((!this.noPrimaryAction && this._renderPrimaryAction) ? this._renderPrimaryAction(this._contentId) : null);
 		const tooltipForId = (primaryAction ? this._primaryActionId : (this.selectable ? this._checkboxId : null));
 
 		const innerView = html`
@@ -543,7 +550,8 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				class="${classMap(classes)}"
 				data-breakpoint="${this._breakpoint}"
 				data-separators="${ifDefined(this._separators)}"
-				?grid-active="${this.role === 'rowgroup'}">
+				?grid-active="${this.role === 'rowgroup'}"
+				?no-primary-action="${this.noPrimaryAction}">
 				<div slot="outside-control-container"></div>
 				${this._renderDropTarget()}
 				${this._renderDragHandle(this._renderOutsideControl)}

--- a/mixins/arrow-keys-mixin.js
+++ b/mixins/arrow-keys-mixin.js
@@ -96,6 +96,7 @@ export const ArrowKeysMixin = superclass => class extends superclass {
 		} else {
 			return;
 		}
+		e.stopPropagation();
 		e.preventDefault();
 	}
 

--- a/mixins/interactive-mixin.js
+++ b/mixins/interactive-mixin.js
@@ -11,6 +11,13 @@ const keyCodes = {
 	ESCAPE: 27
 };
 
+export function isInteractiveDescendant(node) {
+	if (!node) return false;
+	return !!findComposedAncestor(node, node => {
+		return node.classList && node.classList.contains('interactive-trap');
+	});
+}
+
 export const InteractiveMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
 	static get properties() {
@@ -70,17 +77,19 @@ export const InteractiveMixin = superclass => class extends LocalizeCoreElement(
 
 		return html`
 			<div class="${classMap(classes)}" @keydown="${this._handleInteractiveKeyDown}">
-					<button
-						class="interactive-toggle d2l-offscreen"
-						@blur="${this._handleInteractiveToggleBlur}"
-						@click="${this._handleInteractiveToggleClick}"
-						@focus="${this._handleInteractiveToggleFocus}"
-						tabindex="${ifDefined(this._hasInteractiveAncestor && !this._interactive ? '0' : '-1')}">
-						${`${label}, ${this.localize('components.interactive.instructions')}`}
-					</button>
+				<button
+					class="interactive-toggle d2l-offscreen"
+					@blur="${this._handleInteractiveToggleBlur}"
+					@click="${this._handleInteractiveToggleClick}"
+					@focus="${this._handleInteractiveToggleFocus}"
+					tabindex="${ifDefined(this._hasInteractiveAncestor && !this._interactive ? '0' : '-1')}">
+					${`${label}, ${this.localize('components.interactive.instructions')}`}
+				</button>
+				<div class="interactive-trap">
 					<span class="interactive-trap-start" @focus="${this._handleInteractiveTrapStartFocus}" tabindex="${ifDefined(this._hasInteractiveAncestor ? '0' : undefined)}"></span>
 					<div class="interactive-container-content" @focusin="${this._handleInteractiveContentFocusIn}" @focusout="${this._handleInteractiveContentFocusOut}">${inner}</div>
 					<span class="interactive-trap-end" @focus="${this._handleInteractiveTrapEndFocus}" tabindex="${ifDefined(this._hasInteractiveAncestor ? '0' : undefined)}"></span>
+				</div>
 			</div>
 		`;
 	}


### PR DESCRIPTION
This PR updates the list-item components to support interactive elements inside their content.  The consumer must specify `no-primary-action` to ensure the interactive elements are not blocked by action layers for mouse users.