### PR TITLE
fix: content not available early in mobile rendering pipeline

### DIFF
--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -106,7 +106,6 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 		this.describeContent = false;
 		this.width = 600;
 		this._handleResize = this._handleResize.bind(this);
-		this._handleResize();
 	}
 
 	get asyncContainerCustom() {
@@ -121,6 +120,11 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 	disconnectedCallback() {
 		if (mediaQueryList.removeEventListener) mediaQueryList.removeEventListener('change', this._handleResize);
 		super.disconnectedCallback();
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		this._handleResize();
 	}
 
 	render() {


### PR DESCRIPTION
Noticed this JS error gets thrown during dialog initialization in `_updateOverflow` if the viewport is initially small enough to fall into the "mobile" category.

The reason is that `_updateSize` is called from `resize()` which is called from `_handleResize()` which is called [from Dialog's constructor](https://github.com/BrightspaceUI/core/blob/main/components/dialog/dialog.js#L109). In Lit 2, the constructor runs before there's a shadow root.

In mobile mode, the code skips past all [this autoSize logic](https://github.com/BrightspaceUI/core/blob/main/components/dialog/dialog-mixin.js#L461) which has a bunch of `await this.updateComplete`s in it and therefore defers the run long enough for the component to have rendered.