### PR TITLE
fix: exclude d2l-focus-trap for native dialogs

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -14,6 +14,8 @@ import { tryGetIfrauBackdropService } from '../../helpers/ifrauBackdropService.j
 window.D2L = window.D2L || {};
 window.D2L.DialogMixin = window.D2L.DialogMixin || {};
 
+// while implemented in Webkit, native <dialog> focus mangement across slotted content is buggy
+// https://bugs.webkit.org/show_bug.cgi?id=233320
 window.D2L.DialogMixin.hasNative = (window.HTMLDialogElement !== undefined)
 	&& (navigator.vendor && navigator.vendor.toLowerCase().indexOf('apple') === -1);
 if (window.D2L.DialogMixin.preferNative === undefined) {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -412,12 +412,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			'd2l-dialog-fullscreen-within': this._fullscreenWithin !== 0
 		};
 
-		inner = html`<d2l-focus-trap
-			@d2l-focus-trap-enter="${this._handleFocusTrapEnter}"
-			?trap="${this.opened}">
-				${inner}
-			</d2l-focus-trap>`;
-
 		return html`${this._useNative ?
 			html`<dialog
 				aria-describedby="${ifDefined(info.descId)}"
@@ -443,7 +437,9 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 				id="${this._dialogId}"
 				role="${info.role}"
 				style=${styleMap(styles)}>
-					${inner}
+					<d2l-focus-trap
+						@d2l-focus-trap-enter="${this._handleFocusTrapEnter}"
+						?trap="${this.opened}">${inner}</d2l-focus-trap>
 				</div>
 				<d2l-backdrop for-target="${this._dialogId}" ?shown="${this._state === 'showing'}"></d2l-backdrop>`}
 		`;

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -184,7 +184,16 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 				return;
 			}
 		}
-		this.shadowRoot.querySelector('d2l-focus-trap').focus();
+		const focusTrap = this.shadowRoot.querySelector('d2l-focus-trap');
+		if (focusTrap) {
+			focusTrap.focus();
+			return;
+		}
+		const header = this.shadowRoot.querySelector('.d2l-dialog-header');
+		if (header) {
+			const firstFocusable = getNextFocusable(header);
+			if (firstFocusable) forceFocusVisible(firstFocusable);
+		}
 	}
 
 	_focusInitial() {

--- a/components/tag-list/test/tag-list.visual-diff.js
+++ b/components/tag-list/test/tag-list.visual-diff.js
@@ -21,7 +21,7 @@ describe('d2l-tag-list', () => {
 
 	it('is correct at 1400px page width', async function() {
 		const rect = await visualDiff.getRect(page, '#default');
-		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 	});
 
 	describe('tag list item style behaviour', () => {
@@ -29,20 +29,20 @@ describe('d2l-tag-list', () => {
 		it('is correct on focus on tag list item', async function() {
 			await page.keyboard.press('Tab');
 			const rect = await visualDiff.getRect(page, '#default');
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 		});
 
 		it('is correct on hover on tag list item', async function() {
 			await page.hover('d2l-tag-list-item');
 			const rect = await visualDiff.getRect(page, '#default');
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 		});
 
 		it('is correct on focus and hover tag list item', async function() {
 			await page.keyboard.press('Tab');
 			await page.hover('d2l-tag-list-item');
 			const rect = await visualDiff.getRect(page, '#default');
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 		});
 
 	});
@@ -63,7 +63,7 @@ describe('d2l-tag-list', () => {
 
 				it('is correct', async function() {
 					const rect = await visualDiff.getRect(page, selector);
-					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 				});
 
 				it('is correct after adding items', async function() {
@@ -77,7 +77,7 @@ describe('d2l-tag-list', () => {
 					});
 					await page.waitForTimeout(500);
 					const rect = await visualDiff.getRect(page, selector);
-					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 				});
 
 				it('is correct when show more button clicked if applicable', async function() {
@@ -92,7 +92,7 @@ describe('d2l-tag-list', () => {
 					});
 					await page.waitForTimeout(500);
 					const rect = await visualDiff.getRect(page, selector);
-					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 				});
 
 			});
@@ -119,7 +119,7 @@ describe('d2l-tag-list', () => {
 			});
 			await page.waitForTimeout(500);
 			const rect = await visualDiff.getRect(page, selector);
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 		});
 
 		it('is correct when deleting first item', async function() {
@@ -138,14 +138,14 @@ describe('d2l-tag-list', () => {
 			});
 			await openEvent;
 			const rect = await visualDiff.getRect(page, selector);
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 		});
 
 		it('is correct after clicking Clear All', async function() {
 			await page.$eval(selector, (elem) => elem.shadowRoot.querySelector('d2l-button-subtle.d2l-tag-list-clear-button').click());
 			await page.waitForTimeout(500);
 			const rect = await visualDiff.getRect(page, selector);
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 		});
 
 	});
@@ -154,13 +154,13 @@ describe('d2l-tag-list', () => {
 
 		it('normal', async function() {
 			const rect = await visualDiff.getRect(page, '#interactive');
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 		});
 
 		it('focus', async function() {
 			const rect = await visualDiff.getRect(page, '#interactive');
 			await page.$eval('#interactive', elem => elem.focus());
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 		});
 
 	});


### PR DESCRIPTION
Native `<dialog>` elements essentially implement the `inert` behaviour in that they come with their own focus trap logic, so we don't need `<d2l-focus-trap>` when native dialogs are used.

The only difference between theirs and ours is that focus will cycle up to the browser chrome and then back into the window, just like it normally does -- which I think is better anyway.