### PR TITLE
Make sure we're also fixing newlines in noDeferredRendering case

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -56,19 +56,24 @@ export class HtmlBlockMathRenderer {
 
 		await loadMathJax(mathJaxConfig);
 
+		// MathJax 3 does not support newlines, but it does persist styles, so add custom styles to mimic a linebreak
+		// This work-around should be removed when linebreaks are natively supported.
+		// MathJax issue: https://github.com/mathjax/MathJax/issues/2312
+		// A duplicate that explains our exact issue: https://github.com/mathjax/MathJax/issues/2495
+		const lineBreakStyle = 'display: block; height: 0.5rem;'
+
 		// If we're opting out of deferred rendering, we need to rely
 		// on the global MathJax install for rendering.
 		if (options.noDeferredRendering) {
+			elem.querySelectorAll('mspace[linebreak="newline"]').forEach(elm => {
+				elm.setAttribute('style', lineBreakStyle);
+			});
 			await window.MathJax.startup.promise;
 			window.MathJax.typeset([elem]);
 			return elem;
 		}
 
-		// MathJax 3 does not support newlines, but it does persist styles, so add custom styles to mimic a linebreak
-		// This work-around should be removed when linebreaks are natively supported.
-		// MathJax issue: https://github.com/mathjax/MathJax/issues/2312
-		// A duplicate that explains our exact issue: https://github.com/mathjax/MathJax/issues/2495
-		const inner = elem.innerHTML.replaceAll('<mspace linebreak="newline">', '<mspace linebreak="newline" style="display: block; height: 0.5rem;">');
+		const inner = elem.innerHTML.replaceAll('<mspace linebreak="newline">', `<mspace linebreak="newline" style="${lineBreakStyle}">`);
 
 		const temp = document.createElement('div');
 		temp.style.display = 'none';

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -60,7 +60,7 @@ export class HtmlBlockMathRenderer {
 		// This work-around should be removed when linebreaks are natively supported.
 		// MathJax issue: https://github.com/mathjax/MathJax/issues/2312
 		// A duplicate that explains our exact issue: https://github.com/mathjax/MathJax/issues/2495
-		const lineBreakStyle = 'display: block; height: 0.5rem;'
+		const lineBreakStyle = 'display: block; height: 0.5rem;';
 
 		// If we're opting out of deferred rendering, we need to rely
 		// on the global MathJax install for rendering.


### PR DESCRIPTION
Occurs to me that I missed the `noDeferredRendering` case. Not sure we need to bother backporting this because it's already a bit of an edge case, but we should still fix it.