### PR TITLE
Allow html-block to render inline

### DIFF
--- a/components/html-block/README.md
+++ b/components/html-block/README.md
@@ -78,25 +78,23 @@ Examples are provided to display how user-authored math can be embedded within y
   import '@brightspace-ui/core/components/icons/icon.js';
 </script>
 <d2l-html-block>
-  <div class="mathml-container">
-    <math xmlns="http://www.w3.org/1998/Math/MathML">
-      <msqrt>
-        <mn>3</mn>
-        <mi>x</mi>
-        <mo>&#x2212;</mo>
-        <mn>1</mn>
-      </msqrt>
-      <mo>+</mo>
-      <mo stretchy="false">(</mo>
-      <mn>1</mn>
-      <mo>+</mo>
+  <math xmlns="http://www.w3.org/1998/Math/MathML">
+    <msqrt>
+      <mn>3</mn>
       <mi>x</mi>
-      <msup>
-        <mo stretchy="false">)</mo>
-        <mn>2</mn>
-      </msup>
-    </math>
-  </div>
+      <mo>&#x2212;</mo>
+      <mn>1</mn>
+    </msqrt>
+    <mo>+</mo>
+    <mo stretchy="false">(</mo>
+    <mn>1</mn>
+    <mo>+</mo>
+    <mi>x</mi>
+    <msup>
+      <mo stretchy="false">)</mo>
+      <mn>2</mn>
+    </msup>
+  </math>
 </d2l-html-block>
 ```
 
@@ -109,9 +107,7 @@ Examples are provided to display how user-authored math can be embedded within y
   import '@brightspace-ui/core/tools/mathjax-test-context.js';
 </script>
 <d2l-html-block>
-  <div class="latex-container">
     $$ f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x $$ $$ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} $$
-  </div>
 </d2l-html-block>
 ```
 

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -131,6 +131,10 @@ class HtmlBlock extends RtlMixin(LitElement) {
 			 */
 			compact: { type: Boolean },
 			/**
+			 * Whether to display the HTML in inline mode
+			 */
+			inline: { type: Boolean },
+			/**
 			 * Whether to disable deferred rendering of the user-authored HTML. Do *not* set this
 			 * unless your HTML relies on script executions that may break upon stamping.
 			 * @type {Boolean}
@@ -149,11 +153,13 @@ class HtmlBlock extends RtlMixin(LitElement) {
 				position: relative;
 				text-align: left;
 			}
-			:host([hidden]) {
-				display: none;
-			}
+			:host([hidden]),
 			:host([no-deferred-rendering]) div.d2l-html-block-rendered {
 				display: none;
+			}
+			:host([inline]),
+			:host([inline]) div.d2l-html-block-rendered {
+				display: inline;
 			}
 		`];
 	}
@@ -161,6 +167,7 @@ class HtmlBlock extends RtlMixin(LitElement) {
 	constructor() {
 		super();
 		this.compact = false;
+		this.inline = false;
 		this.noDeferredRendering = false;
 
 		const rendererContextAttributes = getRenderers().reduce((attrs, currentRenderer) => {


### PR DESCRIPTION
Backport of this PR into 2.10.x: https://github.com/BrightspaceUI/core/pull/2439