### PR TITLE
Remove relative positioning; consumers should decide this

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -156,7 +156,6 @@ class HtmlBlock extends RtlMixin(LitElement) {
 				overflow-wrap: break-word;
 				overflow-x: auto;
 				overflow-y: hidden;
-				position: relative;
 				text-align: left;
 			}
 			:host([hidden]),


### PR DESCRIPTION
I believe we only want this specified for untrusted HTML. Otherwise if we were to try to render a profile card or something of the like inside an html-block and it didn't fit the bounds of the component, we wouldn't have a means to position it properly outside of fixed positioning shenanigans.