### PR TITLE
fix: US138545 make sure blur event gets to d2l-input-text-container div

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -402,7 +402,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 
 		const input = html`
 			<div class="d2l-input-container">
-				<div class="d2l-input-text-container d2l-skeletize" style="${styleMap(inputContainerStyles)}">
+				<div class="d2l-input-text-container d2l-skeletize" tabindex="-1" style="${styleMap(inputContainerStyles)}">
 					<input aria-atomic="${ifDefined(this.atomic)}"
 						aria-describedby="${ifDefined(this.description ? this._descriptionId : undefined)}"
 						aria-haspopup="${ifDefined(this.ariaHaspopup)}"


### PR DESCRIPTION
https://rally1.rallydev.com/#/?detail=/userstory/632387188999&fdp=true

As part of updating Activity Feed (FRA) to Lit 2, I noticed that the `d2l-input-text` sometimes validated on blur, but most of the time it did not. It's because the `d2l-input-text-container` div usually doesn't get the blur event. This div handles the blur event to do the validation. Adding `tabindex=-1` to this div forces it to get the event.

I don't understand why without the tabindex it gets the event _sometimes_, however with the tabindex it seems to get it _always_.