### PR TITLE
Make sure autoloaded MathJax extensions are actually loaded before typesetting

### DIFF
--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -383,6 +383,7 @@
 									<mo>)</mo>
 								</mrow>
 							</math>
+							$$ {\color{red}x} + {\color{blue}y} = {\color{green}z} $$
 							<p>The wizard (<span data-replace-me-id="0">Elmer Fudd</span>) quickly jinxed the gnomes before they vaporized.</p>
 						</div>
 					</d2l-html-block>
@@ -495,6 +496,7 @@
 				<template>
 					<d2l-html-block>
 						<div>$$ f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x $$ $$ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} $$</div>
+						<div>$$ {\color{red}x} + {\color{blue}y} = {\color{green}z} $$</div>
 					</d2l-html-block>
 				</template>
 			</d2l-demo-snippet>
@@ -507,7 +509,7 @@
 						<div>
 							An equation rendered using LaTeX...
 							\( f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x \)
-							... and some text!
+							... and some text ...
 						</div>
 					</d2l-html-block>
 				</template>

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -69,7 +69,7 @@ export class HtmlBlockMathRenderer {
 				elm.setAttribute('style', lineBreakStyle);
 			});
 			await window.MathJax.startup.promise;
-			window.MathJax.typeset([elem]);
+			await window.MathJax.typesetPromise([elem]);
 			return elem;
 		}
 
@@ -82,7 +82,7 @@ export class HtmlBlockMathRenderer {
 
 		elem.appendChild(temp);
 		await window.MathJax.startup.promise;
-		window.MathJax.typesetShadow(temp.shadowRoot);
+		await window.MathJax.typesetShadow(temp.shadowRoot);
 
 		return temp.shadowRoot.firstChild;
 	}
@@ -182,12 +182,15 @@ export function loadMathJax(mathJaxConfig) {
 				//  renders the document.  The MathDocument is returned in case
 				//  you need to rerender the shadowRoot later.
 				//
-				window.MathJax.typesetShadow = function(root) {
-					const InputJax = startup.getInputJax();
-					const OutputJax = startup.getOutputJax();
-					const html = mathjax.document(root, { InputJax, OutputJax });
-					html.render().typeset();
-					return html;
+				window.MathJax.typesetShadow = async function(root) {
+					return await mathjax.handleRetriesFor(() => {
+						const InputJax = startup.getInputJax();
+						const OutputJax = startup.getOutputJax();
+						const html = mathjax.document(root, { InputJax, OutputJax });
+
+						html.render().typeset();
+						return html;
+					});
 				};
 
 				//

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -204,7 +204,7 @@ export function loadMathJax(mathJaxConfig) {
 					html.options.elements = [elem];
 					html.render().typeset();
 					return html;
-				}
+				};
 
 				//
 				//  Now do the usual startup now that the extensions are in place

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -68,8 +68,9 @@ export class HtmlBlockMathRenderer {
 			elem.querySelectorAll('mspace[linebreak="newline"]').forEach(elm => {
 				elm.setAttribute('style', lineBreakStyle);
 			});
+
 			await window.MathJax.startup.promise;
-			window.MathJax.typesetElement(elem);
+			window.MathJax.typesetShadow(elem.getRootNode(), elem);
 			return elem;
 		}
 
@@ -187,21 +188,13 @@ export function loadMathJax(mathJaxConfig) {
 				//  renders the document.  The MathDocument is returned in case
 				//  you need to rerender the shadowRoot later.
 				//
-				window.MathJax.typesetShadow = function(root) {
+				window.MathJax.typesetShadow = function(root, elem) {
 					const InputJax = startup.getInputJax();
 					const OutputJax = startup.getOutputJax();
 					const html = mathjax.document(root, { InputJax, OutputJax });
 
-					html.render().typeset();
-					return html;
-				};
+					if (elem) html.options.elements = [elem];
 
-				window.MathJax.typesetElement = function(elem) {
-					const InputJax = startup.getInputJax();
-					const OutputJax = startup.getOutputJax();
-					const html = mathjax.document(document, { InputJax, OutputJax });
-
-					html.options.elements = [elem];
 					html.render().typeset();
 					return html;
 				};


### PR DESCRIPTION
The MathJax output processor we're using loads a bunch of TeX extensions automatically, but this loading is lazy and only happens when math using it is detected on the page. This means, however, that we also need to explicitly wait for these extensions to load before we can typeset anything.

Context: The symptom here was that the LaTeX `\color` command wasn't always working properly. A forced re-render of the math seemed to kick it into functioning properly, hence my realization that the extension wasn't always loading when first typesetting.