### PR TITLE
Use safer replace API to support older browsers

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -74,7 +74,7 @@ export class HtmlBlockMathRenderer {
 			return elem;
 		}
 
-		const inner = elem.innerHTML.replace(/<mspace linebreak="newline">/, `<mspace linebreak="newline" style="${lineBreakStyle}">`);
+		const inner = elem.innerHTML.replace(/<mspace linebreak="newline">/gi, `<mspace linebreak="newline" style="${lineBreakStyle}">`);
 
 		const temp = document.createElement('div');
 		temp.style.display = 'none';

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -74,7 +74,7 @@ export class HtmlBlockMathRenderer {
 			return elem;
 		}
 
-		const inner = elem.innerHTML.replaceAll('<mspace linebreak="newline">', `<mspace linebreak="newline" style="${lineBreakStyle}">`);
+		const inner = elem.innerHTML.replace(/<mspace linebreak="newline">/, `<mspace linebreak="newline" style="${lineBreakStyle}">`);
 
 		const temp = document.createElement('div');
 		temp.style.display = 'none';


### PR DESCRIPTION
While `string.prototype.replaceAll` is supported in all of our supported browsers, including all of our maintenance versions, it's easy enough to just switch to using `replace` with regex to make that almost universal. So... May as well.