### PR TITLE
fix: Daylight: Visibility switch: override text definition

### DIFF
--- a/components/switch/switch-visibility.js
+++ b/components/switch/switch-visibility.js
@@ -8,6 +8,10 @@ import { SwitchMixin } from './switch-mixin.js';
  */
 class VisibilitySwitch extends LocalizeCoreElement(SwitchMixin(LitElement)) {
 
+	/**
+	 * The text that is displayed for the switch label.
+	 * @default "Visibility"
+	 */
 	get text() {
 		return (this._text ? this._text : this.localize('components.switch.visibility'));
 	}


### PR DESCRIPTION
`text` in visibility switch was using the definition in the mixin, which marks it as required. For visibility switch, it is not required since it does have the fallback default of "Visibility".