### PR TITLE
Update dropdown position logic to handle wrapping case

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -683,7 +683,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 
 			const centerDelta = contentRect.width - targetRect.width;
 			const position = this._getPosition(spaceAround, centerDelta);
-			if (position) {
+			if (position !== null) {
 				this._position = position;
 			}
 


### PR DESCRIPTION
This PR fixes the dropdown content positioning logic to handle the target wrapping case.  The problem would only arise when the dropdown was previously shown with the target not wrapping, and then subsequently shown with the target wrapping.

For example, before fix, not wrapping:
![image](https://user-images.githubusercontent.com/9042472/168701275-646fa84a-52f2-4f32-9e58-a7455de6faa0.png)

Then resize to cause wrapping, before fix, wrapping:
![image](https://user-images.githubusercontent.com/9042472/168701346-d640a661-4296-407e-bdfe-065c181fc97b.png)

After fix, wrapping:
![image](https://user-images.githubusercontent.com/9042472/168701415-b0c5f4fd-f3d1-401b-9d1f-4c8dd62dfa8c.png)
