### PR TITLE
US138697 - Update localize event

### DIFF
--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -422,7 +422,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 		this.addEventListener('blur', () => this._isInitialFocusDate = true);
 
-		this.addEventListener('d2l-localize-behavior-language-changed', () => {
+		this.addEventListener('d2l-localize-resources-change', () => {
 			calendarData = null;
 			getCalendarData(true);
 			this.requestUpdate();

--- a/components/calendar/test/calendar.visual-diff.js
+++ b/components/calendar/test/calendar.visual-diff.js
@@ -60,7 +60,7 @@ describe('d2l-calendar', () => {
 				await page.evaluate((lang, firstCalendarOfPage) => {
 					const calendar = document.querySelector(firstCalendarOfPage);
 					return new Promise((resolve) => {
-						calendar.addEventListener('d2l-localize-behavior-language-changed', resolve, { once: true });
+						calendar.addEventListener('d2l-localize-resources-change', resolve, { once: true });
 						document.querySelector('html').setAttribute('lang', lang);
 					});
 				}, lang, firstCalendarOfPage);

--- a/components/filter/test/filter.visual-diff.js
+++ b/components/filter/test/filter.visual-diff.js
@@ -225,7 +225,7 @@ describe('d2l-filter', () => {
 				const selector = '#multiple-closed';
 				await page.$eval(selector, async(filter) => {
 					await new Promise((resolve) => {
-						filter.addEventListener('d2l-localize-behavior-language-changed', resolve, { once: true });
+						filter.addEventListener('d2l-localize-resources-change', resolve, { once: true });
 						document.querySelector('html').setAttribute('lang', 'ar');
 					});
 					filter._totalAppliedCount = 100;

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -200,7 +200,7 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 		this._textInput = this.shadowRoot.querySelector('d2l-input-text');
 
 		this.addEventListener('blur', this._handleBlur);
-		this.addEventListener('d2l-localize-behavior-language-changed', () => {
+		this.addEventListener('d2l-localize-resources-change', () => {
 			this._dateTimeDescriptor = getDateTimeDescriptorShared(true);
 			this.requestUpdate();
 			this.updateComplete.then(() => {

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -308,7 +308,7 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-		this.addEventListener('d2l-localize-behavior-language-changed', () => {
+		this.addEventListener('d2l-localize-resources-change', () => {
 			this._descriptor = getNumberDescriptor();
 			if (this._formattedValue.length > 0) {
 				this._updateFormattedValue();

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -271,7 +271,7 @@ class InputTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 		}
 
 		const hiddenContent = this.shadowRoot.querySelector('.d2l-input-time-hidden-content');
-		this.addEventListener('d2l-localize-behavior-language-changed', async() => {
+		this.addEventListener('d2l-localize-resources-change', async() => {
 			await this.updateComplete;
 			this._formattedValue = formatTime(getDateFromISOTime(this.value));
 			INTERVALS.clear();

--- a/components/inputs/test/input-date.visual-diff.js
+++ b/components/inputs/test/input-date.visual-diff.js
@@ -118,7 +118,7 @@ describe('d2l-input-date', () => {
 				await page.evaluate(lang => {
 					const input = document.querySelector('#placeholder');
 					return new Promise((resolve) => {
-						input.addEventListener('d2l-localize-behavior-language-changed', resolve, { once: true });
+						input.addEventListener('d2l-localize-resources-change', resolve, { once: true });
 						document.querySelector('html').setAttribute('lang', lang);
 					});
 				}, lang);

--- a/components/inputs/test/input-time.visual-diff.js
+++ b/components/inputs/test/input-time.visual-diff.js
@@ -107,7 +107,7 @@ describe('d2l-input-time', () => {
 					const input = document.querySelector('#localizationAM');
 					const timeout = lang === 'da' ? 1000 : 100;
 					return new Promise((resolve) => {
-						input.addEventListener('d2l-localize-behavior-language-changed', () => {
+						input.addEventListener('d2l-localize-resources-change', () => {
 							input.addEventListener('d2l-input-time-hidden-content-width-change', () => input.updateComplete.then(setTimeout(resolve, timeout)));
 						}, { once: true });
 						document.querySelector('html').setAttribute('lang', lang);

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -35,11 +35,10 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 							}
 						}
 						this.__resources = resources;
+						this._onResourcesChange();
 						if (first) {
 							resolve();
 							first = false;
-						} else {
-							this._languageChange();
 						}
 					});
 			};
@@ -183,11 +182,9 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 		return this.constructor['getLocalizeResources'] !== undefined;
 	}
 
-	_languageChange() {
+	_onResourcesChange() {
 		/** @ignore */
-		this.dispatchEvent(new CustomEvent(
-			'd2l-localize-behavior-language-changed', { bubbles: true, composed: true }
-		));
+		this.dispatchEvent(new CustomEvent('d2l-localize-resources-change'));
 	}
 
 });

--- a/mixins/test/localize-mixin.test.js
+++ b/mixins/test/localize-mixin.test.js
@@ -227,10 +227,10 @@ describe('LocalizeMixin', () => {
 				const myEventListener = () => {
 					const val = elem.localize('hello', { name: 'Mary' });
 					expect(val).to.equal('Bonjour Mary');
-					elem.removeEventListener('d2l-localize-behavior-language-changed', myEventListener);
+					elem.removeEventListener('d2l-localize-resources-change', myEventListener);
 					done();
 				};
-				elem.addEventListener('d2l-localize-behavior-language-changed', myEventListener);
+				elem.addEventListener('d2l-localize-resources-change', myEventListener);
 				documentLocaleSettings.language = 'fr';
 			});
 
@@ -329,10 +329,10 @@ describe('LocalizeMixin', () => {
 				expect(val2).to.equal('This is English from Test2LocalizeStaticMixin');
 				expect(val3).to.equal('This is French from Test3LocalizeMixin');
 				expect(val4).to.equal('This is English from Test4LocalizeMixin');
-				elem.removeEventListener('d2l-localize-behavior-language-changed', myEventListener);
+				elem.removeEventListener('d2l-localize-resources-change', myEventListener);
 				done();
 			};
-			elem.addEventListener('d2l-localize-behavior-language-changed', myEventListener);
+			elem.addEventListener('d2l-localize-resources-change', myEventListener);
 			documentLocaleSettings.language = 'fr';
 		});
 	});


### PR DESCRIPTION
This PR does a few things:
- Update the name of the localize event we fire to be more accurate.  I audited all outside usages and they're all using the Polymer behaviour, which does still fire the old event.
- Make that event no longer `bubble` or `composed`, because it doesn't need to be.
- Fire the event every time the resources change, not just after the first time.  This doesn't change how anything works here in `core` (because we always listen in `firstUpdated`, meaning we miss the first event and will only get language updates) but this is helpful for HM components using OSLO.  They may get their data faster then the langterms, and they need to know when to update any stored terms.  Ideally they don't store these terms, but we have some components that send these terms in an event, and they need to know when to resend the event (rather than resend every `render`).

Not tied to the event name, if anyone has a different preference.