### PR TITLE
fix: adjust mathjax demo helper

### DIFF
--- a/tools/mathjax-test-context.js
+++ b/tools/mathjax-test-context.js
@@ -1,8 +1,6 @@
 console.warn('Using mathjax test context, this is intended for demo pages and tests only');
 
-const disabled = window.location.search.indexOf('latex=false') !== -1;
-
 document.getElementsByTagName('html')[0].dataset.mathjaxContext = JSON.stringify({
 	outputScale: 1.1,
-	renderLatex: !disabled
+	renderLatex: !(window.location.search.indexOf('latex=false') !== -1)
 });


### PR DESCRIPTION
Had some demo pages that were auto adding this script via the dev server config and had also explicitly added it. This cause errors about `disabled` being already defined. Just removing intermediate variable to avoid issue.