### PR TITLE
fix: check for null parent

### DIFF
--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -176,8 +176,8 @@ function hideAccessible(target) {
 	};
 
 	let parent = getComposedParent(target);
-	while (parent !== document.documentElement) {
-		if (parent.nodeType === Node.ELEMENT_NODE && parent !== null) {
+	while (parent !== document.documentElement && parent !== null) {
+		if (parent.nodeType === Node.ELEMENT_NODE) {
 			path.push(parent);
 			hideAccessibleChildren(parent);
 		}

--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -177,7 +177,7 @@ function hideAccessible(target) {
 
 	let parent = getComposedParent(target);
 	while (parent !== document.documentElement) {
-		if (parent.nodeType === Node.ELEMENT_NODE) {
+		if (parent.nodeType === Node.ELEMENT_NODE && parent !== null) {
 			path.push(parent);
 			hideAccessibleChildren(parent);
 		}


### PR DESCRIPTION
I noticed this in a test fixture in another repo where it opened a dialog but then didn't close the dialog before moving on to the next fixture. The backdrop would then try to hide itself but it had already been detached from the DOM, so `parent` became `null`.