### PR TITLE
Documentation: Added live code demo to nested menus

### DIFF
--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -288,7 +288,6 @@ Nested menus can be defined by placing a `d2l-menu` inside a `d2l-menu-item`.  F
 <script type="module">
   import '@brightspace-ui/core/components/menu/menu.js';
   import '@brightspace-ui/core/components/menu/menu-item.js';
-  import '@brightspace-ui/core/components/menu/menu-item-separator.js';
 </script>
 
 <d2l-menu label="Astronomy">
@@ -307,7 +306,6 @@ Nested menus can be defined by placing a `d2l-menu` inside a `d2l-menu-item`.  F
   </d2l-menu-item>
   <d2l-menu-item text="Stars &amp; Galaxies">
     <d2l-menu>
-      <d2l-menu-item text="What is a Star?"></d2l-menu-item>
       <d2l-menu-item text="Lifecycle of a Star"></d2l-menu-item>
       <d2l-menu-item text="Galaxies"></d2l-menu-item>
     </d2l-menu>

--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -283,7 +283,7 @@ Nested menus can be defined by placing a `d2l-menu` inside a `d2l-menu-item`.  F
 ![Nested Menu](./screenshots/nested-menu.png?raw=true)
 <!-- docs: end hidden content -->
 
-<!-- docs: demo live -->
+<!-- docs: demo code -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/menu/menu.js';

--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -283,7 +283,7 @@ Nested menus can be defined by placing a `d2l-menu` inside a `d2l-menu-item`.  F
 ![Nested Menu](./screenshots/nested-menu.png?raw=true)
 <!-- docs: end hidden content -->
 
-<!-- docs: demo -->
+<!-- docs: demo live -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/menu/menu.js';
@@ -292,24 +292,16 @@ Nested menus can be defined by placing a `d2l-menu` inside a `d2l-menu-item`.  F
 </script>
 
 <d2l-menu label="Astronomy">
-  <d2l-menu-item text="Introduction"></d2l-menu-item>
-  <d2l-menu-item-separator></d2l-menu-item-separator>
-  <d2l-menu-item text="Searching the Heavens"></d2l-menu-item>
   <d2l-menu-item text="The Solar System">
     <d2l-menu>
-      <d2l-menu-item text="Formation"></d2l-menu-item>
-      <d2l-menu-item text="Modern Solar System"></d2l-menu-item>
+      <d2l-menu-item text="The Sun"></d2l-menu-item>
       <d2l-menu-item text="The Planets">
         <d2l-menu>
           <d2l-menu-item text="Mercury"></d2l-menu-item>
           <d2l-menu-item text="Venus"></d2l-menu-item>
           <d2l-menu-item text="Earth"></d2l-menu-item>
-          <d2l-menu-item text="Mars"></d2l-menu-item>
-          <d2l-menu-item text="..."></d2l-menu-item>
         </d2l-menu>
       </d2l-menu-item>
-      <d2l-menu-item text="The Sun"></d2l-menu-item>
-      <d2l-menu-item text="Asteroids"></d2l-menu-item>
       <d2l-menu-item text="Comets"></d2l-menu-item>
     </d2l-menu>
   </d2l-menu-item>
@@ -317,9 +309,6 @@ Nested menus can be defined by placing a `d2l-menu` inside a `d2l-menu-item`.  F
     <d2l-menu>
       <d2l-menu-item text="What is a Star?"></d2l-menu-item>
       <d2l-menu-item text="Lifecycle of a Star"></d2l-menu-item>
-      <d2l-menu-item text="Binaries &amp; Multiples"></d2l-menu-item>
-      <d2l-menu-item text="Star Clusters"></d2l-menu-item>
-      <d2l-menu-item text="Star Death"></d2l-menu-item>
       <d2l-menu-item text="Galaxies"></d2l-menu-item>
     </d2l-menu>
   </d2l-menu-item>


### PR DESCRIPTION
Nested menus on the menu component page ([Link to Daylight](https://daylight.d2l.dev/components/menu/#nested-menus)) did not have a live code demo showing how to create nested menus.

I made the demo code visible and shortened the example to make the code more readable. I maintained all of the important things that the demo is showing (multi-level nested menus, multiple nested menus in a single menu) but removed some of the excess menu-items. 

![Screen Shot 2022-06-17 at 1 53 30 PM](https://user-images.githubusercontent.com/12901943/174352312-0459d39c-758f-43c6-901c-d18f19821071.png)

