### PR TITLE
Filter scrollbar disappearing defect

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -550,7 +550,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		if (shouldRecount) this._setFilterCounts(dimension);
 		if (shouldUpdate)  this.requestUpdate();
 		if (shouldResizeDropdown) {
-			this._resizeDropdown();
+			this._requestDropdownResize();
 		}
 	}
 
@@ -713,11 +713,11 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				break;
 		}
 
-		this._resizeDropdown();
+		this._requestDropdownResize();
 		this.requestUpdate();
 	}
 
-	_resizeDropdown() {
+	_requestDropdownResize() {
 		const singleDimension = this._dimensions.length === 1;
 		if (singleDimension && this.opened) {
 			const dropdown = this.shadowRoot.querySelector('d2l-dropdown-content');


### PR DESCRIPTION
https://rally1.rallydev.com/#/?detail=/defect/639773755745&fdp=true

Solved a bug where scrollbars were disappearing when unfiltering search results in the filter component. (See rally ticket)

The reason this bug was occurring was that the filter component was not resizing the dropdown after each search, so the size of the dropdown would be set when it was first opened. If the dropdown was opened already filtered to a small number of elements then the size of the dropdown would be set to smaller than the total number of unfiltered elements and there would be no scrollbar after unfiltering the search results.

Now it calls the resizeDropdown function after every search, fixing the problem.