### PR TITLE
[ignore for now] fix: tag-list: initial work to fix flicker

### DIFF
--- a/components/filter/demo/filter-tags.html
+++ b/components/filter/demo/filter-tags.html
@@ -11,6 +11,11 @@
 			import '../filter-dimension-set-value.js';
 			import '../filter-tags.js';
 		</script>
+		<style>
+			d2l-demo-snippet {
+				max-width: 1400px;
+			}
+		</style>
 	</head>
 	<body unresolved class="d2l-typography">
 
@@ -23,14 +28,14 @@
 			<d2l-filter id="core-filter">
 				<d2l-filter-dimension-set key="1" text="Dim 1">
 					<d2l-filter-dimension-set-value selected text="Option 1 - 1" key="1" ></d2l-filter-dimension-set-value>
-					<d2l-filter-dimension-set-value text="Option 1 - 2" key="2"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value selected text="Option 1 - 2" key="2"></d2l-filter-dimension-set-value>
 					<d2l-filter-dimension-set-value text="Option 1 - 3" key="3"></d2l-filter-dimension-set-value>
 					<d2l-filter-dimension-set-value text="Option 1 - 4" key="4"></d2l-filter-dimension-set-value>
 				</d2l-filter-dimension-set>
 				<d2l-filter-dimension-set key="2" text="Dim 2">
-					<d2l-filter-dimension-set-value selected text="Option 2 - 1" key="1"></d2l-filter-dimension-set-value>
-					<d2l-filter-dimension-set-value text="Option 2 - 2" key="2"></d2l-filter-dimension-set-value>
-					<d2l-filter-dimension-set-value text="Option 2 - 3" key="3"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 2 - 1" key="1"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value selected text="Option 2 - 2" key="2"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value selected text="Option 2 - 3" key="3"></d2l-filter-dimension-set-value>
 				</d2l-filter-dimension-set>
 			</d2l-filter>
 

--- a/components/filter/test/filter-tags.visual-diff.html
+++ b/components/filter/test/filter-tags.visual-diff.html
@@ -18,10 +18,10 @@
 		<meta charset="UTF-8">
 		<style>
 			#basic d2l-filter-tags {
-				max-width: calc(100% - 120px);
+				width: calc(100% - 120px);
 			}
 			#two-filters d2l-filter-tags {
-				max-width: calc(100% - 250px);
+				width: calc(100% - 250px);
 			}
 		</style>
 	</head>

--- a/components/tag-list/README.md
+++ b/components/tag-list/README.md
@@ -57,6 +57,10 @@ The corresponding `*-clear` event must be listened to for whatever component (`d
 </d2l-tag-list>
 ```
 
+### Methods
+
+* `setParentNode(node)`: Sets the parent node to be used for the `ResizeObserver` that detects when page size has changed and updates the chomping of tag list items. Useful if `tag-list` is wrapped in a non-block element which can cause flicker. For example: `tagList.setParentNode(this.parentNode);`
+
 ## Tag List Item [d2l-tag-list-item]
 The `d2l-tag-list-item` provides the appropriate `listitem` semantics and styling for children within a tag list. Tag List items do not work outside of a Tag List and should not be used on their own.
 

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -133,9 +133,9 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 		});
 		this._clearButtonResizeObserver.observe(clearButton);
 
-		const container = this.shadowRoot.querySelector('.tag-list-outer-container');
 		this._resizeObserver = new ResizeObserver((e) => requestAnimationFrame(() => this._handleResize(e)));
-		this._resizeObserver.observe(container);
+		if (this._parentNode) this._resizeObserver.observe(this._parentNode);
+		else this._resizeObserver.observe(this.parentNode);
 
 		const listContainer = this.shadowRoot.querySelector('.tag-list-container');
 		this._listContainerObserver = new ResizeObserver(() => requestAnimationFrame(() => this._handleSlotChange()));
@@ -226,6 +226,14 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 
 	async arrowKeysFocusablesProvider() {
 		return this._getVisibleEffectiveChildren();
+	}
+
+	setParentNode(node) {
+		this._parentNode = node;
+		if (!this._resizeObserver) return;
+
+		this._resizeObserver.disconnect();
+		this._resizeObserver.observe(node);
 	}
 
 	_chomp() {

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -120,6 +120,8 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
+		this._outerContainer = this.shadowRoot.querySelector('.tag-list-outer-container');
+
 		const subtleButton = this.shadowRoot.querySelector('.d2l-tag-list-hidden-button');
 		this._subtleButtonResizeObserver = new ResizeObserver(() => {
 			this._subtleButtonWidth = Math.ceil(parseFloat(getComputedStyle(subtleButton).getPropertyValue('width')));
@@ -375,7 +377,7 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 	}
 
 	async _handleResize(entries) {
-		this._availableWidth = Math.floor(entries[0].contentRect.width);
+		this._availableWidth = Math.floor(this._outerContainer.offsetWidth);
 		if (this._availableWidth >= PAGE_SIZE.large) this._lines = PAGE_SIZE_LINES.large;
 		else if (this._availableWidth < PAGE_SIZE.large && this._availableWidth >= PAGE_SIZE.medium) this._lines = PAGE_SIZE_LINES.medium;
 		else this._lines = PAGE_SIZE_LINES.small;

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -135,7 +135,7 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 		});
 		this._clearButtonResizeObserver.observe(clearButton);
 
-		this._resizeObserver = new ResizeObserver((e) => requestAnimationFrame(() => this._handleResize(e)));
+		this._resizeObserver = new ResizeObserver((e) => requestAnimationFrame(() => this._handleResize()));
 		if (this._parentNode) this._resizeObserver.observe(this._parentNode);
 		else this._resizeObserver.observe(this.parentNode);
 
@@ -376,7 +376,7 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 		this._hasShownKeyboardTooltip = true;
 	}
 
-	async _handleResize(entries) {
+	async _handleResize() {
 		this._availableWidth = Math.floor(this._outerContainer.offsetWidth);
 		if (this._availableWidth >= PAGE_SIZE.large) this._lines = PAGE_SIZE_LINES.large;
 		else if (this._availableWidth < PAGE_SIZE.large && this._availableWidth >= PAGE_SIZE.medium) this._lines = PAGE_SIZE_LINES.medium;


### PR DESCRIPTION
The problem I am seeing is that when `d2l-filter-tags` is used in Nova, which wraps `filter-tags` in a flex box in order to right align, we need to remove the `width: 100%` in order for the flex to actually work, but then there is flicker caused by continuous re-triggering of the ResizeObserver when a certain number of filters are hit which could be grouped into the +X more hidden group.

This updates `tag-list` to use the `parentNode` for the `ResizeObserver` or the wrapping component's `parentNode`. The issue seems to be basically when the parent is a non-block element that doesn't set the width at 100%.

I modified the filter-tags demo in order to show the problem.

To do:
- [x] ensure visual diffs pass or change in an expected way
- [ ] test with user-profile-card-tag-list-item (including consistent-eval usage)
- [ ] test Daylight tag list and filter tags examples