### PR TITLE
fix: Have menu wait before checking the role of its menu items

### DIFF
--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -234,9 +234,7 @@ class Menu extends FocusVisiblePolyfillMixin(ThemeMixin(HierarchicalViewMixin(Li
 			items.unshift(returnItem);
 		}
 		// Wait for menu items to have their role attribute set
-		await Promise.all(items.map(async(item) => {
-			await item.updateComplete;
-		}));
+		await Promise.all(items.map(item => item.updateComplete));
 		return items.filter((item) => {
 			const role = item.getAttribute('role');
 			return (role === 'menuitem' || role === 'menuitemcheckbox' || role === 'menuitemradio' || item.tagName === 'D2L-MENU-ITEM-RETURN');

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -224,7 +224,7 @@ class Menu extends FocusVisiblePolyfillMixin(ThemeMixin(HierarchicalViewMixin(Li
 		return this.shadowRoot && this.shadowRoot.querySelector('d2l-menu-item-return');
 	}
 
-	_getMenuItems() {
+	async _getMenuItems() {
 		const slot = this.shadowRoot && this.shadowRoot.querySelector('slot');
 		if (!slot) return;
 		const items = slot.assignedNodes({ flatten: true }).filter((node) => node.nodeType === Node.ELEMENT_NODE);
@@ -233,6 +233,10 @@ class Menu extends FocusVisiblePolyfillMixin(ThemeMixin(HierarchicalViewMixin(Li
 		if (returnItem) {
 			items.unshift(returnItem);
 		}
+		// Wait for menu items to have their role attribute set
+		await Promise.all(items.map(async(item) => {
+			await item.updateComplete;
+		}));
 		return items.filter((item) => {
 			const role = item.getAttribute('role');
 			return (role === 'menuitem' || role === 'menuitemcheckbox' || role === 'menuitemradio' || item.tagName === 'D2L-MENU-ITEM-RETURN');
@@ -328,8 +332,8 @@ class Menu extends FocusVisiblePolyfillMixin(ThemeMixin(HierarchicalViewMixin(Li
 	}
 
 	_onMenuItemsChanged() {
-		requestAnimationFrame(() => {
-			this._items = this._getMenuItems();
+		requestAnimationFrame(async() => {
+			this._items = await this._getMenuItems();
 			this._updateItemAttributes();
 		});
 	}


### PR DESCRIPTION
Using both `LocalizeDynamicMixin` and `MenuItemMixin` in a component is resulting in the `menu` trying to get its menu-items before their `role` attribute has been set (because of the delay in updating caused by `LocalizeDynamicMixin`).  There's a number of ways we could try to solve this (changes to how localizing works, using a MutationObserver in `menu`, adding a way for menu items to re-trigger the menu initializing code, etc.) This PR first checks that all the potential menu items have updated before checking their `role` attribute.