### PR TITLE
Help Tooltip > Allow opener text to inherit cursor from ancestor, but always keep tooltip contents as text cursor

### DIFF
--- a/components/tooltip/tooltip-help.js
+++ b/components/tooltip/tooltip-help.js
@@ -48,7 +48,7 @@ class TooltipHelp extends FocusMixin(FocusVisiblePolyfillMixin(LitElement)) {
 			#d2l-tooltip-help-text {
 				background: none;
 				border: none;
-				cursor: text;
+				cursor: inherit;
 				padding: 0;
 				text-decoration-line: underline;
 				text-decoration-style: dashed;
@@ -71,6 +71,9 @@ class TooltipHelp extends FocusMixin(FocusVisiblePolyfillMixin(LitElement)) {
 				letter-spacing: inherit;
 				line-height: inherit;
 				margin: inherit;
+			}
+			d2l-tooltip {
+				cursor: text;
 			}
 		`];
 	}


### PR DESCRIPTION
[Related US](https://rally1.rallydev.com/#/15545167705d/dashboard?detail=%2Fuserstory%2F639335980519)

Necessary for backport into Grades.

Small PR. Contains changes decided from discussion with Jeff and Nicole [here](https://d2l.slack.com/archives/C03H8KH2FKN/p1657307056131889).

In particular to note: [this ](https://d2l.slack.com/archives/C03H8KH2FKN/p1657556062926539?thread_ts=1657307056.131889&cid=C03H8KH2FKN) and [this](https://d2l.slack.com/archives/C03H8KH2FKN/p1657556573509059?thread_ts=1657307056.131889&cid=C03H8KH2FKN).