### PR TITLE
fix: add button type for help tooltip opener

### DIFF
--- a/components/tooltip/tooltip-help.js
+++ b/components/tooltip/tooltip-help.js
@@ -102,7 +102,7 @@ class TooltipHelp extends FocusMixin(FocusVisiblePolyfillMixin(LitElement)) {
 			'd2l-body-small': !this.inheritFontStyle
 		};
 		return html`
-			<button id="d2l-tooltip-help-text" class="${classMap(classes)}">
+			<button id="d2l-tooltip-help-text" class="${classMap(classes)}" type="button">
 				${this.text}
 			</button>
 			<d2l-tooltip for="d2l-tooltip-help-text" delay="0" offset="13" position="${ifDefined(this.position)}" ?showing="${this.showing}">


### PR DESCRIPTION
Addressing [this ](https://github.com/BrightspaceUI/core/pull/2635#discussion_r920344939)comment for the reasoning mentioned in [this ](https://github.com/BrightspaceUILabs/navigation/pull/161)PR.