### PR TITLE
fix: clean up aria-describedby/labelledby on tooltip target

### DIFF
--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -32,12 +32,29 @@ describe('d2l-tooltip', () => {
 		it('should add aria-labelledby to its target if for-type is \'label\'', async() => {
 			const tooltipLabelFixture = await fixture(labelFixture);
 			const target = tooltipLabelFixture.querySelector('#label-target');
-			expect(target.hasAttribute('aria-labelledby')).to.be.true;
+			const tooltip = tooltipLabelFixture.querySelector('d2l-tooltip');
+			expect(target.getAttribute('aria-labelledby')).to.equal(tooltip.id);
+		});
+
+		it('should remove aria-labelledby from its target when tooltip is removed', async() => {
+			const tooltipLabelFixture = await fixture(labelFixture);
+			const target = tooltipLabelFixture.querySelector('#label-target');
+			const tooltip = tooltipLabelFixture.querySelector('d2l-tooltip');
+			tooltip.remove();
+			expect(target.hasAttribute('aria-labelledby')).to.be.false;
 		});
 
 		it('should add aria-describedby to its target if for-type is \'descriptor\'', async() => {
 			const target = tooltipFixture.querySelector('#explicit-target');
-			expect(target.hasAttribute('aria-describedby')).to.be.true;
+			const tooltip = tooltipFixture.querySelector('d2l-tooltip');
+			expect(target.getAttribute('aria-describedby')).to.equal(tooltip.id);
+		});
+
+		it('should remove aria-describedby from its target when tooltip is removed', async() => {
+			const target = tooltipFixture.querySelector('#explicit-target');
+			const tooltip = tooltipFixture.querySelector('d2l-tooltip');
+			tooltip.remove();
+			expect(target.hasAttribute('aria-describedby')).to.be.false;
 		});
 
 	});

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -1,6 +1,6 @@
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { css, html, LitElement } from 'lit';
-import { cssEscape, elemIdListAdd, getBoundingAncestor, getOffsetParent } from '../../helpers/dom.js';
+import { cssEscape, elemIdListAdd, elemIdListRemove, getBoundingAncestor, getOffsetParent } from '../../helpers/dom.js';
 import { announce } from '../../helpers/announce.js';
 import { bodySmallStyles } from '../typography/styles.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
@@ -446,6 +446,10 @@ class Tooltip extends RtlMixin(LitElement) {
 		clearDismissible(this._dismissibleId);
 		delayTimeoutId = null;
 		this._dismissibleId = null;
+		if (this._target) {
+			elemIdListRemove(this._target, 'aria-labelledby', this.id);
+			elemIdListRemove(this._target, 'aria-describedby', this.id);
+		}
 	}
 
 	render() {


### PR DESCRIPTION
Ran into this issue in a scenario where a tooltip is conditionally rendered. When the tooltip is initially rendered, it adds `aria-labelledby` (or `aria-describedby`) to the target pointing back at the tooltip -- all good.

But then when it's removed and then re-added later, now the target will have TWO values for `aria-labelledby`, only one of which is now valid.