### PR TITLE
Update Prism line-numbers background-color

### DIFF
--- a/helpers/prism.js
+++ b/helpers/prism.js
@@ -41,7 +41,7 @@ const darkColors = Object.freeze({
 	background: '#202122',
 	language: '#90989d',
 	lineNumbers: '#9ea5a9',
-	lineNumbersBackground: '#6e747733', // galena 20%
+	lineNumbersBackground: '#303133',
 	tokenDefault: '#cdd5dc',
 	tokenComment: '#81898d',
 	tokenPunctuation: '#cdd5dc',


### PR DESCRIPTION
When code is long, CodeMirror allows horizontal scrolling of the code, which causes the code to scroll underneath the code numbers container, so we prefer an opaque color for the line-numbers background. This change converts from the semi-transparent HEX color to the equivalent opaque color. We don't need to worry about different background colors since they are present for light & dark color schemes. The light scheme already uses an opaque color.

Example showing issue.
![image](https://user-images.githubusercontent.com/9042472/178839182-c1a06eef-7984-48c8-995a-dcc60316d6df.png)
