### PR TITLE
fix: tag-list: also check d2l-backdrop-role to get list items

### DIFF
--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -3,6 +3,8 @@ import { css, html, LitElement } from 'lit';
 import { cssEscape, getComposedChildren, getComposedParent, isVisible } from '../../helpers/dom.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 
+export const BACKDROP_ROLE = 'd2l-backdrop-role';
+
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 const scrollKeys = [];
@@ -159,7 +161,7 @@ function hideAccessible(target) {
 			if (child.hasAttribute('d2l-backdrop-hidden')) continue;
 
 			const role = child.getAttribute('role');
-			if (role) child.setAttribute('d2l-backdrop-role', role);
+			if (role) child.setAttribute(BACKDROP_ROLE, role);
 			child.setAttribute('role', 'presentation');
 
 			if (child.nodeName === 'FORM' || child.nodeName === 'A') {
@@ -200,10 +202,10 @@ export function preventBodyScroll() {
 function showAccessible(elems) {
 	for (let i = 0; i < elems.length; i++) {
 		const elem = elems[i];
-		const role = elem.getAttribute('d2l-backdrop-role');
+		const role = elem.getAttribute(BACKDROP_ROLE);
 		if (role) {
 			elem.setAttribute('role', role);
-			elem.removeAttribute('d2l-backdrop-role');
+			elem.removeAttribute(BACKDROP_ROLE);
 		} else {
 			elem.removeAttribute('role');
 		}

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -2,6 +2,7 @@ import '../button/button-subtle.js';
 import { css, html, LitElement } from 'lit';
 import { announce } from '../../helpers/announce.js';
 import { ArrowKeysMixin } from '../../mixins/arrow-keys-mixin.js';
+import { BACKDROP_ROLE } from '../backdrop/backdrop.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { getOffsetParent } from '../../helpers/dom.js';
 import { InteractiveMixin } from '../../mixins/interactive-mixin.js';
@@ -312,7 +313,7 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 			await node.updateComplete;
 
 			const role = node.getAttribute('role');
-			const backdropRole = node.getAttribute('d2l-backdrop-role');
+			const backdropRole = node.getAttribute(BACKDROP_ROLE);
 			if (role !== 'listitem' && backdropRole !== 'listitem') return false;
 
 			if (this.clearable) node.setAttribute('clearable', 'clearable');

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -312,7 +312,8 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 			await node.updateComplete;
 
 			const role = node.getAttribute('role');
-			if (role !== 'listitem') return false;
+			const backdropRole = node.getAttribute('d2l-backdrop-role');
+			if (role !== 'listitem' && backdropRole !== 'listitem') return false;
 
 			if (this.clearable) node.setAttribute('clearable', 'clearable');
 			node.removeAttribute('data-is-chomped');


### PR DESCRIPTION
**Issue:**
At mobile widths, filter appears at the side and uses `d2l-backdrop`. `d2l-backdrop` changes the role of everything behind it to be `presentation`. When a filter change would happen (and `d2l-filter` would remain open), `d2l-tag-list` would look for `listitem`s to do the necessary chomping to 3 lines, but the problem was they would have a role of `presentation` instead of `listitem` and so the `d2l-tag-list` would do no such chomping.

**Solution Notes:**
When `d2l-backdrop` is enabled, it stores the previous role as `d2l-backdrop-role`. This solution uses that to get the list items.

This solution knows a bit too much about how `d2l-backdrop` is working and so is intended to be temporary. One suggestion for a more permanent solution by Stacey is having a `d2l-role` on the list items that reflects the `role` and that this, menu, etc look at that in cases like this rather than relying on `role`.