### PR TITLE
fix: List paging documentation: Small tweaks

### DIFF
--- a/components/list/README.md
+++ b/components/list/README.md
@@ -158,12 +158,6 @@ The `d2l-list` is the container to create a styled list of items using `d2l-list
 
 The `d2l-list` supports selectable items within a list, including both single and multi selection. Selection is enabled when `d2l-list-item`s have the `selectable` attribute. When items are selectable, multiple selection is the default behaviour, however the `selection-single` attribute can be applied to the `d2l-list` to enable single selection. A `d2l-list-header` component can be added to `d2l-list`'s `header` slot to provide select-all and bulk actions.
 
-## Pageable Lists
-
-Load-More paging functionality can be implemented in lists by placing a `d2l-pager-load-more` in `d2l-list`'s `pager` slot. The consumer must handle the `d2l-pager-load-more` event by loading more items, updating the pager state, and signalling completion by calling `complete()` on the event detail. Focus will be automatically moved on the first new item once complete. See [Paging](../../components/paging) for more details.
-
-
-
 ### Accessibility Properties
 
 If a `d2l-list-item` is selectable then it should have a `label` attribute that corresponds to the hidden label for the checkbox.
@@ -198,6 +192,10 @@ If a `d2l-list-item` is selectable then it should have a `label` attribute that 
   </d2l-list-item>
 </d2l-list>
 ```
+
+## Pageable Lists
+
+Load-More paging functionality can be implemented in lists by placing a `d2l-pager-load-more` in `d2l-list`'s `pager` slot. The consumer must handle the `d2l-pager-load-more` event by loading more items, updating the pager state, and signalling completion by calling `complete()` on the event detail. Focus will be automatically moved on the first new item once complete. See [Paging](../../components/paging) for more details.
 
 ## Drag & Drop Lists
 

--- a/components/paging/README.md
+++ b/components/paging/README.md
@@ -15,6 +15,7 @@ The paging components and mixins can be used to provide consistent paging functi
 <!-- docs: start dos -->
 * Consider the performance impact of acquiring the optional total `item-count`. The `item-count` provides useful context for the user, but counting large numbers of rows can be detrimental to performance. As a very general guide, when the total number of rows that needs to be counted is < 50,000, it's not a performance concern.
 <!-- docs: end dos -->
+<!-- docs: end best practices -->
 
 ## Load More Paging [d2l-pager-load-more]
 
@@ -39,7 +40,6 @@ pager.addEventListener('d2l-pager-load-more', e => {
 });
 ```
 
-<!-- docs: start hidden content -->
 ### Properties
 | Property | Type | Description |
 |---|---|---|
@@ -52,4 +52,3 @@ pager.addEventListener('d2l-pager-load-more', e => {
 | Event | Description |
 |---|---|
 | `d2l-pager-load-more` | Dispatched when the user clicks the Load More button. The `pageSize` can be accessed from the event `target`. The consumer must call the `complete()` method on the event detail to signal completion after the new items have been loaded. |
-<!-- docs: end hidden content -->


### PR DESCRIPTION
Changes:
- The `Pageable Lists` section was placed within the `Selection Lists` section so I moved that to be below `Selection Lists`
- Fixed the best practices block in `Paging`
- Removed hiding the properties and events in `Paging` just temporarily until there's an interactive demo that exhibits these so they aren't missing on the page.

I also updated the `Paging` issue in the documentation repo so that it will properly use the new Paging readme.