### PR TITLE
[ignore for now] fix: tag-list resizing algorithm

### DIFF
--- a/components/filter/test/filter-tags.visual-diff.html
+++ b/components/filter/test/filter-tags.visual-diff.html
@@ -21,7 +21,7 @@
 				display: flex;
 				justify-content: space-between;
 			}
-			d2l-filter-tags {
+			d2l-filter-tags.single-line {
 				align-self: center;
 				position: relative;
 				width: 100%;
@@ -31,7 +31,7 @@
 	<body class="d2l-typography">
 		<div>
 			<div class="visual-diff" id="basic">
-				<d2l-filter-tags filter-ids="filter"></d2l-filter-tags>
+				<d2l-filter-tags filter-ids="filter" class="single-line"></d2l-filter-tags>
 				<d2l-filter id="filter">
 					<d2l-filter-dimension-set key="1" text="Category 1">
 						<d2l-filter-dimension-set-value selected text="Value 1 - 1" key="1"></d2l-filter-dimension-set-value>
@@ -49,7 +49,7 @@
 				</d2l-filter>
 			</div>
 			<div class="visual-diff" id="two-filters">
-				<d2l-filter-tags filter-ids="filter-1 filter-2" label="An optional filter label"></d2l-filter-tags>
+				<d2l-filter-tags filter-ids="filter-1 filter-2" label="An optional filter label" class="single-line"></d2l-filter-tags>
 				<d2l-filter id="filter-1">
 					<d2l-filter-dimension-set key="1" text="Category 1">
 						<d2l-filter-dimension-set-value selected text="Value 1 - 1" key="1"></d2l-filter-dimension-set-value>
@@ -63,6 +63,9 @@
 						<d2l-filter-dimension-set-value selected text="Value" key="1"></d2l-filter-dimension-set-value>
 					</d2l-filter-dimension-set>
 				</d2l-filter>
+			</div>
+			<div class="visual-diff" id="flex-end" style="display: flex; justify-content: flex-end;">
+				<d2l-filter-tags filter-ids="filter"></d2l-filter-tags>
 			</div>
 		</div>
 	</body>

--- a/components/filter/test/filter-tags.visual-diff.js
+++ b/components/filter/test/filter-tags.visual-diff.js
@@ -24,6 +24,11 @@ describe('d2l-filter-tags', () => {
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
 	});
 
+	it('flex-end is correct', async function() {
+		const rect = await visualDiff.getRect(page, '#flex-end');
+		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { captureBeyondViewport: false, clip: rect });
+	});
+
 	[1500, 980, 969, 601, 599, 400, 320].forEach((width) => {
 		describe(`basic at width ${width}`, () => {
 			const selector = '#basic';

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -371,7 +371,7 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 		this._hasShownKeyboardTooltip = true;
 	}
 
-	async _handleResize(entries) {
+	async _handleResize() {
 		this._chompIndex = 10000;
 		await this.updateComplete;
 

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -135,8 +135,10 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 		});
 		this._clearButtonResizeObserver.observe(clearButton);
 
+		let container = getOffsetParent(this);
+		if (!container) container = this.shadowRoot.querySelector('.tag-list-outer-container');
 		this._resizeObserver = new ResizeObserver((e) => requestAnimationFrame(() => this._handleResize(e)));
-		this._resizeObserver.observe(this);
+		this._resizeObserver.observe(container);
 
 		this._listContainer = this.shadowRoot.querySelector('.tag-list-container');
 		this._listContainerObserver = new ResizeObserver(() => requestAnimationFrame(() => this._handleSlotChange()));


### PR DESCRIPTION
This updates the resizing algorithm to be more like the multi-select list one (https://github.com/BrightspaceUILabs/multi-select/blob/main/multi-select-list.js#L372).

Issues that were happening:
- A fun dance at certain widths where tag list items would be constantly re-triggering the resize observer (mostly when wrapped in a flex container)
- Chomping was incorrect at small widths

The idea is that the max available width is equivalent to the max width the `flex` container that wraps the items (`div.tag-list-container`) is when all the items are visible.

Testing:
- [ ] Visual-diff tests
- [ ] Nova (2 filter-tags usages, 1 tag-list usage)
- [ ] Consistent-eval