### PR TITLE
fix: Daylight: filter-tags: label default

### DIFF
--- a/components/filter/filter-tags.js
+++ b/components/filter/filter-tags.js
@@ -23,7 +23,7 @@ class FilterTags extends RtlMixin(LocalizeCoreElement(LitElement)) {
 			filterIds: { type: String, attribute: 'filter-ids' },
 			/**
 			 * The text displayed in this component's label
-			 * @default "Applied Filters:"
+			 * @default "Active Filters:"
 			 * @type {string}
 			 */
 			label: { type: String }

--- a/components/filter/filter-tags.js
+++ b/components/filter/filter-tags.js
@@ -22,7 +22,7 @@ class FilterTags extends RtlMixin(LocalizeCoreElement(LitElement)) {
 			 */
 			filterIds: { type: String, attribute: 'filter-ids' },
 			/**
-			 * The text displayed in this component's label
+			 * The text displayed in this component's label (hidden when default is used)
 			 * @default "Active Filters:"
 			 * @type {string}
 			 */


### PR DESCRIPTION
The default value used for `tag-list` description within `filter-tags` is `Active Filters`. I also added a bit more information to the description.