### PR TITLE
feat: Switch > label hover and click improvements

### DIFF
--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -215,7 +215,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 	}
 
 	get _labelContent() {
-		return html`<span @click='${this._handleClick}' @mouseover='${this._handleSwitchHover}' @mouseout='${this._handleSwitchHoverLeave}'>${this.text}</span>`;
+		return html`<span @click='${this._handleClick}' @mouseenter='${this._handleSwitchHover}' @mouseleave='${this._handleSwitchHoverLeave}'>${this.text}</span>`;
 	}
 
 	_handleClick() {

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -1,11 +1,11 @@
 import '../colors/colors.js';
 import { css, html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { FocusVisiblePolyfillMixin } from '../../mixins/focus-visible-polyfill-mixin.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
-
 export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(FocusVisiblePolyfillMixin(superclass))) {
 
 	static get properties() {
@@ -29,7 +29,8 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 			 * @type {'start'|'end'|'hidden'}
 			 * @default end
 			 */
-			textPosition: { type: String, attribute: 'text-position', reflect: true }
+			textPosition: { type: String, attribute: 'text-position', reflect: true },
+			_labelHovering: { type: Boolean, state: true }
 		};
 	}
 
@@ -48,7 +49,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 				border: 2px solid transparent;
 				border-radius: 1rem;
 				box-sizing: border-box;
-				cursor: pointer;
+				cursor: default;
 				display: inline-block;
 				font-size: 0;
 				line-height: 0;
@@ -146,8 +147,13 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 				transform: scale(0.35);
 			}
 			.d2l-switch-text {
+				cursor: default;
 				font-size: 0.8rem;
 				font-weight: 400;
+			}
+			.switch-hover {
+				border-color: var(--d2l-color-celestine);
+				box-shadow: 0 0 0 1px var(--d2l-color-celestine) inset;
 			}
 			@media (prefers-reduced-motion: reduce) {
 				.d2l-switch-toggle,
@@ -181,6 +187,9 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 
 	render() {
 		const tabindex = (!this.disabled ? '0' : undefined);
+		const innerSwitchClasses = {
+			'switch-hover': this._labelHovering
+		};
 		const switchLabel = html`<span id="${this._textId}" class="d2l-switch-text">${this._labelContent}</span>`;
 		const textPosition = (this.textPosition === 'start' || this.textPosition === 'hidden'
 			? this.textPosition : 'end');
@@ -197,7 +206,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 				@keyup="${this._handleKeyUp}"
 				role="switch"
 				tabindex="${ifDefined(tabindex)}">
-				<div class="d2l-switch-inner">
+				<div class="d2l-switch-inner ${classMap(innerSwitchClasses)}">
 					<div class="d2l-switch-toggle"><div></div></div>
 					<div class="d2l-switch-icon-on">${this.onIcon}</div>
 					<div class="d2l-switch-icon-off">${this.offIcon}</div>
@@ -208,7 +217,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 	}
 
 	get _labelContent() {
-		return html`${this.text}`;
+		return html`<span @click='${this._handleClick}' @mouseover='${this._handleLabelHover}' @mouseout='${this._handleLabelHoverLeave}'>${this.text}</span>`;
 	}
 
 	_handleClick() {
@@ -223,6 +232,14 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 	_handleKeyUp(e) {
 		// space pressed... toggle state
 		if (e.keyCode === 32) this._toggleState();
+	}
+
+	_handleLabelHover() {
+		this._labelHovering = true;
+	}
+
+	_handleLabelHoverLeave() {
+		this._labelHovering = false;
 	}
 
 	_toggleState() {

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -6,6 +6,7 @@ import { FocusVisiblePolyfillMixin } from '../../mixins/focus-visible-polyfill-m
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
+
 export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(FocusVisiblePolyfillMixin(superclass))) {
 
 	static get properties() {

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -31,7 +31,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 			 * @default end
 			 */
 			textPosition: { type: String, attribute: 'text-position', reflect: true },
-			_hovering: { type: Boolean, state: true }
+			_hovering: { state: true }
 		};
 	}
 
@@ -169,6 +169,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 		this.on = false;
 		this.textPosition = 'end';
 		this._textId = getUniqueId();
+		this._hovering = false;
 	}
 
 	static get focusElementSelector() {

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -148,7 +148,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 				font-size: 0.8rem;
 				font-weight: 400;
 			}
-			.switch-hover {
+			.d2l-switch-inner:hover, .switch-hover {
 				border-color: var(--d2l-color-celestine);
 				box-shadow: 0 0 0 1px var(--d2l-color-celestine) inset;
 			}
@@ -204,7 +204,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 				@keyup="${this._handleKeyUp}"
 				role="switch"
 				tabindex="${ifDefined(tabindex)}">
-				<div class="d2l-switch-inner ${classMap(innerSwitchClasses)}" @mouseover='${this._handleSwitchHover}' @mouseout='${this._handleSwitchHoverLeave}'>
+				<div class="d2l-switch-inner ${classMap(innerSwitchClasses)}">
 					<div class="d2l-switch-toggle"><div></div></div>
 					<div class="d2l-switch-icon-on">${this.onIcon}</div>
 					<div class="d2l-switch-icon-off">${this.offIcon}</div>

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -31,7 +31,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 			 * @default end
 			 */
 			textPosition: { type: String, attribute: 'text-position', reflect: true },
-			_labelHovering: { type: Boolean, state: true }
+			_hovering: { type: Boolean, state: true }
 		};
 	}
 
@@ -60,10 +60,6 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 			}
 			.d2l-switch-container.focus-visible {
 				border-color: var(--d2l-color-celestine);
-			}
-			.d2l-switch-container:hover > .d2l-switch-inner {
-				border-color: var(--d2l-color-celestine);
-				box-shadow: 0 0 0 1px var(--d2l-color-celestine) inset;
 			}
 			:host([disabled]) .d2l-switch-container {
 				cursor: default;
@@ -189,7 +185,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 	render() {
 		const tabindex = (!this.disabled ? '0' : undefined);
 		const innerSwitchClasses = {
-			'switch-hover': this._labelHovering
+			'switch-hover': this._hovering
 		};
 		const switchLabel = html`<span id="${this._textId}" class="d2l-switch-text">${this._labelContent}</span>`;
 		const textPosition = (this.textPosition === 'start' || this.textPosition === 'hidden'
@@ -207,7 +203,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 				@keyup="${this._handleKeyUp}"
 				role="switch"
 				tabindex="${ifDefined(tabindex)}">
-				<div class="d2l-switch-inner ${classMap(innerSwitchClasses)}">
+				<div class="d2l-switch-inner ${classMap(innerSwitchClasses)}" @mouseover='${this._handleSwitchHover}' @mouseout='${this._handleSwitchHoverLeave}'>
 					<div class="d2l-switch-toggle"><div></div></div>
 					<div class="d2l-switch-icon-on">${this.onIcon}</div>
 					<div class="d2l-switch-icon-off">${this.offIcon}</div>
@@ -218,7 +214,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 	}
 
 	get _labelContent() {
-		return html`<span @click='${this._handleClick}' @mouseover='${this._handleLabelHover}' @mouseout='${this._handleLabelHoverLeave}'>${this.text}</span>`;
+		return html`<span @click='${this._handleClick}' @mouseover='${this._handleSwitchHover}' @mouseout='${this._handleSwitchHoverLeave}'>${this.text}</span>`;
 	}
 
 	_handleClick() {
@@ -235,12 +231,12 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 		if (e.keyCode === 32) this._toggleState();
 	}
 
-	_handleLabelHover() {
-		this._labelHovering = true;
+	_handleSwitchHover() {
+		this._hovering = true;
 	}
 
-	_handleLabelHoverLeave() {
-		this._labelHovering = false;
+	_handleSwitchHoverLeave() {
+		this._hovering = false;
 	}
 
 	_toggleState() {

--- a/components/switch/switch-visibility.js
+++ b/components/switch/switch-visibility.js
@@ -47,7 +47,6 @@ class VisibilitySwitch extends LocalizeCoreElement(SwitchMixin(LitElement)) {
 		}
 	}
 
-	// TODO: remove this (along with this._text) when we no longer have any consumers overriding the label text
 	set text(val) {
 		const oldVal = this._text;
 		if (oldVal !== val) {


### PR DESCRIPTION
[Rally Story](https://rally1.rallydev.com/#/?detail=/userstory/629821423167&fdp=true)

Similar to our checkbox or radio options, we'd like the Switch component to allow users to click on the label to toggle it on/off. Hovering over the label should also trigger the hover state. 

This PR also updates the cursor to be the default one for both the switch icon/graphic and it's label (including the conditions met opener), as discussed [here](https://d2l.slack.com/archives/C03FC0GDVB7/p1658771035474229?thread_ts=1658519924.626809&cid=C03FC0GDVB7).

Note that the new `click`/`hover` changes specifically _do not_ apply to the `conditions met` opener for the visibility switch, which was how we wanted the requirements for this story to apply.

Also worth noting that when the user clicks on the label to toggle the switch, there is currently no expected output from the screen reader (unlike when the user toggles the switch icon directly). 
Adding support for some screen reader announcements was initially considered, but was deemed a use case that wasn't worth supporting (i.e. sighted users using the mouse + screen reader).