### PR TITLE
Add dynamic typography style generation helpers

### DIFF
--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -1,6 +1,13 @@
 import '../colors/colors.js';
 import { css, unsafeCSS } from 'lit';
 
+export const _isValidCssSelector = (selector) => {
+	const re = /[#.]?([a-zA-Z0-9-_]+)(\[[a-zA-Z0-9-_]+\])?([a-zA-Z0-9-_]+)?/g;
+	const match = selector.match(re);
+
+	return !!match && match.length === 1 && match[0].length === selector.length;
+};
+
 export const bodyStandardStyles = css`
 	.d2l-body-standard {
 		font-size: 0.95rem;
@@ -45,6 +52,8 @@ export const bodyStandardStyles = css`
  * A private helper method that should not be used by general consumers
  */
 export const _generateBodyCompactStyles = (selector) => {
+	if (!_isValidCssSelector(selector)) return;
+
 	selector = unsafeCSS(selector);
 	return css`
 		${selector} {
@@ -224,6 +233,8 @@ export const heading4Styles = css`
  * A private helper method that should not be used by general consumers
  */
 export const _generateLabelStyles = (selector) => {
+	if (!_isValidCssSelector(selector)) return;
+
 	selector = unsafeCSS(selector);
 	return css`
 		${selector} {

--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -1,5 +1,5 @@
 import '../colors/colors.js';
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
 
 export const bodyStandardStyles = css`
 	.d2l-body-standard {
@@ -41,26 +41,31 @@ export const bodyStandardStyles = css`
 	}
 `;
 
-export const bodyCompactStyles = css`
-	.d2l-body-compact {
-		font-size: 0.8rem;
-		font-weight: 400;
-		line-height: 1.2rem;
-	}
-	:host([skeleton]) .d2l-body-compact.d2l-skeletize::before {
-		bottom: 0.3rem;
-		top: 0.3rem;
-	}
-	:host([skeleton]) .d2l-body-compact.d2l-skeletize-paragraph-2 {
-		max-height: 2.4rem;
-	}
-	:host([skeleton]) .d2l-body-compact.d2l-skeletize-paragraph-3 {
-		max-height: 3.6rem;
-	}
-	:host([skeleton]) .d2l-body-compact.d2l-skeletize-paragraph-5 {
-		max-height: 6rem;
-	}
-`;
+export const generateBodyCompactStyles = (selector) => {
+	selector = unsafeCSS(selector);
+	return css`
+		${selector} {
+			font-size: 0.8rem;
+			font-weight: 400;
+			line-height: 1.2rem;
+		}
+		:host([skeleton]) ${selector}.d2l-skeletize::before {
+			bottom: 0.3rem;
+			top: 0.3rem;
+		}
+		:host([skeleton]) ${selector}.d2l-skeletize-paragraph-2 {
+			max-height: 2.4rem;
+		}
+		:host([skeleton]) ${selector}.d2l-skeletize-paragraph-3 {
+			max-height: 3.6rem;
+		}
+		:host([skeleton]) ${selector}.d2l-skeletize-paragraph-5 {
+			max-height: 6rem;
+		}
+	`;
+};
+
+export const bodyCompactStyles = generateBodyCompactStyles('.d2l-body-compact');
 
 export const bodySmallStyles = css`
 	.d2l-body-small {
@@ -212,18 +217,23 @@ export const heading4Styles = css`
 	}
 `;
 
-export const labelStyles = css`
-	.d2l-label-text {
-		font-size: 0.7rem;
-		font-weight: 700;
-		letter-spacing: 0.2px;
-		line-height: 1rem;
-	}
-	:host([skeleton]) .d2l-label-text.d2l-skeletize::before {
-		bottom: 0.25rem;
-		top: 0.15rem;
-	}
-`;
+export const generateLabelStyles = (selector) => {
+	selector = unsafeCSS(selector);
+	return css`
+		${selector} {
+			font-size: 0.7rem;
+			font-weight: 700;
+			letter-spacing: 0.2px;
+			line-height: 1rem;
+		}
+		:host([skeleton]) ${selector}.d2l-skeletize::before {
+			bottom: 0.25rem;
+			top: 0.15rem;
+		}
+	`;
+};
+
+export const labelStyles = generateLabelStyles('.d2l-label-text');
 
 export const blockquoteStyles = css`
 	.d2l-blockquote {

--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -41,7 +41,10 @@ export const bodyStandardStyles = css`
 	}
 `;
 
-export const generateBodyCompactStyles = (selector) => {
+/**
+ * A private helper method that should not be used by general consumers
+ */
+export const _generateBodyCompactStyles = (selector) => {
 	selector = unsafeCSS(selector);
 	return css`
 		${selector} {
@@ -65,7 +68,7 @@ export const generateBodyCompactStyles = (selector) => {
 	`;
 };
 
-export const bodyCompactStyles = generateBodyCompactStyles('.d2l-body-compact');
+export const bodyCompactStyles = _generateBodyCompactStyles('.d2l-body-compact');
 
 export const bodySmallStyles = css`
 	.d2l-body-small {
@@ -217,7 +220,10 @@ export const heading4Styles = css`
 	}
 `;
 
-export const generateLabelStyles = (selector) => {
+/**
+ * A private helper method that should not be used by general consumers
+ */
+export const _generateLabelStyles = (selector) => {
 	selector = unsafeCSS(selector);
 	return css`
 		${selector} {
@@ -233,7 +239,7 @@ export const generateLabelStyles = (selector) => {
 	`;
 };
 
-export const labelStyles = generateLabelStyles('.d2l-label-text');
+export const labelStyles = _generateLabelStyles('.d2l-label-text');
 
 export const blockquoteStyles = css`
 	.d2l-blockquote {

--- a/components/typography/test/styles.test.js
+++ b/components/typography/test/styles.test.js
@@ -37,6 +37,9 @@ describe.only('_isValidCssSelector', () => {
 		expect(_isValidCssSelector('a[b[c]]')).to.be.false;
 		expect(_isValidCssSelector('abc$')).to.be.false;
 		expect(_isValidCssSelector('@')).to.be.false;
+		expect(_isValidCssSelector('@import')).to.be.false;
+		expect(_isValidCssSelector('@media')).to.be.false;
 		expect(_isValidCssSelector('%')).to.be.false;
+		expect(_isValidCssSelector('.class-name{display:block}')).to.be.false;
 	});
 });

--- a/components/typography/test/styles.test.js
+++ b/components/typography/test/styles.test.js
@@ -1,0 +1,42 @@
+import { _isValidCssSelector } from '../styles.js';
+import { expect } from '@open-wc/testing';
+
+describe.only('_isValidCssSelector', () => {
+
+	it('should support simple tag names', () => {
+		expect(_isValidCssSelector('a')).to.be.true;
+		expect(_isValidCssSelector('button')).to.be.true;
+		expect(_isValidCssSelector('table')).to.be.true;
+		expect(_isValidCssSelector('dl')).to.be.true;
+	});
+
+	it('should support simple class selectors', () => {
+		expect(_isValidCssSelector('.d2l-label-styles')).to.be.true;
+		expect(_isValidCssSelector('.d2l-body-compact')).to.be.true;
+		expect(_isValidCssSelector('.className')).to.be.true;
+	});
+
+	it('should support simple id selectors', () => {
+		expect(_isValidCssSelector('#opener')).to.be.true;
+	});
+
+	it('should support simple property selectors', () => {
+		expect(_isValidCssSelector('button[loading]')).to.be.true;
+		expect(_isValidCssSelector('p[loading]')).to.be.true;
+	});
+
+	it('should not support complex selectors', () => {
+		expect(_isValidCssSelector('dl dd')).to.be.false;
+		expect(_isValidCssSelector('dt.class')).to.be.false;
+		expect(_isValidCssSelector('dt#id')).to.be.false;
+		expect(_isValidCssSelector('dl .class')).to.be.false;
+		expect(_isValidCssSelector('dl #id')).to.be.false;
+	});
+
+	it('should not support invalid selectors', () => {
+		expect(_isValidCssSelector('a[b[c]]')).to.be.false;
+		expect(_isValidCssSelector('abc$')).to.be.false;
+		expect(_isValidCssSelector('@')).to.be.false;
+		expect(_isValidCssSelector('%')).to.be.false;
+	});
+});


### PR DESCRIPTION
## Description

The current approach taken in #2688 requires elements to be styled without adding a class.

This can be achieved by generating styles for a specific CSS selector. ([Lit docs](https://lit.dev/docs/components/styles/#expressions) on using expressions in styles)

Looking for any feedback/thoughts/concerns/gotchas 😄 

## Known limitations/issues
- Wrapping the selector in `unsafeCSS`
  - Ideally, we'd use `css` string (like in the [docs](https://lit.dev/docs/components/styles/#expressions)), but Stylelint can't parse since `css'.class'` is not _technically_ a valid css block.
  - We could mitigate potential issues with `unsafeCSS` by writing validation to ensure the string is safe