### PR TITLE
fix: List items not read in Tooltip contents for safari and voiceover

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -466,12 +466,12 @@ class Tooltip extends RtlMixin(LitElement) {
 			}
 		}
 
+		// Note: role="text" is a workaround for Safari. Otherwise, list-item content is not announced with VoiceOver
 		return html`
 			<div class="d2l-tooltip-container">
 				<div class="d2l-tooltip-position" style=${styleMap(tooltipPositionStyle)}>
 					<div class="d2l-body-small d2l-tooltip-content">
 						<div role="text">
-							<!-- Note: role="text" is a workaround for Safari. Otherwise, list-item content is not announced with VoiceOver" -->
 							<slot></slot>
 						</div>
 					</div>

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -471,6 +471,7 @@ class Tooltip extends RtlMixin(LitElement) {
 				<div class="d2l-tooltip-position" style=${styleMap(tooltipPositionStyle)}>
 					<div class="d2l-body-small d2l-tooltip-content">
 						<div role="text">
+							<!-- Note: role="text" is a workaround for Safari. Otherwise, list-item content is not announced with VoiceOver" -->
 							<slot></slot>
 						</div>
 					</div>

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -470,7 +470,9 @@ class Tooltip extends RtlMixin(LitElement) {
 			<div class="d2l-tooltip-container">
 				<div class="d2l-tooltip-position" style=${styleMap(tooltipPositionStyle)}>
 					<div class="d2l-body-small d2l-tooltip-content">
-						<slot></slot>
+						<div role="text">
+							<slot></slot>
+						</div>
 					</div>
 				</div>
 				<div class="d2l-tooltip-pointer">


### PR DESCRIPTION
Note: this is the same PR as #2715, just with the base branch set to the feature branch for Visibility Switch-related changes, rather than `main`.

[Rally ticket](https://rally1.rallydev.com/#/?detail=/defect/643273080983&fdp=true)

This PR attempts to fix, or at least work around, the issue where ordered (`ol`)/unordered (`ul`)/definition(`dl`) list items are not read in `Safari + VoiceOver` within a `Tooltip`. 

Margaree also found out that it's not just the `li` elements within the list element that aren't being announced - it's also any other content, such as plain text before the `li`s.

After discussing with [Margaree and Dave B](https://d2l.slack.com/archives/C03FC0GDVB7/p1659465104621859?thread_ts=1658950757.652959&cid=C03FC0GDVB7), we decided to go with a work around where we can get the list content _announced_, but with the tradeoff that the list semantics (`"bullet/list item #"` etc) still aren't announced (only for VoiceOver + Safari).

Note that this change was also tested with:
* VoiceOver + Chrome, 
* NVDA + Chrome/Edge/Firefox, 
* and JAWS + Chrome/Edge/Firefox,   

to check that list contents are still properly announced there (with list semantics), along with plain text still being announced normally. 

It was interesting to note that out of the above combinations, only the following actually had list semantics as part of its announcements (i.e. even without this change, and regardless of verbosity setting):
* NVDA + Firefox
* JAWS + Chrome/Edge/Firefox