### PR TITLE
feat: add "d2l-dropdown-opener-click" event

### DIFF
--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -174,6 +174,13 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.dropdownOpened = !this.dropdownOpened;
 	}
 
+	__dispatchOpenerClickEvent() {
+		/** Dispatched when the opener is clicked, useful for when no-auto-open is enabled */
+		this.dispatchEvent(new CustomEvent(
+			'd2l-dropdown-opener-click', { bubbles: false, composed: false }
+		));
+	}
+
 	__getContentElement() {
 		if (!this.shadowRoot) return undefined;
 		return this.shadowRoot.querySelector('slot:not([name])').assignedNodes()
@@ -202,6 +209,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	__onKeypress(e) {
 		if (e.srcElement === this || isComposedAncestor(this.getOpenerElement(), e.srcElement)) {
 			if (e.keyCode !== 13 && e.keyCode !== 32) return;
+			this.__dispatchOpenerClickEvent();
 			if (this.noAutoOpen) return;
 			if (!this.openOnHover) {
 				this.toggleOpen(true);
@@ -256,6 +264,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	}
 
 	__onOpenerMouseUp(e) {
+		this.__dispatchOpenerClickEvent();
 		if (this.noAutoOpen) return;
 		if (this.openOnHover) {
 			// prevent propogation to window and triggering _onOutsideClick

--- a/components/dropdown/test/dropdown-openers.test.js
+++ b/components/dropdown/test/dropdown-openers.test.js
@@ -2,6 +2,7 @@ import '../dropdown-button-subtle.js';
 import '../dropdown-button.js';
 import '../dropdown-context-menu.js';
 import '../dropdown-more.js';
+import { fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-dropdown-openers', () => {
@@ -22,6 +23,33 @@ describe('d2l-dropdown-openers', () => {
 
 		it('should construct dropdown-more', () => {
 			runConstructor('d2l-dropdown-more');
+		});
+
+	});
+
+	describe('events', () => {
+
+		it('should fire "d2l-dropdown-opener-click" event when opener is clicked', async() => {
+			const elem = await fixture(html`<d2l-dropdown-button></d2l-dropdown-button>`);
+			setTimeout(() => elem.getOpenerElement().dispatchEvent(new MouseEvent('mouseup', { composed: true })));
+			await oneEvent(elem, 'd2l-dropdown-opener-click');
+		});
+
+		it('should fire "d2l-dropdown-opener-click" event even when no-auto-open is enabled', async() => {
+			const elem = await fixture(html`<d2l-dropdown-button no-auto-open></d2l-dropdown-button>`);
+			setTimeout(() => elem.getOpenerElement().dispatchEvent(new MouseEvent('mouseup', { composed: true })));
+			await oneEvent(elem, 'd2l-dropdown-opener-click');
+		});
+
+		it('should fire "d2l-dropdown-opener-click" event when ENTER is pressed', async() => {
+			const elem = await fixture(html`<d2l-dropdown-button></d2l-dropdown-button>`);
+			setTimeout(() => {
+				const event = new CustomEvent('keypress', { composed: true });
+				event.keyCode = 13;
+				event.code = 13;
+				elem.getOpenerElement().dispatchEvent(event);
+			});
+			await oneEvent(elem, 'd2l-dropdown-opener-click');
 		});
 
 	});


### PR DESCRIPTION
For many of the LMS dropdowns in the navbar, they actually use the `no-auto-open` property to prevent the default open/close behaviour when the opener is clicked. That's because they have some logic where on the first open they want to do a partial render before actually opening the dropdown.

Unfortunately, when I switched from using a `<d2l-dropdown>` with a custom opener to having `<d2l-navigation-dropdown-button-icon>` actually be the opener (which is better), there's now no way to distinguish between a click on the opener and a click inside the dropdown to manually open/close it.

So this PR introduces a `d2l-dropdown-opener-click` event that consumers who are using `no-auto-open` can listen for to know when the opener was clicked (or ENTER was pressed).