### PR TITLE
fix: SubscriberControllers: fix error caused by space on end

### DIFF
--- a/controllers/subscriber/subscriberControllers.js
+++ b/controllers/subscriber/subscriberControllers.js
@@ -151,7 +151,7 @@ export class IdSubscriberController {
 		let registryIds = this._host[this._idPropertyName];
 		if (!registryIds) return;
 
-		registryIds = registryIds.split(' ');
+		registryIds = registryIds.trim().split(' ');
 		registryIds.forEach(registryId => {
 			this._updateRegistry(registryId, 0);
 		});

--- a/controllers/subscriber/test/subscriberControllers.test.js
+++ b/controllers/subscriber/test/subscriberControllers.test.js
@@ -322,7 +322,7 @@ describe('IdSubscriberController', () => {
 		</${separateRegistries}>
 		<${separateRegistries} id="registry-2"></${separateRegistries}>
 		<${idSubscriber} id="single" for="registry-1"></${idSubscriber}>
-		<${idSubscriber} id="multiple" for="registry-1 registry-2 non-existant"></${idSubscriber}>
+		<${idSubscriber} id="multiple" for="registry-1 registry-2 non-existant "></${idSubscriber}>
 		<${idSubscriber} id="error" for="non-existant"></${idSubscriber}>
 	</div>`;
 


### PR DESCRIPTION
When ids ended with a space the error `SyntaxError: Failed to execute 'querySelector' on 'Document': '#' is not a valid selector.` was being thrown.