### PR TITLE
Reintroduce support for templates within html-blocks

### DIFF
--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -402,6 +402,120 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>HTML Block (math, template)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-html-block>
+						<template>
+							<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+								<mi>x</mi>
+								<mo>=</mo>
+								<mrow>
+									<mfrac>
+										<mrow>
+											<mo>&#x2212;</mo>
+											<mi>b</mi>
+											<mo>&#xB1;</mo>
+											<msqrt>
+												<msup>
+													<mi>b</mi>
+													<mn>2</mn>
+												</msup>
+												<mo>&#x2212;</mo>
+												<mn>4</mn>
+												<mi>a</mi>
+												<mi>c</mi>
+											</msqrt>
+										</mrow>
+										<mrow>
+											<mn>2</mn>
+											<mi>a</mi>
+										</mrow>
+									</mfrac>
+								</mrow>
+								<mtext>.</mtext>
+							</math>
+							<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+								<msup>
+									<mrow>
+										<mo>(</mo>
+										<mrow>
+											<munderover>
+												<mo>∑<!-- ∑ --></mo>
+												<mrow class="MJX-TeXAtom-ORD">
+													<mi>k</mi>
+													<mo>=</mo>
+													<mn>1</mn>
+												</mrow>
+												<mi>n</mi>
+											</munderover>
+											<msub>
+												<mi>a</mi>
+												<mi>k</mi>
+											</msub>
+											<msub>
+												<mi>b</mi>
+												<mi>k</mi>
+											</msub>
+										</mrow>
+										<mo>)</mo>
+									</mrow>
+									<mrow class="MJX-TeXAtom-ORD">
+										<mspace width="negativethinmathspace"></mspace>
+										<mspace width="negativethinmathspace"></mspace>
+										<mn>2</mn>
+									</mrow>
+								</msup>
+								<mo>≤<!-- ≤ --></mo>
+								<mrow>
+									<mo>(</mo>
+									<mrow>
+										<munderover>
+											<mo>∑<!-- ∑ --></mo>
+											<mrow class="MJX-TeXAtom-ORD">
+												<mi>k</mi>
+												<mo>=</mo>
+												<mn>1</mn>
+											</mrow>
+											<mi>n</mi>
+										</munderover>
+										<msubsup>
+											<mi>a</mi>
+											<mi>k</mi>
+											<mn>2</mn>
+										</msubsup>
+									</mrow>
+									<mo>)</mo>
+								</mrow>
+								<mrow>
+									<mo>(</mo>
+									<mrow>
+										<munderover>
+											<mo>∑<!-- ∑ --></mo>
+											<mrow class="MJX-TeXAtom-ORD">
+												<mi>k</mi>
+												<mo>=</mo>
+												<mn>1</mn>
+											</mrow>
+											<mi>n</mi>
+										</munderover>
+										<msubsup>
+											<mi>b</mi>
+											<mi>k</mi>
+											<mn>2</mn>
+										</msubsup>
+									</mrow>
+									<mo>)</mo>
+								</mrow>
+							</math>
+							$$ {\color{red}x} + {\color{blue}y} = {\color{green}z} $$
+							<p>The wizard (<span data-replace-me-id="0">Elmer Fudd</span>) quickly jinxed the gnomes before they vaporized.</p>
+						</template>
+					</d2l-html-block>
+				</template>
+			</d2l-demo-snippet>
+
 			<h2>HTML Block (inline math)</h2>
 
 			<d2l-demo-snippet>

--- a/components/html-block/test/html-block.visual-diff.html
+++ b/components/html-block/test/html-block.visual-diff.html
@@ -407,5 +407,101 @@ helloGrumpy('Wizard');</code></pre>
 		</d2l-html-block>
 	</div>
 
+	<div class="visual-diff" style="width: 650px;">
+		<d2l-html-block id="math--and-code-template">
+			<template>
+				<pre class="d2l-code d2l-code-dark"><code class="language-javascript">function helloGrumpy(name) {
+	console.log(`Hi there ${name}.`);
+}
+helloGrumpy('Wizard');</code>
+				</pre>
+				<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+					<msup>
+						<mrow>
+							<mo>(</mo>
+							<mrow>
+								<munderover>
+									<mo>∑<!-- ∑ --></mo>
+									<mrow class="MJX-TeXAtom-ORD">
+										<mi>k</mi>
+										<mo>=</mo>
+										<mn>1</mn>
+									</mrow>
+									<mi>n</mi>
+								</munderover>
+								<msub>
+									<mi>a</mi>
+									<mi>k</mi>
+								</msub>
+								<msub>
+									<mi>b</mi>
+									<mi>k</mi>
+								</msub>
+							</mrow>
+							<mo>)</mo>
+						</mrow>
+						<mrow class="MJX-TeXAtom-ORD">
+							<mspace width="negativethinmathspace"></mspace>
+							<mspace width="negativethinmathspace"></mspace>
+							<mn>2</mn>
+						</mrow>
+					</msup>
+					<mo>≤<!-- ≤ --></mo>
+					<mrow>
+						<mo>(</mo>
+						<mrow>
+							<munderover>
+								<mo>∑<!-- ∑ --></mo>
+								<mrow class="MJX-TeXAtom-ORD">
+									<mi>k</mi>
+									<mo>=</mo>
+									<mn>1</mn>
+								</mrow>
+								<mi>n</mi>
+							</munderover>
+							<msubsup>
+								<mi>a</mi>
+								<mi>k</mi>
+								<mn>2</mn>
+							</msubsup>
+						</mrow>
+						<mo>)</mo>
+					</mrow>
+					<mrow>
+						<mo>(</mo>
+						<mrow>
+							<munderover>
+								<mo>∑<!-- ∑ --></mo>
+								<mrow class="MJX-TeXAtom-ORD">
+									<mi>k</mi>
+									<mo>=</mo>
+									<mn>1</mn>
+								</mrow>
+								<mi>n</mi>
+							</munderover>
+							<msubsup>
+								<mi>b</mi>
+								<mi>k</mi>
+								<mn>2</mn>
+							</msubsup>
+						</mrow>
+						<mo>)</mo>
+					</mrow>
+					<mspace linebreak="newline"></mspace>
+					<msup>
+						<mi>e</mi>
+						<mrow>
+							<mi>i</mi>
+							<mi>π<!-- π --></mi>
+						</mrow>
+					</msup>
+					<mo>+</mo>
+					<mn>1</mn>
+					<mo>=</mo>
+					<mn>0</mn>
+				</math>
+			</template>
+		</d2l-html-block>
+	</div>
 </body>
 </html>

--- a/components/html-block/test/html-block.visual-diff.js
+++ b/components/html-block/test/html-block.visual-diff.js
@@ -34,7 +34,8 @@ describe('d2l-html-block', () => {
 		{ name: 'math (inline)', selector: '#math-inline' },
 		{ name: 'code (block)', selector: '#code-block' },
 		{ name: 'code (inline)', selector: '#code-inline' },
-		{ name: 'math (block) and code (block)', selector: '#math-block-and-code-block' }
+		{ name: 'math (block) and code (block)', selector: '#math-block-and-code-block' },
+		{ name: 'math and code (template)', selector: '#math-and-code-template' }
 	].forEach((info) => {
 
 		it(info.name, async function() {


### PR DESCRIPTION
So... I think in hindsight there are a few unfortunate flaws that came up when we removed templates from the html-block API. Specifically, there are certain elements that will continue to load even if they're slotted in a `display: none` container. The two issues I'm currently aware of are as follows:
1. Scripts within iframes will still run. This case is only temporary because the iframe won't render after stamping has completed, but depending on the order things load in, if the iframe contents make web requests, those can still end up going out before the component renders. Those requests get canceled by the browser, but we still end up with tons of duplicate requests being made.
2. Audio elements with `autoplay` enabled will play regardless of being in a `display: none` container. This one is arguably worse because the user can't stop the audio without either disabling it in the browser tab or by using the dev console to delete the unstamped version.

So I figure... We may want to consider re-introducing support for templates. This PR makes a first go at that, with the paradigm of maintaining both methods simultaneously. As a reminder, we need to support the non-template case for components that need to render dynamic HTML, as Lit won't render dynamic HTML within `<template>`s. I figure we have two options here...
1. We support both, as in this PR. The norm would be to use `<template`s but components that absolutely need dynamic HTML can opt not to use them.
2. We accept that any component that can't use `<template>`s needs to set `no-deferred-rendering` and import the HTML block styles itself.

I'm open to ideas. I'm leaning a bit towards (2), personally, since it would go the furthest towards maintaining a consistent experience... The issue with (1) is that the two issues noted above would still potentially occur if the html-block is used in this way.