### PR TITLE
feat: added querySelectorComposed to DOM helpers

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -107,6 +107,10 @@ isComposedAncestor(ancestorNode, node);
 
 // returns true/false whether the element is visible regardless of positioning
 isVisible(node);
+
+// similar to document.querySelector or element.querySelector,
+// except it queries not just the light DOM but also shadow DOM
+querySelectorComposed(node, selector)
 ```
 
 ## Focus

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -234,9 +234,9 @@ export function querySelectorComposed(node, selector) {
 	if (elem) return elem;
 
 	const allElems = node.querySelectorAll('*');
-	for (let i = 0; i < allElems.length; i++) {
-		if (allElems[i].shadowRoot) {
-			const nestedElem = querySelectorComposed(allElems[i].shadowRoot, selector);
+	for (const elem of allElems) {
+		if (elem.shadowRoot) {
+			const nestedElem = querySelectorComposed(elem.shadowRoot, selector);
 			if (nestedElem) return nestedElem;
 		}
 	}

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -230,6 +230,13 @@ export function isVisible(node) {
 
 export function querySelectorComposed(node, selector) {
 
+	if (!node || (node.nodeType !== 1 && node.nodeType !== 9 && node.nodeType !== 11)) {
+		throw new TypeError('Invalid node. Must be nodeType document, element or document fragment');
+	}
+	if (typeof selector !== 'string') {
+		throw new TypeError('Invalid selector');
+	}
+
 	const elem = node.querySelector(selector);
 	if (elem) return elem;
 

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -227,3 +227,19 @@ export function isVisible(node) {
 	return true;
 
 }
+
+export function querySelectorComposed(node, selector) {
+
+	const elem = node.querySelector(selector);
+	if (elem) return elem;
+
+	const allElems = node.querySelectorAll('*');
+	for (let i = 0; i < allElems.length; i++) {
+		if (allElems[i].shadowRoot) {
+			const nestedElem = querySelectorComposed(allElems[i].shadowRoot, selector);
+			if (nestedElem) return nestedElem;
+		}
+	}
+
+	return null;
+}

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -1,3 +1,4 @@
+import '../../components/button/button-icon.js';
 import { css, html, LitElement } from 'lit';
 import {
 	cssEscape,
@@ -10,7 +11,8 @@ import {
 	getNextAncestorSibling,
 	getOffsetParent,
 	isComposedAncestor,
-	isVisible
+	isVisible,
+	querySelectorComposed
 } from '../dom.js';
 import { defineCE, expect, fixture } from '@open-wc/testing';
 
@@ -753,6 +755,56 @@ describe('dom', () => {
 			const elem = await fixture(mixedFixture);
 			expect(isComposedAncestor(elem, elem.querySelector('#light2')))
 				.to.be.true;
+		});
+
+	});
+
+	describe('querySelectorComposed', () => {
+
+		const slottedElement = defineCE(
+			class extends LitElement {
+				render() {
+					return html`<div class="shadowDiv"><slot></slot></div>`;
+				}
+			},
+		);
+
+		const nestedElement = defineCE(
+			class extends LitElement {
+				render() {
+					return html`<d2l-button-icon icon="tier1:delete" text="delete"></d2l-button-icon>`;
+				}
+			},
+		);
+
+		it('should find element in the root document', async() => {
+			await fixture(html`<h1>heading</h1><button>button</button>`);
+			const result = querySelectorComposed(document, 'button');
+			expect(result.tagName).to.equal('BUTTON');
+		});
+
+		it('should return null if no element is found in root document', async() => {
+			await fixture(html`<h1>heading</h1><button>button</button>`);
+			const result = querySelectorComposed(document, 'a');
+			expect(result).to.be.null;
+		});
+
+		it('should find slotted element', async() => {
+			await fixture(`<${slottedElement}><h2 class="h">heading</h2></${slottedElement}>`);
+			const result = querySelectorComposed(document, '.h');
+			expect(result.tagName).to.equal('H2');
+		});
+
+		it('should find element in shadow root', async() => {
+			await fixture(`<${slottedElement}></${slottedElement}>`);
+			const result = querySelectorComposed(document, '.shadowDiv');
+			expect(result.tagName).to.equal('DIV');
+		});
+
+		it('should find element in nested shadow root', async() => {
+			await fixture(`<${nestedElement}></${nestedElement}>`);
+			const result = querySelectorComposed(document, '.d2l-button-icon');
+			expect(result.tagName).to.equal('D2L-ICON');
 		});
 
 	});

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -1,4 +1,3 @@
-import '../../components/button/button-icon.js';
 import { css, html, LitElement } from 'lit';
 import {
 	cssEscape,
@@ -105,6 +104,13 @@ const visibilityFixture = html`
 		<div style="visibility:hidden;"><div id="parentVisibilityNone"></div></div>
 	</div>
 `;
+
+class TestElement extends LitElement {
+	render() {
+		return html`<div class="nested"></div>`;
+	}
+}
+customElements.define('test-elem', TestElement);
 
 describe('dom', () => {
 
@@ -772,7 +778,7 @@ describe('dom', () => {
 		const nestedElement = defineCE(
 			class extends LitElement {
 				render() {
-					return html`<d2l-button-icon icon="tier1:delete" text="delete"></d2l-button-icon>`;
+					return html`<test-elem></test-elem>`;
 				}
 			},
 		);
@@ -803,8 +809,8 @@ describe('dom', () => {
 
 		it('should find element in nested shadow root', async() => {
 			await fixture(`<${nestedElement}></${nestedElement}>`);
-			const result = querySelectorComposed(document, '.d2l-button-icon');
-			expect(result.tagName).to.equal('D2L-ICON');
+			const result = querySelectorComposed(document, '.nested');
+			expect(result.tagName).to.equal('DIV');
 		});
 
 	});

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -783,14 +783,40 @@ describe('dom', () => {
 			},
 		);
 
+		const expectedNodeErrorMsg = 'Invalid node. Must be nodeType document, element or document fragment';
+		const expectedSelectorErrorMsg = 'Invalid selector';
+
+		it('should throw on undefined node type', () => {
+			expect(() => querySelectorComposed(undefined)).to.throw(expectedNodeErrorMsg);
+		});
+
+		it('should throw on null node type', () => {
+			expect(() => querySelectorComposed(null)).to.throw(expectedNodeErrorMsg);
+		});
+
+		it('should throw on invalid node type', () => {
+			expect(() => querySelectorComposed({ nodeType: 3 })).to.throw(expectedNodeErrorMsg);
+		});
+
+		it('should throw on invalid selector', () => {
+			expect(() => querySelectorComposed(document, null)).to.throw(expectedSelectorErrorMsg);
+		});
+
 		it('should find element in the root document', async() => {
-			await fixture(html`<h1>heading</h1><button>button</button>`);
+			await fixture(html`<div><h1>heading</h1><button>button</button></div>`);
 			const result = querySelectorComposed(document, 'button');
 			expect(result.tagName).to.equal('BUTTON');
 		});
 
+		it('should find element in an element subtree', async() => {
+			const elem = await fixture(html`<div><h2 id="one">heading 1</h2><div class="subtree"><h2 id="two">heading 2</h2></div></div>`);
+			const subtree = elem.querySelector('.subtree');
+			const result = querySelectorComposed(subtree, 'h2');
+			expect(result.id).to.equal('two');
+		});
+
 		it('should return null if no element is found in root document', async() => {
-			await fixture(html`<h1>heading</h1><button>button</button>`);
+			await fixture(html`<div><h1>heading</h1><button>button</button></div>`);
 			const result = querySelectorComposed(document, 'a');
 			expect(result).to.be.null;
 		});


### PR DESCRIPTION
For the "skip nav" link accessibility fixes, we'd like to change the behavior such that it searches for a `<main>` or `[role="main"]` and then falls back to `<h1>` when moving focus. We'd also like for that search to include those elements inside web component shadow roots, since page or app templates [like our primary/secondary template](https://github.com/BrightspaceUI/core/blob/main/templates/primary-secondary/primary-secondary.js#L939) sometimes render those elements.

This adds a new DOM helper that works just like `document.querySelector` except that it also reaches into custom element shadow roots and queries them as well. I considered adding a `querySelectorComposedAll`, but decided to leave that for when/if the use case comes up.