### PR TITLE
Add description property to tag-list-item to better control tooltip - US141912

### DIFF
--- a/components/tag-list/README.md
+++ b/components/tag-list/README.md
@@ -82,4 +82,4 @@ The `d2l-tag-list-item` provides the appropriate `listitem` semantics and stylin
 | Property | Type | Description |
 |--|--|--|
 | `text` | String, required | Text displayed on the tag item. Will truncate automatically if text exceeds a certain width and will display full `text` value in a tooltip. |
-| `description` | String, optional | Text displayed in tag item tooltip. Setting this property will make tooltip available at all times when hovering. If tooltip `text` is truncated, it will be included in the `text` value before the `description` string in the tooltip. |
+| `description` | String, optional | Additional text to display in tag item tooltip. Setting this property will make tooltip available at all times when hovering. |

--- a/components/tag-list/README.md
+++ b/components/tag-list/README.md
@@ -76,3 +76,10 @@ The `d2l-tag-list-item` provides the appropriate `listitem` semantics and stylin
   <d2l-tag-list-item text="Tag"></d2l-tag-list-item>
 </d2l-tag-list>
 ```
+
+### `d2l-tag-list-item` properties
+
+| Property | Type | Description |
+|--|--|--|
+| `text` | String, required | Text displayed on the tag item. Will truncate automatically if text exceeds a certain width and will display full `text` value in a tooltip. |
+| `description` | String, optional | Text displayed in tag item tooltip. Setting this property will make tooltip available at all times when hovering. If tooltip `text` is truncated, it will be included in the `text` value before the `description` string in the tooltip. |

--- a/components/tag-list/demo/tag-list.html
+++ b/components/tag-list/demo/tag-list.html
@@ -86,6 +86,16 @@
 				</div>
 			</d2l-demo-snippet>
 
+			<h2>Tag List with custom tooltip text</h2>
+			<d2l-demo-snippet fullscreen>
+				<d2l-tag-list description="A bunch of example tags">
+					<d2l-tag-list-item text="Longer Example Tag - much much much much much longer" description="display text and description value when truncated"></d2l-tag-list-item>
+					<d2l-tag-list-item text="Example Tag 5" description="custom tooltip text - display description only when not truncated"></d2l-tag-list-item>
+					<d2l-tag-list-item text="Truncated list item without a custom tooltip description"></d2l-tag-list-item>
+					<d2l-tag-list-item text="No tooltip"></d2l-tag-list-item>
+				</d2l-tag-list>
+			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 	</body>
 </html>

--- a/components/tag-list/demo/tag-list.html
+++ b/components/tag-list/demo/tag-list.html
@@ -86,7 +86,7 @@
 				</div>
 			</d2l-demo-snippet>
 
-			<h2>Tag List with custom tooltip text</h2>
+			<h2>Tag List - Custom Tooltip Description</h2>
 			<d2l-demo-snippet fullscreen>
 				<d2l-tag-list description="A bunch of example tags">
 					<d2l-tag-list-item text="Longer Example Tag - much much much much much longer" description="display text and description value when truncated"></d2l-tag-list-item>

--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -1,7 +1,7 @@
 import '../button/button-icon.js';
 import '../colors/colors.js';
 import '../tooltip/tooltip.js';
-import { css, html } from 'lit';
+import { css, html, nothing } from 'lit';
 import { announce } from '../../helpers/announce.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { findComposedAncestor } from '../../helpers/dom.js';
@@ -120,6 +120,9 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 			.d2l-tag-list-item-tooltip-title-key {
 				font-weight: 600;
 			}
+			d2l-tooltip h4 {
+				margin-top: 0;
+			}
 		`];
 	}
 
@@ -200,14 +203,16 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 		));
 	}
 
-	_renderTag(tagContent, isTruncated, description) {
+	_renderTag(tagContent, hasTruncationTooltip, description) {
 		const buttonText = typeof tagContent === 'object'
 			? this.localize('components.tag-list.clear', { value: '' })
 			: this.localize('components.tag-list.clear', { value: tagContent });
 		const hasDescription = !!description;
-		const tooltipTagOverflow = isTruncated || hasDescription ? html`
-				<d2l-tooltip for="${this._id}">
-					${hasDescription ? description : tagContent}
+		const tooltipHeader = hasDescription ? html`<h4>${tagContent}</h4>` : tagContent;
+		const tooltipTagOverflow = hasTruncationTooltip ? html`
+				<d2l-tooltip for="${this._id}" ?show-truncated-only="${!hasDescription}">
+					${tooltipHeader}
+					${hasDescription ? description : nothing}
 				</d2l-tooltip>
 			` : null;
 		const tooltipKeyboardInstructions = this._displayKeyboardTooltip ? html`

--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -2,11 +2,11 @@ import '../button/button-icon.js';
 import '../colors/colors.js';
 import '../tooltip/tooltip.js';
 import { css, html, nothing } from 'lit';
+import { heading4Styles, labelStyles } from '../typography/styles.js';
 import { announce } from '../../helpers/announce.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { findComposedAncestor } from '../../helpers/dom.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
-import { labelStyles } from '../typography/styles.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
@@ -39,7 +39,7 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 	}
 
 	static get styles() {
-		return [labelStyles, css`
+		return [labelStyles, heading4Styles, css`
 			:host {
 				display: grid;
 				max-width: 100%;
@@ -120,8 +120,8 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 			.d2l-tag-list-item-tooltip-title-key {
 				font-weight: 600;
 			}
-			d2l-tooltip h4 {
-				margin-top: 0;
+			.d2l-heading-4 {
+				margin: 0 0 0.5rem 0;
 			}
 		`];
 	}
@@ -208,7 +208,7 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 			? this.localize('components.tag-list.clear', { value: '' })
 			: this.localize('components.tag-list.clear', { value: tagContent });
 		const hasDescription = !!description;
-		const tooltipHeader = hasDescription ? html`<h4>${tagContent}</h4>` : tagContent;
+		const tooltipHeader = hasDescription ? html`<div class="d2l-heading-4">${tagContent}</div>` : tagContent;
 		const tooltipTagOverflow = hasTruncationTooltip ? html`
 				<d2l-tooltip for="${this._id}" ?show-truncated-only="${!hasDescription}">
 					${tooltipHeader}

--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -200,7 +200,7 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 		));
 	}
 
-	_renderTag(tagContent, hasTruncationTooltip = false, description = '') {
+	_renderTag(tagContent, hasTruncationTooltip, description) {
 		const buttonText = typeof tagContent === 'object'
 			? this.localize('components.tag-list.clear', { value: '' })
 			: this.localize('components.tag-list.clear', { value: tagContent });

--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -200,13 +200,13 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 		));
 	}
 
-	_renderTag(tagContent, hasTruncationTooltip, description) {
+	_renderTag(tagContent, isTruncated, description) {
 		const buttonText = typeof tagContent === 'object'
 			? this.localize('components.tag-list.clear', { value: '' })
 			: this.localize('components.tag-list.clear', { value: tagContent });
 		const hasDescription = !!description;
-		const tooltipTagOverflow = hasTruncationTooltip ? html`
-				<d2l-tooltip for="${this._id}" ?show-truncated-only="${!hasDescription}">
+		const tooltipTagOverflow = isTruncated || hasDescription ? html`
+				<d2l-tooltip for="${this._id}">
 					${hasDescription ? description : tagContent}
 				</d2l-tooltip>
 			` : null;

--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -200,13 +200,14 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 		));
 	}
 
-	_renderTag(tagContent, hasTruncationTooltip) {
+	_renderTag(tagContent, hasTruncationTooltip = false, description = '') {
 		const buttonText = typeof tagContent === 'object'
 			? this.localize('components.tag-list.clear', { value: '' })
 			: this.localize('components.tag-list.clear', { value: tagContent });
+		const hasDescription = !!description;
 		const tooltipTagOverflow = hasTruncationTooltip ? html`
-				<d2l-tooltip for="${this._id}" show-truncated-only>
-					${tagContent}
+				<d2l-tooltip for="${this._id}" ?show-truncated-only="${!hasDescription}">
+					${hasDescription ? description : tagContent}
 				</d2l-tooltip>
 			` : null;
 		const tooltipKeyboardInstructions = this._displayKeyboardTooltip ? html`

--- a/components/tag-list/tag-list-item.js
+++ b/components/tag-list/tag-list-item.js
@@ -33,18 +33,19 @@ class TagListItem extends TagListItemMixin(LitElement) {
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-		if (this.description) {
-			// observe resize events so we can update tooltip text when truncated
-			const itemContent = this.shadowRoot.querySelector('.tag-list-item-content');
-			this._onListItemResize();
-			this._resizeObserver = new ResizeObserver(() => this._onListItemResize());
-			this._resizeObserver.observe(itemContent);
-		}
+		// observe resize events so we can update tooltip text when truncated
+		const itemContent = this.shadowRoot.querySelector('.tag-list-item-content');
+		this._onListItemResize();
+		this._resizeObserver = new ResizeObserver(() => this._onListItemResize());
+		this._resizeObserver.observe(itemContent);
 	}
 
 	render() {
-		const description = this._isTruncated ? `${this.text} ${this.description}` : this.description;
-		return this._renderTag(this.text, true, description);
+		let description =  null;
+		if (this.description) {
+			description = this._isTruncated ? `${this.text} ${this.description}` : this.description;
+		}
+		return this._renderTag(this.text, this._isTruncated, description);
 	}
 
 	_onListItemResize() {

--- a/components/tag-list/tag-list-item.js
+++ b/components/tag-list/tag-list-item.js
@@ -1,4 +1,5 @@
 import { LitElement } from 'lit';
+import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { TagListItemMixin } from './tag-list-item-mixin.js';
 
 class TagListItem extends TagListItemMixin(LitElement) {
@@ -9,12 +10,47 @@ class TagListItem extends TagListItemMixin(LitElement) {
 			 * REQUIRED: Text to display
 			 * @type {string}
 			 */
-			text: { type: String }
+			text: { type: String },
+			/**
+			 * Optional: Text to display in tooltip.
+			 * Tooltip will also include text property value if truncated.
+			 * @type {string}
+			 */
+			description: { type: String },
+			_isTruncated: { attribute: false },
+			_resizeObserver: { attribute: false }
 		};
 	}
 
+	constructor() {
+		super();
+		this._isTruncated = false;
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		if (this._resizeObserver) this._resizeObserver.disconnect();
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		if (this.description) {
+			// observe resize events so we can update tooltip text when truncated
+			const itemContent = this.shadowRoot.querySelector('.tag-list-item-content');
+			this._onListItemResize();
+			this._resizeObserver = new ResizeObserver(() => this._onListItemResize());
+			this._resizeObserver.observe(itemContent);
+		}
+	}
+
 	render() {
-		return this._renderTag(this.text, true);
+		const description = this._isTruncated ? `${this.text} ${this.description}` : this.description;
+		return this._renderTag(this.text, true, description);
+	}
+
+	_onListItemResize() {
+		const itemContent = this.shadowRoot.querySelector('.tag-list-item-content');
+		this._isTruncated = itemContent.scrollWidth > itemContent.offsetWidth;
 	}
 }
 

--- a/components/tag-list/tag-list-item.js
+++ b/components/tag-list/tag-list-item.js
@@ -1,5 +1,5 @@
 import { LitElement } from 'lit';
-import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
+// import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { TagListItemMixin } from './tag-list-item-mixin.js';
 
 class TagListItem extends TagListItemMixin(LitElement) {
@@ -33,10 +33,10 @@ class TagListItem extends TagListItemMixin(LitElement) {
 
 	firstUpdated() {
 		// observe resize events so we can update tooltip text when truncated
-		const itemContent = this.shadowRoot.querySelector('.tag-list-item-content');
+		// const itemContent = this.shadowRoot.querySelector('.tag-list-item-content');
 		this._onListItemResize();
-		this._resizeObserver = new ResizeObserver(() => this._onListItemResize());
-		this._resizeObserver.observe(itemContent);
+		// this._resizeObserver = new ResizeObserver(() => this._onListItemResize());
+		// this._resizeObserver.observe(itemContent);
 	}
 
 	render() {

--- a/components/tag-list/tag-list-item.js
+++ b/components/tag-list/tag-list-item.js
@@ -27,12 +27,11 @@ class TagListItem extends TagListItemMixin(LitElement) {
 	}
 
 	disconnectedCallback() {
-		super.disconnectedCallback();
 		if (this._resizeObserver) this._resizeObserver.disconnect();
+		super.disconnectedCallback();
 	}
 
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
+	firstUpdated() {
 		// observe resize events so we can update tooltip text when truncated
 		const itemContent = this.shadowRoot.querySelector('.tag-list-item-content');
 		this._onListItemResize();

--- a/components/tag-list/tag-list-item.js
+++ b/components/tag-list/tag-list-item.js
@@ -22,11 +22,6 @@ class TagListItem extends TagListItemMixin(LitElement) {
 	render() {
 		return this._renderTag(this.text, true, this.description);
 	}
-
-	_onListItemResize() {
-		const itemContent = this.shadowRoot.querySelector('.tag-list-item-content');
-		this._isTruncated = itemContent.scrollWidth > itemContent.offsetWidth;
-	}
 }
 
 customElements.define('d2l-tag-list-item', TagListItem);

--- a/components/tag-list/tag-list-item.js
+++ b/components/tag-list/tag-list-item.js
@@ -17,7 +17,7 @@ class TagListItem extends TagListItemMixin(LitElement) {
 			 * @type {string}
 			 */
 			description: { type: String },
-			_isTruncated: { attribute: false }
+			_isTruncated: { state: true }
 		};
 	}
 

--- a/components/tag-list/tag-list-item.js
+++ b/components/tag-list/tag-list-item.js
@@ -17,8 +17,7 @@ class TagListItem extends TagListItemMixin(LitElement) {
 			 * @type {string}
 			 */
 			description: { type: String },
-			_isTruncated: { attribute: false },
-			_resizeObserver: { attribute: false }
+			_isTruncated: { attribute: false }
 		};
 	}
 

--- a/components/tag-list/tag-list-item.js
+++ b/components/tag-list/tag-list-item.js
@@ -1,5 +1,4 @@
 import { LitElement } from 'lit';
-// import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { TagListItemMixin } from './tag-list-item-mixin.js';
 
 class TagListItem extends TagListItemMixin(LitElement) {
@@ -16,35 +15,12 @@ class TagListItem extends TagListItemMixin(LitElement) {
 			 * Tooltip will also include text property value if truncated.
 			 * @type {string}
 			 */
-			description: { type: String },
-			_isTruncated: { state: true }
+			description: { type: String }
 		};
 	}
 
-	constructor() {
-		super();
-		this._isTruncated = false;
-	}
-
-	disconnectedCallback() {
-		if (this._resizeObserver) this._resizeObserver.disconnect();
-		super.disconnectedCallback();
-	}
-
-	firstUpdated() {
-		// observe resize events so we can update tooltip text when truncated
-		// const itemContent = this.shadowRoot.querySelector('.tag-list-item-content');
-		this._onListItemResize();
-		// this._resizeObserver = new ResizeObserver(() => this._onListItemResize());
-		// this._resizeObserver.observe(itemContent);
-	}
-
 	render() {
-		let description =  null;
-		if (this.description) {
-			description = this._isTruncated ? `${this.text} ${this.description}` : this.description;
-		}
-		return this._renderTag(this.text, this._isTruncated, description);
+		return this._renderTag(this.text, true, this.description);
 	}
 
 	_onListItemResize() {


### PR DESCRIPTION
This change will allow us to use the `d2l-tag-list` core component instead of `d2l-labs-multi-select-list` component [in d2l-activity-alignments](https://github.com/Brightspace/d2l-activity-alignments/blob/main/src/components/tags/activity-alignment-tag-list.js#L84). 

We require the tooltip to contain separate info than the text displayed on tag item to give the users context on selected standards aligned to a given activity. This PR addresses this gap by adding a `description` property to `d2l-tag-list-item` to better control what we can display in the tooltip. 

See demo for functionality added:
![tag-item-description-property](https://user-images.githubusercontent.com/64804046/185174532-2c3548e7-46bc-4aa2-a2b3-5daee0ea3cbd.gif)

Rally ticket: https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F644105367505