### PR TITLE
fix: Visibility Switch > remove ability to highlight text

### DIFF
--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -39,8 +39,8 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 		return css`
 			:host {
 				display: inline-block;
-				white-space: nowrap;
 				user-select: none;
+				white-space: nowrap;
 			}
 			:host([hidden]) {
 				display: none;

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -40,6 +40,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(Focus
 			:host {
 				display: inline-block;
 				white-space: nowrap;
+				user-select: none;
 			}
 			:host([hidden]) {
 				display: none;


### PR DESCRIPTION
[Rally Defect](https://rally1.rallydev.com/#/?detail=/defect/644299602729&fdp=true)

We noticed a UX bug where parts of the label, if not the entire label + conditions opener tooltip contents, would get highlighted if you toggled the switch sometimes (particularly if you toggled back and forth in a faster pace).

This PR fixes that issue by removing the ability for any text in the label to be highlighted (confirmed with Jeff that we want this behaviour), whether this highlighting occurs by trying to select the label text with the cursor, or when toggling the switch (as per above defect).
