### PR TITLE
Add docs ignore on README for `d2l-tag-list-item` properties

### DIFF
--- a/components/tag-list/README.md
+++ b/components/tag-list/README.md
@@ -77,9 +77,11 @@ The `d2l-tag-list-item` provides the appropriate `listitem` semantics and stylin
 </d2l-tag-list>
 ```
 
+<!-- docs: start hidden content -->
 ### `d2l-tag-list-item` properties
 
 | Property | Type | Description |
 |--|--|--|
 | `text` | String, required | Text displayed on the tag item. Will truncate automatically if text exceeds a certain width and will display full `text` value in a tooltip. |
 | `description` | String, optional | Additional text to display in tag item tooltip. Setting this property will make tooltip available at all times when hovering. |
+<!-- docs: end hidden content -->


### PR DESCRIPTION
Daylight sight creates property table from code so adding ignore comment on README so it does not get duplicated.