### PR TITLE
fix: switch away from using `lit-element`

### DIFF
--- a/helpers/prism.js
+++ b/helpers/prism.js
@@ -1,4 +1,4 @@
-import { css, unsafeCSS } from 'lit-element/lit-element.js';
+import { css, unsafeCSS } from 'lit';
 
 window.Prism = window.Prism || {};
 Prism.manual = true;


### PR DESCRIPTION
Looks like this was just missed. Came up during failing build of FRA.