### PR TITLE
Added d2l-alert-toast-button-press event

### DIFF
--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -141,16 +141,6 @@ class AlertToast extends LitElement {
 		}
 	}
 
-	connectedCallback() {
-		super.connectedCallback();
-		this.addEventListener('d2l-alert-button-press', this._handleButtonPress);
-	}
-
-	disconnectedCallback() {
-		super.disconnectedCallback();
-		this.removeEventListener('d2l-alert-button-press', this._handleButtonPress);
-	}
-
 	render() {
 		return html`
 			<div
@@ -160,6 +150,7 @@ class AlertToast extends LitElement {
 				<d2l-alert
 					@blur=${this._onBlur}
 					button-text="${ifDefined(this.buttonText)}"
+					@d2l-alert-button-press=${this._handleButtonPress}
 					@d2l-alert-close=${this._onCloseClicked}
 					@focus=${this._onFocus}
 					?has-close-button="${!this.hideCloseButton}"
@@ -209,7 +200,8 @@ class AlertToast extends LitElement {
 		clearTimeout(this._setTimeoutId);
 	}
 
-	_handleButtonPress() {
+	_handleButtonPress(e) {
+		e.stopPropagation();
 		this.dispatchEvent(new CustomEvent('d2l-alert-toast-button-press'));
 	}
 

--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -15,6 +15,7 @@ const states = {
 /**
  *  A component for communicating important information relating to the state of the system and the user's work flow, displayed as a pop-up at the bottom of the screen that automatically dismisses itself by default.
  * @slot - Default content placed inside of the component
+ * @fires d2l-alert-toast-button-press - Dispatched when the toast's action button is clicked
  * @fires d2l-alert-toast-close - Dispatched when the toast is closed
  */
 class AlertToast extends LitElement {
@@ -140,6 +141,16 @@ class AlertToast extends LitElement {
 		}
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		this.addEventListener('d2l-alert-button-press', this._handleButtonPress);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.removeEventListener('d2l-alert-button-press', this._handleButtonPress);
+	}
+
 	render() {
 		return html`
 			<div
@@ -196,6 +207,10 @@ class AlertToast extends LitElement {
 
 	_closeTimerStop() {
 		clearTimeout(this._setTimeoutId);
+	}
+
+	_handleButtonPress() {
+		this.dispatchEvent(new CustomEvent('d2l-alert-toast-button-press'));
 	}
 
 	_onBlur() {

--- a/components/alert/demo/alert-toast.html
+++ b/components/alert/demo/alert-toast.html
@@ -40,7 +40,7 @@
 			</template>
 		</d2l-demo-snippet>
 
-		<h2>With Subtext</h2>
+		<h2>With Subtext and Button</h2>
 		<d2l-demo-snippet>
 			<template>
 				<d2l-alert-toast id="toast4" type="success" button-text="Do it!" has-close-button
@@ -66,6 +66,11 @@
 				openToast(toast);
 			});
 		});
+	});
+
+	const buttonAlertToast = document.querySelector('#toast4');
+	buttonAlertToast.addEventListener('d2l-alert-toast-button-press', (e) => {
+		console.log('d2l-alert-toast-button-press', e);
 	});
 
 	document.body.addEventListener('d2l-alert-toast-close', (e) => {

--- a/components/alert/test/alert-toast.test.js
+++ b/components/alert/test/alert-toast.test.js
@@ -12,6 +12,17 @@ describe('d2l-alert-toast', () => {
 
 	});
 
+	describe('button-press', () => {
+
+		it('should fire "d2l-alert-toast-button-press" event when alert button is pressed', async() => {
+			const el = await fixture(html`<d2l-alert-toast button-text="Click Me" open>message</d2l-alert-toast>`);
+			const alert = el.shadowRoot.querySelector('d2l-alert');
+			setTimeout(() => alert.dispatchEvent(new CustomEvent('d2l-alert-button-press', { bubbles: true, composed: true })));
+			await oneEvent(el, 'd2l-alert-toast-button-press');
+		});
+
+	});
+
 	describe('close', () => {
 
 		it('should close when close button is clicked', async() => {


### PR DESCRIPTION
Added the `d2l-alert-toast-button-press` event to the `<d2l-alert-toast>` component. The component will listen for the `d2l-alert-button-press` event, stop it from propagating and then dispatch it's own event.

The only existing usage of a button press event in a `d2l-alert-toast` is listening for the `d2l-alert-button-pressed` event which I did not stop from propagating so this change should not break any existing uses of the component. In a later PR, I plan to remove that event from the `<d2l-alert>` component after existing uses have been changed.