### PR TITLE
Fix the grid focus logic.

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -208,17 +208,13 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 		if (!cell) return;
 
 		const firstFocusable = getFirstFocusableDescendant(cell);
-		if (!firstFocusable) {
-			const listItem = findComposedAncestor(this, node => node.role === 'rowgroup');
-			if (listItem) {
-				const nextFocusable = previous ? getPreviousFocusable(listItem) : getNextFocusable(listItem);
-				if (nextFocusable) nextFocusable.focus();
-			}
-			return;
-		}
+		if (!firstFocusable) return;
 
-		if (itemNum === 1 || !this._focusNextWithinCell(firstFocusable, itemNum)) {
+		if (itemNum === 1) {
 			firstFocusable.focus();
+			return firstFocusable;
+		} else {
+			return this._focusNextWithinCell(firstFocusable, itemNum);
 		}
 	}
 
@@ -290,7 +286,16 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 		if (!listItem) return;
 		const listItemRow = listItem.shadowRoot.querySelector('[role="gridrow"]');
-		listItemRow._focusCellItem(previous, this._cellNum, this._cellFocusedItem);
+		const focusedCellItem = listItemRow._focusCellItem(previous, this._cellNum, this._cellFocusedItem);
+
+		if (!focusedCellItem) {
+			// could not focus on same cell in adjacent list-item so try general focus on item
+			if (!listItem._tryFocus()) {
+				// ultimate fallback to generic method for getting next/previous focusable
+				const nextFocusable = previous ? getPreviousFocusable(listItem) : getNextFocusable(listItem);
+				if (nextFocusable) nextFocusable.focus();
+			}
+		}
 
 	}
 

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -398,8 +398,7 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 	}
 
 	focus() {
-		const node = getFirstFocusableDescendant(this);
-		if (node) node.focus();
+		this._tryFocus();
 	}
 
 	async highlight() {
@@ -621,6 +620,13 @@ export const ListItemMixin = superclass => class extends LocalizeCoreElement(Lis
 				<li><span class="d2l-list-item-tooltip-key">${this.localize('components.list-item-tooltip.page-up-down-key')}</span> - ${this.localize('components.list-item-tooltip.page-up-down-desc')}</li>
 			</ul>
 		`;
+	}
+
+	_tryFocus() {
+		const node = getFirstFocusableDescendant(this);
+		if (!node) return false;
+		node.focus();
+		return true;
 	}
 
 };


### PR DESCRIPTION
This PR fixes an issue with the `grid` focus logic - specifically when focus is being moved backwards in the list (pressing `[up arrow]` key) and the previous adjacent list-item does not have a focusable element in the corresponding cell. 

The logic would simply use `getPreviousFocusable` with respect to the adjacent list-item as a fallback, which would cause focus to be applied to **any** previous focusable **before** the adjacent list-item, effectively skipping the item. What we really want is for focus to be applied to another cell in that list-item, preferably the primary action, and if that still doesn't work, then do the ultimate generic fallback.