### PR TITLE
Spike - table-wrapper with selection components/bulk actions

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -2,6 +2,7 @@ import '../colors/colors.js';
 import '../scroll-wrapper/scroll-wrapper.js';
 import { css, html, LitElement } from 'lit';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
+import { SelectionMixin } from '../selection/selection-mixin.js';
 
 export const tableStyles = css`
 	.d2l-table {
@@ -167,7 +168,7 @@ export const tableStyles = css`
  * Wraps a native <table> element, providing styling and scroll buttons for overflow.
  * @slot - Content to wrap
  */
-export class TableWrapper extends RtlMixin(LitElement) {
+export class TableWrapper extends RtlMixin(SelectionMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -245,11 +246,13 @@ export class TableWrapper extends RtlMixin(LitElement) {
 	}
 
 	render() {
-		const slot = html`<slot @slotchange="${this._handleSlotChange}"></slot>`;
+		const inner = html`
+			<slot @slotchange="${this._handleSlotChange}"></slot>
+		`;
 		if (this.stickyHeaders) {
-			return slot;
+			return inner;
 		} else {
-			return html`<d2l-scroll-wrapper>${slot}</d2l-scroll-wrapper>`;
+			return html`<d2l-scroll-wrapper>${inner}</d2l-scroll-wrapper>`;
 		}
 	}
 


### PR DESCRIPTION
This spike shows what would generally be required to support using the selection components similar to `d2l-list`. It includes the following, which automatically handles wire-up for the standard action behaviours.

* `d2l-selection-input`
* `d2l-selection-select-all`
* `d2l-selection-summary`
* `d2l-selection-action`
* `d2l-selection-action-dropdown`
* `d2l-selection-action-menu-item`
* `SelectionMixin` - required to be extended by `d2l-table-wrapper`

What's not covered here is:

* layout as per Design - might require a header component like `d2l-list-header` (ex. spacing, overflow, etc)
* probably require a new slot for the actions header so we can control layout
* stickiness - likely we want the header actions to stick along with the actual table header
* `d2l-selection-select-all-pages` - likely need a new component to manage things like `d2l-list-header`
* what happens to the actions header when scroll-wrapper is in play and the table is overflowing?