### PR TITLE
Added option for img tag in empty state illustration slot

### DIFF
--- a/components/empty-state/empty-state-styles.js
+++ b/components/empty-state/empty-state-styles.js
@@ -15,8 +15,8 @@ export const emptyStateStyles = css`
 		display: none;
 	}
 
-	.action-slot::slotted(d2l-empty-state-action-button:first-child),
-	.action-slot::slotted(d2l-empty-state-action-link:first-child) {
+	.action-slot::slotted(d2l-empty-state-action-button:first-of-type),
+	.action-slot::slotted(d2l-empty-state-action-link:first-of-type) {
 		display: inline;
 	}
 
@@ -52,6 +52,7 @@ export const emptyStateIllustratedStyles = css`
 		display: none;
 	}
 
+	.illustration-slot::slotted(img:first-of-type),
 	.illustration-slot::slotted(svg:first-of-type) {
 		display: inline-block;
 	}


### PR DESCRIPTION
I added an option to use `<img>` tags in addition to `<svg>` tags in the custom illustration slot so it can be used in the lms with the `Image` control.

I also made a small change to the action slot (default slot) which will now accept the `first-of-type` of the action components instead of the `first-child`. This opens up some room for abuse by putting one of each action component but I don't really foresee that being an issue that comes up. I made this change because previously if you put the custom illustration above the action slot, it would not render the action since it is not the `first-child`. This change should make the component a little easier to use.