### PR TITLE
Removed empty state illustration slotted styles

### DIFF
--- a/components/empty-state/empty-state-styles.js
+++ b/components/empty-state/empty-state-styles.js
@@ -48,15 +48,6 @@ export const emptyStateIllustratedStyles = css`
 		text-align: center;
 	}
 
-	.illustration-slot::slotted(*) {
-		display: none;
-	}
-
-	.illustration-slot::slotted(img:first-of-type),
-	.illustration-slot::slotted(svg:first-of-type) {
-		display: inline-block;
-	}
-
 	svg {
 		height: 100%;
 		max-width: 500px;


### PR DESCRIPTION
This is a fix after my previous empty state change #2806. I removed all `::slotted` styles from the illustration slot. `::slotted` styles only work on top level elements so to make an `svg` or `img` visible they would need to be top level elements. In order to get this working in the LMS without directly editing the `Image` control, the image needs to be wrapped in a container like a `div` and so it will no longer be a top level element and would have `display: none`. 

e.g.
```
w.WriteTagBegin( "div" );
  w.WriteAttribute( "slot", "illustration" );
  w.WriteTagBeginRightChar();
  viewData.IllustrationView.Render( rc );
w.WriteTagEnd( "div" );
```

There doesn't seem to be another way to control what goes in the slot so it looks like we will just need to trust the consumer to use it correctly.