### PR TITLE
Add support for async renderer fetching in html-block component

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -121,7 +121,7 @@ let renderers;
 const getRenderers = async() => {
 	if (renderers) return renderers;
 	const rendererLoader = requestInstance(document, 'html-block-renderer-loader');
-	const tempRenderers = await rendererLoader.getRenderers();
+	const tempRenderers = rendererLoader ? await rendererLoader.getRenderers() : undefined;
 	const defaultRenderers = [ createMathRenderer(), createCodeRenderer() ];
 	renderers = (tempRenderers ? [ ...defaultRenderers, ...tempRenderers ] : defaultRenderers);
 	return renderers;

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -121,7 +121,7 @@ let renderers;
 const getRenderers = async() => {
 	if (renderers) return renderers;
 	const rendererLoader = requestInstance(document, 'html-block-renderer-loader');
-	const tempRenderers = await rendererLoader.renderers();
+	const tempRenderers = await rendererLoader.getRenderers();
 	const defaultRenderers = [ createMathRenderer(), createCodeRenderer() ];
 	renderers = (tempRenderers ? [ ...defaultRenderers, ...tempRenderers ] : defaultRenderers);
 	return renderers;

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -120,12 +120,8 @@ let renderers;
 
 const getRenderers = async() => {
 	if (renderers) return renderers;
-	let tempRenderers = requestInstance(document, 'html-block-renderers');
-	if (!tempRenderers) {
-		const tempRendererLoader = requestInstance(document, 'html-block-renderer-loader');
-		tempRenderers = await tempRendererLoader.renderers();
-	}
-
+	const rendererLoader = requestInstance(document, 'html-block-renderer-loader');
+	const tempRenderers = await rendererLoader.renderers();
 	const defaultRenderers = [ createMathRenderer(), createCodeRenderer() ];
 	renderers = (tempRenderers ? [ ...defaultRenderers, ...tempRenderers ] : defaultRenderers);
 	return renderers;

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -144,7 +144,7 @@ describe('d2l-html-block', () => {
 		expect(spans[1].innerHTML).to.equal('2');
 	});
 
-	it.only('should do async replacements', async() => {
+	it('should do async replacements', async() => {
 		const replacementComplete = oneEvent(document, 'd2l-test-replacement-complete');
 		const htmlBlock = await fixture(asyncReplacementFixture);
 		await replacementComplete;

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -41,11 +41,8 @@ class TestAsyncRenderer {
 			elemToReplace.innerText = `${someId}: ${asyncValue}`;
 		});
 
-		// just for test so it can wait
-		setTimeout(() => {
-			document.dispatchEvent(new CustomEvent('d2l-test-replacement-complete'));
-		}, 0);
-
+		// Don't need a setTimeout because this renderer is already async.
+		document.dispatchEvent(new CustomEvent('d2l-test-replacement-complete'));
 		return elem;
 	}
 }
@@ -88,12 +85,16 @@ class TestSecondaryRenderer {
 	}
 }
 
-provideInstance(document, 'html-block-renderers', [
-	new TestRenderer(),
-	new TestAsyncRenderer(),
-	new TestNoInlineRenderer(),
-	new TestSecondaryRenderer()
-]);
+provideInstance(document, 'html-block-renderer-loader', {
+	getRenderers() {
+		return [
+			new TestRenderer(),
+			new TestAsyncRenderer(),
+			new TestNoInlineRenderer(),
+			new TestSecondaryRenderer()
+		];
+	}
+});
 
 describe('d2l-html-block', () => {
 
@@ -143,7 +144,7 @@ describe('d2l-html-block', () => {
 		expect(spans[1].innerHTML).to.equal('2');
 	});
 
-	it('should do async replacements', async() => {
+	it.only('should do async replacements', async() => {
 		const replacementComplete = oneEvent(document, 'd2l-test-replacement-complete');
 		const htmlBlock = await fixture(asyncReplacementFixture);
 		await replacementComplete;

--- a/components/html-block/test/html-block.visual-diff.js
+++ b/components/html-block/test/html-block.visual-diff.js
@@ -42,7 +42,9 @@ describe('d2l-html-block', () => {
 		it(info.name, async function() {
 			const rect = await visualDiff.getRect(page, info.selector);
 			if (info.action) await info.action(info.selector);
-			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			setTimeout(async() => {
+				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+			}), 0;
 		});
 
 	});

--- a/components/html-block/test/html-block.visual-diff.js
+++ b/components/html-block/test/html-block.visual-diff.js
@@ -42,7 +42,7 @@ describe('d2l-html-block', () => {
 		it(info.name, async function() {
 			const rect = await visualDiff.getRect(page, info.selector);
 			if (info.action) await info.action(info.selector);
-			await new Promise(resolve => setTimeout(resolve, 0));
+			await new Promise(resolve => setTimeout(resolve, 100));
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 

--- a/components/html-block/test/html-block.visual-diff.js
+++ b/components/html-block/test/html-block.visual-diff.js
@@ -42,7 +42,7 @@ describe('d2l-html-block', () => {
 		it(info.name, async function() {
 			const rect = await visualDiff.getRect(page, info.selector);
 			if (info.action) await info.action(info.selector);
-			await new Promise(resolve => setTimeout(resolve, 100));
+			await new Promise(resolve => setTimeout(resolve, 0));
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 

--- a/components/html-block/test/html-block.visual-diff.js
+++ b/components/html-block/test/html-block.visual-diff.js
@@ -42,9 +42,8 @@ describe('d2l-html-block', () => {
 		it(info.name, async function() {
 			const rect = await visualDiff.getRect(page, info.selector);
 			if (info.action) await info.action(info.selector);
-			setTimeout(async() => {
-				await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
-			}), 0;
+			await new Promise(resolve => setTimeout(resolve, 0));
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 
 	});

--- a/controllers/attributeObserver/htmlAttributeObserverController.js
+++ b/controllers/attributeObserver/htmlAttributeObserverController.js
@@ -14,9 +14,9 @@ export class HtmlAttributeObserverController {
 		);
 
 		this._host = host;
-		host.addController(this);
 		this._attributes = attributes;
 		this.values = new Map();
+		host.addController(this);
 	}
 
 	hostConnected() {

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -33,7 +33,7 @@ const mathjaxFontMappings = new Map([
 let mathJaxLoaded;
 let renderingPromise = Promise.resolve();
 
-export class HtmlBlockMathRenderer {
+class HtmlBlockMathRenderer {
 
 	get contextAttributes() {
 		return [mathjaxContextAttribute];
@@ -75,6 +75,10 @@ export class HtmlBlockMathRenderer {
 		await renderingPromise;
 	}
 
+}
+
+export function createHtmlBlockRenderer() {
+	return new HtmlBlockMathRenderer();
 }
 
 export function loadMathJax(mathJaxConfig) {

--- a/helpers/prism.js
+++ b/helpers/prism.js
@@ -452,7 +452,7 @@ export async function formatCodeElement(elem) {
 	Prism.highlightElement(code);
 }
 
-export class HtmlBlockCodeRenderer {
+class HtmlBlockCodeRenderer {
 
 	get canRenderInline() {
 		return true;
@@ -470,4 +470,8 @@ export class HtmlBlockCodeRenderer {
 		return elem;
 	}
 
+}
+
+export function createHtmlBlockRenderer() {
+	return new HtmlBlockCodeRenderer();
 }


### PR DESCRIPTION
So there's a bit of an issue with how the non-default renderers load in the html-block component. Specifically, they're _very_ order-dependent and we currently don't have a fantastic way to guarantee that ordering.

This PR is the first of a few meant to bridge that gap - it refactors the html-block component to be resilient to asynchronously loaded renders, while leaving the existing logic in place to cover our bases until existing renderers are switched over.