### PR TITLE
Make sure context attribute observer is loaded before rendering

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -195,7 +195,7 @@ class HtmlBlock extends RtlMixin(LitElement) {
 		this._hasSlottedContent = false;
 
 		this._contextObserverControllerResolve = undefined;
-		this._contextObserverControllerLoaded = new Promise(resolve => {
+		this._contextObserverControllerInitialized = new Promise(resolve => {
 			this._contextObserverControllerResolve = resolve;
 		});
 
@@ -262,7 +262,7 @@ class HtmlBlock extends RtlMixin(LitElement) {
 	}
 
 	async _contextChanged() {
-		await this._contextObserverControllerLoaded;
+		await this._contextObserverControllerInitialized;
 		if (!this._contextKeys) {
 			this._updateContextKeys();
 			return true;
@@ -296,7 +296,7 @@ class HtmlBlock extends RtlMixin(LitElement) {
 	}
 
 	async _processRenderers(elem) {
-		await this._contextObserverControllerLoaded;
+		await this._contextObserverControllerInitialized;
 		const renderers = await getRenderers();
 		for (const renderer of renderers) {
 			if (renderer.contextAttributes) {

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -194,11 +194,17 @@ class HtmlBlock extends RtlMixin(LitElement) {
 		this.noDeferredRendering = false;
 		this._hasSlottedContent = false;
 
+		this._contextObserverControllerResolve = undefined;
+		this._contextObserverControllerLoaded = new Promise(resolve => {
+			this._contextObserverControllerResolve = resolve;
+		});
+
 		getRenderers().then(renderers => renderers.reduce((attrs, currentRenderer) => {
 			if (currentRenderer.contextAttributes) currentRenderer.contextAttributes.forEach(attr => attrs.push(attr));
 			return attrs;
 		}, [])).then(rendererContextAttributes => {
 			this._contextObserverController = new HtmlAttributeObserverController(this, ...rendererContextAttributes);
+			this._contextObserverControllerResolve();
 		});
 	}
 
@@ -245,7 +251,7 @@ class HtmlBlock extends RtlMixin(LitElement) {
 		if (changedProperties.has('html') && this.html !== undefined && this.html !== null && !this._hasSlottedContent) {
 			await this._updateRenderContainer();
 		}
-		if (this._contextChanged()) {
+		if (await this._contextChanged()) {
 			if (this._hasSlottedContent) this._render();
 			else if (this.html !== undefined && this.html !== null) {
 				await this._updateRenderContainer();
@@ -255,8 +261,8 @@ class HtmlBlock extends RtlMixin(LitElement) {
 		}
 	}
 
-	_contextChanged() {
-		if (!this._contextObserverController) return false;
+	async _contextChanged() {
+		await this._contextObserverControllerLoaded;
 		if (!this._contextKeys) {
 			this._updateContextKeys();
 			return true;
@@ -290,9 +296,10 @@ class HtmlBlock extends RtlMixin(LitElement) {
 	}
 
 	async _processRenderers(elem) {
+		await this._contextObserverControllerLoaded;
 		const renderers = await getRenderers();
 		for (const renderer of renderers) {
-			if (this._contextObserverController && renderer.contextAttributes) {
+			if (renderer.contextAttributes) {
 				const contextValues = new Map();
 				renderer.contextAttributes.forEach(attr => contextValues.set(attr, this._contextObserverController.values.get(attr)));
 				await renderer.render(elem, {


### PR DESCRIPTION
We always expect this observer to load eventually, so it seems reasonable for us to wait for it. If we don't, we can get into an unfortunate race condition because the observer doesn't trigger a host update when it first registers.