### PR TITLE
fix: Description List - use more specific css selectors

### DIFF
--- a/components/description-list/description-list-wrapper.js
+++ b/components/description-list/description-list-wrapper.js
@@ -4,26 +4,26 @@ import { classMap } from 'lit/directives/class-map.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 
 export const descriptionListStyles = [
-	_generateLabelStyles('dt'),
-	_generateBodyCompactStyles('dd'),
+	_generateLabelStyles('d2l-dl-wrapper > dl > dt'),
+	_generateBodyCompactStyles('d2l-dl-wrapper > dl > dd'),
 	css`
-		:host {
+		d2l-dl-wrapper {
 			--d2l-dl-wrapper-dt-min-width: min-content;
 			--d2l-dl-wrapper-dt-max-width: 10rem;
 			--d2l-dl-wrapper-dd-min-width: 50%;
 		}
-		dl {
+		d2l-dl-wrapper > dl {
 			align-items: baseline;
 			display: var(--d2l-dl-wrapper-dl-display, grid);
 			gap: 0.3rem 1.5rem;
 			grid-auto-flow: row;
 			grid-template-columns: minmax(var(--d2l-dl-wrapper-dt-min-width), auto) minmax(var(--d2l-dl-wrapper-dd-min-width), 1fr);
 		}
-		dt {
+		d2l-dl-wrapper > dl > dt {
 			margin: var(--d2l-dl-wrapper-dt-margin, 0);
 			max-width: var(--d2l-dl-wrapper-dt-max-width);
 		}
-		dd {
+		d2l-dl-wrapper > dl > dd {
 			margin: var(--d2l-dl-wrapper-dd-margin, 0);
 		}
 	`,

--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -2,7 +2,7 @@ import '../colors/colors.js';
 import { css, unsafeCSS } from 'lit';
 
 export const _isValidCssSelector = (selector) => {
-	const re = /[#.]?([a-zA-Z0-9-_]+)(\[[a-zA-Z0-9-_]+\])?([a-zA-Z0-9-_]+)?/g;
+	const re = /([a-zA-Z0-9-_ >.#]+)(\[[a-zA-Z0-9-_]+\])?([a-zA-Z0-9-_ >.#]+)?/g;
 	const match = selector.match(re);
 
 	return !!match && match.length === 1 && match[0].length === selector.length;
@@ -52,7 +52,7 @@ export const bodyStandardStyles = css`
  * A private helper method that should not be used by general consumers
  */
 export const _generateBodyCompactStyles = (selector) => {
-	// if (!_isValidCssSelector(selector)) return;
+	if (!_isValidCssSelector(selector)) return;
 
 	selector = unsafeCSS(selector);
 	return css`
@@ -233,7 +233,7 @@ export const heading4Styles = css`
  * A private helper method that should not be used by general consumers
  */
 export const _generateLabelStyles = (selector) => {
-	// if (!_isValidCssSelector(selector)) return;
+	if (!_isValidCssSelector(selector)) return;
 
 	selector = unsafeCSS(selector);
 	return css`

--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -52,7 +52,7 @@ export const bodyStandardStyles = css`
  * A private helper method that should not be used by general consumers
  */
 export const _generateBodyCompactStyles = (selector) => {
-	if (!_isValidCssSelector(selector)) return;
+	// if (!_isValidCssSelector(selector)) return;
 
 	selector = unsafeCSS(selector);
 	return css`
@@ -233,7 +233,7 @@ export const heading4Styles = css`
  * A private helper method that should not be used by general consumers
  */
 export const _generateLabelStyles = (selector) => {
-	if (!_isValidCssSelector(selector)) return;
+	// if (!_isValidCssSelector(selector)) return;
 
 	selector = unsafeCSS(selector);
 	return css`

--- a/components/typography/test/styles.test.js
+++ b/components/typography/test/styles.test.js
@@ -1,7 +1,7 @@
 import { _isValidCssSelector } from '../styles.js';
 import { expect } from '@open-wc/testing';
 
-describe.only('_isValidCssSelector', () => {
+describe('_isValidCssSelector', () => {
 
 	it('should support simple tag names', () => {
 		expect(_isValidCssSelector('a')).to.be.true;
@@ -25,12 +25,14 @@ describe.only('_isValidCssSelector', () => {
 		expect(_isValidCssSelector('p[loading]')).to.be.true;
 	});
 
-	it('should not support complex selectors', () => {
-		expect(_isValidCssSelector('dl dd')).to.be.false;
-		expect(_isValidCssSelector('dt.class')).to.be.false;
-		expect(_isValidCssSelector('dt#id')).to.be.false;
-		expect(_isValidCssSelector('dl .class')).to.be.false;
-		expect(_isValidCssSelector('dl #id')).to.be.false;
+	it('should support complex selectors', () => {
+		expect(_isValidCssSelector('dl dd')).to.be.true;
+		expect(_isValidCssSelector('dt.class')).to.be.true;
+		expect(_isValidCssSelector('dt#id')).to.be.true;
+		expect(_isValidCssSelector('dl .class')).to.be.true;
+		expect(_isValidCssSelector('dl #id')).to.be.true;
+		expect(_isValidCssSelector('dl > dt')).to.be.true;
+		expect(_isValidCssSelector('dl > dt > dd')).to.be.true;
 	});
 
 	it('should not support invalid selectors', () => {

--- a/components/typography/test/styles.test.js
+++ b/components/typography/test/styles.test.js
@@ -35,6 +35,13 @@ describe('_isValidCssSelector', () => {
 		expect(_isValidCssSelector('dl > dt > dd')).to.be.true;
 	});
 
+	it('should not support valid :host selectors', () => {
+		expect(_isValidCssSelector(':host')).to.be.false;
+		expect(_isValidCssSelector(':host p')).to.be.false;
+		expect(_isValidCssSelector(':host([hidden])')).to.be.false;
+		expect(_isValidCssSelector(':host([dir="rtl"])')).to.be.false;
+	});
+
 	it('should not support invalid selectors', () => {
 		expect(_isValidCssSelector('a[b[c]]')).to.be.false;
 		expect(_isValidCssSelector('abc$')).to.be.false;


### PR DESCRIPTION
## Description

Since `descriptionListStyles` are being applied as a global stylesheet, the CSS selectors should be more specific.

In order to support complex CSS selectors in our style generation functions, the regex for `_isValidCssSelector` had to be updated