### PR TITLE
fix: Ignore fr-on language file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ components/*/test/screenshots/current/
 components/*/test/screenshots/golden/
 helpers/test/screenshots/current/
 helpers/test/screenshots/golden/
+lang/fr-on.js
 mixins/*/test/screenshots/current/
 mixins/*/test/screenshots/golden/
 templates/*/test/screenshots/current/


### PR DESCRIPTION
This was @svanherk 's suggestion:
https://github.com/BrightspaceUI/core/pull/2819#discussion_r965007587

The idea is that this will prevent `fr-on.js` from being included in future translation updates.

Rally: https://rally1.rallydev.com/#/?detail=/userstory/646017396039&fdp=true