### PR TITLE
Don't set Prism to manual mode unless we're loading it ourselves

### DIFF
--- a/helpers/prism.js
+++ b/helpers/prism.js
@@ -1,8 +1,5 @@
 import { css, unsafeCSS } from 'lit';
 
-window.Prism = window.Prism || {};
-Prism.manual = true;
-
 const prismLocation = 'https://s.brightspace.com/lib/prismjs/1.28.0';
 //const prismLocation = '/node_modules/prismjs'; // for local debugging
 
@@ -406,6 +403,12 @@ let prismLoaded;
 
 const loadPrism = () => {
 	if (prismLoaded) return prismLoaded;
+
+	// Set Prism to manual mode before loading to make sure
+	// we don't automatically highlight before we finish
+	// configuring it.
+	window.Prism = window.Prism || {};
+	Prism.manual = true;
 
 	prismLoaded = Promise.all([
 		new Promise(resolve => {


### PR DESCRIPTION
Because we always load the Prism loader, we always set Prism to manual mode whether or not we're actually loading Prism. This causes problems in HTML files where Prism is already loaded and our code samples aren't being used.