### PR TITLE
US143322 - Fix flaky list tests in Firefox

### DIFF
--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -49,6 +49,7 @@ describe('d2l-list', () => {
 			await elem.updateComplete;
 			await elem.querySelector('[key="L1-1"]').updateComplete;
 			await elem.querySelector('[key="L1-2"]').updateComplete;
+			await new Promise(resolve => requestAnimationFrame(resolve));  // US143322: Needed by Firefox
 		});
 
 		it('dispatches d2l-list-selection-changes event when selectable item is clicked', async() => {
@@ -97,6 +98,7 @@ describe('d2l-list', () => {
 			await elem.querySelector('[slot="nested"]').updateComplete;
 			await elem.querySelector('[key="L2-1"]').updateComplete;
 			await elem.querySelector('[key="L2-2"]').updateComplete;
+			await new Promise(resolve => requestAnimationFrame(resolve)); // US143322: Needed by Firefox
 		});
 
 		it('dispatches d2l-list-selection-changes event when selectable leaf item is clicked', async() => {


### PR DESCRIPTION
I was not able to reproduce the failure locally, but I was able to get it to fail in Firefox on a Sauce Labs machine. I was seeing that any list test that clicks an input too early could have the issue, so I applied the fix to all those tests.  The below fixed the issue on Sauce Labs, but we'll have to monitor in CI to see if its actually fixed.