### PR TITLE
DE50056: disable skeleton pulse animation in Safari

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   lint:
     name: Lint
-    timeout-minutes: 2
+    timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,6 +2,7 @@
   "extends": "@brightspace-ui/stylelint-config",
 	"ignoreFiles": [
     "components/demo/code-dark-plus-styles.js",
-    "components/demo/code-tomorrow-styles.js"
+    "components/demo/code-tomorrow-styles.js",
+    "components/skeleton/skeleton-mixin.js"
   ]
 }

--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -3,6 +3,11 @@ import { css } from 'lit';
 import { dedupeMixin } from '@open-wc/dedupe-mixin';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
+// DE50056: starting in Safari 16, the pulsing animation causes FACE
+// (and possibly elsewhere) to render a blank page
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+const animation = isSafari ? css`none` : css`loadingPulse 1.8s linear infinite`;
+
 export const skeletonStyles = css`
 	@keyframes loadingPulse {
 		0% { background-color: var(--d2l-color-sylvite); }
@@ -14,7 +19,7 @@ export const skeletonStyles = css`
 		opacity: 0.999;
 	}
 	:host([skeleton]) .d2l-skeletize::before {
-		animation: loadingPulse 1.8s linear infinite;
+		animation: ${animation};
 		background-color: var(--d2l-color-sylvite);
 		border-radius: 0.2rem;
 		bottom: 0;


### PR DESCRIPTION
DE50056:
https://rally1.rallydev.com/#/15545167705d/custom/21568985922?detail=%2Fdefect%2F647111877577

For an unknown reason, starting with Safari 16 the pulsing skeleton animation causes FACE (assignments, quizzing) and possibly other pages that make use of skeletons to render a blank page.

I tried a few different alternatives, but in the end disabling the animation was the only thing that worked reliably. I'm hoping that Apple fixes this relatively quickly and we can restore things.

This will be cert-fixed to `20.22.10` and possibly hotfixed on `20.22.09`.