### PR TITLE
add getFirstDescendant function with predicate

### DIFF
--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -159,6 +159,21 @@ export function getPreviousAncestorSibling(node, predicate = () => true) {
 	return null;
 }
 
+export function getFirstDescendant(node, predicate) {
+	if (predicate === undefined) predicate = () => true;
+
+	const composedChildren = getComposedChildren(node);
+
+	for (let i = 0; i < composedChildren.length; i++) {
+		if (predicate(composedChildren[i])) return composedChildren[i];
+
+		const found = getFirstDescendant(composedChildren[i], predicate);
+		if (found) return found;
+	}
+
+	return null;
+}
+
 export function getOffsetParent(node) {
 
 	if (!window.ShadowRoot) {

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -7,6 +7,7 @@ import {
 	getBoundingAncestor,
 	getComposedChildren,
 	getComposedParent,
+	getFirstDescendant,
 	getNextAncestorSibling,
 	getOffsetParent,
 	isComposedAncestor,
@@ -722,6 +723,43 @@ describe('dom', () => {
 			`);
 			expect(getNextAncestorSibling(elem.querySelector('#target')))
 				.to.be.equal(elem.querySelector('#expected'));
+		});
+	});
+
+	describe('getFirstDescendant', () => {
+
+		const childFixture = html`
+		<div>
+			<div id="outer">
+				<div>
+					<div id="child1"></div>
+				</div>
+				<div id="child2"></div>
+			</div>
+			<div id="child3"></div>
+		</div>
+		`;
+
+		it('finds descendant with specified id', async() => {
+			const elem = await fixture(childFixture);
+			const predicate = (node) => { return node.id === 'child2'; };
+			const expected = elem.querySelector('#child2');
+			expect(getFirstDescendant(elem.querySelector('#outer'), predicate))
+				.to.equal(expected);
+		});
+
+		it('does not find descendant with specified id', async() => {
+			const elem = await fixture(childFixture);
+			const predicate = (node) => { return node.id === 'x'; };
+			expect(getFirstDescendant(elem.querySelector('#outer'), predicate))
+				.to.be.null;
+		});
+
+		it('does not find descendant when node has no children', async() => {
+			const elem = await fixture(childFixture);
+			const predicate = (node) => { return node.id === 'child2'; };
+			expect(getFirstDescendant(elem.querySelector('#child3'), predicate))
+				.to.be.null;
 		});
 	});
 


### PR DESCRIPTION
A previous bug fix broke accessibility of the html editor in FACE pages. This addition allows us to find which child node has the invalid attribute (i.e. our predicate) so that we can handle the error, without changing the editor's tabindex.

https://rally1.rallydev.com/#/?detail=/defect/650517971645&fdp=true
Goes with https://github.com/BrightspaceHypermediaComponents/activities/pull/2978