### PR TITLE
fix: Use display block on object-property-list

### DIFF
--- a/components/object-property-list/object-property-list.js
+++ b/components/object-property-list/object-property-list.js
@@ -8,14 +8,11 @@ import { bodySmallStyles } from '../typography/styles.js';
 class ObjectPropertyList extends LitElement {
 	static get styles() {
 		return [bodySmallStyles, css`
-			:host {
-				display: contents;
+			:host, slot {
+				display: block;
 			}
 			:host([hidden]) {
 				display: none;
-			}
-			slot {
-				display: block;
 			}
 			::slotted(:last-child) {
 				--d2l-object-property-list-item-separator-display: none;


### PR DESCRIPTION
This PR switches the object-property-list to have a default `display: block` instead of its previous `display: contents`.

Relevant Slack discussion: https://d2l.slack.com/archives/G03Q166G2/p1663788781091659
