### PR TITLE
fix: Add aria-hidden to object-property-list icons

### DIFF
--- a/components/object-property-list/object-property-list-item.js
+++ b/components/object-property-list/object-property-list-item.js
@@ -56,7 +56,7 @@ export class ObjectPropertyListItem extends RtlMixin(LitElement) {
 	}
 
 	_renderIcon() {
-		return this.icon ? html`<d2l-icon icon="${this.icon}" class="item-icon"></d2l-icon>` : nothing;
+		return this.icon ? html`<d2l-icon icon="${this.icon}" class="item-icon" aria-hidden="true"></d2l-icon>` : nothing;
 	}
 
 	_renderSeparator() {


### PR DESCRIPTION
Small fix to add aria-hidden to icons.

Relevant Slack thread: https://d2l.slack.com/archives/C03FB9DKVLL/p1661876160090209?thread_ts=1661875106.547899&cid=C03FB9DKVLL
