### PR TITLE
DE50150: Fix d2l-pager-load-more for Firefox+NVDA.

### DIFF
--- a/components/paging/pager-load-more.js
+++ b/components/paging/pager-load-more.js
@@ -98,9 +98,12 @@ class LoadMore extends FocusMixin(FocusVisiblePolyfillMixin(LocalizeCoreElement(
 
 	render() {
 		if (!this.hasMore) return;
-		return html`<button ?disabled="${this._loading}" class="d2l-label-text" @click="${this._handleClick}" type="button">
+		return html`
 			${this._loading ? html`
 				<span class="d2l-offscreen" role="alert">${this.localize('components.pager-load-more.status-loading')}</span>
+			` : nothing}
+			<button class="d2l-label-text" @click="${this._handleClick}" type="button">
+			${this._loading ? html`
 				<d2l-loading-spinner size="24"></d2l-loading-spinner>
 			` : html`
 				<span class="action">${this.localize('components.pager-load-more.action', { count: formatNumber(this.pageSize) })}</span>
@@ -115,6 +118,7 @@ class LoadMore extends FocusMixin(FocusVisiblePolyfillMixin(LocalizeCoreElement(
 	}
 
 	async _handleClick() {
+		if (this._loading) return;
 		const pageable = findComposedAncestor(this, node => node._pageable);
 		if (!pageable) return;
 		const lastItemIndex = pageable._getLastItemIndex();


### PR DESCRIPTION
With Firefox+NVDA, the load-more pager would announce the following when loading more:

> Loading More Items. Unavailable. Loading More Items.

Two issues here:

1. It announces "Unavailable" because we are disabling the button while the user is focused on it. This is potentially confusing for Firefox+NVDA users.
2. It announces "Loading More Items" twice - once for the alert, and once because the alert is contained within the button which is focused

This PR addresses these issues by reverting back to the original solution which doesn't disable the button while loading (originally discussed [here](https://github.com/BrightspaceUI/core/pull/2635#discussion_r919400865)). Instead, it simply bails from the click handler to prevent loading more while already loading. Secondly, it moves the alert out of the button so that it only gets announced once. These changes fix Firefox+NVDA. Other browser combinations still announce fine.

