### PR TITLE
fix: wait for "invalid" to be updated before firing change event

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -438,6 +438,7 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 		}
 
 		if (dispatchEvent) {
+			await this.updateComplete; // wait for validity logic to re-run
 			this.dispatchEvent(new CustomEvent(
 				'change',
 				{ bubbles: true, composed: false }

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -387,6 +387,14 @@ describe('d2l-input-number', () => {
 			await aTimeout(1);
 
 			expect(fired).to.be.false;
+
+		});
+
+		it('should have correct "invalid" state when change event fires', async() => {
+			const elem = await fixture(minMaxFixture);
+			setTimeout(() => setInnerInputValue(elem, '0'));
+			await oneEvent(elem, 'change');
+			expect(elem.invalid).to.be.true;
 		});
 	});
 


### PR DESCRIPTION
There's some logic in the LMS that needs to listen for a number input's `change` event, and then perform different actions based on whether the value the user entered is valid or not. And by invalid, I mean if a min/max is set and the user enters a number outside that range.

The issue is that the input's `invalid` property gets updated in the `updated()` lifecycle callback, which was happening _after_ the event was fired. This change just waits for that to run before firing the event.