### PR TITLE
fix: wait even longer for validity to resolve

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -438,7 +438,7 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 		}
 
 		if (dispatchEvent) {
-			await this.updateComplete; // wait for validity logic to re-run
+			await this.requestValidate(true); // wait for validity logic to re-run
 			this.dispatchEvent(new CustomEvent(
 				'change',
 				{ bubbles: true, composed: false }


### PR DESCRIPTION
Follow-up to #2910.

Turns out just waiting for `this.updateComplete` doesn't quite cut it in all scenarios. If the input blurs and triggers a `change` event, it works. But if the user presses ENTER and that triggers the `change` event, then `this.invalid` hasn't been updated yet.

I can't quite get to the bottom of why these two different scenarios behave differently, but it's consistent in all browsers. I think the reason it's not enough makes sense though:

1. `change` event fires, at which point input-number parses the raw value, sets `this.value` to the new value and decides whether to fire its own `change` event. Before doing that, we need to wait for the internal `invalid` state to get updated.
2. If we just wait for `this.updateComplete`, we're waiting for our own `updated()` lifecycle. Inside there, it sets the form value, checks for range under/over flow and calls `this.setValidity()` with those values. It then calls `this.requestValidate()` but importantly can't wait for that `async` method to complete before `updateComplete` resolves.
3. Inside `requestValidate()`, it now checks the validity and sets its own `validationError` property, which in turn triggers its own `updated()` to get called, so it further awaits `updateComplete` again.
4. In there, this is finally where `this.invalid` gets set to `true` if there was a `validationError` set. This is what we want to wait for before firing our own `change` event!

I definitely don't love how all the layers are playing together, as it definitely seems like a delicate dance around Lit's lifecycle callbacks. The fact that validation can be `async` doesn't help matters either. But so far this is the best I can come up with -- open to other suggestions though!