### PR TITLE
Spike - list-header bulk-action mode

### DIFF
--- a/components/list/demo/demo-list.js
+++ b/components/list/demo/demo-list.js
@@ -117,6 +117,7 @@ class DemoList extends LitElement {
 	static get properties() {
 		return {
 			grid: { type: Boolean },
+			headerRequiresSelection: { type: Boolean, attribute: 'header-requires-selection' },
 			_lastItemLoadedIndex: { state: true }
 		};
 	}
@@ -148,7 +149,7 @@ class DemoList extends LitElement {
 		const remainingItemCount = this.items.length - loadedItems.length;
 		return html`
 			<d2l-list ?grid="${this.grid}" item-count="${this.items.length}">
-				<d2l-list-header slot="header" select-all-pages-allowed>
+				<d2l-list-header ?requires-selection="${this.headerRequiresSelection}" slot="header" select-all-pages-allowed>
 					<d2l-selection-action icon="tier1:plus-default" text="Add" @d2l-selection-action-click="${this._handleAddItem}"></d2l-selection-action>
 					<d2l-selection-action-dropdown text="Move To" requires-selection>
 						<d2l-dropdown-menu>

--- a/components/list/demo/list.html
+++ b/components/list/demo/list.html
@@ -75,7 +75,7 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-demo-list grid></d2l-demo-list>
+					<d2l-demo-list grid header-requires-selection></d2l-demo-list>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/list/list-header.js
+++ b/components/list/list-header.js
@@ -133,12 +133,6 @@ class ListHeader extends SelectionObserverMixin(RtlMixin(LocalizeCoreElement(Lit
 			:host([dir="rtl"]) .d2l-list-header-actions {
 				text-align: left;
 			}
-
-			/*
-			:host([_state="pre-showing"]), :host([_state="hiding"]) {
-				display: block;
-			}
-			*/
 		`;
 	}
 


### PR DESCRIPTION
This spike simply shows how bulk-action mode could be implemented for the list-header, where the header is only displayed when one or more items are selected. The exact requirements are uncertain for this story, and some questions are outlined in [US144294](https://rally1.rallydev.com/#/15545167705ud/custom/21568985922?detail=%2Fuserstory%2F660025810659&fdp=true).