### PR TITLE
Add support for localizing based on browser settings

### DIFF
--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -5,13 +5,13 @@ import IntlMessageFormat from 'intl-messageformat';
 
 export const LocalizeMixin = dedupeMixin(superclass => class extends superclass {
 
-	static documentLocaleSettings = getDocumentLocaleSettings();
-
 	static get properties() {
 		return {
 			__resources: { type: Object, attribute: false  }
 		};
 	}
+
+	static documentLocaleSettings = getDocumentLocaleSettings();
 
 	constructor() {
 		super();
@@ -44,7 +44,6 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 		});
 
 		this.__updatedProperties = new Map();
-
 	}
 
 	connectedCallback() {
@@ -132,7 +131,7 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 	static _generatePossibleLanguages(config) {
 
 		if (config?.useBrowserLangs) return navigator.languages.map(e => e.toLowerCase());
-		
+
 		const { language, fallbackLanguage } = this.documentLocaleSettings;
 		const langs = [ language, fallbackLanguage ]
 			.filter(e => e)
@@ -152,7 +151,7 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 		}
 		if (Object.hasOwn(this, 'getLocalizeResources') || Object.hasOwn(this, 'resources')) {
 			const possibleLanguages = this._generatePossibleLanguages(config);
-			const res = this.getLocalizeResources([...possibleLanguages], config);
+			const res = this.getLocalizeResources(possibleLanguages, config);
 			resourcesLoadedPromises.push(res);
 		}
 		return resourcesLoadedPromises;

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -130,7 +130,7 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 
 	static _generatePossibleLanguages(config) {
 
-		if (config?.useBrowserLangs) return navigator.languages.map(e => e.toLowerCase());
+		if (config?.useBrowserLangs) return navigator.languages.map(e => e.toLowerCase()).concat('en');
 
 		const { language, fallbackLanguage } = this.documentLocaleSettings;
 		const langs = [ language, fallbackLanguage ]

--- a/mixins/localize-mixin.md
+++ b/mixins/localize-mixin.md
@@ -77,13 +77,12 @@ class MyComponent extends LocalizeDynamicMixin(LitElement) {
        // Import path must be relative
       importFunc: async lang => (await import(`../lang/${lang}.js`)).default,
       // Optionally enable OSLO
-      osloCollection: 'my-project\\myComponent',
+      osloCollection: '@d2l\\my-project\\myComponent',
     };
   }
 }
 ```
-
-When using this method, depending on various user settings, it's possible that a language file that does not exist will be requested, resulting in a network error (404). In production, your build system should prevent this by transpiling the variable dynamic import into a `switch` statement.
+Occasionally, it may be desirable to localize based on the user's browser settings. To do this, add `useBrowserLangs: true` to your `localizeConfig` object. This option should only be used if *all* supported *locales* have corresponding files named with their 4-character locale code, and all supported *languages*, in addition, have 2-character files. (e.g. `en-us.js`, `en-ca.js` and `en.js`)
 
 If your build system does not support variable dynamic imports, you'll need to manually set up imports for each supported language:
 

--- a/mixins/test/localize-mixin.test.js
+++ b/mixins/test/localize-mixin.test.js
@@ -321,13 +321,13 @@ describe('LocalizeMixin', () => {
 			localizedTerm: 'Labour Day',
 			it: 'should localize text based on browser settings'
 		},
-	  {
+		{
 			browserLangs: ['fr-CA', 'fr-BE', 'fr-FR', 'fr'],
 			resolvedLang: 'fr',
 			localizedTerm: 'Fête du travail',
 			it: 'should loop until an alternative is found'
 		},
-	  {
+		{
 			browserLangs: ['fr-CA', 'fr-BE', 'fr-FR'],
 			resolvedLang: 'en',
 			localizedTerm: 'Labor Day',
@@ -335,7 +335,6 @@ describe('LocalizeMixin', () => {
 		}].forEach(test => {
 
 			it(test.it, async() => {
-
 				setBrowserLangs(test.browserLangs);
 				const elem = await fixture(browserLangsFixture);
 

--- a/mixins/test/localize-mixin.test.js
+++ b/mixins/test/localize-mixin.test.js
@@ -117,9 +117,9 @@ const Test3LocalizeDynamicMixn = superclass => class extends LocalizeDynamicMixi
 			importFunc: (lang) => {
 				return new Promise((resolve) => {
 					setTimeout(() => {
-						switch(lang) {
+						switch (lang) {
 							default:
-							resolve(this.translations[lang]);
+								resolve(this.translations[lang]);
 						}
 					}, 50);
 				});


### PR DESCRIPTION
The `awards-public-ui` repo renders a component on a public-facing page that should be localized based on the viewing-user's preferences, not the creator's account settings or the default tenant settings.

- Allows the `localize-dynamic-mixin` to get its `possibleLanguages` from the browser with `useBrowserLangs`
- Moves `documentLocaleSettings` to a static property
- Refactors `generatePossibleLanguages`, moves it to a static method, and calls it only where needed
- Replaces `hasOwnProperty` calls
- Adds `useBrowserLangs` docs

[DE50422](https://rally1.rallydev.com/#/?detail=/defect/662854795259&fdp=true): [awards-public-ui] Spanish is not getting translated properly