### PR TITLE
proof of concept of how to track heading levels

### DIFF
--- a/components/demo/demo-page.js
+++ b/components/demo/demo-page.js
@@ -1,6 +1,7 @@
 import './demo-snippet.js';
 import './code-view.js';
 import '../colors/colors.js';
+import '../heading/heading-stack.js';
 import '../typography/typography.js';
 import { css, html, LitElement } from 'lit';
 import { heading2Styles } from '../typography/styles.js';
@@ -59,7 +60,9 @@ class DemoPage extends LitElement {
 		return html`
 			<main>
 				<h1 class="d2l-heading-2">${this.pageTitle}</h1>
-				<div class="d2l-demo-page-content"><slot></slot></div>
+				<d2l-heading-stack>
+					<div class="d2l-demo-page-content"><slot></slot></div>
+				</d2l-heading-stack>
 			</main>
 		`;
 	}

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -1,4 +1,5 @@
 import '../button/button-icon.js';
+import '../heading/heading-stack.js';
 import '../loading-spinner/loading-spinner.js';
 import { AsyncContainerMixin, asyncStates } from '../../mixins/async-container/async-container-mixin.js';
 import { css, html, LitElement } from 'lit';
@@ -242,7 +243,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 						<d2l-button-icon icon="${this._icon}" text="${this.localize('components.dialog.close')}" @click="${this._abort}"></d2l-button-icon>
 					</div>
 				</div>
-				<div class="d2l-dialog-content" @pending-state="${this._handleAsyncItemState}">${content}</div>
+				<d2l-heading-stack override-level="3" class="d2l-dialog-content" @pending-state="${this._handleAsyncItemState}" style="display: block;">${content}</d2l-heading-stack>
 				<div class="${classMap(footerClasses)}">
 					<slot name="footer" @slotchange="${this._handleFooterSlotChange}"></slot>
 				</div>

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -1,4 +1,5 @@
 import '../button/button-icon.js';
+import '../heading/heading-stack.js';
 import '../loading-spinner/loading-spinner.js';
 import { AsyncContainerMixin, asyncStates } from '../../mixins/async-container/async-container-mixin.js';
 import { css, html, LitElement } from 'lit';
@@ -149,7 +150,7 @@ class Dialog extends LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElem
 						<d2l-button-icon icon="tier1:close-small" text="${this.localize('components.dialog.close')}" @click="${this._abort}"></d2l-button-icon>
 					</div>
 				</div>
-				<div class="d2l-dialog-content" @pending-state="${this._handleAsyncItemState}">${content}</div>
+				<d2l-heading-stack class="d2l-dialog-content" override-level="3" @pending-state="${this._handleAsyncItemState}" style="display: block;">${content}</d2l-heading-stack>
 				<div class="${classMap(footerClasses)}">
 					<slot name="footer" @slotchange="${this._handleFooterSlotChange}"></slot>
 				</div>

--- a/components/heading/demo/heading-stack-test.js
+++ b/components/heading/demo/heading-stack-test.js
@@ -1,0 +1,41 @@
+import { html, literal } from 'lit/static-html.js';
+import { HeadingLevelController } from '../heading-stack.js';
+import { LitElement } from 'lit';
+
+class TestHeadingStack extends LitElement {
+
+	constructor() {
+		super();
+		this._headingLevelController = new HeadingLevelController(this);
+	}
+
+	render() {
+		let headingLevel;
+		switch (this._headingLevelController.level) {
+			case 1:
+				headingLevel = literal`h1`;
+				break;
+			case 2:
+				headingLevel = literal`h2`;
+				break;
+			case 3:
+				headingLevel = literal`h3`;
+				break;
+			case 4:
+				headingLevel = literal`h4`;
+				break;
+			case 5:
+				headingLevel = literal`h5`;
+				break;
+			case 6:
+				headingLevel = literal`h6`;
+				break;
+		}
+		return html`
+			<${headingLevel}>heading</${headingLevel}>
+			<slot></slot>
+		`;
+	}
+
+}
+customElements.define('d2l-test-heading-stack', TestHeadingStack);

--- a/components/heading/demo/heading-stack-test.js
+++ b/components/heading/demo/heading-stack-test.js
@@ -1,3 +1,5 @@
+/* eslint-disable lit/no-invalid-html */
+/* eslint-disable lit/binding-positions */
 import { html, literal } from 'lit/static-html.js';
 import { HeadingLevelController } from '../heading-stack.js';
 import { LitElement } from 'lit';

--- a/components/heading/demo/heading-stack.html
+++ b/components/heading/demo/heading-stack.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+		<script type="module">
+			import '../../demo/demo-page.js';
+			import '../heading-stack.js';
+			import './heading-stack-test.js';
+		</script>
+	</head>
+	<body unresolved>
+		<d2l-demo-page page-title="d2l-heading-stack">
+
+			<h2>Test</h2>
+			<d2l-heading-stack>
+				<d2l-demo-snippet>
+					<template>
+						<d2l-test-heading-stack></d2l-test-heading-stack>
+					</template>
+				</d2l-demo-snippet>
+			</d2l-heading-stack>
+
+		</d2l-demo-page>
+	</body>
+</html>

--- a/components/heading/heading-stack.js
+++ b/components/heading/heading-stack.js
@@ -21,10 +21,21 @@ export class HeadingLevelController {
 
 class HeadingStack extends ProviderMixin(LitElement) {
 
+	static properties = {
+		/**
+		 * Override the heading level this stack returns.
+		 * @type {boolean}
+		 */
+		overrideLevel: { attribute: 'override-level', type: Number }
+	};
+
 	constructor() {
 		super();
 		const headingLevelController = new HeadingLevelController(this);
 		this.provideInstance('d2l-heading-level', () => {
+			if (this.overrideLevel !== undefined && this.overrideLevel > 0 && this.overrideLevel <= 6) {
+				return this.overrideLevel;
+			}
 			let level = headingLevelController.level;
 			if (level < 6) {
 				level++;

--- a/components/heading/heading-stack.js
+++ b/components/heading/heading-stack.js
@@ -1,0 +1,41 @@
+import { html, LitElement } from 'lit';
+import { ProviderMixin, requestInstance } from '../../mixins/provider-mixin.js';
+
+export class HeadingLevelController {
+
+	constructor(host) {
+		this._host = host;
+		host.addController(this);
+		this.level = 1;
+	}
+
+	hostConnected() {
+		let level = requestInstance(this._host, 'd2l-heading-level')();
+		if (level === undefined) {
+			level = 1;
+		}
+		this.level = level;
+	}
+
+}
+
+class HeadingStack extends ProviderMixin(LitElement) {
+
+	constructor() {
+		super();
+		const headingLevelController = new HeadingLevelController(this);
+		this.provideInstance('d2l-heading-level', () => {
+			let level = headingLevelController.level;
+			if (level < 6) {
+				level++;
+			}
+			return level;
+		});
+	}
+
+	render() {
+		return html`<slot></slot>`;
+	}
+
+}
+customElements.define('d2l-heading-stack', HeadingStack);


### PR DESCRIPTION
This is a really rough draft to demonstrate an idea to solve the problem of arbitrary components that need to render a heading, but don't know what semantic level (`h1`, `h2`, etc.) to use because they don't have the necessary context.

Similar to the MVC framework, this introduces a `<heading-stack>` component. You'd use this whenever you render a heading and have some nested views who might need to render a heading at a higher level. I've consumed this inside our `<demo-page>` component since it does this.

In addition, there's a `HeadingLevelController`. Any place that needs to render a heading but doesn't know what level to use would have one of these. I've created a test component in the demo page that does this.

The code to actually render out the heading here is pretty gnarly. It uses Lit's new [static expressions](https://lit.dev/docs/templates/expressions/#static-expressions) stuff, but because those values need to be static I had to resort to a `switch` statement, which I don't love. We could instead use [non-literal static](https://lit.dev/docs/templates/expressions/#non-literal-statics) stuff since we "trust" this value, but yeah.. kind of gross.

Another alternative would be to introduce actual `<d2l-heading>` controls that do all this for the consumer. I worry though that it would involve giving up too much control to style/position the actual heading elements?

