### PR TITLE
Remove language filtering when using browser langs

### DIFF
--- a/mixins/localize-dynamic-mixin.js
+++ b/mixins/localize-dynamic-mixin.js
@@ -6,10 +6,10 @@ const supportedLangpacks = ['ar', 'cy', 'da', 'de', 'en', 'es', 'es-es', 'fr', '
 
 export const LocalizeDynamicMixin = superclass => class extends LocalizeMixin(superclass) {
 
-	static async getLocalizeResources(langs, { importFunc, osloCollection }) {
+	static async getLocalizeResources(langs, { importFunc, osloCollection, useBrowserLangs }) {
 
 		// in dev, don't request unsupported langpacks
-		if (!importFunc.toString().includes('switch')) {
+		if (!importFunc.toString().includes('switch') && !useBrowserLangs) {
 			langs = langs.filter(lang => supportedLangpacks.includes(lang));
 		}
 

--- a/mixins/test/localize-mixin.test.js
+++ b/mixins/test/localize-mixin.test.js
@@ -117,10 +117,7 @@ const Test3LocalizeDynamicMixn = superclass => class extends LocalizeDynamicMixi
 			importFunc: (lang) => {
 				return new Promise((resolve) => {
 					setTimeout(() => {
-						switch (lang) {
-							default:
-								resolve(this.translations[lang]);
-						}
+						resolve(this.translations[lang]);
 					}, 50);
 				});
 			},


### PR DESCRIPTION
Initially thought this was fine, but 404s shouldn't happen at all with normal usage of `useBrowserLangs` in dev, and if they do it's likely something to fix, not ignore.