### PR TITLE
fix: just use a local variable for unique-id tracking

### DIFF
--- a/helpers/uniqueId.js
+++ b/helpers/uniqueId.js
@@ -1,12 +1,6 @@
-window.D2L = window.D2L || {};
-window.D2L.UniqueId = window.D2L.UniqueId || {};
+let uniqueIndex = 0;
 
 export function getUniqueId() {
-
-	if (window.D2L.UniqueId._unique_index === undefined) {
-		window.D2L.UniqueId._unique_index = 0;
-	}
-	window.D2L.UniqueId._unique_index++;
-	return `d2l-uid-${window.D2L.UniqueId._unique_index}`;
-
+	uniqueIndex++;
+	return `d2l-uid-${uniqueIndex}`;
 }


### PR DESCRIPTION
This came up in the context of how older versions of `frau-framed` used the presence/absence of a global `D2L` to determine whether they're in an iFRA or a normal Brightspace page. Our usage here was tricking it into thinking an iFRA was a Brightspace page.

`frau-framed` has since been updated to additionally look for the aptly named `D2L.IsNotAnIFramedApp`, but while investigating I had this change ready and figured it was still a preferable solution to using globals.