### PR TITLE
Re-add tooltip display fix for a11y

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -184,11 +184,13 @@ class Tooltip extends RtlMixin(LitElement) {
 				box-sizing: border-box;
 				color: white;
 				display: inline-block;
+				height: 0;
 				overflow: hidden;
 				position: absolute;
 				text-align: left;
 				visibility: hidden;
 				white-space: normal;
+				width: 0;
 				z-index: 1001; /* position on top of floating buttons */
 			}
 
@@ -201,9 +203,12 @@ class Tooltip extends RtlMixin(LitElement) {
 				text-align: right;
 			}
 
+			:host([force-show]),
 			:host([showing]) {
+				height: auto;
 				overflow: visible;
 				visibility: visible;
+				width: auto;
 			}
 
 			.d2l-tooltip-pointer {
@@ -544,7 +549,7 @@ class Tooltip extends RtlMixin(LitElement) {
 	}
 
 	async updatePosition() {
-
+		console.log(this.style.height, this.style.width);
 		if (!this._target) {
 			return;
 		}

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -183,9 +183,11 @@ class Tooltip extends RtlMixin(LitElement) {
 				--d2l-tooltip-outline-color: rgba(255, 255, 255, 0.32);
 				box-sizing: border-box;
 				color: white;
-				display: none;
+				display: inline-block;
+				overflow: hidden;
 				position: absolute;
 				text-align: left;
+				visibility: hidden;
 				white-space: normal;
 				z-index: 1001; /* position on top of floating buttons */
 			}
@@ -200,7 +202,8 @@ class Tooltip extends RtlMixin(LitElement) {
 			}
 
 			:host([showing]) {
-				display: inline-block;
+				overflow: visible;
+				visibility: visible;
 			}
 
 			.d2l-tooltip-pointer {

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -549,7 +549,6 @@ class Tooltip extends RtlMixin(LitElement) {
 	}
 
 	async updatePosition() {
-		console.log(this.style.height, this.style.width);
 		if (!this._target) {
 			return;
 		}

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -549,6 +549,7 @@ class Tooltip extends RtlMixin(LitElement) {
 	}
 
 	async updatePosition() {
+
 		if (!this._target) {
 			return;
 		}


### PR DESCRIPTION
[Rally ticket](https://rally1.rallydev.com/#/?detail=/defect/664018732801&fdp=true)

Re-adding the changes from #2927 in addition to adding `overflow: hidden`, `height: 0`, `width: 0` when the tooltip is not shown. The failing visual diff tests seemed to be caused by some text overflowing when the tooltip is hidden. JAWS works as expected after this change.

The additions of `overflow: hidden` and `width: 0`, `height: 0` were messing up `force-show` positioning so I added an exception for that attribute where it will never be hidden

This PR fixes an issue where JAWS was not reading tooltip labels of interactive elements.


