### PR TITLE
Replace Object.hasOwn with Object.prototype.hasOwnProperty

### DIFF
--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -146,10 +146,10 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 		const superCtor = Object.getPrototypeOf(this);
 		// get imported terms for each config, head up the chain to get them all
 		if ('_getAllLocalizeResources' in superCtor) {
-			const superConfig = Object.hasOwn(superCtor, 'localizeConfig') && superCtor.localizeConfig.importFunc ? superCtor.localizeConfig : config;
+			const superConfig = Object.prototype.hasOwnProperty.call(superCtor, 'localizeConfig') && superCtor.localizeConfig.importFunc ? superCtor.localizeConfig : config;
 			resourcesLoadedPromises = superCtor._getAllLocalizeResources(superConfig);
 		}
-		if (Object.hasOwn(this, 'getLocalizeResources') || Object.hasOwn(this, 'resources')) {
+		if (Object.prototype.hasOwnProperty.call(this, 'getLocalizeResources') || Object.prototype.hasOwnProperty.call(this, 'resources')) {
 			const possibleLanguages = this._generatePossibleLanguages(config);
 			const res = this.getLocalizeResources(possibleLanguages, config);
 			resourcesLoadedPromises.push(res);


### PR DESCRIPTION
Fixes older Safari errors (in SauceLabs) on `hasOwn`.