### PR TITLE
Remove card hover style when href is not set

### DIFF
--- a/components/card/card.js
+++ b/components/card/card.js
@@ -218,7 +218,6 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 			:host(:not([href])),
 			:host([subtle]:not([href])) {
 				box-shadow: none;
-				transform: none;
 			}
 			@media (prefers-reduced-motion: no-preference) {
 				:host {
@@ -230,6 +229,11 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 				:host([_active]:hover),
 				:host([subtle][_active]:hover) {
 					transform: translateY(-4px);
+				}
+
+				:host(:not([href])),
+				:host([subtle]:not([href])) {
+					transform: none;
 				}
 			}
 		`];


### PR DESCRIPTION
[DE50590](https://rally1.rallydev.com/#/?detail=/defect/666104817131&fdp=true)

This PR removes the transform hover style on cards that do not have the `href` attribute set. This was likely a regression from this [commit](https://github.com/BrightspaceUI/core/commit/d68ebc7ab249a4f544bd275af9e186e84a321bb3) which added support for reduced motion in the component.