### PR TITLE
Fix dialog initial focus behaviour for Safari.

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -408,16 +408,18 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			|| !isComposedAncestor(dialog, activeElement)
 			|| !activeElement.classList.contains('focus-visible')) {
 				// wait till the dialog is visible for Safari
-				requestAnimationFrame(() => {
-					this._focusInitial();
-				});
+				requestAnimationFrame(() => this._focusInitial());
 			}
 
-			if (!reduceMotion) await animPromise;
+			// if not animating, we need to wait a frame before dispatching due to focus rAF above
+			if (reduceMotion) await new Promise(resolve => requestAnimationFrame(resolve));
+			else await animPromise;
+
 			/** Dispatched when the dialog is opened */
 			this.dispatchEvent(new CustomEvent(
 				'd2l-dialog-open', { bubbles: true, composed: true }
 			));
+
 		}, 0);
 
 	}

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -407,7 +407,10 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			if (!activeElement
 			|| !isComposedAncestor(dialog, activeElement)
 			|| !activeElement.classList.contains('focus-visible')) {
-				this._focusInitial();
+				// wait till the dialog is visible for Safari
+				requestAnimationFrame(() => {
+					this._focusInitial();
+				});
 			}
 
 			if (!reduceMotion) await animPromise;

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -1,4 +1,4 @@
-import { findComposedAncestor, getComposedChildren, getComposedParent, getNextAncestorSibling, getPreviousAncestorSibling } from './dom.js';
+import { findComposedAncestor, getComposedChildren, getComposedParent, getNextAncestorSibling, getPreviousAncestorSibling, isVisible } from './dom.js';
 
 const focusableElements = {
 	a: true,
@@ -175,7 +175,7 @@ export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDi
 
 	if (_isFocusable && !includeHidden) {
 		// only perform visibility check if absolutely necessary
-		if (nodeName !== 'body' && node.offsetParent === null) return false;
+		if (nodeName !== 'body' && !isVisible(node)) return false;
 	}
 
 	return _isFocusable;


### PR DESCRIPTION
[DE50625](https://rally1.rallydev.com/#/15545167705ud/custom/21568985922?detail=%2Fdefect%2F667903731881&fdp=true)

Our dialog components (ex `d2l-dialog-confirm`) have been failing to place focus on workflow buttons in Safari. This boils down to some changes that are being made by the browsers to what `offsetParent` will return when inside of web component slots/shadowDOM and an ancestor is `position: fixed;`. See: [Chromium Issue 1331803: modal dialog inside shadow root results in elements having a null offsetParent](https://bugs.chromium.org/p/chromium/issues/detail?id=1331803).

This change breaks our dialog focus logic because we rely on our [isFocusable](https://github.com/BrightspaceUI/core/blob/main/helpers/focus.js#L178) helper method to identify focusable elements within the dialog, and `isFocusable` relies on a very common approach to detecting whether or not the element is hidden: check `elem.offsetParent === null`.

In the above mentioned issue, one of the browser developers (who's working on these changes) linked to [a Polyfill for the original offsetParent behaviour](https://github.com/josepharhar/offsetparent-polyfills/blob/main/offsetParent-polyfill.js). I factored the logic from the Polyfill into something that we could include in core as a stateless helper and did some experiments with it. While it does work as we'd expect, and could be used to solve our issue, it isn't really a better solution than just using our [isVisible](https://github.com/BrightspaceUI/core/blob/main/helpers/dom.js#L207) helper that already exists in core because it too recursively walks up the DOM tree calling `getComputedStyle` on all the ancestors to identify elements that are not displayed. 