### PR TITLE
Add description property to d2l-input-search.

### DIFF
--- a/components/inputs/docs/input-search.md
+++ b/components/inputs/docs/input-search.md
@@ -56,6 +56,7 @@ For text searches use `<d2l-input-search>`, which wraps the native `<input type=
 | Property | Type | Description |
 |---|---|---|
 | `label` | String, required | Accessible label for the input |
+| `description` | String | Additional information communicated in the `aria-describedby` on the input |
 | `disabled` | Boolean | Disables the input |
 | `maxlength` | Number | Imposes an upper character limit |
 | `no-clear` | Boolean | Prevents the "clear" button from appearing |
@@ -82,4 +83,5 @@ To make your usage of `d2l-input-search` accessible, use the following property 
 
 | Attribute | Description |
 |---|---|
+| `description` | Use when label on input does not provide enough context. |
 | label | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Not visible. |

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -17,6 +17,11 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 	static get properties() {
 		return {
 			/**
+			 * Additional information communicated in the aria-describedby on the input
+			 * @type {string}
+			 */
+			description: { type: String, reflect: true },
+			/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
@@ -115,6 +120,7 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 			<d2l-input-text
 				label="${ifDefined(this.label)}"
 				label-hidden
+				description="${this.description}"
 				?disabled="${this.disabled}"
 				@input="${this._handleInput}"
 				@keypress="${this._handleInputKeyPress}"

--- a/components/inputs/test/input-search.axe.js
+++ b/components/inputs/test/input-search.axe.js
@@ -30,4 +30,9 @@ describe('d2l-input-search', () => {
 		await expect(elem).to.be.accessible();
 	});
 
+	it('description', async() => {
+		const elem = await fixture(html`<d2l-input-search label="search" description="description"></d2l-input-search>`);
+		await expect(elem).to.be.accessible();
+	});
+
 });

--- a/components/inputs/test/input-text.axe.js
+++ b/components/inputs/test/input-text.axe.js
@@ -48,4 +48,9 @@ describe('d2l-input-text', () => {
 		await expect(elem).to.be.accessible();
 	});
 
+	it('description', async() => {
+		const elem = await fixture(html`<d2l-input-text label="label" description="description"></d2l-input-text>`);
+		await expect(elem).to.be.accessible();
+	});
+
 });


### PR DESCRIPTION
This just adds a new `description` property to `d2l-input-search` that gets passed down to the underlying `d2l-input-text` element.