### PR TITLE
feat: Pass provider to selection-observer children

### DIFF
--- a/components/selection/selection-observer-mixin.js
+++ b/components/selection/selection-observer-mixin.js
@@ -28,6 +28,8 @@ export const SelectionObserverMixin = superclass => class extends superclass {
 
 	connectedCallback() {
 		super.connectedCallback();
+		this.addEventListener('d2l-selection-observer-subscribe', this._handleSelectionObserverSubscribe);
+
 		// delay subscription otherwise import/upgrade order can cause selection mixin to miss event
 		requestAnimationFrame(() => {
 			if (this.selectionFor) {
@@ -49,6 +51,7 @@ export const SelectionObserverMixin = superclass => class extends superclass {
 		super.disconnectedCallback();
 		this._disconnectSelectionForObserver();
 		this._disconnectProvider();
+		this.removeEventListener('d2l-selection-observer-subscribe', this._handleSelectionObserverSubscribe);
 	}
 
 	updated(changedProperties) {
@@ -80,6 +83,15 @@ export const SelectionObserverMixin = superclass => class extends superclass {
 				childList: true,
 				subtree: true
 			});
+		}
+	}
+
+	_handleSelectionObserverSubscribe(e) {
+		if (e.target !== this && this._provider) {
+			e.stopPropagation();
+			e.detail.provider = this._provider;
+			const target = e.composedPath()[0];
+			this._provider.subscribeObserver(target);
 		}
 	}
 

--- a/components/selection/test/selection-component.js
+++ b/components/selection/test/selection-component.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit';
 import { SelectionMixin } from '../selection-mixin.js';
+import { SelectionObserverMixin } from '../selection-observer-mixin.js';
 
 class TestSelection extends SelectionMixin(LitElement) {
 	static get styles() {
@@ -15,4 +16,19 @@ class TestSelection extends SelectionMixin(LitElement) {
 		`;
 	}
 }
+
+class TestSelectionObserver extends SelectionObserverMixin(LitElement) {
+	render() {
+		return html`<slot></slot>`;
+	}
+}
+
+class TestSelectionObserverShadow extends LitElement {
+	render() {
+		return html`<d2l-test-selection-observer></d2l-test-selection-observer>`;
+	}
+}
+
 customElements.define('d2l-test-selection', TestSelection);
+customElements.define('d2l-test-selection-observer', TestSelectionObserver);
+customElements.define('d2l-test-selection-observer-shadow', TestSelectionObserverShadow);

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -296,6 +296,9 @@ describe('SelectionObserverMixin', () => {
 				<d2l-test-selection id="d2l-test-selection-3">
 					<d2l-selection-action></d2l-selection-action>
 				</d2l-test-selection>
+				<d2l-test-selection-observer selection-for="d2l-test-selection-2">
+					<d2l-test-selection-observer-shadow></d2l-test-selection-observer-shadow>
+				</d2l-test-selection-observer>
 			</div>
 		`);
 		await el.querySelector('#obs1').updateComplete;
@@ -388,17 +391,26 @@ describe('SelectionObserverMixin', () => {
 		expect(observer._provider).not.to.be.undefined;
 	});
 
+	it('should automatically subscribe any child selection-observers', async() => {
+		const collection2 = el.querySelector('#d2l-test-selection-2');
+		const observer = el.querySelector('d2l-test-selection-observer-shadow').shadowRoot.querySelector('d2l-test-selection-observer');
+		expect(observer._provider).to.equal(collection2);
+		expect(collection2._selectionObservers.size).to.equal(2);
+	});
+
 	it('should attach to a new provider when connected in a different context', async() => {
 		const collection2 = el.querySelector('#d2l-test-selection-2');
 		const collection3 = el.querySelector('#d2l-test-selection-3');
 		const observer = collection3.querySelector('d2l-selection-action');
+		expect(collection2._selectionObservers.size).to.equal(2);
+		expect(collection3._selectionObservers.size).to.equal(1);
 
 		collection2.appendChild(observer);
 		await nextFrame();
 		await nextFrame();
 		await collection2.updateComplete;
 		await collection3.updateComplete;
-		expect(collection2._selectionObservers.size).to.equal(1);
+		expect(collection2._selectionObservers.size).to.equal(3);
 		expect(collection3._selectionObservers.size).to.equal(0);
 		expect(observer._provider).to.equal(collection2);
 	});

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -291,6 +291,11 @@ describe('SelectionObserverMixin', () => {
 					<d2l-selection-input key="key2" label="label2" selected></d2l-selection-input>
 					<d2l-selection-input key="key3" label="label3"></d2l-selection-input>
 				</d2l-test-selection>
+
+				<d2l-test-selection id="d2l-test-selection-2"></d2l-test-selection>
+				<d2l-test-selection id="d2l-test-selection-3">
+					<d2l-selection-action></d2l-selection-action>
+				</d2l-test-selection>
 			</div>
 		`);
 		await el.querySelector('#obs1').updateComplete;
@@ -322,11 +327,12 @@ describe('SelectionObserverMixin', () => {
 	});
 
 	it('unregisters observers', async() => {
+		expect(collection._selectionObservers.size).to.equal(2);
 		el.removeChild(el.querySelector('d2l-selection-action'));
 		await collection.updateComplete;
 		expect(collection._selectionObservers.size).to.equal(1);
 
-		el.querySelector('d2l-selection-select-all').selectionFor = 'some-other-selection"';
+		el.querySelector('d2l-selection-select-all').selectionFor = 'some-other-selection';
 		await collection.updateComplete;
 		expect(collection._selectionObservers.size).to.equal(0);
 	});
@@ -349,7 +355,51 @@ describe('SelectionObserverMixin', () => {
 		await observer.updateComplete;
 		expect(observer._provider).to.equal(newProvider);
 		expect(observer.selectionInfo.state).to.equal(SelectionInfo.states.none);
-
 	});
 
+	it('should unsubscribe and remove provider/observer when selectionFor is cleared', async() => {
+		const observer = el.querySelector('d2l-selection-action');
+		expect(collection._selectionObservers.size).to.equal(2);
+		expect(observer._provider).to.equal(collection);
+		expect(observer._selectionForObserver).not.to.be.undefined;
+
+		observer.selectionFor = '';
+		await observer.updateComplete;
+		expect(collection._selectionObservers.size).to.equal(1);
+		expect(observer._provider).to.be.undefined;
+		expect(observer._selectionForObserver).to.be.undefined;
+	});
+
+	it('should resubscribe/observe when disconnected and reconnected', async() => {
+		const observer = el.querySelector('d2l-selection-action');
+
+		el.removeChild(observer);
+		await collection.updateComplete;
+		expect(collection._selectionObservers.size).to.equal(1);
+		expect(observer._selectionForObserver).to.be.undefined;
+		expect(observer._provider).to.be.undefined;
+
+		el.appendChild(observer);
+		await nextFrame();
+		await nextFrame();
+		await collection.updateComplete;
+		expect(collection._selectionObservers.size).to.equal(2);
+		expect(observer._selectionForObserver).not.to.be.undefined;
+		expect(observer._provider).not.to.be.undefined;
+	});
+
+	it('should attach to a new provider when connected in a different context', async() => {
+		const collection2 = el.querySelector('#d2l-test-selection-2');
+		const collection3 = el.querySelector('#d2l-test-selection-3');
+		const observer = collection3.querySelector('d2l-selection-action');
+
+		collection2.appendChild(observer);
+		await nextFrame();
+		await nextFrame();
+		await collection2.updateComplete;
+		await collection3.updateComplete;
+		expect(collection2._selectionObservers.size).to.equal(1);
+		expect(collection3._selectionObservers.size).to.equal(0);
+		expect(observer._provider).to.equal(collection2);
+	});
 });


### PR DESCRIPTION
This PR replaces #2966. It improves the `SelectionObserverMixin` to automatically subscribe any of its selection-observer children, if it receives a subscription event from them. This is to support the case where a selection-observer is using `selection-for="some-id"` and has children in its shadow DOM that need to subscribe to that ID, which would otherwise be outside of their visible scope.

The PR also improves a few existing issues identified in #2966, with added test cases to cover them (see the first commit).

There is one possible edge case where the new behaviour may affect existing usages:

- a selection-observer is **nested** inside a selection-provider (e.g. `<selection-provider id="some-id1">`)
- it subscribes to a different provider instead, using `selection-for="some-id2"`
- and it has children that don't specify any `selection-for`
- in this case, the previous behaviour would have those children subscribe to `some-id1`, whereas the new behaviour would subscribe them to `some-id2`

Maintaining that old behaviour would directly contradict the proposed new behaviour - I assume there's no cases where it would have been used that way, but please correct me if I'm wrong!

Rally: https://rally1.rallydev.com/#/?detail=/userstory/668445846425&fdp=true
