### PR TITLE
Add another fix to ensure actual duplicate messages are announced.

### DIFF
--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -43,6 +43,6 @@ export function announce(message) {
 		container.parentNode.removeChild(container);
 		container = null;
 		timeoutId = null;
-	}, 20000);
+	}, 10000);
 
 }

--- a/helpers/announce.js
+++ b/helpers/announce.js
@@ -25,9 +25,13 @@ export function announce(message) {
 	/* Need to give browser enough time to create the live region so that it will
 	treat the change as an update. Firefox sometimes ignores changes if the region
 	and update are made too quickly in succession. RequestAnimationFrame is not
-	sufficient here. */
+	sufficient here. Also, for some strange reason, sometimes VO will not announce
+	duplicate messages even if we remove the child so we also append a non-breaking space. */
 	const elem = [...container.childNodes].find((c) => c.textContent === message);
-	if (elem) elem.parentNode.removeChild(elem);
+	if (elem) {
+		elem.parentNode.removeChild(elem);
+		message = message.concat('\u00A0');
+	}
 	setTimeout(() => {
 		container.appendChild(document.createTextNode(message));
 	}, 200);
@@ -39,6 +43,6 @@ export function announce(message) {
 		container.parentNode.removeChild(container);
 		container = null;
 		timeoutId = null;
-	}, 10000);
+	}, 20000);
 
 }


### PR DESCRIPTION
Oscar previously noticed that duplicate messages would not be announced in DataList File Drag & Drop test page as per https://github.com/Brightspace/lms/pull/28986#discussion_r998579192. This PR applies the fix he suggested for the DataList case, but to our `announce` helper.

I did a bunch of testing around this and was only able to reproduce this issue using VO. I observed the expected behaviour when testing with NVDA. I tried a bunch of things to reproduce this in the core demo page, but was only able to reproduce in the DataList page - eventually I gave up and just tested it in the context of that page.