### PR TITLE
Fix the backdrop showAccessible method.

### DIFF
--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -3,9 +3,9 @@ import { css, html, LitElement } from 'lit';
 import { cssEscape, getComposedChildren, getComposedParent, isVisible } from '../../helpers/dom.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 
-export const BACKDROP_ROLE = 'd2l-backdrop-role';
-
-const BACKDROP_ARIA_HIDDEN = 'd2l-backdrop-aria-hidden';
+export const BACKDROP_ROLE = 'data-d2l-backdrop-role';
+const BACKDROP_HIDDEN = 'data-d2l-backdrop-hidden';
+const BACKDROP_ARIA_HIDDEN = 'data-d2l-backdrop-aria-hidden';
 
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
@@ -160,7 +160,7 @@ function hideAccessible(target) {
 
 			if (child.tagName === 'SCRIPT' || child.tagName === 'STYLE') continue;
 			if (path.indexOf(child) !== -1) continue;
-			if (child.hasAttribute('d2l-backdrop-hidden')) continue;
+			if (child.hasAttribute(BACKDROP_HIDDEN)) continue;
 
 			const role = child.getAttribute('role');
 			if (role) child.setAttribute(BACKDROP_ROLE, role);
@@ -172,7 +172,7 @@ function hideAccessible(target) {
 				child.setAttribute('aria-hidden', 'true');
 			}
 
-			child.setAttribute('d2l-backdrop-hidden', 'd2l-backdrop-hidden');
+			child.setAttribute(BACKDROP_HIDDEN, BACKDROP_HIDDEN);
 			hiddenElements.push(child);
 
 			hideAccessibleChildren(child);
@@ -220,7 +220,7 @@ function showAccessible(elems) {
 				elem.removeAttribute('aria-hidden');
 			}
 		}
-		elem.removeAttribute('d2l-backdrop-hidden');
+		elem.removeAttribute(BACKDROP_HIDDEN);
 	}
 }
 

--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -209,12 +209,14 @@ function showAccessible(elems) {
 		} else {
 			elem.removeAttribute('role');
 		}
-		const ariaHidden = elem.getAttribute('d2l-backdrop-aria-hidden');
-		if (ariaHidden) {
-			elem.setAttribute('aria-hidden', ariaHidden);
-			elem.removeAttribute('d2l-backdrop-aria-hidden');
-		} else {
-			elem.removeAttribute('aria-hidden');
+		if (elem.nodeName === 'FORM' || elem.nodeName === 'A') {
+			const ariaHidden = elem.getAttribute('d2l-backdrop-aria-hidden');
+			if (ariaHidden) {
+				elem.setAttribute('aria-hidden', ariaHidden);
+				elem.removeAttribute('d2l-backdrop-aria-hidden');
+			} else {
+				elem.removeAttribute('aria-hidden');
+			}
 		}
 		elem.removeAttribute('d2l-backdrop-hidden');
 	}

--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -5,6 +5,8 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 
 export const BACKDROP_ROLE = 'd2l-backdrop-role';
 
+const BACKDROP_ARIA_HIDDEN = 'd2l-backdrop-aria-hidden';
+
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 const scrollKeys = [];
@@ -166,7 +168,7 @@ function hideAccessible(target) {
 
 			if (child.nodeName === 'FORM' || child.nodeName === 'A') {
 				const ariaHidden = child.getAttribute('aria-hidden');
-				if (ariaHidden) child.setAttribute('d2l-backdrop-aria-hidden', ariaHidden);
+				if (ariaHidden) child.setAttribute(BACKDROP_ARIA_HIDDEN, ariaHidden);
 				child.setAttribute('aria-hidden', 'true');
 			}
 
@@ -210,10 +212,10 @@ function showAccessible(elems) {
 			elem.removeAttribute('role');
 		}
 		if (elem.nodeName === 'FORM' || elem.nodeName === 'A') {
-			const ariaHidden = elem.getAttribute('d2l-backdrop-aria-hidden');
+			const ariaHidden = elem.getAttribute(BACKDROP_ARIA_HIDDEN);
 			if (ariaHidden) {
 				elem.setAttribute('aria-hidden', ariaHidden);
-				elem.removeAttribute('d2l-backdrop-aria-hidden');
+				elem.removeAttribute(BACKDROP_ARIA_HIDDEN);
 			} else {
 				elem.removeAttribute('aria-hidden');
 			}

--- a/components/backdrop/test/backdrop.test.js
+++ b/components/backdrop/test/backdrop.test.js
@@ -1,5 +1,35 @@
 import '../backdrop.js';
+import { expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
+
+const backdropFixture = html`
+	<div>
+		<div>
+			<div id="target"><button>toggle backdrop</button></div>
+			<div id="targetSibling"></div>
+			<div aria-hidden="true"></div>
+			<a></a>
+			<a aria-hidden="false"></a>
+			<form></form>
+			<script></script>
+			<style></style>
+			<d2l-backdrop for-target="target" no-animate-hide></d2l-backdrop>
+		</div>
+		<div id="targetParentSibling"></div>
+	</div>
+`;
+
+const multiBackdropFixture = html`
+	<div>
+		<div id="target1">
+			<div id="target2"></div>
+			<div id="target2Sibling"></div>
+			<d2l-backdrop for-target="target2" no-animate-hide></d2l-backdrop>
+		</div>
+		<div id="target1Sibling"></div>
+		<d2l-backdrop for-target="target1" no-animate-hide></d2l-backdrop>
+	</div>
+`;
 
 describe('d2l-backdrop', () => {
 
@@ -7,6 +37,101 @@ describe('d2l-backdrop', () => {
 
 		it('should construct', () => {
 			runConstructor('d2l-backdrop');
+		});
+
+	});
+
+	describe('updates for accessibility', () => {
+
+		it('should hide accessible elements', async() => {
+			const elem = await fixture(backdropFixture);
+			const backdrop = elem.querySelector('d2l-backdrop');
+			backdrop.shown = true;
+			await backdrop.updateComplete;
+
+			expect(backdrop.getAttribute('role')).to.equal('presentation');
+			expect(elem.querySelector('#target').getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('#target').parentNode.getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('script').getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('style').getAttribute('role')).to.equal(null);
+
+			expect(elem.querySelector('#targetSibling').getAttribute('role')).to.equal('presentation');
+			expect(elem.querySelector('#targetParentSibling').getAttribute('role')).to.equal('presentation');
+
+			const link = elem.querySelector('a');
+			expect(link.getAttribute('role')).to.equal('presentation');
+			expect(link.getAttribute('aria-hidden')).to.equal('true');
+
+			const form = elem.querySelector('form');
+			expect(form.getAttribute('role')).to.equal('presentation');
+			expect(form.getAttribute('aria-hidden')).to.equal('true');
+
+			const divAriaHidden = elem.querySelector('div[aria-hidden]');
+			expect(divAriaHidden.getAttribute('role')).to.equal('presentation');
+			expect(divAriaHidden.getAttribute('aria-hidden')).to.equal('true');
+
+			const linkAriaHidden = elem.querySelector('a[aria-hidden]');
+			expect(linkAriaHidden.getAttribute('role')).to.equal('presentation');
+			expect(linkAriaHidden.getAttribute('aria-hidden')).to.equal('true');
+		});
+
+		it('should show accessible elements', async() => {
+			const elem = await fixture(backdropFixture);
+			const backdrop = elem.querySelector('d2l-backdrop');
+			backdrop.shown = true;
+			await backdrop.updateComplete;
+			backdrop.shown = false;
+			await backdrop.updateComplete;
+
+			expect(backdrop.getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('#target').getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('#target').parentNode.getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('script').getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('style').getAttribute('role')).to.equal(null);
+
+			expect(elem.querySelector('#targetSibling').getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('#targetParentSibling').getAttribute('role')).to.equal(null);
+
+			const link = elem.querySelector('a');
+			expect(link.getAttribute('role')).to.equal(null);
+			expect(link.getAttribute('aria-hidden')).to.equal(null);
+
+			const form = elem.querySelector('form');
+			expect(form.getAttribute('role')).to.equal(null);
+			expect(form.getAttribute('aria-hidden')).to.equal(null);
+
+			const divAriaHidden = elem.querySelector('div[aria-hidden]');
+			expect(divAriaHidden.getAttribute('role')).to.equal(null);
+			expect(divAriaHidden.getAttribute('aria-hidden')).to.equal('true');
+
+			const linkAriaHidden = elem.querySelector('a[aria-hidden]');
+			expect(linkAriaHidden.getAttribute('role')).to.equal(null);
+			expect(linkAriaHidden.getAttribute('aria-hidden')).to.equal('false');
+		});
+
+		it('should not show accessible elements hidden by other backdrops', async() => {
+			const elem = await fixture(multiBackdropFixture);
+
+			const backdrop1 = elem.querySelector('d2l-backdrop[for-target="target1"]');
+			backdrop1.shown = true;
+			await backdrop1.updateComplete;
+
+			const backdrop2 = elem.querySelector('d2l-backdrop[for-target="target2"]');
+			backdrop2.shown = true;
+			await backdrop2.updateComplete;
+
+			backdrop2.shown = false;
+			await backdrop2.updateComplete;
+
+			expect(backdrop2.getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('#target2').getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('#target2Sibling').getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('#target2').parentNode.getAttribute('role')).to.equal(null);
+
+			expect(backdrop1.getAttribute('role')).to.equal('presentation');
+			expect(elem.querySelector('#target1').getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('#target1Sibling').getAttribute('role')).to.equal('presentation');
+			expect(elem.querySelector('#target1').parentNode.getAttribute('role')).to.equal(null);
 		});
 
 	});


### PR DESCRIPTION
This PR fixes an issue where non-`form`/`a` elements that previously had `aria-hidden="true|false"` would not have their `aria-hidden` attributes properly restored when "showing" the accessible elements upon hiding the backdrop. 

The root of the issue is that the `showAccessible` method was assuming that any element should have their `aria-hidden` attribute removed, regardless of whether or not `d2l-backdrop-aria-hidden` was set, but this attribute would only be set for `form` and `a` elements.  

Example case:
```html
<button aria-hidden="true">...</button>
<div>
     <div id="target">...</div>
     <d2l-backdrop for-target="target"></d2l-backdrop>
</div>
```

I think it is worth looking into whether we should just be setting `role="presentation"` and `aria-hidden="true"` on all elements. I think this code was copied from elsewhere - specifically, the [LMS Shim.js](https://search.d2l.dev/xref/lms/lp/framework/web/D2L.LP.Web.UI/Desktop/Controls/Shim/Shim.js?r=d3403c8c#159). [Looks like Nick Matthews introduced that logic](https://search.d2l.dev/history/lms/lp/framework/web/D2L.LP.Web.UI/Desktop/Controls/Shim/Shim.js?n=25&start=25&r1=4&r2=3), but there doesn't appear to be any notes about those elements.