### PR TITLE
Update the d2l-input-number component to recheck validity.

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -352,27 +352,35 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
+		let checkValidity = false;
 		changedProperties.forEach((oldVal, prop) => {
 			if (prop === 'value') {
 				this.setFormValue(this.value);
-
-				let rangeUnderflowCondition = false;
-				if (typeof(this.min) === 'number') {
-					rangeUnderflowCondition = this.minExclusive ? this.value <= this.min : this.value < this.min;
-				}
-
-				let rangeOverflowCondition = false;
-				if (typeof(this.max) === 'number') {
-					rangeOverflowCondition = this.maxExclusive ? this.value >= this.max : this.value > this.max;
-				}
-
-				this.setValidity({
-					rangeUnderflow: rangeUnderflowCondition,
-					rangeOverflow: rangeOverflowCondition
-				});
-				this.requestValidate(true);
+				checkValidity = true;
+			} else if ((prop === 'min' && oldVal !== undefined)
+				|| (prop === 'max' && oldVal !== undefined)
+				|| (prop === 'minExclusive' && oldVal !== undefined)
+				|| (prop === 'maxExclusive' && oldVal !== undefined)) {
+				checkValidity = true;
 			}
 		});
+
+		if (checkValidity) {
+			let rangeUnderflowCondition = false;
+			if (typeof(this.min) === 'number') {
+				rangeUnderflowCondition = this.minExclusive ? this.value <= this.min : this.value < this.min;
+			}
+			let rangeOverflowCondition = false;
+			if (typeof(this.max) === 'number') {
+				rangeOverflowCondition = this.maxExclusive ? this.value >= this.max : this.value > this.max;
+			}
+
+			this.setValidity({
+				rangeUnderflow: rangeUnderflowCondition,
+				rangeOverflow: rangeOverflowCondition
+			});
+			this.requestValidate(true);
+		}
 	}
 
 	async validate() {

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -339,12 +339,72 @@ describe('d2l-input-number', () => {
 				fixture: maxExclusiveFixture,
 				value: 10,
 				expectedError: 'Number must be less than 10.'
+			},
+			{
+				name: 'should be invalid if number is less than updated min',
+				fixture: minFixture,
+				value: 10,
+				change: { prop: 'min', value: 15 },
+				expectedError: 'Number must be greater than or equal to 15.'
+			},
+			{
+				name: 'should be valid if number is greater than updated min',
+				fixture: minFixture,
+				value: 3,
+				change: { prop: 'min', value: 0 },
+				expectedError: ''
+			},
+			{
+				name: 'should be invalid if number is greater than updated max',
+				fixture: maxFixture,
+				value: 8,
+				change: { prop: 'max', value: 5 },
+				expectedError: 'Number must be less than or equal to 5.'
+			},
+			{
+				name: 'should be valid if number is less than updated max',
+				fixture: maxFixture,
+				value: 12,
+				change: { prop: 'max', value: 15 },
+				expectedError: ''
+			},
+			{
+				name: 'should be invalid if number is equal to min and minExclusive added',
+				fixture: minFixture,
+				value: 5,
+				change: { prop: 'minExclusive', value: true },
+				expectedError: 'Number must be greater than 5.'
+			},
+			{
+				name: 'should be valid if number is equal to min and minExclusive removed',
+				fixture: minExclusiveFixture,
+				value: 5,
+				change: { prop: 'minExclusive', value: false },
+				expectedError: ''
+			},
+			{
+				name: 'should be invalid if number is equal to max and maxExclusive added',
+				fixture: maxFixture,
+				value: 10,
+				change: { prop: 'maxExclusive', value: true },
+				expectedError: 'Number must be less than 10.'
+			},
+			{
+				name: 'should be valid if number is equal to max and maxExclusive removed',
+				fixture: maxFixture,
+				value: 10,
+				change: { prop: 'maxExclusive', value: false },
+				expectedError: ''
 			}
 		].forEach((test) => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture);
 				if (test.value !== null) elem.value = test.value;
 				await elem.updateComplete;
+				if (test.change) {
+					elem[test.change.prop] = test.change.value;
+					await elem.updateComplete;
+				}
 				const errors = await elem.validate();
 				if (test.expectedError) expect(errors).to.contain(test.expectedError);
 				else expect(errors).to.be.empty;


### PR DESCRIPTION
[DE50582](https://rally1.rallydev.com/#/?detail=/defect/666083170587&fdp=true)

This PR updates the `d2l-input-number` component to reset validity if the `min`, `minExclusive`, `max`, or `maxExclusive` properties are updated. i.e. if these properties are updated, they may change the state from invalid to valid or vice versa depending on the current value.

