### PR TITLE
Fix d2l-input-number so that invalid property reflects internal d2l-input-text validation state.

### DIFF
--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -155,7 +155,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		return this.localize('components.form-element.defaultError', { label });
 	}
 
-	/** @ignore */
+	/** @ignore Note: this may be our custom FormElementValidityState or native ValidityState depending on the source. */
 	get validity() {
 		return this._validity;
 	}

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -328,7 +328,6 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 	render() {
 		return html`
 			<d2l-input-text
-				@invalid-change="${this._handleInvalidChange}"
 				autocomplete="${ifDefined(this.autocomplete)}"
 				?noValidate="${this.noValidate}"
 				?autofocus="${this.autofocus}"
@@ -341,6 +340,7 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 				?hide-invalid-icon="${this.hideInvalidIcon}"
 				id="${this._inputId}"
 				input-width="${this.inputWidth}"
+				@invalid-change="${this._handleInvalidChange}"
 				label="${ifDefined(this.label)}"
 				?label-hidden="${this.labelHidden || this.labelledBy}"
 				.labelRequired="${false}"

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -306,6 +306,15 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 		return super.validationMessage;
 	}
 
+	/** @ignore */
+	get validity() {
+		const elem = this.shadowRoot && this.shadowRoot.querySelector('d2l-input-text');
+		if (elem && !elem.validity.valid) {
+			return elem.validity;
+		}
+		return super.validity;
+	}
+
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 		this.addEventListener('d2l-localize-resources-change', () => {
@@ -319,6 +328,7 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 	render() {
 		return html`
 			<d2l-input-text
+				@invalid-change="${this._handleInvalidChange}"
 				autocomplete="${ifDefined(this.autocomplete)}"
 				?noValidate="${this.noValidate}"
 				?autofocus="${this.autofocus}"
@@ -462,6 +472,10 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 		if (e.inputType !== 'insertText') {
 			this._hintType = HINT_TYPES.NONE;
 		}
+	}
+
+	_handleInvalidChange() {
+		this.requestValidate(true);
 	}
 
 	_handleKeyPress(e) {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -307,7 +307,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 	/** @ignore */
 	get validity() {
 		const elem = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
-		if (!elem.validity.valid) {
+		if (elem && !elem.validity.valid) {
 			return elem.validity;
 		}
 		return super.validity;

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -408,6 +408,7 @@ describe('d2l-input-number', () => {
 				const errors = await elem.validate();
 				if (test.expectedError) expect(errors).to.contain(test.expectedError);
 				else expect(errors).to.be.empty;
+				expect(elem.invalid).to.equal(!!test.expectedError);
 			});
 		});
 	});


### PR DESCRIPTION
[DE50568](https://rally1.rallydev.com/#/?detail=/defect/666002656097&fdp=true)

This PR updates the `d2l-input-number` component so that it's `invalid` property properly reflects the validation rules defined for both `d2l-input-number` as well as the underlying `d2l-input-text` element. When the validity of the underlying element changes (ex. due to `required`), we need to update the validity of `d2l-input-number`.