### PR TITLE
fix: selection-observers are not correctly subscribing their children

### DIFF
--- a/components/selection/selection-observer-mixin.js
+++ b/components/selection/selection-observer-mixin.js
@@ -87,10 +87,12 @@ export const SelectionObserverMixin = superclass => class extends superclass {
 	}
 
 	_handleSelectionObserverSubscribe(e) {
-		if (e.target !== this && this._provider) {
+		if (this._provider) {
+			const target = e.composedPath()[0];
+			if (target === this) return;
+
 			e.stopPropagation();
 			e.detail.provider = this._provider;
-			const target = e.composedPath()[0];
 			this._provider.subscribeObserver(target);
 		}
 	}

--- a/components/selection/test/selection-component.js
+++ b/components/selection/test/selection-component.js
@@ -17,13 +17,9 @@ class TestSelection extends SelectionMixin(LitElement) {
 	}
 }
 
-class TestSelectionObserver extends SelectionObserverMixin(LitElement) {
-	render() {
-		return html`<slot></slot>`;
-	}
-}
+class TestSelectionObserver extends SelectionObserverMixin(LitElement) {}
 
-class TestSelectionObserverShadow extends LitElement {
+class TestSelectionObserverShadow extends SelectionObserverMixin(LitElement) {
 	render() {
 		return html`<d2l-test-selection-observer></d2l-test-selection-observer>`;
 	}

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -298,7 +298,7 @@ describe('SelectionObserverMixin', () => {
 				</d2l-test-selection>
 				<d2l-test-selection id="d2l-test-selection-4"></d2l-test-selection>
 				<d2l-test-selection-observer-shadow selection-for="d2l-test-selection-2"></d2l-test-selection-observer-shadow>
-				</div>
+			</div>
 		`);
 		await el.querySelector('#obs1').updateComplete;
 		await el.querySelector('#obs2').updateComplete;

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -296,10 +296,9 @@ describe('SelectionObserverMixin', () => {
 				<d2l-test-selection id="d2l-test-selection-3">
 					<d2l-selection-action></d2l-selection-action>
 				</d2l-test-selection>
-				<d2l-test-selection-observer selection-for="d2l-test-selection-2">
-					<d2l-test-selection-observer-shadow></d2l-test-selection-observer-shadow>
-				</d2l-test-selection-observer>
-			</div>
+				<d2l-test-selection id="d2l-test-selection-4"></d2l-test-selection>
+				<d2l-test-selection-observer-shadow selection-for="d2l-test-selection-2"></d2l-test-selection-observer-shadow>
+				</div>
 		`);
 		await el.querySelector('#obs1').updateComplete;
 		await el.querySelector('#obs2').updateComplete;
@@ -399,19 +398,19 @@ describe('SelectionObserverMixin', () => {
 	});
 
 	it('should attach to a new provider when connected in a different context', async() => {
-		const collection2 = el.querySelector('#d2l-test-selection-2');
 		const collection3 = el.querySelector('#d2l-test-selection-3');
+		const collection4 = el.querySelector('#d2l-test-selection-4');
 		const observer = collection3.querySelector('d2l-selection-action');
-		expect(collection2._selectionObservers.size).to.equal(2);
 		expect(collection3._selectionObservers.size).to.equal(1);
+		expect(collection4._selectionObservers.size).to.equal(0);
 
-		collection2.appendChild(observer);
+		collection4.appendChild(observer);
 		await nextFrame();
 		await nextFrame();
-		await collection2.updateComplete;
+		await collection4.updateComplete;
 		await collection3.updateComplete;
-		expect(collection2._selectionObservers.size).to.equal(3);
 		expect(collection3._selectionObservers.size).to.equal(0);
-		expect(observer._provider).to.equal(collection2);
+		expect(collection4._selectionObservers.size).to.equal(1);
+		expect(observer._provider).to.equal(collection4);
 	});
 });


### PR DESCRIPTION
There was a defect in #2979, where children are still not being correctly subscribed.

I was using `e.target` instead of `e.composedPath()[0]` when determining whether to process the event (skipping the case where the target is `this`). It works in regular cases but doesn't work when the event is coming from within `this`'s shadow DOM.

I've also fixed the unit tests to catch this specific case.

Rally: https://rally1.rallydev.com/#/?detail=/userstory/668445846425&fdp=true