### PR TITLE
Fix the renderer loader in the d2l-html-block demo page.

### DIFF
--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -39,7 +39,11 @@
 			}
 
 			// demo replacement renderer for html-block
-			provideInstance(document, 'html-block-renderers', [ new DemoReplacementRenderer() ]);
+			provideInstance(document, 'html-block-renderer-loader', {
+				async getRenderers() {
+					return [ new DemoReplacementRenderer() ];
+				}
+			});
 
 		</script>
 		<script type="module">


### PR DESCRIPTION
I think we broke this when we changed to enable loading the renderers `async`. It's also broken in the [user's demo page](https://github.com/BrightspaceHypermediaComponents/users/blob/main/demo/d2l-user-profile-html-block.html) for its renderer - I will be making a separate fix for it along with some other changes.