### PR TITLE
Add helper to enable waiting for updateComplete on all elements in a sub-tree.

### DIFF
--- a/tools/dom-test-helpers.js
+++ b/tools/dom-test-helpers.js
@@ -10,3 +10,18 @@ export function keyDown(element, keycode) {
 	event.code = keycode;
 	element.dispatchEvent(event);
 }
+
+export async function getUpdateCompleteAll(node) {
+
+	if (!node || (node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.DOCUMENT_NODE && node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE)) {
+		throw new TypeError('Invalid node. Must be nodeType document, element or document fragment');
+	}
+
+	const getUpdateComplete = async elem => {
+		if (elem.updateComplete) await elem.updateComplete;
+		const childElements = getComposedChildren(elem);
+		await Promise.all(childElements.map(childElement => getUpdateComplete(childElement)));
+	};
+
+	return getUpdateComplete(node);
+}

--- a/tools/dom-test-helpers.js
+++ b/tools/dom-test-helpers.js
@@ -1,3 +1,4 @@
+import { getComposedChildren } from '../helpers/dom.js';
 
 export function keyDown(element, keycode) {
 	const event = new CustomEvent('keydown', {


### PR DESCRIPTION
This new `getUpdateCompleteAll(node)` helper function walks the composed tree and `await`s any elements that have `updateComplete`. The motivation for this is that sometimes in tests we need to wait arbitrary amount of time for all the components to update - it is not enough to just wait for the root element's `updateComplete`. This is kinda costly, so I was reluctant to add this to our component helpers.