### PR TITLE
feat: Publish to S3 for PRs and main branch

### DIFF
--- a/.github/actions/comment-on-pr/action.yml
+++ b/.github/actions/comment-on-pr/action.yml
@@ -1,0 +1,41 @@
+name: Comment on PR
+description: Adds a comment on the current PR
+
+inputs:
+  MESSAGE:
+    description: The message to display
+    required: true
+  ONLY_POST_ONCE:
+    description: Check whether the current message has already been posted before posting again
+    default: false
+    required: false
+  UNIQUE_KEY:
+    description: A unique key attached invisibly to the comment, for use with the ONLY_POST_ONCE option
+    default: gh-actions--comment-on-pr
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Find Previous Comment
+      if: ${{ inputs.ONLY_POST_ONCE != 'false' }}
+      uses: Brightspace/third-party-actions@peter-evans/find-comment
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body-includes: ${{ inputs.UNIQUE_KEY }}
+
+    - name: PR Deployment URLs
+      if: ${{ inputs.ONLY_POST_ONCE == 'false' || steps.fc.outputs.comment-id == '' }}
+      uses: Brightspace/third-party-actions@actions/github-script
+      env:
+        MESSAGE: ${{ inputs.MESSAGE }}
+        UNIQUE_KEY: ${{ inputs.UNIQUE_KEY }}
+      with:
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `<!-- ${process.env.UNIQUE_KEY} -->\n\n${process.env.MESSAGE}`
+          })

--- a/.github/actions/publish-to-s3/action.yml
+++ b/.github/actions/publish-to-s3/action.yml
@@ -1,0 +1,97 @@
+name: Publish to S3
+description: Publishes the specified directory using aws s3 sync
+
+inputs:
+  AWS_REGION:
+    description: The region of your AWS bucket
+    default: ca-central-1
+    required: false
+  AWS_ROLE:
+    description: The AWS role to assume. This role must have write permission for your bucket
+    required: true
+  BUCKET_PATH:
+    description: The full path of your bucket, including subdirectories, to which to publish
+    required: true
+  BUILD_DIRECTORY:
+    description: The directory within your repo to publish to S3 (e.g. "./build/")
+    required: true
+  CACHE:
+    description: An optional comma-separated list of all file extensions you wish to have cached for 1 year (e.g. "js,css")
+    default: ""
+    required: false
+  CACHE_DEFAULT:
+    description: An optional default caching policy to apply to all files (e.g. "--cache-control 'max-age=120'")
+    default: ""
+    required: false
+  COMPRESS:
+    description: Whether to compress eligible files (if "true", will compress all of html/css/js/json/svg/xml)
+    default: false
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Parse files
+      id: parse-files
+      env:
+        CACHE: ${{ inputs.CACHE }}
+        COMPRESS: ${{ inputs.COMPRESS }}
+      run: |
+        typesToCompress=()
+        [[ $COMPRESS != 'false' ]] && typesToCompress=("html" "css" "js" "json" "svg" "xml")
+        typesToCache=(${CACHE//,/ })
+
+        compressAndCache=""
+        compressOnly=""
+        cacheOnly=""
+        neither=""
+
+        for type in ${typesToCompress[@]}; do
+          if [[ " ${typesToCache[*]} " =~ " ${type} " ]]; then
+            compressAndCache+="--include '*.${type}' "
+          else
+            compressOnly+="--include '*.${type}' "
+          fi
+          neither+="--exclude '*.${type}' "
+        done
+
+        for type in ${typesToCache[@]}; do
+          if [[ ! " ${typesToCompress[*]} " =~ " ${type} " ]]; then
+            cacheOnly+="--include '*.${type}' "
+            neither+="--exclude '*.${type}' "
+          fi
+        done
+
+        echo "COMPRESS_AND_CACHE=$compressAndCache" >> $GITHUB_OUTPUT
+        echo "COMPRESS_ONLY=$compressOnly" >> $GITHUB_OUTPUT
+        echo "CACHE_ONLY=$cacheOnly" >> $GITHUB_OUTPUT
+        echo "DEFAULT=$neither" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Compress
+      id: compress
+      if: ${{ inputs.COMPRESS != 'false' }}
+      env:
+        BUILD_DIRECTORY: ${{ inputs.BUILD_DIRECTORY }}
+      run: |
+        echo "ENCODING=--content-encoding 'br'" >> $GITHUB_OUTPUT
+        find $BUILD_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec brotli {} \; -exec mv {}.br {} \;
+      shell: bash
+
+    - name: Deploy
+      env:
+        BUCKET_PATH: ${{ inputs.BUCKET_PATH }}
+        BUILD_DIRECTORY: ${{ inputs.BUILD_DIRECTORY }}
+        CACHE_POLICY: --cache-control 'public,max-age=31536000,immutable'
+        CACHE_DEFAULT: ${{ inputs.CACHE_DEFAULT }}
+        COMPRESS_ENCODING: ${{ steps.compress.outputs.ENCODING }}
+        FILES_CACHE_ONLY: ${{ steps.parse-files.outputs.CACHE_ONLY }}
+        FILES_COMPRESS_AND_CACHE: ${{ steps.parse-files.outputs.COMPRESS_AND_CACHE }}
+        FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.COMPRESS_ONLY }}
+        FILES_DEFAULT: ${{ steps.parse-files.outputs.DEFAULT }}
+      run: |
+        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude '*.*' $FILES_COMPRESS_AND_CACHE
+        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude '*.*' $FILES_COMPRESS_ONLY
+        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude '*.*' $FILES_CACHE_ONLY
+        aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
+      shell: bash

--- a/.github/actions/publish-to-s3/action.yml
+++ b/.github/actions/publish-to-s3/action.yml
@@ -31,6 +31,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Assume role
+      uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+        role-to-assume: ${{ inputs.AWS_ROLE }}
+        role-duration-seconds: 3600
+        aws-region: ${{ inputs.AWS_REGION }}
+
     - name: Parse files
       id: parse-files
       env:
@@ -90,9 +100,8 @@ runs:
         FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.COMPRESS_ONLY }}
         FILES_DEFAULT: ${{ steps.parse-files.outputs.DEFAULT }}
       run: |
-        aws s3 sync --delete ./build/ s3://brightspace-ui-core.d2l.dev/branches/pr-${{ github.event.number }}
-        # [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude '*.*' $FILES_COMPRESS_AND_CACHE
-        # [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude '*.*' $FILES_COMPRESS_ONLY
-        # [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude '*.*' $FILES_CACHE_ONLY
-        # aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
+        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude '*.*' $FILES_COMPRESS_AND_CACHE
+        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude '*.*' $FILES_COMPRESS_ONLY
+        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude '*.*' $FILES_CACHE_ONLY
+        aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
       shell: bash

--- a/.github/actions/publish-to-s3/action.yml
+++ b/.github/actions/publish-to-s3/action.yml
@@ -2,13 +2,6 @@ name: Publish to S3
 description: Publishes the specified directory using aws s3 sync
 
 inputs:
-  AWS_REGION:
-    description: The region of your AWS bucket
-    default: ca-central-1
-    required: false
-  AWS_ROLE:
-    description: The AWS role to assume. This role must have write permission for your bucket
-    required: true
   BUCKET_PATH:
     description: The full path of your bucket, including subdirectories, to which to publish
     required: true
@@ -31,16 +24,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Assume role
-      uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-        role-to-assume: ${{ inputs.AWS_ROLE }}
-        role-duration-seconds: 3600
-        aws-region: ${{ inputs.AWS_REGION }}
-
     - name: Parse files
       id: parse-files
       env:

--- a/.github/actions/publish-to-s3/action.yml
+++ b/.github/actions/publish-to-s3/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: ""
     required: false
   CACHE_DEFAULT:
-    description: An optional default caching policy to apply to all files (e.g. "--cache-control 'max-age=120'")
+    description: An optional default caching policy to apply to all files (e.g. "--cache-control max-age=120")
     default: ""
     required: false
   COMPRESS:
@@ -41,17 +41,17 @@ runs:
 
         for type in ${typesToCompress[@]}; do
           if [[ " ${typesToCache[*]} " =~ " ${type} " ]]; then
-            compressAndCache+="--include '*.${type}' "
+            compressAndCache+="--include *.${type} "
           else
-            compressOnly+="--include '*.${type}' "
+            compressOnly+="--include *.${type} "
           fi
-          neither+="--exclude '*.${type}' "
+          neither+="--exclude *.${type} "
         done
 
         for type in ${typesToCache[@]}; do
           if [[ ! " ${typesToCompress[*]} " =~ " ${type} " ]]; then
-            cacheOnly+="--include '*.${type}' "
-            neither+="--exclude '*.${type}' "
+            cacheOnly+="--include *.${type} "
+            neither+="--exclude *.${type} "
           fi
         done
 
@@ -67,7 +67,7 @@ runs:
       env:
         PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
       run: |
-        echo "ENCODING=--content-encoding 'br'" >> $GITHUB_OUTPUT
+        echo "ENCODING=--content-encoding br" >> $GITHUB_OUTPUT
         find $PUBLISH_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec brotli {} \; -exec mv {}.br {} \;
       shell: bash
 
@@ -75,7 +75,7 @@ runs:
       env:
         BUCKET_PATH: ${{ inputs.BUCKET_PATH }}
         PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
-        CACHE_POLICY: --cache-control 'public,max-age=31536000,immutable'
+        CACHE_POLICY: --cache-control public,max-age=31536000,immutable
         CACHE_DEFAULT: ${{ inputs.CACHE_DEFAULT }}
         COMPRESS_ENCODING: ${{ steps.compress.outputs.ENCODING }}
         FILES_CACHE_ONLY: ${{ steps.parse-files.outputs.CACHE_ONLY }}
@@ -83,8 +83,12 @@ runs:
         FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.COMPRESS_ONLY }}
         FILES_DEFAULT: ${{ steps.parse-files.outputs.DEFAULT }}
       run: |
-        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude '*.*' $FILES_COMPRESS_AND_CACHE
-        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude '*.*' $FILES_COMPRESS_ONLY
-        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude '*.*' $FILES_CACHE_ONLY
+        # Disable globbing: We want arguments like '*.js' to be treated as string literals, without needing quotes
+        # (Passing quotes in strings does not work as expected during shell expansion)
+        set -f
+
+        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude *.* $FILES_COMPRESS_AND_CACHE
+        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude *.* $FILES_COMPRESS_ONLY
+        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude *.* $FILES_CACHE_ONLY
         aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
       shell: bash

--- a/.github/actions/publish-to-s3/action.yml
+++ b/.github/actions/publish-to-s3/action.yml
@@ -5,7 +5,7 @@ inputs:
   BUCKET_PATH:
     description: The full path of your bucket, including subdirectories, to which to publish
     required: true
-  BUILD_DIRECTORY:
+  PUBLISH_DIRECTORY:
     description: The directory within your repo to publish to S3 (e.g. "./build/")
     required: true
   CACHE:
@@ -65,16 +65,16 @@ runs:
       id: compress
       if: ${{ inputs.COMPRESS != 'false' }}
       env:
-        BUILD_DIRECTORY: ${{ inputs.BUILD_DIRECTORY }}
+        PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
       run: |
         echo "ENCODING=--content-encoding 'br'" >> $GITHUB_OUTPUT
-        find $BUILD_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec brotli {} \; -exec mv {}.br {} \;
+        find $PUBLISH_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec brotli {} \; -exec mv {}.br {} \;
       shell: bash
 
     - name: Deploy
       env:
         BUCKET_PATH: ${{ inputs.BUCKET_PATH }}
-        BUILD_DIRECTORY: ${{ inputs.BUILD_DIRECTORY }}
+        PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
         CACHE_POLICY: --cache-control 'public,max-age=31536000,immutable'
         CACHE_DEFAULT: ${{ inputs.CACHE_DEFAULT }}
         COMPRESS_ENCODING: ${{ steps.compress.outputs.ENCODING }}
@@ -83,8 +83,8 @@ runs:
         FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.COMPRESS_ONLY }}
         FILES_DEFAULT: ${{ steps.parse-files.outputs.DEFAULT }}
       run: |
-        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude '*.*' $FILES_COMPRESS_AND_CACHE
-        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude '*.*' $FILES_COMPRESS_ONLY
-        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude '*.*' $FILES_CACHE_ONLY
-        aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
+        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude '*.*' $FILES_COMPRESS_AND_CACHE
+        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude '*.*' $FILES_COMPRESS_ONLY
+        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude '*.*' $FILES_CACHE_ONLY
+        aws s3 sync --delete "$PUBLISH_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
       shell: bash

--- a/.github/actions/publish-to-s3/action.yml
+++ b/.github/actions/publish-to-s3/action.yml
@@ -16,10 +16,6 @@ inputs:
     description: An optional default caching policy to apply to all files (e.g. "--cache-control max-age=120")
     default: ""
     required: false
-  COMPRESS:
-    description: Whether to compress eligible files (if "true", will compress all of html/css/js/json/svg/xml)
-    default: false
-    required: false
 
 runs:
   using: composite
@@ -28,10 +24,8 @@ runs:
       id: parse-files
       env:
         CACHE: ${{ inputs.CACHE }}
-        COMPRESS: ${{ inputs.COMPRESS }}
       run: |
-        typesToCompress=()
-        [[ $COMPRESS != 'false' ]] && typesToCompress=("html" "css" "js" "json" "svg" "xml")
+        typesToCompress=("html" "css" "js" "json" "svg" "xml")
         typesToCache=(${CACHE//,/ })
 
         compressAndCache=""
@@ -62,13 +56,9 @@ runs:
       shell: bash
 
     - name: Compress
-      id: compress
-      if: ${{ inputs.COMPRESS != 'false' }}
       env:
         PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
-      run: |
-        echo "ENCODING=--content-encoding br" >> $GITHUB_OUTPUT
-        find $PUBLISH_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec brotli {} \; -exec mv {}.br {} \;
+      run: find $PUBLISH_DIRECTORY \( -iname '*.html' -o -iname '*.css' -o -iname '*.js' -o -iname '*.json' -o -iname '*.svg' -o -iname '*.xml' \) -exec brotli {} \; -exec mv {}.br {} \;
       shell: bash
 
     - name: Deploy
@@ -77,7 +67,7 @@ runs:
         PUBLISH_DIRECTORY: ${{ inputs.PUBLISH_DIRECTORY }}
         CACHE_POLICY: --cache-control public,max-age=31536000,immutable
         CACHE_DEFAULT: ${{ inputs.CACHE_DEFAULT }}
-        COMPRESS_ENCODING: ${{ steps.compress.outputs.ENCODING }}
+        COMPRESS_ENCODING: --content-encoding br
         FILES_CACHE_ONLY: ${{ steps.parse-files.outputs.CACHE_ONLY }}
         FILES_COMPRESS_AND_CACHE: ${{ steps.parse-files.outputs.COMPRESS_AND_CACHE }}
         FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.COMPRESS_ONLY }}

--- a/.github/actions/publish-to-s3/action.yml
+++ b/.github/actions/publish-to-s3/action.yml
@@ -90,8 +90,9 @@ runs:
         FILES_COMPRESS_ONLY: ${{ steps.parse-files.outputs.COMPRESS_ONLY }}
         FILES_DEFAULT: ${{ steps.parse-files.outputs.DEFAULT }}
       run: |
-        [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude '*.*' $FILES_COMPRESS_AND_CACHE
-        [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude '*.*' $FILES_COMPRESS_ONLY
-        [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude '*.*' $FILES_CACHE_ONLY
-        aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
+        aws s3 sync --delete ./build/ s3://brightspace-ui-core.d2l.dev/branches/pr-${{ github.event.number }}
+        # [[ $FILES_COMPRESS_AND_CACHE ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_POLICY --exclude '*.*' $FILES_COMPRESS_AND_CACHE
+        # [[ $FILES_COMPRESS_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $COMPRESS_ENCODING $CACHE_DEFAULT --exclude '*.*' $FILES_COMPRESS_ONLY
+        # [[ $FILES_CACHE_ONLY ]] && aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_POLICY --exclude '*.*' $FILES_CACHE_ONLY
+        # aws s3 sync --delete "$BUILD_DIRECTORY" "$BUCKET_PATH" $CACHE_DEFAULT $FILES_DEFAULT
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           AWS_ROLE: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
           BUCKET_PATH: s3://brightspace-ui-core.d2l.dev/branches/pr-${{ github.event.number }}
-          BUILD_DIRECTORY: ./build/
+          PUBLISH_DIRECTORY: ./build/
           COMPRESS: true
 
       - name: Notify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,45 @@ jobs:
         run: npm run test:axe
       - name: Unit Tests
         run: npx web-test-runner --config web-test-runner.config.js --group default --playwright --browsers chromium firefox webkit
+  publish:
+    name: Publish static site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: Brightspace/third-party-actions@actions/checkout
+      - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+
+      - name: Build static
+        run: npm run build-static
+
+      - name: Publish
+        uses: ./.github/actions/publish-to-s3/
+        with:
+          AWS_ROLE: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
+          BUCKET_PATH: s3://brightspace-ui-core.d2l.dev/branches/pr-${{ github.event.number }}
+          BUILD_DIRECTORY: ./build/
+          COMPRESS: true
+
+      - name: Notify
+        uses: ./.github/actions/comment-on-pr/
+        with:
+          MESSAGE: |
+            Thanks for the PR! 🎉
+
+            We've deployed an automatic preview for this PR - you can see your changes here:
+
+            | URL |
+            |---|
+            | https://pr-5-brightspace-ui-core.d2l.dev/ |
+
+            > **Note**
+            > The build needs to finish before your changes are deployed.
+            > Changes to the PR will automatically update the instance.
+          ONLY_POST_ONCE: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
             | URL |
             |---|
-            | https://pr-5-brightspace-ui-core.d2l.dev/ |
+            | https://pr-${{ github.event.number }}-brightspace-ui-core.d2l.dev/ |
 
             > **Note**
             > The build needs to finish before your changes are deployed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
           AWS_ROLE: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
           BUCKET_PATH: s3://brightspace-ui-core.d2l.dev/branches/pr-${{ github.event.number }}
           PUBLISH_DIRECTORY: ./build/
-          COMPRESS: true
 
       - name: Notify
         uses: ./.github/actions/comment-on-pr/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,16 @@ jobs:
       - name: Build static
         run: npm run build-static
 
+      - name: Assume role
+        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          role-to-assume: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
+          role-duration-seconds: 3600
+          aws-region: ca-central-1
+
       - name: Publish
         uses: ./.github/actions/publish-to-s3/
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,5 +68,5 @@ jobs:
         with:
           AWS_ROLE: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
           BUCKET_PATH: s3://brightspace-ui-core.d2l.dev/branches/main
-          BUILD_DIRECTORY: ./build/
+          PUBLISH_DIRECTORY: ./build/
           COMPRESS: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,4 +69,3 @@ jobs:
           AWS_ROLE: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
           BUCKET_PATH: s3://brightspace-ui-core.d2l.dev/branches/main
           PUBLISH_DIRECTORY: ./build/
-          COMPRESS: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,16 @@ jobs:
       - name: Build static
         run: npm run build-static
 
+      - name: Assume role
+        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          role-to-assume: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
+          role-duration-seconds: 3600
+          aws-region: ca-central-1
+
       - name: Publish
         uses: ./.github/actions/publish-to-s3/
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,29 @@ jobs:
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           RALLY_API_KEY: ${{ secrets.RALLY_API_KEY }}
+  publish:
+    name: Publish static site
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: Brightspace/third-party-actions@actions/checkout
+      - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+
+      - name: Build static
+        run: npm run build-static
+
+      - name: Publish
+        uses: ./.github/actions/publish-to-s3/
+        with:
+          AWS_ROLE: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
+          BUCKET_PATH: s3://brightspace-ui-core.d2l.dev/branches/main
+          BUILD_DIRECTORY: ./build/
+          COMPRESS: true


### PR DESCRIPTION
This PR adds a publish step to the CI and release workflows. This builds and publishes a static version of core to S3.

I've created two separate actions for this purpose:
- publish-to-s3
- comment-on-pr

I've designed both actions to be theoretically reusable in the future, but keeping them internal for now. No readmes for them at the moment as they're just internal.

For publishing to S3, I made these decisions:
- no caching, so that changes can be seen immediately without refreshing the cache
    - though I'd be open to putting say a default 2-minute cache on everything if we prefer
- yes to the default compression

Rally: https://rally1.rallydev.com/#/?detail=/userstory/670846679185&fdp=true
