### PR TITLE
chore: Add demo link to readme and remove AWS_ROLE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
       - name: Publish
         uses: ./.github/actions/publish-to-s3/
         with:
-          AWS_ROLE: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
           BUCKET_PATH: s3://brightspace-ui-core.d2l.dev/branches/pr-${{ github.event.number }}
           PUBLISH_DIRECTORY: ./build/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,8 @@ jobs:
 
             We've deployed an automatic preview for this PR - you can see your changes here:
 
-            | URL |
-            |---|
-            | https://pr-${{ github.event.number }}-brightspace-ui-core.d2l.dev/ |
+            | URL | https://pr-${{ github.event.number }}-brightspace-ui-core.d2l.dev/ |
+            |---|---|
 
             > **Note**
             > The build needs to finish before your changes are deployed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,5 @@ jobs:
       - name: Publish
         uses: ./.github/actions/publish-to-s3/
         with:
-          AWS_ROLE: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
           BUCKET_PATH: s3://brightspace-ui-core.d2l.dev/branches/main
           PUBLISH_DIRECTORY: ./build/

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Start a [@web/dev-server](https://modern-web.dev/docs/dev-server/overview/) that
 npm start
 ```
 
+D2L employees can also view the latest main-branch demos at https://brightspace-ui-core.d2l.dev/.
+
 ### Linting
 
 ```shell


### PR DESCRIPTION
Small follow-up to #3011: adding a link to the demos into the readme, and removing an unused var I was passing.

Rally: https://rally1.rallydev.com/#/?detail=/userstory/670846679185&fdp=true