### PR TITLE
DE51092 - Correct List Count

### DIFF
--- a/components/list/demo/list-item-actions.html
+++ b/components/list/demo/list-item-actions.html
@@ -326,11 +326,11 @@
 
 			<d2l-demo-snippet id="grid-button-demo">
 				<template>
-					<d2l-list-header slot="header">
-						<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
-						<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
-					</d2l-list-header>
 					<d2l-list grid>
+						<d2l-list-header slot="header">
+							<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+							<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+						</d2l-list-header>
 						<d2l-list-item-button selectable key="1" label="Introductory Earth Sciences">
 							<d2l-list-item-content>Introductory Earth Sciences</d2l-list-item-content>
 							<div slot="actions">

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -111,11 +111,11 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 	render() {
 		const role = !this.grid ? 'list' : 'application';
 		return html`
-			<div role="${role}" class="d2l-list-container">
-				<slot name="header"></slot>
+			<slot name="header"></slot>
+			<div role="${role}">
 				<slot @keydown="${this._handleKeyDown}" @slotchange="${this._handleSlotChange}"></slot>
-				${this._renderPagerContainer()}
 			</div>
+			${this._renderPagerContainer()}
 		`;
 	}
 

--- a/components/list/test/list.axe.js
+++ b/components/list/test/list.axe.js
@@ -1,10 +1,16 @@
 import '../list.js';
+import '../list-header.js';
 import '../list-item.js';
 import '../list-item-button.js';
+import '../../selection/selection-action.js';
 import { expect, fixture, html } from '@open-wc/testing';
 
 const normalFixture = html`
 	<d2l-list>
+		<d2l-list-header slot="header">
+			<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+			<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+		</d2l-list-header>
 		<d2l-list-item>
 			<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
 			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>


### PR DESCRIPTION
This moves the list header and the list's pager out of the actual list, as both were being counted as list items and causing axe tests to fail.  We didn't actually have an axe test for the header so I've added one, fixed a demo that was broken, and removed an unused class.

In a separate PR, I'm going to try to add a description for the list toolbar.