### PR TITLE
chore: Publish after release for correct version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: release
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node


### PR DESCRIPTION
Fixing a small defect from #3022 - currently the stated version on [our demo page](https://brightspace-ui-core.d2l.dev/) is one version behind.

In the release workflow, we need to force `publish` to happen after `release`, so that the version has been correctly updated before publishing.