### PR TITLE
DE51092 - Add a section and aria label around the list header to add context

### DIFF
--- a/components/list/list.js
+++ b/components/list/list.js
@@ -56,6 +56,9 @@ class List extends PageableMixin(SelectionMixin(LocalizeCoreElement(LitElement))
 			slot[name="pager"]::slotted(*) {
 				margin-top: 12px;
 			}
+			section {
+				display: unset;
+			}
 		`;
 	}
 

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -1,6 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { getNextFocusable, getPreviousFocusable } from '../../helpers/focus.js';
 import { SelectionInfo, SelectionMixin } from '../selection/selection-mixin.js';
+import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { PageableMixin } from '../paging/pageable-mixin.js';
 
 const keyCodes = {
@@ -16,7 +17,7 @@ export const listSelectionStates = SelectionInfo.states;
  * @slot pager - Slot for `d2l-pager-load-more` to be rendered below the list
  * @fires d2l-list-items-move - Dispatched when one or more items are moved. See [Event Details: d2l-list-items-move](#event-details%3A-%40d2l-list-items-move).
  */
-class List extends PageableMixin(SelectionMixin(LitElement)) {
+class List extends PageableMixin(SelectionMixin(LocalizeCoreElement(LitElement))) {
 
 	static get properties() {
 		return {
@@ -111,7 +112,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 	render() {
 		const role = !this.grid ? 'list' : 'application';
 		return html`
-			<slot name="header"></slot>
+			<section aria-label="${this.localize('components.list.toolbar')}"><slot name="header"></slot></section>
 			<div role="${role}">
 				<slot @keydown="${this._handleKeyDown}" @slotchange="${this._handleSlotChange}"></slot>
 			</div>

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "يجب أن يكون تاريخ {startLabel} قبل {endLabel}",
 	"components.input-time-range.startTime": "وقت البدء",
 	"components.interactive.instructions": "اضغط على Enter للتفاعل، وEscape للخروج",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "إعادة ترتيب إجراء المادة لـ {name}",
 	"components.list-item-drag-handle.keyboard": "إعادة ترتيب المواد، الموضع الحالي {currentPosition} من أصل {size}. لنقل هذه المادة، اضغط على السهم المتجه إلى أعلى أو السهم المتجه إلى أسفل.",
 	"components.list-item-tooltip.title": "التنقل عبر لوحة المفاتيح للقوائم:",

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "Rhaid i {startLabel} fod cyn {endLabel}",
 	"components.input-time-range.startTime": "Amser Dechrau",
 	"components.interactive.instructions": "Pwyswch Enter i ryngweithio, Escape i adael",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Aildrefnu gweithred eitem ar gyfer {name}",
 	"components.list-item-drag-handle.keyboard": "Aildrefnu eitemau, safle presennol {currentPosition} allan o {size}. I symud yr eitem hon, pwyswch y saeth i fyny neu'r saeth i lawr.",
 	"components.list-item-tooltip.title": "Llywio Bysellfwrdd ar gyfer Rhestrau:",

--- a/lang/da.js
+++ b/lang/da.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} skal være før {endLabel}",
 	"components.input-time-range.startTime": "Starttidspunkt",
 	"components.interactive.instructions": "Tryk på Enter for at interagere, Escape for at afslutte",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Omarranger elementhandling for {name}",
 	"components.list-item-drag-handle.keyboard": "Omarranger element, aktuel position {currentPosition} ud af {size}. For at flytte dette element skal du trykke på pil op eller pil ned.",
 	"components.list-item-tooltip.title": "Tastaturnavigering for lister:",

--- a/lang/de.js
+++ b/lang/de.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} muss vor {endLabel} liegen",
 	"components.input-time-range.startTime": "Startzeit",
 	"components.interactive.instructions": "Drücken Sie die Eingabetaste zum Interagieren oder die Escape-Taste, um das Fenster zu schließen",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Elementaktion für {name} neu anordnen",
 	"components.list-item-drag-handle.keyboard": "Elemente neu anordnen; aktuelle Position: {currentPosition} von {size}. Drücken Sie zum Bewegen dieses Elements auf den Pfeil nach oben oder den Pfeil nach unten.",
 	"components.list-item-tooltip.title": "Tastaturnavigation für Listen:",

--- a/lang/en.js
+++ b/lang/en.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} must be before {endLabel}",
 	"components.input-time-range.startTime": "Start Time",
 	"components.interactive.instructions": "Press Enter to interact, Escape to exit",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Reorder item action for {name}",
 	"components.list-item-drag-handle.keyboard": "Reorder item, current position {currentPosition} out of {size}. To move this item, press up or down arrows.",
 	"components.list-item-tooltip.title": "Keyboard Navigation for Lists:",

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} debe ser anterior a {endLabel}",
 	"components.input-time-range.startTime": "Hora de inicio",
 	"components.interactive.instructions": "Pulse Enter para interactuar y Escape para salir",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Reordenar acción de elemento para {name}",
 	"components.list-item-drag-handle.keyboard": "Reordenar elementos, posición actual {currentPosition} de {size}. Para mover este elemento, pulse las flechas arriba o abajo.",
 	"components.list-item-tooltip.title": "Navegación de listas con el teclado:",

--- a/lang/es.js
+++ b/lang/es.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} debe estar antes de {endLabel}",
 	"components.input-time-range.startTime": "Hora de inicio",
 	"components.interactive.instructions": "Presione Intro para interactuar y Escape para salir",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Acción de reordenar elemento de {name}",
 	"components.list-item-drag-handle.keyboard": "Reordenar elemento, posición actual {currentPosition} de {size}. Para mover este elemento, presione las flechas hacia arriba o hacia abajo.",
 	"components.list-item-tooltip.title": "Navegación con el teclado para listas:",

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} doit être antérieur à {endLabel}",
 	"components.input-time-range.startTime": "Heure de début",
 	"components.interactive.instructions": "Appuyer sur entrée pour interagir, sur Echap pour quitter",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Action de réorganisation de l'élément pour {name}",
 	"components.list-item-drag-handle.keyboard": "Réordonner les éléments, position actuelle {currentPosition} sur {size}. Pour déplacer cet élément, appuyez sur les flèches vers le haut ou vers le bas.",
 	"components.list-item-tooltip.title": "Navigation au clavier pour les listes :",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} doit précéder {endLabel}",
 	"components.input-time-range.startTime": "Heure de début",
 	"components.interactive.instructions": "Appuyez sur Entrée pour interagir, sur Échapper pour quitter",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Réordonner l'action de l'élément pour {name}",
 	"components.list-item-drag-handle.keyboard": "Réorganiser les éléments, position actuelle {currentPosition} de {size}. Pour déplacer cet élément, utilisez les flèches vers le haut et vers le bas.",
 	"components.list-item-tooltip.title": "Navigation au clavier pour les listes :",

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} {endLabel} से पहले का होना चाहिए",
 	"components.input-time-range.startTime": "प्रारंभ समय",
 	"components.interactive.instructions": "बातचीत करने के लिए Enter दबाएँ, बाहर निकलने के लिए Escape दबाएँ",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "{name} के लिए आइटम कार्रवाई का क्रम बदलें",
 	"components.list-item-drag-handle.keyboard": "आइटम का क्रम बदलें, {size} में से वर्तमान स्थिति {currentPosition} इस आइटम को ले जाने के लिए, ऊपर या नीचे तीर दबाएँ।",
 	"components.list-item-tooltip.title": "सूचियों के लिए कीबोर्ड नेविगेशन:",

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} は {endLabel} より前にする必要があります",
 	"components.input-time-range.startTime": "開始時刻",
 	"components.interactive.instructions": "対話を始めるには Enter キー、終了するには Esc キーを押します",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "{name} の項目並べ替えアクション",
 	"components.list-item-drag-handle.keyboard": "項目の並べ替え、現在の位置 {currentPosition}、サイズ {size}。この項目を移動するには、上矢印または下矢印を押します。",
 	"components.list-item-tooltip.title": "リストのキーボードナビゲーション:",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel}은(는) {endLabel} 앞에 있어야 합니다",
 	"components.input-time-range.startTime": "시작 시각",
 	"components.interactive.instructions": "Enter를 눌러 상호 작용하고 Esc를 눌러 종료합니다",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "{name}에 대한 항목 작업 재정렬",
 	"components.list-item-drag-handle.keyboard": "전체 {size}에서 현재 위치 {currentPosition} 항목 재정렬 이 항목을 이동하라면 위쪽 또는 아래쪽 화살표를 누르십시오.",
 	"components.list-item-tooltip.title": "목록에 대한 키보드 탐색:",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} moet voor {endLabel} liggen",
 	"components.input-time-range.startTime": "Starttijd",
 	"components.interactive.instructions": "Druk op Enter om te communiceren, druk op Escape om af te sluiten",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Itemactie voor {name} opnieuw rangschikken",
 	"components.list-item-drag-handle.keyboard": "Items opnieuw rangschikken, huidige positie {currentPosition} van {size}. Als u dit item wilt verplaatsen, drukt u op de pijl omhoog of omlaag.",
 	"components.list-item-tooltip.title": "Toetsenbordnavigatie voor lijsten:",

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} precisa ser anterior a {endLabel}",
 	"components.input-time-range.startTime": "Hora de início",
 	"components.interactive.instructions": "Pressione Enter para interagir, Escape para sair",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Reordenar ação de item para {name}",
 	"components.list-item-drag-handle.keyboard": "Reordenar item, posição atual {currentPosition} de {size}. Para mover este item, pressione as setas para cima ou para baixo.",
 	"components.list-item-tooltip.title": "Navegação do teclado para listas:",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} måste vara före {endLabel}",
 	"components.input-time-range.startTime": "Starttid",
 	"components.interactive.instructions": "Tryck på Enter för att interagera och Escape för att avsluta",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "Åtgärd för att ändra ordning på objekt för {name}",
 	"components.list-item-drag-handle.keyboard": "Flytta objekt. Aktuell position: {currentPosition} av {size}. Om du vill flytta det här objektet trycker du på uppåt- eller nedåtpilen.",
 	"components.list-item-tooltip.title": "Tangentbordsnavigering för listor:",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel}, {endLabel} tarihinden önce olmalıdır",
 	"components.input-time-range.startTime": "Başlangıç Saati",
 	"components.interactive.instructions": "Etkileşim kurmak için Enter tuşuna, çıkmak için Escape tuşuna basın",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "{name} için öğe eylemini yeniden sırala",
 	"components.list-item-drag-handle.keyboard": "Öğeyi yeniden sırala, mevcut konum {currentPosition} / {size}. Bu öğeyi taşımak için yukarı veya aşağı oklara basın.",
 	"components.list-item-tooltip.title": "Listeler için Klavye ile Gezinme:",

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} 必须早于 {endLabel}",
 	"components.input-time-range.startTime": "开始时间",
 	"components.interactive.instructions": "按 Enter 键进行交互，按 Esc 键退出",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "对 {name} 的项目操作重新排序",
 	"components.list-item-drag-handle.keyboard": "对项目重新排序，当前位置 {currentPosition} 超出 {size}。要移动此项目，请按向上或向下箭头。",
 	"components.list-item-tooltip.title": "列表的键盘导航：",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -65,6 +65,7 @@ export default {
 	"components.input-time-range.errorBadInput": "{startLabel} 必須早於 {endLabel}",
 	"components.input-time-range.startTime": "開始時間",
 	"components.interactive.instructions": "按下 Enter 來互動，按下 Escape 即可結束",
+	"components.list.toolbar": "List toolbar",
 	"components.list-item-drag-handle.default": "重新排序 {name} 的項目動作",
 	"components.list-item-drag-handle.keyboard": "重新排序項目，目前位置 {currentPosition}，總共為 {size}。若要移除這個項目，請按向上或向下箭頭。",
 	"components.list-item-tooltip.title": "清單的鍵盤導覽：",


### PR DESCRIPTION
As discussed, we'd like to add a bit more context for a screen reader user now that the list header is no longer inside the list. 
 We've gone with a `section` to give us a `region` role, since:
- `aria-labelledby` and `aria-describedby` need an interactive element to not be ignored
- `aria-description` doesn't appear to work on Safari
- the `toolbar` role implies keyboard behavior we don't have