### PR TITLE
DE51137 - Fix list to load more pager focusing in grid mode

### DIFF
--- a/components/list/demo/list-nested.html
+++ b/components/list/demo/list-nested.html
@@ -18,6 +18,7 @@
 			import '../list.js';
 			import '../../menu/menu.js';
 			import '../../menu/menu-item.js';
+			import '../../paging/pager-load-more.js';
 			import '../../selection/selection-action.js';
 		</script>
 	</head>
@@ -111,6 +112,8 @@
 						<d2l-list-item selectable key="L1-3" label="Label for L1-3">
 							<div>Computer Science (L1)</div>
 						</d2l-list-item>
+						<d2l-pager-load-more slot="pager" has-more page-size="5">
+						</d2l-pager-load-more>
 					</d2l-list>
 				</template>
 			</d2l-demo-snippet>
@@ -137,6 +140,11 @@
 			setTimeout(() => {
 				document.querySelector('d2l-list').addEventListener('d2l-list-selection-changes', (e) => {
 					console.log('d2l-list-selection-changes', e.detail);
+				});
+
+				document.querySelector('d2l-pager-load-more').addEventListener('d2l-pager-load-more', (e) => {
+					console.log('Load more requested!');
+					setTimeout(() => e.detail.complete(), 2000);
 				});
 			}, 1000);
 		</script>

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -207,8 +207,8 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 		if (!this.grid || this.slot === 'nested' || e.keyCode !== keyCodes.TAB) return;
 		e.preventDefault();
 		if (!this.shadowRoot) return;
-		const focusable = (e.shiftKey ? getPreviousFocusable(this.shadowRoot.querySelector('slot:not([name])'))
-			: getNextFocusable(this, false, true, true));
+		const listSlot = this.shadowRoot.querySelector('slot:not([name])');
+		const focusable = (e.shiftKey ? getPreviousFocusable(listSlot) : getNextFocusable(listSlot, false, true, true));
 		if (focusable) focusable.focus();
 	}
 

--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
 			<ul>
 				<li><a href="components/list/demo/list.html">d2l-list</a></li>
 				<li><a href="components/list/demo/list-drag-and-drop.html">d2l-list (drag & drop)</a></li>
+				<li><a href="components/list/demo/list-nested.html">d2l-list (nested)</a></li>
 				<li><a href="components/list/demo/list-item-actions.html">d2l-list-item (actions)</a></li>
 				<li><a href="components/list/demo/list-item-layouts.html">d2l-list-item (layouts)</a></li>
 				<li><a href="components/list/demo/list-item-scroll.html">d2l-list-item (scrolling)</a></li>


### PR DESCRIPTION
Fixes https://github.com/BrightspaceUI/core/issues/3034. In `grid` mode, the user navigates a list with the arrow keys, and tabbing forward/backwards will bring them to the first focusable element after/before the list.  This was working properly for backwards-tabbing because we were passing in the list `slot` to `getPreviousFocusable`, to account for the header.  But forward tabbing was skipping over the load-more pager, because we were passing `this` into `getNextFocusable`.  This would have worked fine until the pager was added, so now we just pass the list `slot` into both.