### PR TITLE
fix: File pattern was excluding table-test.js

### DIFF
--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -12,7 +12,7 @@ const buildDate = Intl.DateTimeFormat('en-CA', { timeZone: 'America/Toronto' }).
 const jsGlob = [
 	'@(components|controllers|directives|helpers|mixins|templates)/**/*.js',
 	'./index.js',
-	'!**/*@(test|axe|visual-diff).js',
+	'!**/*.@(test|axe|visual-diff).js',
 ];
 const nonJsGlob = [
 	'@(components|controllers|directives|helpers|mixins|templates)/**/*.*',


### PR DESCRIPTION
The table demo was broken on the static build (PR previews) - turns out it's because `table-test.js` was being excluded from the build. I've changed the pattern to only exclude `*.test.js`, instead of `*test.js`.