### PR TITLE
Add `clearable` to `d2l-tag-list` clear demo

### DIFF
--- a/components/tag-list/README.md
+++ b/components/tag-list/README.md
@@ -70,9 +70,17 @@ The `d2l-tag-list-item` provides the appropriate `listitem` semantics and stylin
     e.target.parentNode.removeChild(e.target);
     console.log(`d2l-tag-list-item-clear event dispatched. Value: ${e.detail.value}`);
   });
+
+  document.addEventListener('d2l-tag-list-clear', (e) => {
+    const items = e.target.querySelectorAll('[role="listitem"]');
+    items.forEach((item) => {
+      item.parentNode.removeChild(item);
+    });
+    console.log('d2l-tag-list-clear event dispatched');
+  });
 </script>
 
-<d2l-tag-list description="Example Tags">
+<d2l-tag-list description="Example Tags" clearable>
   <d2l-tag-list-item text="Tag"></d2l-tag-list-item>
 </d2l-tag-list>
 ```

--- a/components/tag-list/README.md
+++ b/components/tag-list/README.md
@@ -49,7 +49,7 @@ The corresponding `*-clear` event must be listened to for whatever component (`d
     console.log('d2l-tag-list-clear event dispatched');
   });
 </script>
-<d2l-tag-list description="Example Tags">
+<d2l-tag-list description="Example Tags" clearable>
   <d2l-tag-list-item text="Lorem ipsum dolor"></d2l-tag-list-item>
   <d2l-tag-list-item text="Reprehenderit in voluptate velit esse lorem ipsum dolor"></d2l-tag-list-item>
   <d2l-tag-list-item text="Sit amet"></d2l-tag-list-item>


### PR DESCRIPTION
Without the `clearable` attribute it doesn't allow removal so it doesn't show the clear actions on the daylight site.