### PR TITLE
remove double language selector

### DIFF
--- a/mixins/demo/localize-mixin.html
+++ b/mixins/demo/localize-mixin.html
@@ -11,36 +11,9 @@
 	</head>
 	<body unresolved>
 		<d2l-demo-page page-title="localize-mixin">
-
-			<div style="margin-bottom: 1rem;">
-				<label>Language:
-					<select id="langSwitcher">
-						<option value="ar">Arabic</option>
-						<option value="de">German</option>
-						<option value="en" selected="">English</option>
-						<option value="en-CA">English (Canada)</option>
-						<option value="es">Spanish</option>
-						<option value="fr">French</option>
-						<option value="ja">Japanese</option>
-						<option value="ko">Korean</option>
-						<option value="pt-BR">Portuguese</option>
-						<option value="tr">Turkish</option>
-						<option value="zh-CN">Chinese (Simplified)</option>
-						<option value="zh-TW">Chinese (Traditional)</option>
-					</select>
-				</label>
-			</div>
 			<d2l-demo-snippet>
 				<d2l-test-localize name="Bill"></d2l-test-localize>
 			</d2l-demo-snippet>
-
 		</d2l-demo-page>
-		<script>
-			const langSwitcher = document.getElementById('langSwitcher');
-			langSwitcher.addEventListener('change', () => {
-				const value = langSwitcher.options[langSwitcher.selectedIndex].value;
-				document.documentElement.setAttribute('lang', value);
-			});
-		</script>
 	</body>
 </html>


### PR DESCRIPTION
Now that `<d2l-demo-page>` has a built-in language selector, the localize mixin demo page doesn't need its own!