### PR TITLE
fix: Wait for aria-valuenow to be defined

### DIFF
--- a/templates/primary-secondary/test/primary-secondary.test.js
+++ b/templates/primary-secondary/test/primary-secondary.test.js
@@ -1,5 +1,5 @@
 import '../primary-secondary.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, nextFrame } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-template-primary-secondary', () => {
@@ -10,6 +10,11 @@ describe('d2l-template-primary-secondary', () => {
 	].forEach((testCase) => {
 		it(`${testCase.name} should pass all aXe tests`, async() => {
 			const elem = await fixture(html`<d2l-template-primary-secondary ?resizable="${testCase.resizable}"></d2l-template-primary-secondary>`);
+
+			// Wait for size to be calculated so that aria-valuenow is defined.
+			await nextFrame();
+			await nextFrame();
+
 			await expect(elem).to.be.accessible();
 		});
 	});


### PR DESCRIPTION
`primary-secondary` was failing the axe test due to its divider's `aria-valuenow` being undefined when it was focusable. The issue is that the `aria-valuenow` relies on the `_size` property, which is only calculated in response to a resize-observer that triggers after the element is already rendered.

I don't love this fix (which is just to wait longer before doing the axe test), but it should work. I'm unsure whether it may introduce flake though, or whether it should always have size calculated within two frames. The alternatives are:

1. Improve the `_size` calculations to happen more immediately
2. Prevent the divider from being focusable until the size is calculated
    - this option might make sense, though our axe tests would then have a false positive of passing because the resizable version would appear as non-resizable when the test actually fires
