### PR TITLE
Fix More-Less bug where it was not setting base height correctly 

### DIFF
--- a/components/more-less/demo/more-less.html
+++ b/components/more-less/demo/more-less.html
@@ -30,7 +30,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-more-less height="8em">
-						<p id="img-target">Hi everybody!Hi everybody!Hi everybody!Hi everybody!Hi everybody!Hi everybody! <a href="">Hi!</a></p>
+						<p id="img-target">Lorem ipsum dolor sit amet, consectetur adipiscing elit, magna aliqua quis. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident <a href="">proident.</a></p>
 					</d2l-more-less>
 				</template>
 			</d2l-demo-snippet>

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -136,9 +136,6 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 
 		this.__content = this.shadowRoot.querySelector('.d2l-more-less-content');
 		this.__contentSlot = this.shadowRoot.querySelector('.d2l-more-less-content slot');
-		if (this.__content.offsetParent !== null) {
-			this.__init_setBaseHeight();
-		}
 		this.__init_setupBlurColour();
 		this.__init_setupListeners();
 


### PR DESCRIPTION
[US146805](https://rally1.rallydev.com/#/?detail=/userstory/673763145497&fdp=true)

This PR removes the `__init_setBaseHeight()` call on the first update of `<d2l-more-less>`. This function was being called twice on initialization. Once from `firstUpdated()` and once from `__adjustToContent()`. `__init_setBaseHeight()` calls `this.__init_measureBaseHeight()` asynchronously with `requestAnimationFrame()` and was causing some odd behaviour where the `__baseHeight` was not being set correctly specifically when using an explicit height attribute.

Removing the call from `firstUpdated()` ensures the function is only called once and the baseHeight is set as expected. I removed it from `firstUpdated()` rather than `adjustToContent()` since it ensures that `adjustToContent()` does not run until the base height is set. `adjustToContent()` is responsible for resizing the component and determining whether the more-less button should be rendered.

I also just changed the code demo to use "Lorem ipsum" to be consistent with the other demos on the page.