### PR TITLE
check for rootView before accessing it

### DIFF
--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -179,7 +179,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 	getActiveView() {
 		const rootView = this.getRootView();
-		const childViews = rootView.querySelectorAll('[child-view][shown]');
+		const childViews = rootView?.querySelectorAll('[child-view][shown]');
 		if (!childViews || childViews.length === 0) {
 			return rootView;
 		}


### PR DESCRIPTION
Check for existance of `rootView` before querying it.
Result of [error in activities CI](https://github.com/BrightspaceHypermediaComponents/activities/actions/runs/3754177963/jobs/6389879264#step:7:446). 