### PR TITLE
fix: Lock to rollup 3.7.5 until defect is fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "lit-analyzer": "^1",
         "messageformat-validator": "^2",
         "node-sass": "^8",
-        "rollup": "^3",
+        "rollup": "3.7.5",
         "rollup-plugin-copy": "^3",
         "rollup-plugin-delete": "^2",
         "sinon": "^15",
@@ -8617,9 +8617,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.8.0.tgz",
-      "integrity": "sha512-+UR6PnUslneJNiJfLSzy4XH6R50ZGF0MS7UCv20ftXrktF/TkvZDwiBtXX65esblLR5p8w6LmXgPwt2f2B8SoQ==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.5.tgz",
+      "integrity": "sha512-z0ZbqHBtS/et2EEUKMrAl2CoSdwN7ZPzL17UMiKN9RjjqHShTlv7F9J6ZJZJNREYjBh3TvBrdfjkFDIXFNeuiQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -17359,9 +17359,9 @@
       }
     },
     "rollup": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.8.0.tgz",
-      "integrity": "sha512-+UR6PnUslneJNiJfLSzy4XH6R50ZGF0MS7UCv20ftXrktF/TkvZDwiBtXX65esblLR5p8w6LmXgPwt2f2B8SoQ==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.5.tgz",
+      "integrity": "sha512-z0ZbqHBtS/et2EEUKMrAl2CoSdwN7ZPzL17UMiKN9RjjqHShTlv7F9J6ZJZJNREYjBh3TvBrdfjkFDIXFNeuiQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lit-analyzer": "^1",
     "messageformat-validator": "^2",
     "node-sass": "^8",
-    "rollup": "^3",
+    "rollup": "3.7.5",
     "rollup-plugin-copy": "^3",
     "rollup-plugin-delete": "^2",
     "sinon": "^15",


### PR DESCRIPTION
I've confirmed that rollup@3.8.0 has introduced a defect for the specific combination of settings we use (`preserveModules` + `resolve()` + `lit`), and filed an issue:
https://github.com/rollup/rollup/issues/4765

This defect won't affect BSI because it's locked on rollup@2 currently, and may not be a widespread issue because of the specific combination of settings involved.

In the meantime, locking to 3.7.5 will unblock the PR previews again. I'll open a draft PR to restore rollup's version so we remember to unlock it when the defect is resolved.