### PR TITLE
fix: remove optional chaining

### DIFF
--- a/components/selection/selection-observer-mixin.js
+++ b/components/selection/selection-observer-mixin.js
@@ -34,7 +34,7 @@ export const SelectionObserverMixin = superclass => class extends superclass {
 		requestAnimationFrame(() => {
 			if (this.selectionFor) {
 				this._handleSelectionFor();
-				return this._provider?.subscribeObserver(this);
+				return this._provider ? this._provider.subscribeObserver(this) : undefined;
 			}
 
 			const evt = new CustomEvent('d2l-selection-observer-subscribe', {


### PR DESCRIPTION
After actually being able to load a page in Chrome 76, this is also causing an error on the homepage and was also introduced in November (December release), so I'm going to fix it too.