### PR TITLE
fix: remove optional chaining and null coalesc

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -203,7 +203,8 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		if (!this.shadowRoot) return;
 		const content = this.shadowRoot.querySelector('.d2l-dialog-content');
 		if (content) {
-			const elementToFocus = this._findAutofocusElement(content) ?? getNextFocusable(content);
+			const autofocusElem = this._findAutofocusElement(content);
+			const elementToFocus = autofocusElem ? autofocusElem : getNextFocusable(content);
 			if (isComposedAncestor(this.shadowRoot.querySelector('.d2l-dialog-inner'), elementToFocus)) {
 				forceFocusVisible(elementToFocus, false);
 				return;

--- a/components/selection/selection-observer-mixin.js
+++ b/components/selection/selection-observer-mixin.js
@@ -34,7 +34,7 @@ export const SelectionObserverMixin = superclass => class extends superclass {
 		requestAnimationFrame(() => {
 			if (this.selectionFor) {
 				this._handleSelectionFor();
-				return this._provider?.subscribeObserver(this);
+				return this._provider ? this._provider.subscribeObserver(this) : undefined;
 			}
 
 			const evt = new CustomEvent('d2l-selection-observer-subscribe', {

--- a/mixins/localize-mixin.js
+++ b/mixins/localize-mixin.js
@@ -130,7 +130,7 @@ export const LocalizeMixin = dedupeMixin(superclass => class extends superclass 
 
 	static _generatePossibleLanguages(config) {
 
-		if (config?.useBrowserLangs) return navigator.languages.map(e => e.toLowerCase()).concat('en');
+		if (config && config.useBrowserLangs) return navigator.languages.map(e => e.toLowerCase()).concat('en');
 
 		const { language, fallbackLanguage } = this.documentLocaleSettings;
 		const langs = [ language, fallbackLanguage ]

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -921,7 +921,7 @@ class TemplatePrimarySecondary extends FocusVisiblePolyfillMixin(RtlMixin(Locali
 
 	render() {
 		let tabindex;
-		const size = this._size ?? 0;
+		const size = this._size ? this._size : 0;
 		const secondaryPanelStyles = {};
 		if (this._isResizable()) {
 			secondaryPanelStyles[this._isMobile ? 'height' : 'width'] = `${size}px`;


### PR DESCRIPTION
Re-applying fixes from #3128 for the January release. We added one new null coalescing usage in the primary/secondary page template, so fixed that as well.