### PR TITLE
feat: Add status indicator slot to object-property-list

### DIFF
--- a/components/object-property-list/README.md
+++ b/components/object-property-list/README.md
@@ -8,9 +8,11 @@ Object property lists are simple dot-separated lists of text, displayed sequenti
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
   import '@brightspace-ui/core/components/object-property-list/object-property-list-item.js';
   import '@brightspace-ui/core/components/object-property-list/object-property-list-item-link.js';
+  import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
 </script>
 
 <d2l-object-property-list>
+  <d2l-status-indicator slot="status" state="default" text="Status"></d2l-status-indicator>
   <d2l-object-property-list-item text="Example item"></d2l-object-property-list-item>
   <d2l-object-property-list-item text="Example item with icon" icon="tier1:grade"></d2l-object-property-list-item>
   <d2l-object-property-list-item-link text="Example link" href="https://www.d2l.com/"></d2l-object-property-list-item-link>
@@ -22,7 +24,7 @@ Object property lists are simple dot-separated lists of text, displayed sequenti
 
 An object property list can be defined using `d2l-object-property-list` and a combination of items (e.g., `d2l-object-property-list-item`, `d2l-object-property-list-item-link`).
 
-<!-- docs: demo code -->
+<!-- docs: demo live name:d2l-object-property-list -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
@@ -36,17 +38,19 @@ An object property list can be defined using `d2l-object-property-list` and a co
 </d2l-object-property-list>
 ```
 
+<!-- docs: start hidden content -->
 ### Properties
 
 | Property | Type | Description |
 |--|--|--|
 | `skeleton-count` | Number | Number of skeleton items to insert if in skeleton mode |
+<!-- docs: end hidden content -->
 
 ### Word wrap
 
 The object property list is designed to wrap in an inline manner if the items are wider than the container.
 
-<!-- docs: demo code -->
+<!-- docs: demo -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
@@ -63,8 +67,7 @@ The object property list is designed to wrap in an inline manner if the items ar
 
 The `d2l-object-property-list-item` component is the basic type of item for an object property list, displaying text and an optional leading icon.
 
-
-<!-- docs: demo code -->
+<!-- docs: demo live name:d2l-object-property-list-item -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
@@ -90,7 +93,7 @@ The `d2l-object-property-list-item` component is the basic type of item for an o
 
 The `d2l-object-property-list-item-link` component is a link item for the object property list. It displays text as a hyperlink, with an optional leading icon.
 
-<!-- docs: demo code -->
+<!-- docs: demo live name:d2l-object-property-list-item-link -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
@@ -114,6 +117,25 @@ The `d2l-object-property-list-item-link` component is a link item for the object
 | `href` | String, required | The URL the item link navigates to |
 | `target` | String | Where to display the linked URL |
 <!-- docs: end hidden content -->
+
+## Status Slot
+
+Object property lists can optionally contain a single `d2l-status-indicator` inserted into the `status` slot.
+
+<!-- docs: demo live name:d2l-status-indicator -->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
+  import '@brightspace-ui/core/components/object-property-list/object-property-list-item.js';
+  import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
+</script>
+
+<d2l-object-property-list>
+  <d2l-status-indicator slot="status" state="default" text="Status"></d2l-status-indicator>
+  <d2l-object-property-list-item text="Example item"></d2l-object-property-list-item>
+  <d2l-object-property-list-item text="Example item with icon" icon="tier1:grade"></d2l-object-property-list-item>
+</d2l-object-property-list>
+```
 
 <!-- docs: start hidden content -->
 ## Future Improvements

--- a/components/object-property-list/README.md
+++ b/components/object-property-list/README.md
@@ -20,6 +20,18 @@ Object property lists are simple dot-separated lists of text, displayed sequenti
 </d2l-object-property-list>
 ```
 
+## Best Practices
+<!-- docs: start best practices -->
+<!-- docs: start dos -->
+* Use object property lists to represent properties and/or metadata related to an object
+<!-- docs: end dos -->
+
+<!-- docs: start donts -->
+* Don't use this pattern to display more than 3-4 items
+* Don't put unsupported elements inside an object property list
+<!-- docs: end donts -->
+<!-- docs: end best practices -->
+
 ## List [d2l-object-property-list]
 
 An object property list can be defined using `d2l-object-property-list` and a combination of items (e.g., `d2l-object-property-list-item`, `d2l-object-property-list-item-link`).

--- a/components/object-property-list/demo/object-property-list.html
+++ b/components/object-property-list/demo/object-property-list.html
@@ -10,6 +10,7 @@
 			import '../object-property-list.js';
 			import '../object-property-list-item.js';
 			import '../object-property-list-item-link.js';
+			import '../../status-indicator/status-indicator.js';
 		</script>
 	</head>
 	<body unresolved>
@@ -30,6 +31,7 @@
 			<d2l-demo-snippet overflow-hidden>
 				<template>
 					<d2l-object-property-list>
+						<d2l-status-indicator slot="status" state="default" text="Status"></d2l-status-indicator>
 						<d2l-object-property-list-item text="Example item"></d2l-object-property-list-item>
 						<d2l-object-property-list-item text="Example item with icon" icon="tier1:grade"></d2l-object-property-list-item>
 						<d2l-object-property-list-item-link text="Example link" href="https://www.d2l.com/"></d2l-object-property-list-item-link>
@@ -53,7 +55,7 @@
 
 			<d2l-demo-snippet overflow-hidden>
 				<template>
-					<d2l-object-property-list skeleton-count=3></d2l-object-property-list>
+					<d2l-object-property-list skeleton-count="3"></d2l-object-property-list>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/object-property-list/object-property-list-item.js
+++ b/components/object-property-list/object-property-list-item.js
@@ -3,14 +3,13 @@ import '../icons/icon.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { getSeparator } from '@brightspace-ui/intl/lib/list.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
-import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 /**
  * A single object property, to be used within an object-property-list,
  * with an optional icon.
  */
-export class ObjectPropertyListItem extends SkeletonMixin(RtlMixin(LitElement)) {
+export class ObjectPropertyListItem extends SkeletonMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
@@ -28,22 +27,23 @@ export class ObjectPropertyListItem extends SkeletonMixin(RtlMixin(LitElement)) 
 
 	static get styles() {
 		return [super.styles, offscreenStyles, css`
+			:host {
+				vertical-align: middle;
+			}
 			d2l-icon {
 				height: 0.9rem;
 				width: 0.9rem;
 			}
 			.separator {
 				display: var(--d2l-object-property-list-item-separator-display, inline);
-				margin: 0 0.05rem;
+				margin: 0 0.1rem;
 			}
 			.separator d2l-icon {
 				color: var(--d2l-color-galena);
 			}
 			.item-icon {
-				margin: -0.1rem 0.3rem 0 0;
-			}
-			:host([dir="rtl"]) .item-icon {
-				margin: -0.1rem 0 0 0.3rem;
+				margin-top: -0.1rem;
+				margin-inline-end: 0.3rem;
 			}
 			:host([skeleton]) d2l-icon {
 				color: var(--d2l-color-sylvite);

--- a/components/object-property-list/object-property-list.js
+++ b/components/object-property-list/object-property-list.js
@@ -21,7 +21,7 @@ class ObjectPropertyList extends LocalizeCoreElement(SkeletonMixin(LitElement)) 
 
 	static get styles() {
 		return [super.styles, bodySmallStyles, css`
-			:host, slot {
+			:host {
 				display: block;
 			}
 			:host([hidden]) {
@@ -30,16 +30,23 @@ class ObjectPropertyList extends LocalizeCoreElement(SkeletonMixin(LitElement)) 
 			::slotted(:last-child), slot :last-child {
 				--d2l-object-property-list-item-separator-display: none;
 			}
+			::slotted([slot="status"]) {
+				margin-inline-end: 0.45rem;
+			}
 		`];
 	}
 
 	render() {
-
 		const slotContents = this.skeleton && this.skeletonCount > 0 ? [...Array(this.skeletonCount)].map(() => html`
 			<d2l-object-property-list-item text="${this.localize('components.object-property-list.item-placeholder-text')}" skeleton></d2l-object-property-list-item>
 		`) : nothing;
 
-		return html`<slot class="d2l-body-small">${slotContents}</slot>`;
+		return html`
+			<div class="d2l-body-small">
+				<slot name="status"></slot>
+				<slot>${slotContents}</slot>
+			</div>
+		`;
 	}
 }
 

--- a/components/object-property-list/test/object-property-list.axe.js
+++ b/components/object-property-list/test/object-property-list.axe.js
@@ -1,6 +1,7 @@
 import '../object-property-list.js';
 import '../object-property-list-item.js';
 import '../object-property-list-item-link.js';
+import '../../status-indicator/status-indicator.js';
 import { expect, fixture, html } from '@open-wc/testing';
 
 describe('d2l-object-property-list', () => {
@@ -8,6 +9,7 @@ describe('d2l-object-property-list', () => {
 	it('should pass all aXe tests', async() => {
 		const elem = await fixture(html`
 			<d2l-object-property-list>
+				<d2l-status-indicator slot="status" state="default" text="Status"></d2l-status-indicator>
 				<d2l-object-property-list-item text="Example item"></d2l-object-property-list-item>
 				<d2l-object-property-list-item text="Example item with icon" icon="tier1:grade"></d2l-object-property-list-item>
 				<d2l-object-property-list-item-link text="Example link" href="https://www.d2l.com/"></d2l-object-property-list-item-link>

--- a/components/object-property-list/test/object-property-list.test.js
+++ b/components/object-property-list/test/object-property-list.test.js
@@ -1,6 +1,7 @@
 import '../object-property-list.js';
 import '../object-property-list-item.js';
 import '../object-property-list-item-link.js';
+import '../../status-indicator/status-indicator.js';
 import { aTimeout, expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
@@ -26,6 +27,7 @@ describe('d2l-object-property-list', () => {
 		it('should not be visible for a single item', async() => {
 			const elem = await fixture(html`
 				<d2l-object-property-list>
+					<d2l-status-indicator slot="status" state="default" text="Status"></d2l-status-indicator>
 					<d2l-object-property-list-item text="Example item"></d2l-object-property-list-item>
 				</d2l-object-property-list>
 			`);
@@ -35,6 +37,7 @@ describe('d2l-object-property-list', () => {
 		it('should hide the final separator for multiple items', async() => {
 			const elem = await fixture(html`
 				<d2l-object-property-list>
+					<d2l-status-indicator slot="status" state="default" text="Status"></d2l-status-indicator>
 					<d2l-object-property-list-item text="Example item"></d2l-object-property-list-item>
 					<d2l-object-property-list-item text="Example item with icon" icon="tier1:grade"></d2l-object-property-list-item>
 					<d2l-object-property-list-item-link text="Example link" href="https://www.d2l.com/"></d2l-object-property-list-item-link>
@@ -47,6 +50,7 @@ describe('d2l-object-property-list', () => {
 		it('should update automatically as items are added/removed', async() => {
 			const elem = await fixture(html`
 				<d2l-object-property-list>
+					<d2l-status-indicator slot="status" state="default" text="Status"></d2l-status-indicator>
 					<d2l-object-property-list-item text="Example item 1"></d2l-object-property-list-item>
 					<d2l-object-property-list-item text="Example item 2"></d2l-object-property-list-item>
 				</d2l-object-property-list>

--- a/components/object-property-list/test/object-property-list.visual-diff.html
+++ b/components/object-property-list/test/object-property-list.visual-diff.html
@@ -6,6 +6,7 @@
 		import '../object-property-list.js';
 		import '../object-property-list-item.js';
 		import '../object-property-list-item-link.js';
+		import '../../status-indicator/status-indicator.js';
 	</script>
 	<title>d2l-object-property-list</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -29,6 +30,7 @@
 
 	<div class="visual-diff" id="all-types">
 		<d2l-object-property-list>
+			<d2l-status-indicator slot="status" state="default" text="Status"></d2l-status-indicator>
 			<d2l-object-property-list-item text="Example item"></d2l-object-property-list-item>
 			<d2l-object-property-list-item text="Example item with icon" icon="tier1:grade"></d2l-object-property-list-item>
 			<d2l-object-property-list-item-link text="Example link" href="https://www.d2l.com/"></d2l-object-property-list-item-link>
@@ -45,6 +47,7 @@
 
 	<div class="visual-diff" id="rtl">
 		<d2l-object-property-list dir="rtl">
+			<d2l-status-indicator slot="status" state="default" text="Status" dir="rtl"></d2l-status-indicator>
 			<d2l-object-property-list-item text="Example item" dir="rtl"></d2l-object-property-list-item>
 			<d2l-object-property-list-item text="Example item with icon" icon="tier1:grade" dir="rtl"></d2l-object-property-list-item>
 			<d2l-object-property-list-item-link text="Example link" href="https://www.d2l.com/" dir="rtl"></d2l-object-property-list-item-link>


### PR DESCRIPTION
This PR adds a slot for a `d2l-status-indicator` that can be rendered at the start of the list. This feature came up while [backporting in consistent-evaluation](https://github.com/Brightspace/consistent-evaluation/pull/1333).

There's an edge case where the separators render incorrectly if the status-indicator is slotted after the items - I have a separate PR ready with a fix, but it requires some changes to how separators are hidden (JS instead of CSS) so I've kept this PR clean of that.

Rally: https://rally1.rallydev.com/#/?detail=/userstory/674102762601&fdp=true

## Screenshots

![image](https://user-images.githubusercontent.com/8449639/210946683-a326c0ea-1bcd-471c-8c29-7e55b5b89f51.png)
