### PR TITLE
Add search-on-input to d2l-input-search

### DIFF
--- a/components/inputs/demo/input-search.html
+++ b/components/inputs/demo/input-search.html
@@ -28,6 +28,14 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Search Input (Search on Input)</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-input-search label="Search" value="Will dispatch search after every input" placeholder="Search for some stuff" search-on-input>
+					</d2l-input-search>
+				</template>
+			</d2l-demo-snippet>
+
 			<script>
 				document.body.addEventListener('d2l-input-search-searched', (e) => {
 					// eslint-disable-next-line no-console

--- a/components/inputs/docs/input-search.md
+++ b/components/inputs/docs/input-search.md
@@ -60,6 +60,7 @@ For text searches use `<d2l-input-search>`, which wraps the native `<input type=
 | `disabled` | Boolean | Disables the input |
 | `maxlength` | Number | Imposes an upper character limit |
 | `no-clear` | Boolean | Prevents the "clear" button from appearing |
+| `search-on-input` | Boolean | Dispatch search events after each input instead of after pressing `Enter` |
 | `placeholder` | String, default:`'Search...'` | Placeholder text |
 | `value` | String, default: `''` | Value of the input |
 

--- a/components/inputs/docs/input-search.md
+++ b/components/inputs/docs/input-search.md
@@ -60,7 +60,7 @@ For text searches use `<d2l-input-search>`, which wraps the native `<input type=
 | `disabled` | Boolean | Disables the input |
 | `maxlength` | Number | Imposes an upper character limit |
 | `no-clear` | Boolean | Prevents the "clear" button from appearing |
-| `search-on-input` | Boolean | Dispatch search events after each input instead of after pressing `Enter` |
+| `search-on-input` | Boolean | Dispatch search events after each input event |
 | `placeholder` | String, default:`'Search...'` | Placeholder text |
 | `value` | String, default: `''` | Value of the input |
 

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -163,9 +163,7 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 	_debounceInput() {
 		clearTimeout(this._inputTimeout);
 		this._setLastSearchValue(this.value);
-		this._inputTimeout = setTimeout(() => {
-			this._dispatchEvent();
-		}, INPUT_TIMEOUT_MS);
+		this._inputTimeout = setTimeout(() => this._dispatchEvent(), INPUT_TIMEOUT_MS);
 	}
 
 	_dispatchEvent() {

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -51,6 +51,11 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 			 */
 			placeholder: { type: String },
 			/**
+			 * Dispatch search events after each input instead of after pressing `Enter`
+			 * @type {boolean}
+			 */
+			searchOnInput: { type: Boolean, attribute: 'search-on-input' },
+			/**
 			 * Value of the input
 			 * @type {string}
 			 */
@@ -84,6 +89,7 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 		this._lastSearchValue = '';
 		this.disabled = false;
 		this.noClear = false;
+		this.searchOnInput = false;
 		this.value = '';
 	}
 
@@ -169,10 +175,14 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 
 	_handleInput(e) {
 		this.value = e.target.value;
+		if (this.searchOnInput) {
+			this._setLastSearchValue(this.value);
+			this._dispatchEvent();
+		}
 	}
 
 	_handleInputKeyPress(e) {
-		if (e.keyCode !== 13) {
+		if (e.keyCode !== 13 || this.searchOnInput) {
 			return;
 		}
 		e.preventDefault();

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -8,7 +8,7 @@ import { inputStyles } from './input-styles.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
-const INPUT_TIMEOUT = 400;
+const INPUT_TIMEOUT_MS = 400;
 
 /**
  * This component wraps the native "<input type="search">"" element and is for text searching.
@@ -163,9 +163,9 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 	_debounceInput() {
 		clearTimeout(this._inputTimeout);
 		this._setLastSearchValue(this.value);
-		this._inputTimeout = setTimeout(async() => {
+		this._inputTimeout = setTimeout(() => {
 			this._dispatchEvent();
-		}, INPUT_TIMEOUT);
+		}, INPUT_TIMEOUT_MS);
 	}
 
 	_dispatchEvent() {

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -184,7 +184,7 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-input-text').focus();
 	}
 
-	async _handleInput(e) {
+	_handleInput(e) {
 		this.value = e.target.value;
 		if (this.searchOnInput) {
 			this._debounceInput();

--- a/components/inputs/test/input-search.test.js
+++ b/components/inputs/test/input-search.test.js
@@ -106,6 +106,21 @@ describe('d2l-input-search', () => {
 			expect(detail.value).to.equal('foobar');
 		});
 
+		it('should fire "search" event only once after two consecutive input events', async() => {
+			const elem = await fixture(searchOnInputFixture);
+			let searchEventsFired = 0;
+			elem.addEventListener('d2l-input-search-searched', () => {
+				searchEventsFired += 1;
+			});
+			setTimeout(() => {
+				getTextInput(elem).dispatchEvent(new Event('input'));
+				getTextInput(elem).dispatchEvent(new Event('input'));
+			});
+			await oneEvent(elem, 'd2l-input-search-searched');
+			await new Promise(resolve => setTimeout(resolve, 50));
+			expect(searchEventsFired).to.equal(1);
+		});
+
 	});
 
 	describe('search & clear button visibility', () => {

--- a/components/inputs/test/input-search.test.js
+++ b/components/inputs/test/input-search.test.js
@@ -5,6 +5,7 @@ import { runConstructor } from '../../../tools/constructor-test-helper.js';
 const normalFixture = html`<d2l-input-search label="search"></d2l-input-search>`;
 const valueSetFixture = html`<d2l-input-search label="search" value="foo"></d2l-input-search>`;
 const noClearFixture = html`<d2l-input-search label="search" value="foo" no-clear></d2l-input-search>`;
+const searchOnInputFixture = html`<d2l-input-search label="search" value="foo" search-on-input></d2l-input-search>`;
 
 function assertSearchVisibility(elem, isVisible) {
 	const visibleButton = elem.shadowRoot.querySelector('d2l-button-icon');
@@ -21,6 +22,10 @@ function getClearButton(elem) {
 
 function getSearchButton(elem) {
 	return elem.shadowRoot.querySelector('d2l-button-icon[icon="tier1:search"]');
+}
+
+function getTextInput(elem) {
+	return elem.shadowRoot.querySelector('d2l-input-text');
 }
 
 function pressEnter(elem) {
@@ -91,6 +96,14 @@ describe('d2l-input-search', () => {
 			setTimeout(() => getSearchButton(elem).click());
 			const { detail } = await oneEvent(elem, 'd2l-input-search-searched');
 			expect(detail.value).to.equal('');
+		});
+
+		it('should fire "search" event when search input changes in search-on-input mode', async() => {
+			const elem = await fixture(searchOnInputFixture);
+			elem.value = 'foobar';
+			setTimeout(() => getTextInput(elem).dispatchEvent(new Event('input')));
+			const { detail } = await oneEvent(elem, 'd2l-input-search-searched');
+			expect(detail.value).to.equal('foobar');
 		});
 
 	});


### PR DESCRIPTION
[US147299](https://rally1.rallydev.com/#/?detail=/userstory/675741349677&fdp=true)

This PR adds the `search-on-input` property to `d2l-input-search`. This changes the component to trigger searches after input changes rather than after pressing Enter. A delay was added to the search events so that the event will only trigger after a user stops typing. The exact delay timing is still being ironed out.