### PR TITLE
Update token for update-package-lock workflow

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
         with:
-          persist-credentials: false
+          token: ${{ secrets.CORE_GITHUB_TOKEN }}
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
           node-version-file: .nvmrc
@@ -20,6 +20,6 @@ jobs:
         uses: BrightspaceUI/actions/update-package-lock@main
         with:
           AUTO_MERGE_METHOD: squash
-          AUTO_MERGE_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}        
+          AUTO_MERGE_TOKEN: ${{ secrets.CORE_GITHUB_TOKEN }}        
           APPROVAL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CORE_GITHUB_TOKEN }}


### PR DESCRIPTION
We are changing `D2L_GITHUB_TOKEN` to use more limited permissions.  We need to update all places that don't _need_ to be using it, like here.

I can't merge this until I see the new token appear, after the `repo-settings` run is approved.