### PR TITLE
fix: Add test directory to rollup

### DIFF
--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -10,12 +10,12 @@ const { version } = JSON.parse(readFileSync('./package.json'));
 const buildDate = Intl.DateTimeFormat('en-CA', { timeZone: 'America/Toronto' }).format(new Date());
 
 const jsGlob = [
-	'@(components|controllers|directives|helpers|mixins|templates)/**/*.js',
+	'@(components|controllers|directives|helpers|mixins|templates|test)/**/*.js',
 	'./index.js',
 	'!**/*.@(test|axe|visual-diff).js',
 ];
 const nonJsGlob = [
-	'@(components|controllers|directives|helpers|mixins|templates)/**/*.*',
+	'@(components|controllers|directives|helpers|mixins|templates|test)/**/*.*',
 	'*.*',
 	'!**/*.@(js|md|json)',
 	'!**/screenshots/**/*',


### PR DESCRIPTION
While investigating #3134 , I noticed the PR preview visual-diff page for `object-property-list` was missing some styles:
https://pr-3134-brightspace-ui-core.d2l.dev/components/object-property-list/test/object-property-list.visual-diff.html

Discovered the cause, which is that it's looking for `test/styles.css`, and we weren't including the `test` directory in rollup, so I've added it.