### PR TITLE
Fix keyboard accessibility issue with grid enabled `d2l-list` and `d2l-dropdown-more` component

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -452,6 +452,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			case keyCodes.SPACE:
 				node = getComposedActiveElement();
 				node.click();
+				// mouseup event is necessary for components like d2l-dropdown-more that control state by listening to this event
+				node.dispatchEvent(new MouseEvent('mouseup', { composed: true }));
 				break;
 			case keyCodes.RIGHT:
 				node = getComposedActiveElement();


### PR DESCRIPTION
### Defect:
- `d2l-list` with `grid` enabled
- Within the actions slot, add a `d2l-dropdown-more` component
- Focus element with keyboard and try to toggle dropdown state with ENTER/SPACE keys
- Component state is not toggled

(this can be tested on the first demo on list expand collapse page)

### Issue:
`d2l-dropdown-more` listens to `mouseup` event to toggle state [here](https://github.com/BrightspaceUI/core/blob/main/components/dropdown/dropdown-opener-mixin.js#L77). This becomes an issue since the `d2l-list-item-generic-layout` component listens to keyboard events and calls `node.click()` on ENTER/SPACE keyboard actions [here](https://github.com/BrightspaceUI/core/blob/main/components/list/list-item-generic-layout.js#L454). (only when grid is enabled) 

### Fix:
Dispatch `mouseup` event on node so that `d2l-dropdown-more` (or other similar components) toggle state as expected.

### Potential concerns:
A component within a list item is listening to a `click` and `mouseup` event and triggers the same logic twice. This is theoretically possible but I don't know of any real-world scenario in which that would actually happen. 