### PR TITLE
fix: Collapsible Panel - make `expand-collapse-label` optional

### DIFF
--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -52,7 +52,7 @@ class CollapsiblePanel extends RtlMixin(LitElement) {
 			 */
 			expanded: { type: Boolean, reflect: true },
 			/**
-			 * REQUIRED: Label describing the contents of the header.
+			 * Optional label describing the contents of the header.
 			 * Used for screen readers.
 			 * @type {string}
 			 */


### PR DESCRIPTION
## Description

This property had a leftover `REQUIRED` doc tag. IT's not a required attribute, so this is just confusing.