### PR TITLE
fix: Collapsible Panel - rename `padding` to `padding-type`

### DIFF
--- a/components/collapsible-panel/README.md
+++ b/components/collapsible-panel/README.md
@@ -130,7 +130,7 @@ The `d2l-collapsible-panel` element is a container that provides specific layout
 | `heading-style` | Number | The heading style to use |
 | `heading-level` | Number | Semantic heading level (h1-h4) |
 | `no-sticky` | Boolean | Disables sticky positioning for the header |
-| `padding` | String | Optionally set horizontal padding of inline panels |
+| `padding-type` | String | Optionally set horizontal padding of inline panels |
 | `panel-title` | String | The title of the panel |
 | `type` | String | The type of collapsible panel |
 <!-- docs: end hidden content -->

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -68,7 +68,7 @@ class CollapsiblePanel extends RtlMixin(LitElement) {
 			 * @type {'default'|'large'}
 			 * @default "default"
 			 */
-			padding: { type: String, reflect: true },
+			paddingType: { attribute: 'padding-type', type: String, reflect: true },
 			/**
 			 * Disables sticky positioning for the header
 			 * @type {boolean}
@@ -93,7 +93,7 @@ class CollapsiblePanel extends RtlMixin(LitElement) {
 			:host([hidden]) {
 				display: none;
 			}
-			:host([padding="large"][type="inline"]) {
+			:host([padding-type="large"][type="inline"]) {
 				--d2l-collapsible-panel-spacing-inline: 2rem;
 			}
 			.d2l-collapsible-panel {
@@ -248,7 +248,7 @@ class CollapsiblePanel extends RtlMixin(LitElement) {
 		this.expanded = false;
 		this.headingLevel = defaultHeading;
 		this.headingStyle = defaultHeading;
-		this.padding = 'default';
+		this.paddingType = 'default';
 		this.type = 'default';
 		this.noSticky = false;
 		this._focused = false;

--- a/components/collapsible-panel/demo/collapsible-panel.html
+++ b/components/collapsible-panel/demo/collapsible-panel.html
@@ -77,10 +77,10 @@
 
 			<h2>Inline with large padding</h2>
 			<d2l-demo-snippet>
-				<d2l-collapsible-panel panel-title="Availability Dates and Conditions" type="inline" padding="large">
+				<d2l-collapsible-panel panel-title="Availability Dates and Conditions" type="inline" padding-type="large">
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor. Praesent lobortis libero in libero sagittis consectetur. Maecenas ut velit efficitur, consectetur augue vitae, finibus turpis. In id tempor quam.
 				</d2l-collapsible-panel>
-				<d2l-collapsible-panel panel-title="Availability Dates and Conditions" type="inline" padding="large">
+				<d2l-collapsible-panel panel-title="Availability Dates and Conditions" type="inline" padding-type="large">
 					<d2l-collapsible-panel-summary-item slot="summary" text="Availability starts 8/16/2022 and ends 8/12/2022"></d2l-collapsible-panel-summary-item>
 					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor. Praesent lobortis libero in libero sagittis consectetur. Maecenas ut velit efficitur, consectetur augue vitae, finibus turpis. In id tempor quam.
 				</d2l-collapsible-panel>

--- a/components/collapsible-panel/test/collapsible-panel.visual-diff.html
+++ b/components/collapsible-panel/test/collapsible-panel.visual-diff.html
@@ -70,17 +70,17 @@
 	</div>
 
 	<div class="visual-diff" id="default-large-padding">
-		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" padding="large">
+		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" padding-type="large">
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor.
 		</d2l-collapsible-panel>
 	</div>
 	<div class="visual-diff" id="default-large-padding-expanded">
-		<d2l-collapsible-panel no-sticky expanded panel-title="Availability Dates and Conditions" padding="large">
+		<d2l-collapsible-panel no-sticky expanded panel-title="Availability Dates and Conditions" padding-type="large">
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor.
 		</d2l-collapsible-panel>
 	</div>
 	<div class="visual-diff" id="default-large-padding-summary">
-		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" padding="large">
+		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" padding-type="large">
 			<d2l-collapsible-panel-summary-item slot="summary" text="Availability starts 8/16/2022 and ends 8/12/2022"></d2l-collapsible-panel-summary-item>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor.
 		</d2l-collapsible-panel>
@@ -119,17 +119,17 @@
 	</div>
 
 	<div class="visual-diff" id="subtle-large-padding">
-		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" type="subtle" padding="large">
+		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" type="subtle" padding-type="large">
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor.
 		</d2l-collapsible-panel>
 	</div>
 	<div class="visual-diff" id="subtle-large-padding-expanded">
-		<d2l-collapsible-panel no-sticky expandeds panel-title="Availability Dates and Conditions" type="subtle" padding="large">
+		<d2l-collapsible-panel no-sticky expandeds panel-title="Availability Dates and Conditions" type="subtle" padding-type="large">
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor.
 		</d2l-collapsible-panel>
 	</div>
 	<div class="visual-diff" id="subtle-large-padding-summary">
-		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" type="subtle" padding="large">
+		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" type="subtle" padding-type="large">
 			<d2l-collapsible-panel-summary-item slot="summary" text="Availability starts 8/16/2022 and ends 8/12/2022"></d2l-collapsible-panel-summary-item>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor.
 		</d2l-collapsible-panel>
@@ -168,17 +168,17 @@
 	</div>
 
 	<div class="visual-diff" id="inline-large-padding">
-		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" type="inline" padding="large">
+		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" type="inline" padding-type="large">
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor.
 		</d2l-collapsible-panel>
 	</div>
 	<div class="visual-diff" id="inline-large-padding-expanded">
-		<d2l-collapsible-panel no-sticky expanded panel-title="Availability Dates and Conditions" type="inline" padding="large">
+		<d2l-collapsible-panel no-sticky expanded panel-title="Availability Dates and Conditions" type="inline" padding-type="large">
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor.
 		</d2l-collapsible-panel>
 	</div>
 	<div class="visual-diff" id="inline-large-padding-summary">
-		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" type="inline" padding="large">
+		<d2l-collapsible-panel no-sticky panel-title="Availability Dates and Conditions" type="inline" padding-type="large">
 			<d2l-collapsible-panel-summary-item slot="summary" text="Availability starts 8/16/2022 and ends 8/12/2022"></d2l-collapsible-panel-summary-item>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas odio ligula, aliquam efficitur sollicitudin non, dignissim quis nisl. Nullam rutrum, lectus sed finibus consectetur, dolor leo blandit lorem, vitae consectetur arcu enim ornare tortor.
 		</d2l-collapsible-panel>


### PR DESCRIPTION
## Description
It can be unclear that `padding` is a "type selector" rather than an extension of the css property.

By renaming to `padding-type`, this becomes more clear.