### PR TITLE
Move input-text tooltip location

### DIFF
--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -8,8 +8,8 @@ export const inputLabelStyles = css`
 		font-weight: 700;
 		letter-spacing: 0.2px;
 		line-height: 1rem;
-		margin: 0;
-		padding: 0 0 7px 0;
+		margin: 0 0 7px 0;
+		padding: 0;
 	}
 	:host([required]) .d2l-input-label::after,
 	.d2l-input-label-required::after {
@@ -25,10 +25,6 @@ export const inputLabelStyles = css`
 	:host([dir="rtl"]) .d2l-input-label-required::after {
 		left: auto;
 		right: 0.15rem;
-	}
-	:host([skeleton]) .d2l-input-label.d2l-skeletize {
-		margin: 0 0 7px 0;
-		padding: 0;
 	}
 	:host([skeleton]) .d2l-input-label.d2l-skeletize::before {
 		bottom: 0.25rem;

--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -26,6 +26,10 @@ export const inputLabelStyles = css`
 		left: auto;
 		right: 0.15rem;
 	}
+	:host([skeleton]) .d2l-input-label.d2l-skeletize {
+		margin: 0 0 7px 0;
+		padding: 0;
+	}
 	:host([skeleton]) .d2l-input-label.d2l-skeletize::before {
 		bottom: 0.25rem;
 		top: 0.15rem;

--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -8,8 +8,8 @@ export const inputLabelStyles = css`
 		font-weight: 700;
 		letter-spacing: 0.2px;
 		line-height: 1rem;
-		margin: 0 0 7px 0;
-		padding: 0;
+		margin: 0;
+		padding: 0 0 7px 0;
 	}
 	:host([required]) .d2l-input-label::after,
 	.d2l-input-label-required::after {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -273,7 +273,6 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		this._hasAfterContent = false;
 		this._hovered = false;
 		this._inputId = getUniqueId();
-		this._inputTextContainerId = getUniqueId();
 		this._intersectionObserver = null;
 		this._isIntersecting = false;
 		this._lastSlotWidth = 0;
@@ -461,7 +460,6 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 					<div class="d2l-input-inside-before" @keypress="${this._suppressEvent}">${this.dir === 'rtl' ? unit : ''}<slot name="${firstSlotName}" @slotchange="${this._handleSlotChange}"></slot></div>
 					<div class="d2l-input-inside-after" @keypress="${this._suppressEvent}">${this.dir !== 'rtl' ? unit : ''}<slot name="${lastSlotName}" @slotchange="${this._handleSlotChange}"></slot></div>
 					${ (!isValid && !this.hideInvalidIcon && !this._focused) ? html`<div class="d2l-input-text-invalid-icon" style="${styleMap(invalidIconStyles)}" @click="${this._handleInvalidIconClick}"></div>` : null}
-					${ this.validationError && !this.skeleton ? html`<d2l-tooltip for=${this._inputTextContainerId} state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>` : null }
 				</div><div id="after-slot" class="d2l-skeletize" ?hidden="${!this._hasAfterContent}"><slot name="after" @slotchange="${this._handleAfterSlotChange}"></slot></div>
 			</div>
 			${offscreenContainer}
@@ -469,10 +467,9 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		if (this.label && !this.labelHidden && !this.labelledBy) {
 			const unitLabel = this._getUnitLabel();
 			return html`
-				<div id="${this._inputTextContainerId}" >
-					<label class="d2l-input-label d2l-skeletize" for="${this._inputId}">${this.label}${unitLabel ? html`<span class="d2l-offscreen">${unitLabel}</span>` : ''}</label>
-					${input}
-				</div>`;
+				${ this.validationError && !this.skeleton ? html`<d2l-tooltip state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>` : null }
+				<label class="d2l-input-label d2l-skeletize" for="${this._inputId}">${this.label}${unitLabel ? html`<span class="d2l-offscreen">${unitLabel}</span>` : ''}</label>
+				${input}`;
 		}
 		return input;
 	}

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -426,7 +426,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 
 		const input = html`
 			<div class="d2l-input-container">
-				<div class="d2l-input-text-container d2l-skeletize" id="${this._inputTextContainerId}" style="${styleMap(inputContainerStyles)}">
+				<div class="d2l-input-text-container d2l-skeletize" style="${styleMap(inputContainerStyles)}">
 					<input aria-atomic="${ifDefined(this.atomic)}"
 						aria-describedby="${ifDefined(this.description ? this._descriptionId : undefined)}"
 						aria-haspopup="${ifDefined(this.ariaHaspopup)}"
@@ -469,8 +469,10 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		if (this.label && !this.labelHidden && !this.labelledBy) {
 			const unitLabel = this._getUnitLabel();
 			return html`
-				<label class="d2l-input-label d2l-skeletize" for="${this._inputId}">${this.label}${unitLabel ? html`<span class="d2l-offscreen">${unitLabel}</span>` : ''}</label>
-				${input}`;
+				<div id="${this._inputTextContainerId}">
+					<label class="d2l-input-label d2l-skeletize" for="${this._inputId}">${this.label}${unitLabel ? html`<span class="d2l-offscreen">${unitLabel}</span>` : ''}</label>
+					${input}
+				</div>`;
 		}
 		return input;
 	}

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -1,6 +1,6 @@
 import '../colors/colors.js';
 import '../tooltip/tooltip.js';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { formatNumber } from '@brightspace-ui/intl/lib/number.js';
@@ -464,14 +464,17 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			</div>
 			${offscreenContainer}
 		`;
+
+		let label = nothing;
 		if (this.label && !this.labelHidden && !this.labelledBy) {
 			const unitLabel = this._getUnitLabel();
-			return html`
-				${ this.validationError && !this.skeleton ? html`<d2l-tooltip state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>` : null }
-				<label class="d2l-input-label d2l-skeletize" for="${this._inputId}">${this.label}${unitLabel ? html`<span class="d2l-offscreen">${unitLabel}</span>` : ''}</label>
-				${input}`;
+			label = html`<label class="d2l-input-label d2l-skeletize" for="${this._inputId}">${this.label}${unitLabel ? html`<span class="d2l-offscreen">${unitLabel}</span>` : ''}</label>`;
 		}
-		return input;
+
+		return html`
+			${ this.validationError && !this.skeleton ? html`<d2l-tooltip state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>` : nothing }
+			${label}
+			${input}`;
 	}
 
 	updated(changedProperties) {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -272,6 +272,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		this._focused = false;
 		this._hasAfterContent = false;
 		this._hovered = false;
+		this._inputTextContainerId = getUniqueId();
 		this._inputId = getUniqueId();
 		this._intersectionObserver = null;
 		this._isIntersecting = false;
@@ -425,7 +426,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 
 		const input = html`
 			<div class="d2l-input-container">
-				<div class="d2l-input-text-container d2l-skeletize" style="${styleMap(inputContainerStyles)}">
+				<div class="d2l-input-text-container d2l-skeletize" id="${this._inputTextContainerId}" style="${styleMap(inputContainerStyles)}">
 					<input aria-atomic="${ifDefined(this.atomic)}"
 						aria-describedby="${ifDefined(this.description ? this._descriptionId : undefined)}"
 						aria-haspopup="${ifDefined(this.ariaHaspopup)}"
@@ -460,7 +461,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 					<div class="d2l-input-inside-before" @keypress="${this._suppressEvent}">${this.dir === 'rtl' ? unit : ''}<slot name="${firstSlotName}" @slotchange="${this._handleSlotChange}"></slot></div>
 					<div class="d2l-input-inside-after" @keypress="${this._suppressEvent}">${this.dir !== 'rtl' ? unit : ''}<slot name="${lastSlotName}" @slotchange="${this._handleSlotChange}"></slot></div>
 					${ (!isValid && !this.hideInvalidIcon && !this._focused) ? html`<div class="d2l-input-text-invalid-icon" style="${styleMap(invalidIconStyles)}" @click="${this._handleInvalidIconClick}"></div>` : null}
-					${ this.validationError ? html`<d2l-tooltip for=${this._inputId} state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>` : null }
+					${ this.validationError && !this.skeleton ? html`<d2l-tooltip for=${this._inputTextContainerId} state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>` : null }
 				</div><div id="after-slot" class="d2l-skeletize" ?hidden="${!this._hasAfterContent}"><slot name="after" @slotchange="${this._handleAfterSlotChange}"></slot></div>
 			</div>
 			${offscreenContainer}

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -272,8 +272,8 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		this._focused = false;
 		this._hasAfterContent = false;
 		this._hovered = false;
-		this._inputTextContainerId = getUniqueId();
 		this._inputId = getUniqueId();
+		this._inputTextContainerId = getUniqueId();
 		this._intersectionObserver = null;
 		this._isIntersecting = false;
 		this._lastSlotWidth = 0;
@@ -469,7 +469,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		if (this.label && !this.labelHidden && !this.labelledBy) {
 			const unitLabel = this._getUnitLabel();
 			return html`
-				<div id="${this._inputTextContainerId}">
+				<div id="${this._inputTextContainerId}" >
 					<label class="d2l-input-label d2l-skeletize" for="${this._inputId}">${this.label}${unitLabel ? html`<span class="d2l-offscreen">${unitLabel}</span>` : ''}</label>
 					${input}
 				</div>`;

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -471,10 +471,12 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			label = html`<label class="d2l-input-label d2l-skeletize" for="${this._inputId}">${this.label}${unitLabel ? html`<span class="d2l-offscreen">${unitLabel}</span>` : ''}</label>`;
 		}
 
-		return html`
-			${ this.validationError && !this.skeleton ? html`<d2l-tooltip state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>` : nothing }
-			${label}
-			${input}`;
+		let tooltip = nothing;
+		if (this.validationError && !this.skeleton) {
+			tooltip = html`<d2l-tooltip state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>`;
+		}
+
+		return html`${tooltip}${label}${input}`;
 	}
 
 	updated(changedProperties) {


### PR DESCRIPTION
[DE51662](https://rally1.rallydev.com/#/?detail=/defect/676000972225&fdp=true): Input-text > Fix tooltip hover area

This PR moves the tooltip in the `d2l-input-text` component from the `input` element up to the host so that hovering anywhere in the component will open the tooltip. This makes the behaviour consistent with the validation tooltips that are used in the `d2l-input-number` component. There was an edge case where if you opened the tooltip and then turned on skeleton, the tooltip would still appear on hover so I added a check to the tooltip to confirm that the input is not in skeleton.

A separate inconsistency was noticed. Hovering inside of the component but outside of the label and bordered input area, such as to the right of the label, will open the tooltip (if warranted), but it will not enable the hover styles. After discussing with Jeff, we think it would be a good idea to enable hover styles when anywhere inside the input-text component is hovered. I have spun up a separate story to tackle this work: [US148080](https://rally1.rallydev.com/#/?detail=/userstory/684245679355&fdp=true). 