### PR TITLE
Change backdrop to use aria-hidden instead of role=presentation

### DIFF
--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -3,7 +3,6 @@ import { css, html, LitElement } from 'lit';
 import { cssEscape, getComposedChildren, getComposedParent, isVisible } from '../../helpers/dom.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 
-export const BACKDROP_ROLE = 'data-d2l-backdrop-role';
 const BACKDROP_HIDDEN = 'data-d2l-backdrop-hidden';
 const BACKDROP_ARIA_HIDDEN = 'data-d2l-backdrop-aria-hidden';
 
@@ -68,7 +67,8 @@ class Backdrop extends LitElement {
 				transition: none;
 			}
 			@media (prefers-reduced-motion: reduce) {
-				:host {
+				:host,
+				:host([slow-transition]) {
 					transition: none;
 				}
 			}
@@ -162,20 +162,12 @@ function hideAccessible(target) {
 			if (path.indexOf(child) !== -1) continue;
 			if (child.hasAttribute(BACKDROP_HIDDEN)) continue;
 
-			const role = child.getAttribute('role');
-			if (role) child.setAttribute(BACKDROP_ROLE, role);
-			child.setAttribute('role', 'presentation');
-
-			if (child.nodeName === 'FORM' || child.nodeName === 'A') {
-				const ariaHidden = child.getAttribute('aria-hidden');
-				if (ariaHidden) child.setAttribute(BACKDROP_ARIA_HIDDEN, ariaHidden);
-				child.setAttribute('aria-hidden', 'true');
-			}
+			const ariaHidden = child.getAttribute('aria-hidden');
+			if (ariaHidden) child.setAttribute(BACKDROP_ARIA_HIDDEN, ariaHidden);
+			child.setAttribute('aria-hidden', 'true');
 
 			child.setAttribute(BACKDROP_HIDDEN, BACKDROP_HIDDEN);
 			hiddenElements.push(child);
-
-			hideAccessibleChildren(child);
 		}
 	};
 
@@ -204,21 +196,12 @@ export function preventBodyScroll() {
 function showAccessible(elems) {
 	for (let i = 0; i < elems.length; i++) {
 		const elem = elems[i];
-		const role = elem.getAttribute(BACKDROP_ROLE);
-		if (role) {
-			elem.setAttribute('role', role);
-			elem.removeAttribute(BACKDROP_ROLE);
+		const ariaHidden = elem.getAttribute(BACKDROP_ARIA_HIDDEN);
+		if (ariaHidden) {
+			elem.setAttribute('aria-hidden', ariaHidden);
+			elem.removeAttribute(BACKDROP_ARIA_HIDDEN);
 		} else {
-			elem.removeAttribute('role');
-		}
-		if (elem.nodeName === 'FORM' || elem.nodeName === 'A') {
-			const ariaHidden = elem.getAttribute(BACKDROP_ARIA_HIDDEN);
-			if (ariaHidden) {
-				elem.setAttribute('aria-hidden', ariaHidden);
-				elem.removeAttribute(BACKDROP_ARIA_HIDDEN);
-			} else {
-				elem.removeAttribute('aria-hidden');
-			}
+			elem.removeAttribute('aria-hidden');
 		}
 		elem.removeAttribute(BACKDROP_HIDDEN);
 	}

--- a/components/backdrop/test/backdrop.test.js
+++ b/components/backdrop/test/backdrop.test.js
@@ -49,29 +49,25 @@ describe('d2l-backdrop', () => {
 			backdrop.shown = true;
 			await backdrop.updateComplete;
 
-			expect(backdrop.getAttribute('role')).to.equal('presentation');
-			expect(elem.querySelector('#target').getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('#target').parentNode.getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('script').getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('style').getAttribute('role')).to.equal(null);
+			expect(backdrop.getAttribute('aria-hidden')).to.equal('true');
+			expect(elem.querySelector('#target').getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('#target').parentNode.getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('script').getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('style').getAttribute('aria-hidden')).to.equal(null);
 
-			expect(elem.querySelector('#targetSibling').getAttribute('role')).to.equal('presentation');
-			expect(elem.querySelector('#targetParentSibling').getAttribute('role')).to.equal('presentation');
+			expect(elem.querySelector('#targetSibling').getAttribute('aria-hidden')).to.equal('true');
+			expect(elem.querySelector('#targetParentSibling').getAttribute('aria-hidden')).to.equal('true');
 
 			const link = elem.querySelector('a');
-			expect(link.getAttribute('role')).to.equal('presentation');
 			expect(link.getAttribute('aria-hidden')).to.equal('true');
 
 			const form = elem.querySelector('form');
-			expect(form.getAttribute('role')).to.equal('presentation');
 			expect(form.getAttribute('aria-hidden')).to.equal('true');
 
 			const divAriaHidden = elem.querySelector('div[aria-hidden]');
-			expect(divAriaHidden.getAttribute('role')).to.equal('presentation');
 			expect(divAriaHidden.getAttribute('aria-hidden')).to.equal('true');
 
 			const linkAriaHidden = elem.querySelector('a[aria-hidden]');
-			expect(linkAriaHidden.getAttribute('role')).to.equal('presentation');
 			expect(linkAriaHidden.getAttribute('aria-hidden')).to.equal('true');
 		});
 
@@ -83,29 +79,25 @@ describe('d2l-backdrop', () => {
 			backdrop.shown = false;
 			await backdrop.updateComplete;
 
-			expect(backdrop.getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('#target').getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('#target').parentNode.getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('script').getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('style').getAttribute('role')).to.equal(null);
+			expect(backdrop.getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('#target').getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('#target').parentNode.getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('script').getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('style').getAttribute('aria-hidden')).to.equal(null);
 
-			expect(elem.querySelector('#targetSibling').getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('#targetParentSibling').getAttribute('role')).to.equal(null);
+			expect(elem.querySelector('#targetSibling').getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('#targetParentSibling').getAttribute('aria-hidden')).to.equal(null);
 
 			const link = elem.querySelector('a');
-			expect(link.getAttribute('role')).to.equal(null);
 			expect(link.getAttribute('aria-hidden')).to.equal(null);
 
 			const form = elem.querySelector('form');
-			expect(form.getAttribute('role')).to.equal(null);
 			expect(form.getAttribute('aria-hidden')).to.equal(null);
 
 			const divAriaHidden = elem.querySelector('div[aria-hidden]');
-			expect(divAriaHidden.getAttribute('role')).to.equal(null);
 			expect(divAriaHidden.getAttribute('aria-hidden')).to.equal('true');
 
 			const linkAriaHidden = elem.querySelector('a[aria-hidden]');
-			expect(linkAriaHidden.getAttribute('role')).to.equal(null);
 			expect(linkAriaHidden.getAttribute('aria-hidden')).to.equal('false');
 		});
 
@@ -123,15 +115,15 @@ describe('d2l-backdrop', () => {
 			backdrop2.shown = false;
 			await backdrop2.updateComplete;
 
-			expect(backdrop2.getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('#target2').getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('#target2Sibling').getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('#target2').parentNode.getAttribute('role')).to.equal(null);
+			expect(backdrop2.getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('#target2').getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('#target2Sibling').getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('#target2').parentNode.getAttribute('aria-hidden')).to.equal(null);
 
-			expect(backdrop1.getAttribute('role')).to.equal('presentation');
-			expect(elem.querySelector('#target1').getAttribute('role')).to.equal(null);
-			expect(elem.querySelector('#target1Sibling').getAttribute('role')).to.equal('presentation');
-			expect(elem.querySelector('#target1').parentNode.getAttribute('role')).to.equal(null);
+			expect(backdrop1.getAttribute('aria-hidden')).to.equal('true');
+			expect(elem.querySelector('#target1').getAttribute('aria-hidden')).to.equal(null);
+			expect(elem.querySelector('#target1Sibling').getAttribute('aria-hidden')).to.equal('true');
+			expect(elem.querySelector('#target1').parentNode.getAttribute('aria-hidden')).to.equal(null);
 		});
 
 	});


### PR DESCRIPTION
[DE51746](https://rally1.rallydev.com/#/?detail=/defect/681718782515&fdp=true): nicc>nicc>20.22.12.18407>Quizzes>Error when editing quiz

This PR changes the backdrop component to hide the backdrop by using `aria-hidden="true"` instead of `role="presentation"`. Setting role is causing quizzing to crash when dialogs are opened on Chrome 109. After updating Chrome, I can reliably reproduce this defect and can confirm that this change fixes the issue.

`role="presentation"` is not meant for hiding or showing content as it is being used for here. It is meant to ignore certain content that has no semantic meaning on the page like decorative icons. `aria-hidden` makes more semantic sense for these purposes and should also be more efficient as well since we don't need to set the roles on all of the child elements anymore.

Also fixes a small defect where the `slow-transition` property would override reduced-motion.