### PR TITLE
fix: github-script usage after upgrade to v6

### DIFF
--- a/.github/actions/comment-on-pr/action.yml
+++ b/.github/actions/comment-on-pr/action.yml
@@ -33,7 +33,7 @@ runs:
         UNIQUE_KEY: ${{ inputs.UNIQUE_KEY }}
       with:
         script: |
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
This PR should fix the PR previews! They've started failing because `third-party-actions@actions/github-script` was upgraded yesterday to v6 (from v3), and the Octokit API moved a lot of commands e.g. `github.issues` to `github.rest.issues`.