### PR TITLE
fix: undefined errors in tabs component

### DIFF
--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -414,6 +414,9 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	_calculateScrollPosition(selectedTabInfo, measures) {
 
 		const selectedTabIndex = this._tabInfos.indexOf(selectedTabInfo);
+
+		if (!measures.tabRects[selectedTabIndex]) return 0;
+
 		const selectedTabMeasures = measures.tabRects[selectedTabIndex];
 
 		const isOverflowingLeft = (selectedTabMeasures.offsetLeft + this._translationValue < 0);
@@ -635,10 +638,12 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 			this._updateMeasures();
 		}
 
-		Promise.all(animPromises).then(() => {
-			this._updateMeasures();
-			return this._updateScrollPosition(selectedTabInfo);
-		});
+		if (selectedTabInfo) {
+			Promise.all(animPromises).then(() => {
+				this._updateMeasures();
+				return this._updateScrollPosition(selectedTabInfo);
+			});
+		}
 
 		this.dispatchEvent(new CustomEvent(
 			'd2l-tabs-initialized', { bubbles: true, composed: true }


### PR DESCRIPTION
This fixes two issues in the tabs component that were causing crashes in the d2l-my-courses-ui repo's tests but could potentially cause issues elsewhere as well.

The first change in `_calculateScrollPosition()` checks if the selected tab exists. It's possible, due to timing issues, for the selected tab to be removed in between when the tab is selected and the tab measures are updated. This would probably happen very rarely but in these situations, the component's translation value is reset to the default position.

The second change in `handlePanelsSlotChange()` checks that there is a selected tab. This was previously crashing because if all of the tabs were removed from the component, it would pass in a null `selectedTabInfo` to `_updateScrollPosition()`