### PR TITLE
fix: Sticky behaviour in selection header demos

### DIFF
--- a/components/list/README.md
+++ b/components/list/README.md
@@ -175,7 +175,7 @@ If a `d2l-list-item` is selectable then it should have a `label` attribute that 
 </script>
 
 <d2l-list>
-  <d2l-list-controls slot="controls">
+  <d2l-list-controls slot="controls" no-sticky>
     <d2l-selection-action icon="tier1:delete" text="Delete" requires-selection></d2l-selection-action>
   </d2l-list-controls>
   <d2l-list-item selectable key="eth" label="Earth Sciences">
@@ -329,7 +329,7 @@ If an item is draggable, the `drag-handle-text` attribute should be used to prov
 
 The `d2l-list-controls` component can be placed in the `d2l-list`'s `controls` slot to provide a select-all checkbox, summary, a slot for `d2l-selection-action`s, and overflow-group behaviour.
 
-<!-- docs: demo live name:d2l-list-controls display:block autoSize:false size:medium -->
+<!-- docs: demo live name:d2l-list-controls display:block autoSize:false size:small -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/list/list.js';
@@ -338,6 +338,14 @@ The `d2l-list-controls` component can be placed in the `d2l-list`'s `controls` s
   import '@brightspace-ui/core/components/list/list-item-content.js';
   import '@brightspace-ui/core/components/selection/selection-action.js';
 </script>
+<!-- docs: start hidden content -->
+<style>
+  #demo-element {
+    margin-bottom: 300px;
+    margin-top: 0;
+  }
+</style>
+<!-- docs: end hidden content -->
 
 <d2l-list>
   <d2l-list-controls slot="controls">

--- a/components/selection/README.md
+++ b/components/selection/README.md
@@ -64,7 +64,7 @@ The `SelectionMixin` defines the `selection-single` attribute that consumers can
 </style>
 <!-- docs: end hidden content -->
 <d2l-demo-selection>
-  <d2l-selection-controls>
+  <d2l-selection-controls no-sticky>
     <d2l-selection-action text="Bookmark" icon="tier1:bookmark-hollow" requires-selection></d2l-selection-action>
     <d2l-selection-action text="Settings" icon="tier1:gear"></d2l-selection-action>
   </d2l-selection-controls>
@@ -435,7 +435,7 @@ The `d2l-selection-controls` provides a standardized wrapper to display selectio
 
 When using lists, use the list-specific `d2l-list-controls` instead, which extends this component's behaviour.
 
-<!-- docs: demo live name:d2l-selection-controls display:block -->
+<!-- docs: demo live name:d2l-selection-controls display:block autoSize:false size:small -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/selection/selection-action.js';
@@ -445,6 +445,10 @@ When using lists, use the list-specific `d2l-list-controls` instead, which exten
 </script>
 <!-- docs: start hidden content -->
 <style>
+  #demo-element {
+    margin-bottom: 250px;
+    margin-top: 0;
+  }
   ul {
     padding: 0;
   }

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -329,7 +329,7 @@ The `d2l-table-controls` component can be placed in the `d2l-table-wrapper`'s `c
     render() {
       return html`
         <d2l-table-wrapper>
-          <d2l-table-controls slot="controls" no-sticky>
+          <d2l-table-controls slot="controls">
             <d2l-selection-action icon="tier1:delete" text="Delete" requires-selection></d2l-selection-action>
             <d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
           </d2l-table-controls>
@@ -342,9 +342,9 @@ The `d2l-table-controls` component can be placed in the `d2l-table-wrapper`'s `c
             </thead>
             <tbody>
               ${Object.keys(this._data).map((key, i) => html`
-                <tr ?selected="${i === 0}">
+                <tr>
                   <td>
-                    <d2l-selection-input selected key="${key}" label="${key}" ?checked="${this._data[key].checked}" @d2l-selection-change="${this._selectRow}"></d2l-selection-input>
+                    <d2l-selection-input key="${key}" label="${key}" ?selected="${this._data[key].checked}" @d2l-selection-change="${this._selectRow}"></d2l-selection-input>
                   </td>
                   <td>this row is ${!this._data[key].checked ? 'not' : ''} selected</td>
                 </tr>
@@ -357,7 +357,8 @@ The `d2l-table-controls` component can be placed in the `d2l-table-wrapper`'s `c
 
     _selectRow(e) {
       const key = e.target.key;
-      this._data[key].checked = !this._data[key].checked;
+      this._data[key].checked = e.target.selected;
+      this.requestUpdate();
     }
 
   }

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -363,6 +363,14 @@ The `d2l-table-controls` component can be placed in the `d2l-table-wrapper`'s `c
   }
   customElements.define('d2l-sample-table-with-controls', SampleTableWithControls);
 </script>
+<!-- docs: start hidden content -->
+<style>
+  #demo-element {
+    margin-bottom: 300px;
+    margin-top: 0;
+  }
+</style>
+<!-- docs: end hidden content -->
 <d2l-sample-table-with-controls></d2l-sample-table-with-controls>
 ```
 

--- a/components/table/table-controls.js
+++ b/components/table/table-controls.js
@@ -1,6 +1,6 @@
 import '../selection/selection-select-all-pages.js';
 import '../selection/selection-summary.js';
-import { html, nothing } from 'lit';
+import { css, html, nothing } from 'lit';
 import { SelectionControls } from '../selection/selection-controls.js';
 
 /**
@@ -15,6 +15,18 @@ class TableControls extends SelectionControls {
 			 */
 			noSelection: { type: Boolean, attribute: 'no-selection' }
 		};
+	}
+
+	static get styles() {
+		return [super.styles, css`
+			:host {
+				--d2l-selection-controls-background-color: var(--d2l-table-controls-background-color);
+				z-index: 2; /* must be greater than d2l-table rows */
+			}
+			:host([no-sticky]) {
+				z-index: auto;
+			}
+		`];
 	}
 
 	_renderSelection() {


### PR DESCRIPTION
On our `list`, `selection`, and `table` demos, the sticky behaviour of the "controls" component wasn't being properly demonstrated. It was the worst of both worlds: the controls don't stick to the top of the page, but it still gets styled as if it's stuck, adding a shadow underline that looks out of place.

This PR fixes those by using `no-sticky` in most demos, and making the demo container scrollable in the demo of the controls itself.

I've also included two other fixes for the table demo specifically:

1. Fixed the logic of the `<d2l-sample-table-with-controls>` itself, which wasn't handling selection correctly
2. Added a `z-index` to the `d2l-table-controls`, to make it float properly over the table
    - This is sort of a placeholder, I have a whole other story to improve `d2l-table-controls` sticky behaviour, which has a complicated interaction with the table's own sticky header

Rally: https://rally1.rallydev.com/#/?detail=/userstory/684983995587&fdp=true

## Screenshots

### Broken

![d2l-list-header sticky broken](https://user-images.githubusercontent.com/8449639/217065682-d5aaedac-1b29-454a-9adb-264111996f96.png)

### Fixed

![d2l-list-header sticky fixed](https://user-images.githubusercontent.com/8449639/217067393-186f325f-9880-4432-ab4c-51e10351052d.png)
