### PR TITLE
feat: Remove d2l-list-header

### DIFF
--- a/components/list/list-controls.js
+++ b/components/list/list-controls.js
@@ -15,7 +15,7 @@ export class ListControls extends SelectionControls {
 	static get styles() {
 		return [super.styles, css`
 			:host {
-				--d2l-selection-controls-background-color: var(--d2l-list-controls-background-color, var(--d2l-list-header-background-color));
+				--d2l-selection-controls-background-color: var(--d2l-list-controls-background-color);
 				z-index: 6; /* must be greater than d2l-list-item-active-border */
 			}
 			:host([no-sticky]) {

--- a/components/list/list-header.js
+++ b/components/list/list-header.js
@@ -1,5 +1,0 @@
-import { ListControls } from './list-controls.js';
-
-class ListHeader extends ListControls {}
-
-customElements.define('d2l-list-header', ListHeader);


### PR DESCRIPTION
This PR removes `d2l-list-header` from core! [All consumers ](https://search.d2l.dev/search?full=%22d2l-list-header%22&defs=&refs=&path=&hist=&type=&xrd=&nn=8&si=full&searchall=true&si=full) have been renamed to `d2l-list-controls` except for:

- `manager-view-fra`, where I raised [an issue](https://github.com/Brightspace/manager-view-fra/issues/2564) with migration details (they're still stuck on core v1)
- historical references in `blog.d2l.dev`
- a ".har" file in `har-filter-k6`, which is a demo "HTTP Archive" from 2022 before the renaming

I've also removed the import from the [List issue on BrightspaceUI/documentation](https://github.com/BrightspaceUI/documentation/issues/138).

This is technically a breaking change for any external consumers of `core`, but we've resolved all usage within our "walled garden".

Rally: https://rally1.rallydev.com/#/?detail=/userstory/673800144323&fdp=true
