### PR TITLE
Updating Readme after adding in new reflection properties.

### DIFF
--- a/components/selection/README.md
+++ b/components/selection/README.md
@@ -246,6 +246,7 @@ Note: `d2l-list-item` already provides a selection input for selectable list ite
 | `key` | String, required | Key to identify the selectable. |
 | `label` | String | Accessible hidden label for the input. |
 | `labelled-by` | String | Id reference to the accessible label for the input. **Note:** if specified, it must reference an element in the same DOM context. |
+| `disabled` | Boolean | Disables the input element(checkbox/radio btn). |
 | `selected` | Boolean | State of the input. |
 
 ### Events


### PR DESCRIPTION
Updating readme with `disabled` property information after adding `reflect:true` properties for `d2l-selection-input` component in a previous PR.
https://github.com/BrightspaceUI/core/pull/3246