### PR TITLE
demonstrate firefox failure

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -169,6 +169,8 @@ class HtmlBlock extends LitElement {
 			:host {
 				display: block;
 				overflow-wrap: break-word;
+				overflow-x: auto;
+				overflow-y: hidden;
 				text-align: start;
 			}
 			:host([inline]),

--- a/components/html-block/test/html-block.axe.js
+++ b/components/html-block/test/html-block.axe.js
@@ -4,7 +4,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 describe('d2l-html-block', () => {
 
 	it('simple', async() => {
-		const elem = await fixture(html`<d2l-html-block>some html</d2l-html-block>`);
+		const elem = await fixture(html`<d2l-html-block inline>some html</d2l-html-block>`);
 		await expect(elem).to.be.accessible();
 	});
 

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -12,13 +12,14 @@ export default {
 			name: 'aXe',
 			files: getPattern('axe'),
 			browsers: [
-				playwrightLauncher({
+				/*playwrightLauncher({
 					async createPage({ context }) {
 						const page = await context.newPage();
 						await page.emulateMedia({ reducedMotion: 'reduce' });
 						return page;
 					}
-				})
+				})*/
+				playwrightLauncher({ product: 'firefox', launchOptions: { args: ['--no-sandbox'] } }),
 			]
 		}
 	],


### PR DESCRIPTION
@dbatiste this should demonstrate the aXe failure in Firefox. Turns out the "inline" mode was needed to trigger it.