### PR TITLE
fix: remove support for disabled property

### DIFF
--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -10,12 +10,6 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 	static get properties() {
 		return {
 			/**
-			 * **Selection:** Disables the input
-			 * @type {boolean}
-			 * @ignore
-			 */
-			disabled: { type: Boolean }, // deprecated
-			/**
 			 * **Selection:** Disables selection
 			 * @type {boolean}
 			 */
@@ -99,10 +93,6 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 		if (this.selected === selected || (this.selected === undefined && !selected)) return;
 		this.selected = selected;
 		if (!suppressEvent) this._dispatchSelected(selected);
-	}
-
-	willUpdate(changedProperties) {
-		if (changedProperties.has('disabled')) this.selectionDisabled = this.disabled;
 	}
 
 	async _dispatchSelected(value) {

--- a/components/list/test/list-item-checkbox-mixin.test.js
+++ b/components/list/test/list-item-checkbox-mixin.test.js
@@ -30,28 +30,6 @@ describe('ListItemCheckboxMixin', () => {
 		}
 	});
 
-	describe('Adds selection-disabled property when setting deprecated disabled property', () => {
-		const cases = [{
-			input: '',
-			expected: false
-		}, {
-			input: 'disabled',
-			expected: true,
-		}, {
-			input: 'disabled selected',
-			expected: true,
-		}, {
-			input: 'selected',
-			expected: false
-		}];
-		for (const test of cases) {
-			it(test.input || 'empty', async() => {
-				const element = await fixture(`<${tag} key="1234" ${test.input}></${tag}>`);
-				expect(element['selectionDisabled']).to.be.equal(test.expected);
-			});
-		}
-	});
-
 	describe('Does not render checkbox or action area when not selectable', () => {
 		const cases = [{
 			input: '',


### PR DESCRIPTION
Remove support for `disabled` property replacing it with the `selection-disabled` property to have clearer semantics. Consumers of the property have been changed to consume the new one.

Rally:https://rally1.rallydev.com/#/?detail=/userstory/684760630163&fdp=true


## Consumers
Changes occur in `ListItemCheckboxMixin`, whose only consumer is `ListItemMixin` whose descendants are:

### [`CourseListItemMixin`](https://search.d2l.dev/xref/Brightspace/ipsis-sis-course-merge/mixins/course-list-item-mixin.js?r=1114e188) 
| Consumer | PRs |
| - | - |
| [`TargetCourseListItem`](https://search.d2l.dev/xref/Brightspace/ipsis-sis-course-merge/components/target-course-list-item.js?r=1114e188) defining [`target-course-list-item`](https://search.d2l.dev/search?full=%22target-course-list-item%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) | 8 |
| [`CourseListItem`](https://search.d2l.dev/xref/Brightspace/ipsis-sis-course-merge/components/course-list-item.js?r=1114e188) defining [`course-list-item`](https://search.d2l.dev/search?full=%22course-list-item%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) | 8 |

### [`ListItemButtonMixin`](https://search.d2l.dev/search?full=&defs=&refs=ListItemButtonMixin&path=&hist=&type=&xrd=&nn=8&searchall=true) (PR: 1)
| Consumer | PRs |
| - | - |
| [`ListItemButton`](https://search.d2l.dev/xref/BrightspaceUI/core/components/list/list-item-button.js?r=f191f763) defining [`d2l-list-item-button`](https://search.d2l.dev/search?full=%22d2l-list-item-button%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) | 1,3 |
| [ `componentClass`](https://search.d2l.dev/xref/BrightspaceHypermediaComponents/activities/components/d2l-activity-editor/d2l-activity-quiz-editor/questions/d2l-activity-question-activity.js?r=a162c4ce) defining [`d2l-activity-question-activity`](https://search.d2l.dev/search?full=%22d2l-activity-question-activity%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) | - |
| [ `componentClass`](https://search.d2l.dev/xref/BrightspaceHypermediaComponents/activities/components/d2l-activity-editor/d2l-activity-quiz-editor/questions/d2l-activity-question.js?r=a162c4ce) defining [`d2l-activity-question`](https://search.d2l.dev/search?full=%22d2l-activity-question%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) | - |
| [ `componentClass`](https://search.d2l.dev/xref/BrightspaceHypermediaComponents/activities/components/d2l-activity-editor/d2l-activity-quiz-editor/questions/d2l-activity-question-section.js?r=a162c4ce) defining [`d2l-activity-question-section`](https://search.d2l.dev/search?full=%22d2l-activity-question-section%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) | - |
| [ `componentClass`](https://search.d2l.dev/xref/BrightspaceHypermediaComponents/activities/components/d2l-activity-editor/d2l-activity-quiz-editor/questions/d2l-activity-question-pool.js?r=a162c4ce) defining [`d2l-activity-question-pool`](https://search.d2l.dev/search?full=%22d2l-activity-question-pool%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) | - |
| [`ListItemButton`](https://search.d2l.dev/xref/Brightspace/insights-engagement-dashboard/components/user-selector.js?r=02d8ed95) defining [`d2l-insights-list-item-button`](https://search.d2l.dev/search?full=%22d2l-insights-list-item-button%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&si=full&searchall=true&si=full) | - |
| [ `componentClass`](https://search.d2l.dev/xref/BrightspaceHypermediaComponents/foundation-components/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js?r=7242ee4e#35) defining [`d2l-activity-collection-item-quiz`](https://search.d2l.dev/search?full=%22d2l-activity-question-pool%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) | - |

### [`ListItemLinkMixin`](https://search.d2l.dev/xref/BrightspaceUI/core/components/list/list-item-button-mixin.js?r=e901c93c)
| Consumer | PRs |
| - | - |
| [`ListItem`](https://search.d2l.dev/xref/BrightspaceUI/core/components/list/list-item.js?r=f191f763#11) defining [`d2l-list-item`](https://search.d2l.dev/search?full=%22d2l-list-item%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) | 1-7,9 |

#### `manager-view-fra` repo has not been backported yet

### No Mixin
| Consumer | PRs |
| - | - |
| [`ActivityListItem`](https://search.d2l.dev/xref/BrightspaceHypermediaComponents/foundation-components/components/activity/list/d2l-activity-list-item.js?r=14a16533) defining [`d2l-activity-list-item`](https://search.d2l.dev/search?full=%22d2l-activity-list-item%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true)  | - |
| [`OutcomesManagementLowerLevelStandardListItem`](https://search.d2l.dev/xref/Brightspace/d2l-outcomes/src/components/outcomes-management/outcomes-management-lower-level-standard-list-item.js?r=0a2c6eb8) defining [`d2l-outcomes-management-lower-level-standard-list-item`](https://search.d2l.dev/search?full=%22d2l-outcomes-management-lower-level-standard-list-item%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true)  | - |
| [`OutcomesManagementListItem`](https://search.d2l.dev/xref/Brightspace/d2l-outcomes/src/components/outcomes-management/outcomes-management-list-item.js?r=4076e8c1) defining [`d2l-outcomes-management-list-item`](https://search.d2l.dev/search?full=%22d2l-outcomes-management-list-item%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true)  | - |
| [`DemoListItemCustom`](https://search.d2l.dev/xref/BrightspaceUI/core/components/list/demo/list-item-custom.js?r=f191f763) defining [`d2l-demo-list-item-custom`](https://search.d2l.dev/search?full=%22d2l-demo-list-item-custom%22+disabled&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true)  | - |



## Pull Requests 
 1) BrightspaceUI/core [#3220](https://github.com/BrightspaceUI/core/pull/3220) 
 2) BrightspaceUI/core [#3232](https://github.com/BrightspaceUI/core/pull/3232)
 3) Brightspace/content-components [#652](https://github.com/Brightspace/content-components/commit/32f1c023f8ab76db56261b55e6c95fc580eedd79)
 4) Brightspace/copy-announcement-to-other-courses [#26](https://github.com/Brightspace/copy-announcement-to-other-courses/pull/26)
 5) Brightspace/copy-assignment-to-other-courses [#149](https://github.com/Brightspace/copy-assignment-to-other-courses/pull/149) 
 6) Brightspace/discovery-fra [#615](https://github.com/Brightspace/discovery-fra/pull/615)
 7) Brightspace/insights-assessment-quality-dashboard [#653](https://github.com/Brightspace/insights-assessment-quality-dashboard/pull/653)
 8) Brightspace/ipsis-sis-course-merge [#77](https://github.com/Brightspace/ipsis-sis-course-merge/pull/77)
 9) BrightspaceHypermediaComponents/foundation-components [#639](https://github.com/BrightspaceHypermediaComponents/foundation-components/pull/639)

