### PR TITLE
fix: menu-item-selectable-mixin aria-checked

### DIFF
--- a/components/menu/menu-item-selectable-mixin.js
+++ b/components/menu/menu-item-selectable-mixin.js
@@ -48,7 +48,7 @@ export const MenuItemSelectableMixin = superclass => class extends MenuItemMixin
 	}
 
 	__onSelectedChanged(selected) {
-		selected ? this.setAttribute('aria-checked', 'true') : this.removeAttribute('aria-checked');
+		selected ? this.setAttribute('aria-checked', 'true') : this.setAttribute('aria-checked', 'false');
 	}
 
 };

--- a/components/menu/test/menu-item-selectable-mixin.test.js
+++ b/components/menu/test/menu-item-selectable-mixin.test.js
@@ -10,7 +10,7 @@ describe('MenuItemSelectableMixin', () => {
 
 	describe('accessibility', () => {
 
-		it('has no "aria-checked" false by default', async() => {
+		it('has "aria-checked" false by default', async() => {
 			const elem = await fixture(`<${tag}></${tag}>`);
 			expect(elem.getAttribute('aria-checked')).to.equal('false');
 		});

--- a/components/menu/test/menu-item-selectable-mixin.test.js
+++ b/components/menu/test/menu-item-selectable-mixin.test.js
@@ -10,12 +10,12 @@ describe('MenuItemSelectableMixin', () => {
 
 	describe('accessibility', () => {
 
-		it('has no "aria-checked by default', async() => {
+		it('has no "aria-checked" false by default', async() => {
 			const elem = await fixture(`<${tag}></${tag}>`);
-			expect(elem.hasAttribute('aria-checked')).to.be.false;
+			expect(elem.getAttribute('aria-checked')).to.equal('false');
 		});
 
-		it('has no "aria-checked when selected', async() => {
+		it('has "aria-checked" true when selected', async() => {
 			const elem = await fixture(`<${tag} selected></${tag}>`);
 			expect(elem.getAttribute('aria-checked')).to.equal('true');
 		});
@@ -27,11 +27,11 @@ describe('MenuItemSelectableMixin', () => {
 			expect(elem.getAttribute('aria-checked')).to.equal('true');
 		});
 
-		it('removes "aria-checked when unselected', async() => {
+		it('sets "aria-checked" to false when unselected', async() => {
 			const elem = await fixture(`<${tag} selected></${tag}>`);
 			elem.selected = false;
 			await elem.updateComplete;
-			expect(elem.hasAttribute('aria-checked')).to.be.false;
+			expect(elem.getAttribute('aria-checked')).to.equal('false');
 		});
 
 	});


### PR DESCRIPTION
I have just run npm update on a repo and am now getting a failing axe test:
> Required ARIA attribute not present: aria-checked
on default unselected `<d2l-menu-item-radio>`s.

Adding aria-checked in my `render()` doesn't seem to work (it vanishes), and the Daylight page doesn't mention it, so I suppose it is managed by the component. I see a change handler here that sets the property here. Nothing in our code seems to have changed recently, but the MDN docs seem to suggest that the property should be present with a value of "false" for unselected items, whereas our code removes it in that case - so I think it's just that the axe lib just got more picky.

- [x] try axe tests with this change
- [x] check behaviour with this change