### PR TITLE
Remove z-index from d2l-input-textarea.

### DIFF
--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -114,7 +114,6 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 				position: absolute;
 				resize: none;
 				top: 0;
-				z-index: 2;
 			}
 			:host([no-border]) textarea.d2l-input {
 				border-color: transparent;
@@ -144,9 +143,6 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 			:host([dir='rtl']) .d2l-input-textarea-mirror[aria-invalid="true"] {
 				padding-left: calc(18px + 0.8rem);
 				padding-right: 0.75rem;
-			}
-			:host([skeleton]) .d2l-skeletize::before {
-				z-index: 3;
 			}
 		`];
 	}


### PR DESCRIPTION
This PR removes the `z-index` from `d2l-input-textarea` to avoid some stacking context issues. It looks like they were introduced when the component was initially converted to Lit, but it appears they aren't actually needed.

There's really two contributing factors to this issue:
1. `d2l-input-textarea` creating a stacking context that is higher than other things on the page when we don't want it to
2. `d2l-card` creating a stacking context for nested `d2l-tooltip`s, effectively overriding the effectiveness of it's `z-index`. It would be good to eliminate this as well, but if it's possible, it will be more involved and can be dealt with separately.

**Before:**
![image](https://user-images.githubusercontent.com/9042472/218612326-9d2d01c0-7383-4187-aecd-614bd8d828dc.png)

**After:**
![image](https://user-images.githubusercontent.com/9042472/218612370-5639f7fe-e446-4878-a346-df95063c1a69.png)
