### PR TITLE
Assign d2l-collapsible-panel's sticky header a z-index.

### DIFF
--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -129,6 +129,7 @@ class CollapsiblePanel extends RtlMixin(LitElement) {
 				box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
 				position: sticky;
 				top: 0;
+				z-index: 11; /* must be greater greater than list-items with open dropdowns or tooltips */
 			}
 			.d2l-collapsible-panel.focused.scrolled .d2l-collapsible-panel-header {
 				top: 2px;

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -110,7 +110,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 
 			:host([_tooltip-showing]),
 			:host([_dropdown-open]) {
-				z-index: 10; /* must be greater than adjacent selected items */
+				z-index: 10; /* must be greater than adjacent selected items (if this is increased, d2l-collapsible-panel must be updated too) */
 			}
 			:host([_fullscreen-within]) {
 				position: fixed; /* required for Safari */

--- a/templates/primary-secondary/demo/integration.html
+++ b/templates/primary-secondary/demo/integration.html
@@ -366,34 +366,34 @@
 						</d2l-dropdown-menu>
 					</d2l-dropdown-more>
 					<div class="cards">
-					<d2l-card align-center text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology">
-						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
-						<d2l-dropdown-more slot="actions" translucent visible-on-ancestor text="Open!">
-								<d2l-dropdown-content>
-									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
-									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
-								</d2l-dropdown-content>
-						</d2l-dropdown-more>
-						<div slot="content">EARTH101</div>
-						<div slot="footer">
-							<d2l-card-footer-link id="googleDriveLink1" icon="tier1:google-drive" text="Google Drive" secondary-count="100" href="https://www.google.ca/drive/">
-								<d2l-tooltip slot="tooltip" for="googleDriveLink1">Go to Google Drive</d2l-tooltip>
-							</d2l-card-footer-link>
-							<d2l-card-footer-link id="rssFeedLink1" icon="tier1:rss" text="RSS Feed" secondary-count="1">
-								<d2l-tooltip slot="tooltip" for="rssFeedLink1">RSS Feed</d2l-tooltip>
-							</d2l-card-footer-link>
-						</div>
-					</d2l-card>
-					<d2l-card align-center text="Painting" href="https://en.wikipedia.org/wiki/Painting">
-						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-low-density-max-size.jpg">
-						<d2l-dropdown-more slot="actions" translucent visible-on-ancestor text="Open!">
-								<d2l-dropdown-content>
-									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
-									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
-								</d2l-dropdown-content>
-						</d2l-dropdown-more>
-						<div slot="content">ART201</div>
-					</d2l-card>
+						<d2l-card align-center text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology">
+							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
+							<d2l-dropdown-more slot="actions" translucent visible-on-ancestor text="Open!">
+									<d2l-dropdown-content>
+										<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+										<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+									</d2l-dropdown-content>
+							</d2l-dropdown-more>
+							<div slot="content">EARTH101</div>
+							<div slot="footer">
+								<d2l-card-footer-link id="googleDriveLink1" icon="tier1:google-drive" text="Google Drive" secondary-count="100" href="https://www.google.ca/drive/">
+									<d2l-tooltip slot="tooltip" for="googleDriveLink1">Go to Google Drive</d2l-tooltip>
+								</d2l-card-footer-link>
+								<d2l-card-footer-link id="rssFeedLink1" icon="tier1:rss" text="RSS Feed" secondary-count="1">
+									<d2l-tooltip slot="tooltip" for="rssFeedLink1">RSS Feed</d2l-tooltip>
+								</d2l-card-footer-link>
+							</div>
+						</d2l-card>
+						<d2l-card align-center text="Painting" href="https://en.wikipedia.org/wiki/Painting">
+							<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-low-density-max-size.jpg">
+							<d2l-dropdown-more slot="actions" translucent visible-on-ancestor text="Open!">
+									<d2l-dropdown-content>
+										<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+										<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+									</d2l-dropdown-content>
+							</d2l-dropdown-more>
+							<div slot="content">ART201</div>
+						</d2l-card>
 					</div>
 					<d2l-input-textarea label="Extra Text" label-hidden rows="6" value="This is a d2l-input-textarea." style="margin-top: 1rem;"></d2l-input-textarea>
 				</d2l-collapsible-panel>

--- a/templates/primary-secondary/demo/integration.html
+++ b/templates/primary-secondary/demo/integration.html
@@ -372,7 +372,6 @@
 								<d2l-dropdown-content>
 									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
 									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
-									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
 								</d2l-dropdown-content>
 						</d2l-dropdown-more>
 						<div slot="content">EARTH101</div>
@@ -389,7 +388,6 @@
 						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-low-density-max-size.jpg">
 						<d2l-dropdown-more slot="actions" translucent visible-on-ancestor text="Open!">
 								<d2l-dropdown-content>
-									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
 									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
 									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
 								</d2l-dropdown-content>

--- a/templates/primary-secondary/demo/integration.html
+++ b/templates/primary-secondary/demo/integration.html
@@ -9,25 +9,41 @@
 			import '../primary-secondary.js';
 			import '../../../components/button/button.js';
 			import '../../../components/button/button-icon.js';
+			import '../../../components/card/card.js';
+			import '../../../components/card/card-footer-link.js';
+			import '../../../components/collapsible-panel/collapsible-panel.js';
+			import '../../../components/collapsible-panel/collapsible-panel-summary-item.js';
 			import '../../../components/demo/demo-page.js';
 			import '../../../components/dialog/dialog-fullscreen.js';
 			import '../../../components/dropdown/dropdown-button-subtle.js';
+			import '../../../components/dropdown/dropdown-content.js';
 			import '../../../components/dropdown/dropdown-menu.js';
 			import '../../../components/dropdown/dropdown-more.js';
+			import '../../../components/inputs/input-textarea.js';
+			import '../../../components/list/list-controls.js';
+			import '../../../components/list/list-item-content.js';
+			import '../../../components/list/list-item.js';
+			import '../../../components/list/list.js';
 			import '../../../components/menu/menu.js';
 			import '../../../components/menu/menu-item.js';
 			import '../../../components/selection/selection-action.js';
 			import '../../../components/selection/selection-action-dropdown.js';
 			import '../../../components/selection/selection-action-menu-item.js';
 			import '../../../components/tooltip/tooltip.js';
-			import '../../../components/list/list-controls.js';
-			import '../../../components/list/list-item-content.js';
-			import '../../../components/list/list-item.js';
-			import '../../../components/list/list.js';
 		</script>
 		<style>
 			html {
 				--d2l-list-controls-background-color: #f1f5fb;
+			}
+			.cards {
+				display: flex;
+				flex-wrap: wrap;
+				gap: 0.5rem;
+			}
+			d2l-card {
+				flex: none;
+				height: 190px;
+				width: 140px;
 			}
 		</style>
 	</head>
@@ -326,28 +342,74 @@
 				</d2l-list>
 
 			</div>
-			<div slot="secondary">
-					<d2l-button id="open">Show Dialog</d2l-button>
-					<d2l-dialog-fullscreen id="dialogFullscreen" title-text="Fullscreen Title">
-						<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
-						<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
-						<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
-						<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
-						<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
-						<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
-						<d2l-button slot="footer" primary data-dialog-action="save">Save</d2l-button>
-						<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
-					</d2l-dialog-fullscreen>
-					<script>
-						document.querySelector('#open').addEventListener('click', () => {
-							document.querySelector('#dialogFullscreen').opened = true;
-						});
-						document.querySelector('#dialogFullscreen').addEventListener('d2l-dialog-close', (e) => {
-							console.log('confirm action:', e.detail.action);
-						});
-					</script>
-				<p>I'm in the <b>secondary</b> slot of the <b>d2l-template-primary-secondary</b> component!</p>
-				Quisque justo risus, elementum quis condimentum vitae, venenatis sit amet nisl. Vivamus interdum pretium libero dictum eleifend. Donec eros tortor, facilisis eget maximus in, malesuada a magna. Nulla ac felis turpis. Donec pellentesque est in rhoncus tempus. Proin ac purus porttitor, interdum est a, venenatis mi. Maecenas nunc nulla, viverra ut ornare id, luctus eu nulla. Pellentesque massa turpis, porta ut tincidunt ut, ullamcorper vitae urna. Nam congue euismod placerat. Vestibulum aliquet, metus vitae viverra posuere, lacus urna hendrerit turpis, vel laoreet ligula odio et nisl. Mauris id lectus magna. Sed gravida tincidunt sapien quis dapibus.Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spankerDeadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spankerDeadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker
+			<div slot="secondary" style="padding: 1rem;">
+				<d2l-dialog-fullscreen id="dialogFullscreen" title-text="Fullscreen Title">
+					<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
+					<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
+					<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
+					<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
+					<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
+					<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
+					<d2l-button slot="footer" primary data-dialog-action="save">Save</d2l-button>
+					<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+				</d2l-dialog-fullscreen>
+				<d2l-collapsible-panel panel-title="Availability" expanded>
+					<d2l-collapsible-panel-summary-item slot="summary" text="Availability starts 8/16/2022 and ends 8/12/2022"></d2l-collapsible-panel-summary-item>
+					<d2l-collapsible-panel-summary-item slot="summary" text="Hidden by special access"></d2l-collapsible-panel-summary-item>
+					<d2l-button-icon slot="actions" icon="tier1:gear" id="open" text="Settings"></d2l-button-icon>
+					<d2l-dropdown-more slot="actions">
+						<d2l-dropdown-menu>
+							<d2l-menu>
+								<d2l-menu-item text="Duplicate"></d2l-menu-item>
+								<d2l-menu-item text="Delete"></d2l-menu-item>
+							</d2l-menu>
+						</d2l-dropdown-menu>
+					</d2l-dropdown-more>
+					<div class="cards">
+					<d2l-card align-center text="Hydrology" href="https://en.wikipedia.org/wiki/Hydrology">
+						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg">
+						<d2l-dropdown-more slot="actions" translucent visible-on-ancestor text="Open!">
+								<d2l-dropdown-content>
+									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+								</d2l-dropdown-content>
+						</d2l-dropdown-more>
+						<div slot="content">EARTH101</div>
+						<div slot="footer">
+							<d2l-card-footer-link id="googleDriveLink1" icon="tier1:google-drive" text="Google Drive" secondary-count="100" href="https://www.google.ca/drive/">
+								<d2l-tooltip slot="tooltip" for="googleDriveLink1">Go to Google Drive</d2l-tooltip>
+							</d2l-card-footer-link>
+							<d2l-card-footer-link id="rssFeedLink1" icon="tier1:rss" text="RSS Feed" secondary-count="1">
+								<d2l-tooltip slot="tooltip" for="rssFeedLink1">RSS Feed</d2l-tooltip>
+							</d2l-card-footer-link>
+						</div>
+					</d2l-card>
+					<d2l-card align-center text="Painting" href="https://en.wikipedia.org/wiki/Painting">
+						<img slot="header" alt="" style="display: block; width: 100%;" src="https://s.brightspace.com/course-images/images/63b162ab-b582-4bf9-8c1d-1dad04714121/tile-low-density-max-size.jpg">
+						<d2l-dropdown-more slot="actions" translucent visible-on-ancestor text="Open!">
+								<d2l-dropdown-content>
+									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+									<div>This is where you could put the super cool features for your card!</div><br><div>As with all dropdowns, you can choose between a generic dropdown container, or a menu specific one.</div>
+								</d2l-dropdown-content>
+						</d2l-dropdown-more>
+						<div slot="content">ART201</div>
+					</d2l-card>
+					</div>
+					<d2l-input-textarea label="Extra Text" label-hidden rows="6" value="This is a d2l-input-textarea." style="margin-top: 1rem;"></d2l-input-textarea>
+				</d2l-collapsible-panel>
+				<script>
+					document.querySelector('#open').addEventListener('click', () => {
+						document.querySelector('#dialogFullscreen').opened = true;
+					});
+					document.querySelector('#dialogFullscreen').addEventListener('d2l-dialog-close', (e) => {
+						console.log('confirm action:', e.detail.action);
+					});
+				</script>
+				<p>
+					Quisque justo risus, elementum quis condimentum vitae, venenatis sit amet nisl. Vivamus interdum pretium libero dictum eleifend. Donec eros tortor, facilisis eget maximus in, malesuada a magna. Nulla ac felis turpis. Donec pellentesque est in rhoncus tempus. Proin ac purus porttitor, interdum est a, venenatis mi. Maecenas nunc nulla, viverra ut ornare id, luctus eu nulla. Pellentesque massa turpis, porta ut tincidunt ut, ullamcorper vitae urna. Nam congue euismod placerat. Vestibulum aliquet, metus vitae viverra posuere, lacus urna hendrerit turpis, vel laoreet ligula odio et nisl. Mauris id lectus magna. Sed gravida tincidunt sapien quis dapibus.Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spankerDeadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spankerDeadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker
+				</p>
 			</div>
 			<div slot="footer">I'm in the <b>footer</b> slot of the <b>d2l-template-primary-secondary</b> component!</div>
 		</d2l-template-primary-secondary>


### PR DESCRIPTION
[DE51932](https://rally1.rallydev.com/#/?detail=/defect/684982721887&fdp=true)

This PR adds a `z-index` to `d2l-collapsible-panel`'s sticky header so that it floats on top of `d2l-card`, or `d2l-list-item` with dropdown or tooltips open. This is similar to what is required for the `d2l-list-controls`.

**Before:**
![image](https://user-images.githubusercontent.com/9042472/218637102-510b97e3-88c7-46d5-9586-300741c42133.png)

**After:**
![image](https://user-images.githubusercontent.com/9042472/218637165-56088d73-43c5-44e3-b412-5e7fe7e9f055.png)
