### PR TITLE
Fix fullscreen d2l-demo-snippet so that dropdowns bounding ancestor is resolved correctly.

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -42,8 +42,9 @@ class DemoSnippet extends LitElement {
 			}
 			.d2l-demo-snippet-demo-wrapper.fullscreen {
 				background-color: white;
-				height: fit-content;
+				height: 100vh;
 				inset: 0;
+				overflow: auto;
 				position: absolute;
 				z-index: 2;
 			}


### PR DESCRIPTION
[DE51507](https://rally1.rallydev.com/#/?detail=/defect/675164420957&fdp=true)

This PR updates the styles for `d2l-demo-snippet` so that the fullscreen container fills the screen and is the bounding ancestor for things like dropdowns. 

The `DropdownContentMixin` uses the [getBoundingAncestor](https://github.com/BrightspaceUI/core/blob/main/helpers/dom.js#L67) helper in its logic to determine the space available for the dropdown content. Previous to this change, the `main` element (which gets `overflow: hidden;` and `height/width: 0;` in fullscreen) would be identified as the bounding ancestor with 0x0px dimensions. The change here will cause the fullscreen container to fill the full height of the viewport and become the bounding ancestor.

**Before:**
![image](https://user-images.githubusercontent.com/9042472/218807167-433def72-0761-4d54-8862-29e8550d582e.png)

![image](https://user-images.githubusercontent.com/9042472/218808596-28f63877-0256-494f-9a7f-d919a90e59ac.png)


**After:**
![image](https://user-images.githubusercontent.com/9042472/218807226-1462d174-4a27-41b3-a42c-beceda1db1a6.png)

![image](https://user-images.githubusercontent.com/9042472/218808685-b0755dc0-7232-424a-b143-1924dc282db9.png)
