### PR TITLE
DE52086 - Hotfix - Revert removal of overflow styles from d2l-html-block.

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -164,6 +164,8 @@ class HtmlBlock extends RtlMixin(LitElement) {
 			:host {
 				display: block;
 				overflow-wrap: break-word;
+				overflow-x: auto;
+				overflow-y: hidden;
 				text-align: left;
 			}
 			:host([inline]),


### PR DESCRIPTION
[DE52086](https://rally1.rallydev.com/#/?detail=/defect/685669235285&fdp=true)

This PR reverts changes from https://github.com/BrightspaceUI/core/pull/3139. This hotfix is for 20.23.2. It reverts the removal of the overflow styles from the d2l-html-block since it can cause regressions with user-authored content that is overflowing.

This has already been reverted for the 20.23.3. That change was done in https://github.com/BrightspaceUI/core/pull/3260.