### PR TITLE
Fix race condition with HierarchicalViewMixin.

### DIFF
--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -125,6 +125,11 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		}
 
 		requestAnimationFrame(() => {
+			/* If the view was disconnected before this could run, just bail. There can be some
+			odd race conditions with d2l-overflow-group where this can happen and results in
+			JavaScript errors finding the root view. */
+			if (!this.isConnected) return;
+
 			if (typeof(IntersectionObserver) !== 'function') {
 				this.__autoSize(this);
 			}


### PR DESCRIPTION
[DE51798](https://rally1.rallydev.com/#/?detail=/defect/683148898117&fdp=true)

This PR updates `HierarchicalViewMixin` to make it more resilient to race conditions that can arise when the view is connected, but disconnected before it's had a chance to fully initialize. The `HierarchicalViewMixin` relies on `requestAnimationFrame` to delay some of the initialization, however in certain contexts (ex. `d2l-overflow-group`) it is possible for the view to be disconnected before that frame runs. Per the Rally defect, this was observed in the Email tool in the reading frame.