### PR TITLE
Update the role when the parent lists grid attribute changes

### DIFF
--- a/components/list/list-item-role-mixin.js
+++ b/components/list/list-item-role-mixin.js
@@ -43,7 +43,7 @@ export const ListItemRoleMixin = superclass => class extends superclass {
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
-		this.observer.disconnect();
+		if (this.observer) this.observer.disconnect();
 	}
 
 };

--- a/components/list/list-item-role-mixin.js
+++ b/components/list/list-item-role-mixin.js
@@ -24,12 +24,26 @@ export const ListItemRoleMixin = superclass => class extends superclass {
 		const parent = findComposedAncestor(this.parentNode, node => node && node.tagName === 'D2L-LIST');
 		if (!parent) return;
 
+		this.observer = new MutationObserver(() => { this.role = parent.hasAttribute('grid') ? 'rowgroup' : 'listitem'; });
+		this.observer.observe(parent, {
+			attributes: true, /* required for legacy-Edge, otherwise attributeFilter throws a syntax error */
+			attributeFilter: ['grid'],
+			childList: false,
+			subtree: false,
+			characterData: false
+		});
+
 		const separators = parent.getAttribute('separators');
 
 		this.role = parent.hasAttribute('grid') ? 'rowgroup' : 'listitem';
 		this._nested = (parent.slot === 'nested');
 		this._separators = separators || undefined;
 		this._extendSeparators = parent.hasAttribute('extend-separators');
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.observer.disconnect();
 	}
 
 };


### PR DESCRIPTION
I need to be able to disable `grid` mode when the list has some components in editing state, for example I want to be able to do something like 

```js
?grid=${!this._editing}
```

This wasn't working however, I tracked down the issue to a role that only gets updated on `connectedCallback`, this PR adds a mutation observer so the role is updated whenever the grid attribute is also updated. 

See [this slack message](https://d2l.slack.com/archives/C036FJMD4P7/p1676400509284509) for the motivation behind this change. 