### PR TITLE
Fix d2l-tooltip so that only one tooltip is displayed at a time.

### DIFF
--- a/components/list/demo/list.html
+++ b/components/list/demo/list.html
@@ -84,16 +84,16 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-list grid>
-						<d2l-list-item selectable key="1" label="Introductory Earth Sciences">
+						<d2l-list-item no-primary-action selectable key="1" label="Introductory Earth Sciences">
 							<img slot="illustration" src="https://s.brightspace.com/course-images/images/38e839b1-37fa-470c-8830-b189ce4ae134/tile-high-density-max-size.jpg"></img>
 							<div>
 								<d2l-list-item-content>
 									<div>Introductory Earth Sciences</div>
 								</d2l-list-item-content>
 								<d2l-tag-list description="Tags for this course">
-									<d2l-tag-list-item text="Science"></d2l-tag-list-item>
-									<d2l-tag-list-item text="Environment"></d2l-tag-list-item>
-									<d2l-tag-list-item text="Earth"></d2l-tag-list-item>
+									<d2l-tag-list-item text="Science" description="This is a description for the Science tag that is really really really long and will overflow onto the next line."></d2l-tag-list-item>
+									<d2l-tag-list-item text="Environment" description="This is a description for the Environment tag."></d2l-tag-list-item>
+									<d2l-tag-list-item text="Earth" description="This is a description for the Earth tag."></d2l-tag-list-item>
 								</d2l-tag-list>
 							</div>
 							<div slot="actions">
@@ -116,8 +116,8 @@
 									<div>Engineering Materials for Energy Systems</div>
 								</d2l-list-item-content>
 								<d2l-tag-list description="Tags for this course">
-									<d2l-tag-list-item text="Engineering"></d2l-tag-list-item>
-									<d2l-tag-list-item text="Energy Systems"></d2l-tag-list-item>
+									<d2l-tag-list-item text="Engineering" description="This is a description for the Engineering tag."></d2l-tag-list-item>
+									<d2l-tag-list-item text="Energy Systems" description="This is a description for the Energy Systems tag."></d2l-tag-list-item>
 								</d2l-tag-list>
 							</div>
 							<div slot="actions">
@@ -140,9 +140,9 @@
 									<div>Geomorphology and GIS</div>
 								</d2l-list-item-content>
 								<d2l-tag-list description="Tags for this course">
-									<d2l-tag-list-item text="Geology"></d2l-tag-list-item>
-									<d2l-tag-list-item text="GIS"></d2l-tag-list-item>
-									<d2l-tag-list-item text="Earth Sciences"></d2l-tag-list-item>
+									<d2l-tag-list-item text="Geology" description="This is a description for the Geology tag."></d2l-tag-list-item>
+									<d2l-tag-list-item text="GIS" description="This is a description for the GIS tag."></d2l-tag-list-item>
+									<d2l-tag-list-item text="Earth Sciences" description="This is a description for the Earth Sciences tag."></d2l-tag-list-item>
 								</d2l-tag-list>
 							</div>
 							<div slot="actions">

--- a/components/tooltip/demo/tooltip.html
+++ b/components/tooltip/demo/tooltip.html
@@ -71,13 +71,18 @@
 		<h2>Tooltip (info)</h2>
 		<d2l-demo-snippet>
 			<template>
-				<d2l-button id="tooltip-info">Hover for Info</d2l-button>
-				<d2l-tooltip for="tooltip-info">
-					Your info message will display here
+				<d2l-button id="tooltip-preview">Preview</d2l-button>
+				<d2l-tooltip for="tooltip-preview">
+					Tooltip for the Preview button.
+				</d2l-tooltip>
+				<d2l-button id="tooltip-settings">Settings</d2l-button>
+				<d2l-tooltip for="tooltip-settings">
+					Tooltip for the Settings button.
 				</d2l-tooltip>
 			</template>
 		</d2l-demo-snippet>
 
+		<!--
 		<h2>Tooltip (error)</h2>
 		<d2l-demo-snippet>
 			<template>
@@ -163,7 +168,6 @@
 					<d2l-tooltip for="link-long" show-truncated-only>
 						Very Very Very Very Long Text - this tooltip will show because the text is truncating.
 					</d2l-tooltip>
-
 				</div>
 			</template>
 		</d2l-demo-snippet>
@@ -194,6 +198,7 @@
 				</p>
 			</template>
 		</d2l-demo-snippet>
+		-->
 
 	</d2l-demo-page>
 

--- a/components/tooltip/demo/tooltip.html
+++ b/components/tooltip/demo/tooltip.html
@@ -82,7 +82,6 @@
 			</template>
 		</d2l-demo-snippet>
 
-		<!--
 		<h2>Tooltip (error)</h2>
 		<d2l-demo-snippet>
 			<template>
@@ -198,7 +197,6 @@
 				</p>
 			</template>
 		</d2l-demo-snippet>
-		-->
 
 	</d2l-demo-page>
 

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -430,6 +430,8 @@ class Tooltip extends RtlMixin(LitElement) {
 		this._onTargetTouchStart = this._onTargetTouchStart.bind(this);
 		this._onTargetTouchEnd = this._onTargetTouchEnd.bind(this);
 
+		this._onTooltipShowOther = this._onTooltipShowOther.bind(this);
+
 		this.announced = false;
 		this.closeOnClick = false;
 		this.delay = 300;
@@ -474,6 +476,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		super.disconnectedCallback();
 		this._removeListeners();
 		window.removeEventListener('resize', this._onTargetResize);
+		document.body.removeEventListener('d2l-tooltip-show', this._onTooltipShowOther);
 		clearDismissible(this._dismissibleId);
 		delayTimeoutId = null;
 		this._dismissibleId = null;
@@ -859,6 +862,11 @@ class Tooltip extends RtlMixin(LitElement) {
 		}, 500);
 	}
 
+	_onTooltipShowOther() {
+		// only allow one tooltip showing at a time
+		this.hide();
+	}
+
 	_removeListeners() {
 		if (!this._target) {
 			return;
@@ -889,6 +897,9 @@ class Tooltip extends RtlMixin(LitElement) {
 			this.dispatchEvent(new CustomEvent(
 				'd2l-tooltip-show', { bubbles: true, composed: true }
 			));
+
+			document.body.addEventListener('d2l-tooltip-show', this._onTooltipShowOther, true);
+
 			if (this.announced && !this._isInteractive(this._target)) announce(this.innerText);
 		} else {
 			this.setAttribute('aria-hidden', 'true');
@@ -899,6 +910,8 @@ class Tooltip extends RtlMixin(LitElement) {
 			this.dispatchEvent(new CustomEvent(
 				'd2l-tooltip-hide', { bubbles: true, composed: true }
 			));
+
+			document.body.removeEventListener('d2l-tooltip-show', this._onTooltipShowOther, true);
 		}
 	}
 


### PR DESCRIPTION
[DE51993](https://rally1.rallydev.com/#/?detail=/defect/685233504963&fdp=true)

This PR fixes the `d2l-tooltip` component so that only one tooltip is displayed at once. Previous to this change, more than one tooltip could be displayed but it was never really supported - as such, tooltip collisions could occur. In addition, logic in `ListItemMixin` assumes only one tooltip is displayed at a time when it adds its `_tooltip-showing` attribute to elevate `z-index` for list-items.

The following screenshots show the results when a tooltip is shown by clicking followed by showing a second tooltip by subsequently hovering.

**Before:**
![image](https://user-images.githubusercontent.com/9042472/219798775-a38c5bbc-56c2-481f-8c39-f3f13e94f117.png)

![image](https://user-images.githubusercontent.com/9042472/219798820-d67f9886-5723-4a90-8ea1-cc734b2edd59.png)

![image](https://user-images.githubusercontent.com/9042472/219798868-a99ee33d-c12d-492c-96de-34281bb359f3.png)

**After:**
![image](https://user-images.githubusercontent.com/9042472/219798904-5bcacd98-2dac-4119-99c0-a41ed124443c.png)

![image](https://user-images.githubusercontent.com/9042472/219798977-1b433fce-6652-4486-864a-46465d6b09cc.png)
