### PR TITLE
Support anchor tabs for single-page app routing

### DIFF
--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -93,11 +93,13 @@
 					const href = e.composedPath().find(el => el.tagName === 'A')?.getAttribute('href');
 					if (href) {
 						e.preventDefault();
-						const state = { page: href, ts: Date.now() };
-						stateLog.splice(stateLog.pos + 1, Infinity, state);
-						stateLog.pos = stateLog.length - 1;
-						window.history.pushState({ ...state, log: stateLog }, '', `${basePath}/${href}`);
-						selectTab(href);
+						if (history.state.page != href) {
+							const state = { page: href, ts: Date.now() };
+							stateLog.splice(stateLog.pos + 1, Infinity, state);
+							stateLog.pos = stateLog.length - 1;
+							window.history.pushState({ ...state, log: stateLog }, '', `${basePath}/${href}`);
+							selectTab(href);
+						}
 					}
 				});
 			</script>

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -67,32 +67,32 @@
 			</div>
 			<script>
 			  const startPath = location.pathname;
-				const basePath = startPath.split('/').slice(0, -1).join('/');
-				const stateLog = [];
+			  const basePath = startPath.split('/').slice(0, -1).join('/');
+			  const stateLog = [];
 
-				const resetHistory = () => history.go((stateLog.pos + 1) * -1);
+			  const resetHistory = () => history.go((stateLog.pos + 1) * -1);
 
-				window.addEventListener('popstate', (event) => {
-					const page = event.state?.page || 'biology';
-					stateLog.pos = stateLog.findIndex(s => s.ts === event.state?.ts);
-					document.querySelector(`#spa-tabs [href="${page}"]`).selected = true;
-				});
+			  window.addEventListener('popstate', (event) => {
+			  	const page = event.state?.page || 'biology';
+			  	stateLog.pos = stateLog.findIndex(s => s.ts === event.state?.ts);
+			  	document.querySelector(`#spa-tabs [href="${page}"]`).selected = true;
+			  });
 
-				document.addEventListener('click', e => {
-					const href = e.composedPath().find(el => el.tagName === 'A')?.getAttribute('href');
-					if (href) {
-						e.preventDefault();
-						const state = { page: href, ts: Date.now() };
-						window.history.pushState(state, '', `${basePath}/${href}`);
-						stateLog.splice(stateLog.pos + 1, Infinity, state);
-						stateLog.pos = stateLog.length - 1;
-						const tab = document.querySelector(`#spa-tabs [href="${href}"]`);
-						document.title = `d2l-tabs - ${tab.text}`
-						tab.selected = true;
-					}
-				});
+			  document.addEventListener('click', e => {
+			  	const href = e.composedPath().find(el => el.tagName === 'A')?.getAttribute('href');
+			  	if (href) {
+			  		e.preventDefault();
+			  		const state = { page: href, ts: Date.now() };
+			  		window.history.pushState(state, '', `${basePath}/${href}`);
+			  		stateLog.splice(stateLog.pos + 1, Infinity, state);
+			  		stateLog.pos = stateLog.length - 1;
+			  		const tab = document.querySelector(`#spa-tabs [href="${href}"]`);
+			  		document.title = `d2l-tabs - ${tab.text}`;
+			  		tab.selected = true;
+			  	}
+			  });
 
-				document.querySelector('#reset-history').addEventListener('click', () => resetHistory());
+			  document.querySelector('#reset-history').addEventListener('click', () => resetHistory());
 			</script>
 
 			<d2l-demo-snippet>

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -69,12 +69,13 @@
 			  const startPath = location.pathname;
 			  const basePath = startPath.split('/').slice(0, -1).join('/');
 			  const stateLog = [];
-
 			  const resetHistory = () => history.go((stateLog.pos + 1) * -1);
 
-			  window.addEventListener('popstate', (event) => {
-			  	const page = event.state?.page || 'biology';
-			  	stateLog.pos = stateLog.findIndex(s => s.ts === event.state?.ts);
+			  document.querySelector('#reset-history').addEventListener('click', resetHistory);
+
+			  window.addEventListener('popstate', e => {
+			  	const page = e.state?.page || 'biology';
+			  	stateLog.pos = stateLog.findIndex(s => s.ts === e.state?.ts);
 			  	document.querySelector(`#spa-tabs [href="${page}"]`).selected = true;
 			  });
 
@@ -91,8 +92,6 @@
 			  		tab.selected = true;
 			  	}
 			  });
-
-			  document.querySelector('#reset-history').addEventListener('click', () => resetHistory());
 			</script>
 
 			<d2l-demo-snippet>

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -60,6 +60,56 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Tabs (with href)</h2>
+
+			<div style="margin-bottom: 30px;">
+				<d2l-button-subtle id="reset-path" text="Reset History"></d2l-button-subtle>
+			</div>
+			<script>
+			  const startPath = location.pathname;
+				const basePath = startPath.split('/').slice(0, -1).join('/');
+
+				const resetHistory = () => {
+					history.go((history.length - 2) * -1);
+					setTimeout(() => {
+						if (location.pathname !== startPath) history.back();
+					}, 10);
+				};
+
+				window.onpopstate = (event) => {
+					if (event.state) {
+						document.querySelector(`#spa-tabs [href="${event.state.page}"]`).selected = true;
+					}
+					else {
+						document.querySelector(`#spa-tabs [href="biology"]`).selected = true;
+					}
+				}
+
+				document.addEventListener('click', e => {
+					const href = e.composedPath().find(el => el.tagName === 'A' && el.href)?.getAttribute('href');
+					if (href) {
+						e.preventDefault();
+						window.history.pushState({ page: href }, '', `${basePath}/${href}`);
+						document.title = `d2l-tabs - ${href}`
+						document.querySelector(`#spa-tabs [href="${href}"]`).selected = true;
+					}
+				});
+
+				document.querySelector('#reset-path').addEventListener('click', () => resetHistory());
+			</script>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-tabs id="spa-tabs">
+						<d2l-tab-panel href="biology" text="Biology">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel href="chemistry" text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+						<d2l-tab-panel href="earth" text="Earth &amp; Planetary Sciences">Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
+						<d2l-tab-panel href="physics" text="Physics">Tab content for Physics</d2l-tab-panel>
+						<d2l-tab-panel href="math" text="Math">Tab content for Math</d2l-tab-panel>
+					</d2l-tabs>
+				</template>
+			</d2l-demo-snippet>
+
 			<h3>Tabs (with slot)</h3>
 
 			<d2l-demo-snippet>

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -66,32 +66,40 @@
 				<d2l-button-subtle id="reset-history" text="Reset History"></d2l-button-subtle>
 			</div>
 			<script>
-			  const startPath = location.pathname;
-			  const basePath = startPath.split('/').slice(0, -1).join('/');
-			  const stateLog = [];
-			  const resetHistory = () => history.go((stateLog.pos + 1) * -1);
+				const startPath = location.pathname;
+				const basePath = startPath.split('/').slice(0, -1).join('/');
+				const stateLog = history.state?.log || [];
+				const resetHistory = () => history.go((stateLog.pos + 1) * -1);
+				const selectTab = href => {
+					const tab = document.querySelector(`#spa-tabs [href="${href}"]`);
+					document.title = `d2l-tabs - ${tab.text}`;
+					tab.selected = true;
+				};
 
-			  document.querySelector('#reset-history').addEventListener('click', resetHistory);
+				if (history.state) {
+					history.replaceState(history.state, '', history.state.page);
+					window.addEventListener('DOMContentLoaded', () => selectTab(history.state.page));
+				}
 
-			  window.addEventListener('popstate', e => {
-			  	const page = e.state?.page || 'biology';
-			  	stateLog.pos = stateLog.findIndex(s => s.ts === e.state?.ts);
-			  	document.querySelector(`#spa-tabs [href="${page}"]`).selected = true;
-			  });
+				document.querySelector('#reset-history').addEventListener('click', resetHistory);
 
-			  document.addEventListener('click', e => {
-			  	const href = e.composedPath().find(el => el.tagName === 'A')?.getAttribute('href');
-			  	if (href) {
-			  		e.preventDefault();
-			  		const state = { page: href, ts: Date.now() };
-			  		window.history.pushState(state, '', `${basePath}/${href}`);
-			  		stateLog.splice(stateLog.pos + 1, Infinity, state);
-			  		stateLog.pos = stateLog.length - 1;
-			  		const tab = document.querySelector(`#spa-tabs [href="${href}"]`);
-			  		document.title = `d2l-tabs - ${tab.text}`;
-			  		tab.selected = true;
-			  	}
-			  });
+				window.addEventListener('popstate', e => {
+					const page = e.state?.page || 'biology';
+					stateLog.pos = stateLog.findIndex(s => s.ts === e.state?.ts);
+					document.querySelector(`#spa-tabs [href="${page}"]`).selected = true;
+				});
+
+				document.addEventListener('click', e => {
+					const href = e.composedPath().find(el => el.tagName === 'A')?.getAttribute('href');
+					if (href) {
+						e.preventDefault();
+						const state = { page: href, ts: Date.now() };
+						stateLog.splice(stateLog.pos + 1, Infinity, state);
+						stateLog.pos = stateLog.length - 1;
+						window.history.pushState({ ...state, log: stateLog }, '', `${basePath}/${href}`);
+						selectTab(href);
+					}
+				});
 			</script>
 
 			<d2l-demo-snippet>

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -93,7 +93,7 @@
 					const href = e.composedPath().find(el => el.tagName === 'A')?.getAttribute('href');
 					if (href) {
 						e.preventDefault();
-						if (history.state.page != href) {
+						if (history.state?.page !== href) {
 							const state = { page: href, ts: Date.now() };
 							stateLog.splice(stateLog.pos + 1, Infinity, state);
 							stateLog.pos = stateLog.length - 1;

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -63,39 +63,36 @@
 			<h2>Tabs (with href)</h2>
 
 			<div style="margin-bottom: 30px;">
-				<d2l-button-subtle id="reset-path" text="Reset History"></d2l-button-subtle>
+				<d2l-button-subtle id="reset-history" text="Reset History"></d2l-button-subtle>
 			</div>
 			<script>
 			  const startPath = location.pathname;
 				const basePath = startPath.split('/').slice(0, -1).join('/');
+				const stateLog = [];
 
-				const resetHistory = () => {
-					history.go((history.length - 2) * -1);
-					setTimeout(() => {
-						if (location.pathname !== startPath) history.back();
-					}, 10);
-				};
+				const resetHistory = () => history.go((stateLog.pos + 1) * -1);
 
-				window.onpopstate = (event) => {
-					if (event.state) {
-						document.querySelector(`#spa-tabs [href="${event.state.page}"]`).selected = true;
-					}
-					else {
-						document.querySelector(`#spa-tabs [href="biology"]`).selected = true;
-					}
-				}
+				window.addEventListener('popstate', (event) => {
+					const page = event.state?.page || 'biology';
+					stateLog.pos = stateLog.findIndex(s => s.ts === event.state?.ts);
+					document.querySelector(`#spa-tabs [href="${page}"]`).selected = true;
+				});
 
 				document.addEventListener('click', e => {
-					const href = e.composedPath().find(el => el.tagName === 'A' && el.href)?.getAttribute('href');
+					const href = e.composedPath().find(el => el.tagName === 'A')?.getAttribute('href');
 					if (href) {
 						e.preventDefault();
-						window.history.pushState({ page: href }, '', `${basePath}/${href}`);
-						document.title = `d2l-tabs - ${href}`
-						document.querySelector(`#spa-tabs [href="${href}"]`).selected = true;
+						const state = { page: href, ts: Date.now() };
+						window.history.pushState(state, '', `${basePath}/${href}`);
+						stateLog.splice(stateLog.pos + 1, Infinity, state);
+						stateLog.pos = stateLog.length - 1;
+						const tab = document.querySelector(`#spa-tabs [href="${href}"]`);
+						document.title = `d2l-tabs - ${tab.text}`
+						tab.selected = true;
 					}
 				});
 
-				document.querySelector('#reset-path').addEventListener('click', () => resetHistory());
+				document.querySelector('#reset-history').addEventListener('click', () => resetHistory());
 			</script>
 
 			<d2l-demo-snippet>

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -5,86 +5,8 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 const keyCodes = {
 	ENTER: 13,
-	SPACE: 32,
-	ARROWS: [35, 36, 37, 38, 39, 40]
+	SPACE: 32
 };
-
-export const tabInternalStyles = css`
-	d2l-tab-internal {
-		box-sizing: border-box;
-		display: inline-block;
-		max-width: 200px;
-	}
-	[role="tab"] {
-		color: inherit;
-		display: inline-block;
-		outline: none;
-		position: relative;
-		text-decoration: unset;
-		vertical-align: middle;
-		max-width: 100%;
-	}
-	.d2l-tab-text {
-		margin: 0.5rem;
-		overflow: hidden;
-		padding: 0.1rem;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-	d2l-tab-internal:first-child .d2l-tab-text {
-		margin-left: 0;
-	}
-	d2l-tab-internal[dir="rtl"]:first-child .d2l-tab-text {
-		margin-left: 0.6rem;
-		margin-right: 0;
-	}
-	.d2l-tab-selected-indicator {
-		border-top: 4px solid var(--d2l-color-celestine);
-		border-top-left-radius: 4px;
-		border-top-right-radius: 4px;
-		bottom: 0;
-		display: none;
-		margin: 1px 0.6rem 0 0.6rem;
-		position: absolute;
-		-webkit-transition: box-shadow 0.2s;
-		transition: box-shadow 0.2s;
-		width: calc(100% - 1.2rem);
-	}
-	d2l-tab-internal:first-child .d2l-tab-selected-indicator {
-		margin-left: 0;
-		width: calc(100% - 0.6rem);
-	}
-	d2l-tab-internal[dir="rtl"]:first-child .d2l-tab-selected-indicator {
-		margin-left: 0.6rem;
-		margin-right: 0;
-	}
-	[role="tab"].focus-visible > .d2l-tab-text {
-		border-radius: 0.3rem;
-		box-shadow: 0 0 0 2px var(--d2l-color-celestine);
-		color: var(--d2l-color-celestine);
-	}
-	d2l-tab-internal[selected] [role="tab"]:focus {
-		text-decoration: none;
-	}
-	[role="tab"]:hover {
-		color: var(--d2l-color-celestine);
-		cursor: pointer;
-	}
-	d2l-tab-internal[selected] [role="tab"]:hover {
-		color: inherit;
-		cursor: default;
-	}
-	d2l-tab-internal[selected] .d2l-tab-selected-indicator {
-		display: block;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.d2l-tab-selected-indicator {
-			-webkit-transition: none;
-			transition: none;
-		}
-	}
-	`;
 
 class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 
@@ -98,10 +20,87 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		};
 	}
 
+	static get styles() {
+		return css`
+			:host {
+				box-sizing: border-box;
+				display: inline-block;
+				max-width: 200px;
+			}
+			[role="tab"] {
+				color: inherit;
+				display: inline-block;
+				outline: none;
+				position: relative;
+				text-decoration: unset;
+				vertical-align: middle;
+			}
+			.d2l-tab-text {
+				margin: 0.5rem;
+				overflow: hidden;
+				padding: 0.1rem;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+			:host(:first-child) .d2l-tab-text {
+				margin-left: 0;
+			}
+			:host([dir="rtl"]:first-child) .d2l-tab-text {
+				margin-left: 0.6rem;
+				margin-right: 0;
+			}
+			.d2l-tab-selected-indicator {
+				border-top: 4px solid var(--d2l-color-celestine);
+				border-top-left-radius: 4px;
+				border-top-right-radius: 4px;
+				bottom: 0;
+				display: none;
+				margin: 1px 0.6rem 0 0.6rem;
+				position: absolute;
+				-webkit-transition: box-shadow 0.2s;
+				transition: box-shadow 0.2s;
+				width: calc(100% - 1.2rem);
+			}
+			:host(:first-child) .d2l-tab-selected-indicator {
+				margin-left: 0;
+				width: calc(100% - 0.6rem);
+			}
+			:host([dir="rtl"]:first-child) .d2l-tab-selected-indicator {
+				margin-left: 0.6rem;
+				margin-right: 0;
+			}
+			.focus-visible > .d2l-tab-text {
+				border-radius: 0.3rem;
+				box-shadow: 0 0 0 2px var(--d2l-color-celestine);
+				color: var(--d2l-color-celestine);
+			}
+			:host([selected]) [role="tab"]:focus {
+				text-decoration: none;
+			}
+			[role="tab"]:hover {
+				color: var(--d2l-color-celestine);
+				cursor: pointer;
+			}
+			:host([selected] [role="tab"]:hover) {
+				color: inherit;
+				cursor: default;
+			}
+			:host([selected]) .d2l-tab-selected-indicator {
+				display: block;
+			}
+			
+			@media (prefers-reduced-motion: reduce) {
+				.d2l-tab-selected-indicator {
+					-webkit-transition: none;
+					transition: none;
+				}
+			}
+		`;
+	}
+	
 	constructor() {
 		super();
 		this.selected = false;
-		this.tabindex = '-1';
 		this.role = 'none';
 	}
 
@@ -111,7 +110,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		 href="${this.href}"
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
-		 aria-selected="${this.selected}"
+		 aria-selected="${this.selected ? 'true' : 'false'}"
 		 aria-controls="${this.controlsPanel}"
 		 title="${this.text}"
 		 @keydown="${this._handleKeyDown}"
@@ -123,7 +122,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		<span
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
-		 aria-selected="${this.selected}"
+		 aria-selected="${this.selected ? 'true' : 'false'}"
 		 aria-controls="${this.controlsPanel}"
 		 title="${this.text}"
 		 @click="${this._handleTabClick}"
@@ -146,16 +145,11 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 	}
 
 	focus() {
-		this.querySelector('[role="tab"]').focus();
+		this.shadowRoot.querySelector('[role="tab"]').focus();
 	}
 
 	_handleKeyDown(e) {
-		if (keyCodes.ARROWS.includes(e.keyCode)) {
-			this.dispatchEvent(new KeyboardEvent('keydown', e));
-		}
-		else if (e.keyCode !== keyCodes.SPACE) {
-			return;
-		}
+		if (e.keyCode !== keyCodes.SPACE) return;
 		e.stopPropagation();
 		e.preventDefault();
 	}
@@ -168,11 +162,6 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 	_handleTabClick() {
 		this.selected = true;
 	}
-
-	createRenderRoot() {
-		return this;
-	}
-
 }
 
 customElements.define('d2l-tab-internal', Tab);

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -1,8 +1,8 @@
 import '../colors/colors.js';
+import { createRef, ref } from 'lit/directives/ref.js';
 import { css, html, LitElement } from 'lit';
 import { FocusVisiblePolyfillMixin } from '../../mixins/focus-visible-polyfill-mixin.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
-import { ref, createRef } from 'lit/directives/ref.js';
 
 const keyCodes = {
 	ENTER: 13,
@@ -10,8 +10,6 @@ const keyCodes = {
 };
 
 class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
-
-	tabRef = createRef();
 
 	static get properties() {
 		return {
@@ -23,7 +21,6 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 			href: { type: String }
 		};
 	}
-
 	static get styles() {
 		return css`
 			:host {
@@ -100,6 +97,8 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 			}
 		`;
 	}
+
+	tabRef = createRef();
 
 	constructor() {
 		super();

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -23,8 +23,8 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		return css`
 			:host {
 				box-sizing: border-box;
-				max-width: 200px;
 				display: inline-block;
+				max-width: 200px;
 			}
 			[role="tab"] {
 				color: unset;
@@ -140,10 +140,6 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		});
 	}
 
-	_handleTabClick() {
-		this.selected = 'true';
-	}
-
 	_handleKeyDown(e) {
 		if (e.keyCode !== keyCodes.SPACE) return;
 		e.stopPropagation();
@@ -153,6 +149,10 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 	_handleKeyUp(e) {
 		if (e.keyCode !== keyCodes.ENTER && e.keyCode !== keyCodes.SPACE) return;
 		e.target.click();
+	}
+
+	_handleTabClick() {
+		this.selected = 'true';
 	}
 
 }

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -5,101 +5,104 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
 const keyCodes = {
 	ENTER: 13,
-	SPACE: 32
+	SPACE: 32,
+	ARROWS: [35, 36, 37, 38, 39, 40]
 };
+
+export const tabInternalStyles = css`
+	d2l-tab-internal {
+		box-sizing: border-box;
+		display: inline-block;
+		max-width: 200px;
+	}
+	[role="tab"] {
+		color: inherit;
+		display: inline-block;
+		outline: none;
+		position: relative;
+		text-decoration: unset;
+		vertical-align: middle;
+		max-width: 100%;
+	}
+	.d2l-tab-text {
+		margin: 0.5rem;
+		overflow: hidden;
+		padding: 0.1rem;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	d2l-tab-internal:first-child .d2l-tab-text {
+		margin-left: 0;
+	}
+	d2l-tab-internal[dir="rtl"]:first-child .d2l-tab-text {
+		margin-left: 0.6rem;
+		margin-right: 0;
+	}
+	.d2l-tab-selected-indicator {
+		border-top: 4px solid var(--d2l-color-celestine);
+		border-top-left-radius: 4px;
+		border-top-right-radius: 4px;
+		bottom: 0;
+		display: none;
+		margin: 1px 0.6rem 0 0.6rem;
+		position: absolute;
+		-webkit-transition: box-shadow 0.2s;
+		transition: box-shadow 0.2s;
+		width: calc(100% - 1.2rem);
+	}
+	d2l-tab-internal:first-child .d2l-tab-selected-indicator {
+		margin-left: 0;
+		width: calc(100% - 0.6rem);
+	}
+	d2l-tab-internal[dir="rtl"]:first-child .d2l-tab-selected-indicator {
+		margin-left: 0.6rem;
+		margin-right: 0;
+	}
+	[role="tab"].focus-visible > .d2l-tab-text {
+		border-radius: 0.3rem;
+		box-shadow: 0 0 0 2px var(--d2l-color-celestine);
+		color: var(--d2l-color-celestine);
+	}
+	d2l-tab-internal[selected] [role="tab"]:focus {
+		text-decoration: none;
+	}
+	[role="tab"]:hover {
+		color: var(--d2l-color-celestine);
+		cursor: pointer;
+	}
+	d2l-tab-internal[selected] [role="tab"]:hover {
+		color: inherit;
+		cursor: default;
+	}
+	d2l-tab-internal[selected] .d2l-tab-selected-indicator {
+		display: block;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.d2l-tab-selected-indicator {
+			-webkit-transition: none;
+			transition: none;
+		}
+	}
+	`;
 
 class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 
 	static get properties() {
 		return {
 			activeFocusable: { type: Boolean, attribute: 'active-focusable' },
-			selected: { type: String, reflect: true, attribute: 'selected' },
+			selected: { type: Boolean, reflect: true },
 			controlsPanel: { type: String, reflect: true, attribute: 'controls-panel' },
 			text: { type: String },
 			href: { type: String }
 		};
 	}
-	static get styles() {
-		return css`
-			:host {
-				box-sizing: border-box;
-				display: inline-block;
-				max-width: 200px;
-			}
-			[role="tab"] {
-				color: inherit;
-				display: inline-block;
-				outline: none;
-				position: relative;
-				text-decoration: unset;
-				vertical-align: middle;
-			}
-			.d2l-tab-text {
-				margin: 0.5rem;
-				overflow: hidden;
-				padding: 0.1rem;
-				text-overflow: ellipsis;
-				white-space: nowrap;
-			}
-			:host(:first-child) .d2l-tab-text {
-				margin-left: 0;
-			}
-			:host([dir="rtl"]:first-child) .d2l-tab-text {
-				margin-left: 0.6rem;
-				margin-right: 0;
-			}
-			.d2l-tab-selected-indicator {
-				border-top: 4px solid var(--d2l-color-celestine);
-				border-top-left-radius: 4px;
-				border-top-right-radius: 4px;
-				bottom: 0;
-				display: none;
-				margin: 1px 0.6rem 0 0.6rem;
-				position: absolute;
-				-webkit-transition: box-shadow 0.2s;
-				transition: box-shadow 0.2s;
-				width: calc(100% - 1.2rem);
-			}
-			:host(:first-child) .d2l-tab-selected-indicator {
-				margin-left: 0;
-				width: calc(100% - 0.6rem);
-			}
-			:host([dir="rtl"]:first-child) .d2l-tab-selected-indicator {
-				margin-left: 0.6rem;
-				margin-right: 0;
-			}
-			.focus-visible > .d2l-tab-text {
-				border-radius: 0.3rem;
-				box-shadow: 0 0 0 2px var(--d2l-color-celestine);
-				color: var(--d2l-color-celestine);
-			}
-			:host([selected="true"]) [role="tab"]:focus {
-				text-decoration: none;
-			}
-			[role="tab"]:hover {
-				color: var(--d2l-color-celestine);
-				cursor: pointer;
-			}
-			:host([selected="true"] [role="tab"]:hover) {
-				color: inherit;
-				cursor: default;
-			}
-			:host([selected="true"]) .d2l-tab-selected-indicator {
-				display: block;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				.d2l-tab-selected-indicator {
-					-webkit-transition: none;
-					transition: none;
-				}
-			}
-		`;
-	}
 
 	constructor() {
 		super();
-		this.selected = 'false';
+		this.selected = false;
+		this.tabindex = '-1';
+		this.role = 'none';
 	}
 
 	render() {
@@ -108,7 +111,9 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		 href="${this.href}"
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
-		 aria-selected="${this.selected ? 'true' : 'false'}"
+		 aria-selected="${this.selected}"
+		 aria-controls="${this.controlsPanel}"
+		 title="${this.text}"
 		 @keydown="${this._handleKeyDown}"
 		 @keyup="${this._handleKeyUp}">
 			<div class="d2l-tab-text">${this.text}</div>
@@ -118,7 +123,9 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		<span
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
-		 aria-selected="${this.selected ? 'true' : 'false'}"
+		 aria-selected="${this.selected}"
+		 aria-controls="${this.controlsPanel}"
+		 title="${this.text}"
 		 @click="${this._handleTabClick}"
 		 @keydown="${this._handleKeyDown}"
 		 @keyup="${this._handleKeyUp}">
@@ -130,18 +137,25 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 	update(changedProperties) {
 		super.update(changedProperties);
 		changedProperties.forEach((oldVal, prop) => {
-			if (prop === 'selected' && this.selected === 'true') {
+			if (prop === 'selected' && this.selected) {
 				this.dispatchEvent(new CustomEvent(
 					'd2l-tab-selected', { bubbles: true, composed: true }
 				));
-			} else if (prop === 'text') {
-				this.title = this.text;
 			}
 		});
 	}
 
+	focus() {
+		this.querySelector('[role="tab"]').focus();
+	}
+
 	_handleKeyDown(e) {
-		if (e.keyCode !== keyCodes.SPACE) return;
+		if (keyCodes.ARROWS.includes(e.keyCode)) {
+			this.dispatchEvent(new KeyboardEvent('keydown', e));
+		}
+		else if (e.keyCode !== keyCodes.SPACE) {
+			return;
+		}
 		e.stopPropagation();
 		e.preventDefault();
 	}
@@ -152,7 +166,11 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 	}
 
 	_handleTabClick() {
-		this.selected = 'true';
+		this.selected = true;
+	}
+
+	createRenderRoot() {
+		return this;
 	}
 
 }

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -109,6 +109,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
 		 aria-selected="${this.selected ? 'true' : 'false'}"
+		 @keydown="${this._handleKeyDown}"
 		 @keyup="${this._handleKeyUp}">
 			<div class="d2l-tab-text">${this.text}</div>
 			<div class="d2l-tab-selected-indicator"></div>

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -23,15 +23,15 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		return css`
 			:host {
 				box-sizing: border-box;
-				display: inline-block;
-				max-width: 200px;
-				position: relative;
-				vertical-align: middle;
 			}
 			[role="tab"] {
 				color: unset;
+				display: inline-block;
+				max-width: 200px;
 				outline: none;
+				position: relative;
 				text-decoration: unset;
+				vertical-align: middle;
 			}
 			.d2l-tab-text {
 				margin: 0.5rem;
@@ -72,14 +72,14 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 				box-shadow: 0 0 0 2px var(--d2l-color-celestine);
 				color: var(--d2l-color-celestine);
 			}
-			:host([selected="true"]), [role="tab"]:focus {
+			:host([selected="true"]) [role="tab"]:focus {
 				text-decoration: none;
 			}
-			:host(:hover) {
+			[role="tab"]:hover {
 				color: var(--d2l-color-celestine);
 				cursor: pointer;
 			}
-			:host([selected="true"]:hover) {
+			:host([selected="true"] [role="tab"]:hover) {
 				color: inherit;
 				cursor: default;
 			}

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -112,7 +112,6 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
 		 aria-selected="${this.selected}"
-		 aria-controls="${this.controlsPanel}"
 		 title="${this.text}"
 		 @keydown="${this._handleKeyDown}"
 		 @keyup="${this._handleKeyUp}">
@@ -124,7 +123,6 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
 		 aria-selected="${this.selected}"
-		 aria-controls="${this.controlsPanel}"
 		 title="${this.text}"
 		 @click="${this._handleTabClick}"
 		 @keydown="${this._handleKeyDown}"

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -1,5 +1,4 @@
 import '../colors/colors.js';
-import { createRef, ref } from 'lit/directives/ref.js';
 import { css, html, LitElement } from 'lit';
 import { FocusVisiblePolyfillMixin } from '../../mixins/focus-visible-polyfill-mixin.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
@@ -97,38 +96,21 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		`;
 	}
 
-	tabRef = createRef();
-
 	constructor() {
 		super();
 		this.selected = 'false';
 	}
 
-	firstUpdated(changedProperties) {
-
-		super.firstUpdated(changedProperties);
-		this.tabRef.value.addEventListener('click', () => {
-			this.selected = 'true';
-		});
-		this.tabRef.value.addEventListener('keydown', (e) => {
-			if (e.keyCode !== keyCodes.SPACE) return;
-			e.stopPropagation();
-			e.preventDefault();
-		});
-		this.tabRef.value.addEventListener('keyup', (e) => {
-			if (e.keyCode !== keyCodes.ENTER && e.keyCode !== keyCodes.SPACE) return;
-			this.tabRef.value.click();
-		});
-	}
-
 	render() {
 		return this.href ? html`
 		<a
-			href="${this.href}"
+		 href="${this.href}"
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
 		 aria-selected="${this.selected ? 'true' : 'false'}"
-		 ${ref(this.tabRef)}>
+		 @click="${this._handleTabClick}"
+		 @keydown="${this._handleKeyDown}"
+		 @keyup="${this._handleKeyUp}">
 			<div class="d2l-tab-text">${this.text}</div>
 			<div class="d2l-tab-selected-indicator"></div>
 		</a>
@@ -137,7 +119,9 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
 		 aria-selected="${this.selected ? 'true' : 'false'}"
-		 ${ref(this.tabRef)}>
+		 @click="${this._handleTabClick}"
+		 @keydown="${this._handleKeyDown}"
+		 @keyup="${this._handleKeyUp}">
 			<div class="d2l-tab-text">${this.text}</div>
 			<div class="d2l-tab-selected-indicator"></div>
 		</span>`;
@@ -154,6 +138,21 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 				this.title = this.text;
 			}
 		});
+	}
+
+	_handleClick() {
+		this.selected = 'true';
+	}
+
+	_handleKeyDown(e) {
+		if (e.keyCode !== keyCodes.SPACE) return;
+		e.stopPropagation();
+		e.preventDefault();
+	}
+
+	_handleKeyUp(e) {
+		if (e.keyCode !== keyCodes.ENTER && e.keyCode !== keyCodes.SPACE) return;
+		e.target.click();
 	}
 
 }

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -30,11 +30,11 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 			[role="tab"] {
 				color: inherit;
 				display: inline-block;
+				max-width: 100%;
 				outline: none;
 				position: relative;
 				text-decoration: unset;
 				vertical-align: middle;
-				max-width: 100%;
 			}
 			.d2l-tab-text {
 				margin: 0.5rem;

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -23,11 +23,11 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		return css`
 			:host {
 				box-sizing: border-box;
+				max-width: 200px;
 			}
 			[role="tab"] {
 				color: unset;
 				display: inline-block;
-				max-width: 200px;
 				outline: none;
 				position: relative;
 				text-decoration: unset;

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -98,7 +98,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 			}
 		`;
 	}
-	
+
 	constructor() {
 		super();
 		this.selected = false;

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -27,7 +27,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 				max-width: 200px;
 			}
 			[role="tab"] {
-				color: unset;
+				color: inherit;
 				display: inline-block;
 				outline: none;
 				position: relative;

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -34,6 +34,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 				position: relative;
 				text-decoration: unset;
 				vertical-align: middle;
+				max-width: 100%;
 			}
 			.d2l-tab-text {
 				margin: 0.5rem;
@@ -81,7 +82,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 				color: var(--d2l-color-celestine);
 				cursor: pointer;
 			}
-			:host([selected] [role="tab"]:hover) {
+			:host([selected]) [role="tab"]:hover {
 				color: inherit;
 				cursor: default;
 			}
@@ -110,7 +111,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		 href="${this.href}"
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
-		 aria-selected="${this.selected ? 'true' : 'false'}"
+		 aria-selected="${this.selected}"
 		 aria-controls="${this.controlsPanel}"
 		 title="${this.text}"
 		 @keydown="${this._handleKeyDown}"
@@ -122,7 +123,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		<span
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
-		 aria-selected="${this.selected ? 'true' : 'false'}"
+		 aria-selected="${this.selected}"
 		 aria-controls="${this.controlsPanel}"
 		 title="${this.text}"
 		 @click="${this._handleTabClick}"

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -2,6 +2,7 @@ import '../colors/colors.js';
 import { css, html, LitElement } from 'lit';
 import { FocusVisiblePolyfillMixin } from '../../mixins/focus-visible-polyfill-mixin.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
+import { ref, createRef } from 'lit/directives/ref.js';
 
 const keyCodes = {
 	ENTER: 13,
@@ -9,6 +10,8 @@ const keyCodes = {
 };
 
 class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
+
+	tabRef = createRef();
 
 	static get properties() {
 		return {
@@ -107,17 +110,17 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 	firstUpdated(changedProperties) {
 
 		super.firstUpdated(changedProperties);
-		this.addEventListener('click', () => {
+		this.tabRef.value.addEventListener('click', () => {
 			this.selected = 'true';
 		});
-		this.addEventListener('keydown', (e) => {
+		this.tabRef.value.addEventListener('keydown', (e) => {
 			if (e.keyCode !== keyCodes.SPACE) return;
 			e.stopPropagation();
 			e.preventDefault();
 		});
-		this.addEventListener('keyup', (e) => {
+		this.tabRef.value.addEventListener('keyup', (e) => {
 			if (e.keyCode !== keyCodes.ENTER && e.keyCode !== keyCodes.SPACE) return;
-			this.selected = 'true';
+			this.tabRef.value.click();
 		});
 	}
 
@@ -127,7 +130,8 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 			href="${this.href}"
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
-		 aria-selected="${this.selected ? 'true' : 'false'}">
+		 aria-selected="${this.selected ? 'true' : 'false'}"
+		 ${ref(this.tabRef)}>
 			<div class="d2l-tab-text">${this.text}</div>
 			<div class="d2l-tab-selected-indicator"></div>
 		</a>
@@ -135,7 +139,8 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		<span
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
-		 aria-selected="${this.selected ? 'true' : 'false'}">
+		 aria-selected="${this.selected ? 'true' : 'false'}"
+		 ${ref(this.tabRef)}>
 			<div class="d2l-tab-text">${this.text}</div>
 			<div class="d2l-tab-selected-indicator"></div>
 		</span>`;

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -16,7 +16,6 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 			activeFocusable: { type: Boolean, attribute: 'active-focusable' },
 			selected: { type: String, reflect: true, attribute: 'selected' },
 			controlsPanel: { type: String, reflect: true, attribute: 'controls-panel' },
-			role: { type: String, reflect: true },
 			text: { type: String },
 			href: { type: String }
 		};
@@ -103,7 +102,6 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 	constructor() {
 		super();
 		this.selected = 'false';
-		this.role = 'tab';
 	}
 
 	firstUpdated(changedProperties) {

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -24,6 +24,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 			:host {
 				box-sizing: border-box;
 				max-width: 200px;
+				display: inline-block;
 			}
 			[role="tab"] {
 				color: unset;

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -108,8 +108,6 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		 role="tab"
 		 tabindex="${this.activeFocusable ? 0 : -1}"
 		 aria-selected="${this.selected ? 'true' : 'false'}"
-		 @click="${this._handleTabClick}"
-		 @keydown="${this._handleKeyDown}"
 		 @keyup="${this._handleKeyUp}">
 			<div class="d2l-tab-text">${this.text}</div>
 			<div class="d2l-tab-selected-indicator"></div>
@@ -140,7 +138,7 @@ class Tab extends RtlMixin(FocusVisiblePolyfillMixin(LitElement)) {
 		});
 	}
 
-	_handleClick() {
+	_handleTabClick() {
 		this.selected = 'true';
 	}
 

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -45,6 +45,11 @@ export const TabPanelMixin = superclass => class extends superclass {
 			:host([selected]) {
 				display: block;
 			}
+			:host(.focus-visible) {
+				outline: none;
+				border-radius: 0.3rem;
+				box-shadow: 0 0 0 2px var(--d2l-color-celestine);
+			}
 		`;
 	}
 

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -80,11 +80,6 @@ export const TabPanelMixin = superclass => class extends superclass {
 				this.dispatchEvent(new CustomEvent(
 					'd2l-tab-panel-text-changed', { bubbles: true, composed: true, detail: { text: this.text } }
 				));
-			} else if (prop === 'href') {
-				/** Dispatched when the href attribute is changed */
-				this.dispatchEvent(new CustomEvent(
-					'd2l-tab-panel-href-changed', { bubbles: true, composed: true, detail: { href: this.href } }
-				));
 			}
 		});
 	}

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -46,9 +46,9 @@ export const TabPanelMixin = superclass => class extends superclass {
 				display: block;
 			}
 			:host(.focus-visible) {
-				outline: none;
 				border-radius: 0.3rem;
 				box-shadow: 0 0 0 2px var(--d2l-color-celestine);
+				outline: none;
 			}
 		`;
 	}

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -23,7 +23,12 @@ export const TabPanelMixin = superclass => class extends superclass {
 			 * REQUIRED: The text used for the tab, as well as labelling the panel
 			 * @type {string}
 			 */
-			text: { type: String }
+			text: { type: String },
+			/**
+			 * Use for single-page-app routing
+			 * @type {string}
+			 */
+			href: { type: String },
 		};
 	}
 
@@ -74,6 +79,11 @@ export const TabPanelMixin = superclass => class extends superclass {
 				/** Dispatched when the text attribute is changed */
 				this.dispatchEvent(new CustomEvent(
 					'd2l-tab-panel-text-changed', { bubbles: true, composed: true, detail: { text: this.text } }
+				));
+			} else if (prop === 'href') {
+				/** Dispatched when the href attribute is changed */
+				this.dispatchEvent(new CustomEvent(
+					'd2l-tab-panel-href-changed', { bubbles: true, composed: true, detail: { href: this.href } }
 				));
 			}
 		});

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -1,7 +1,6 @@
 import '../colors/colors.js';
 import '../icons/icon.js';
 import '../../helpers/queueMicrotask.js';
-import './tab-internal.js';
 import { css, html, LitElement } from 'lit';
 import { cssEscape, findComposedAncestor } from '../../helpers/dom.js';
 import { ArrowKeysMixin } from '../../mixins/arrow-keys-mixin.js';
@@ -13,6 +12,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import { tabInternalStyles } from './tab-internal.js';
 
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
@@ -72,7 +72,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	static get styles() {
-		return [bodyCompactStyles, css`
+		return [bodyCompactStyles, tabInternalStyles, css`
 			:host {
 				--d2l-tabs-background-color: white;
 				box-sizing: border-box;
@@ -296,7 +296,6 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 					await this._updateScrollPosition(tabInfo);
 				}
 			}
-			return tab.shadowRoot.querySelector('[role="tab"]');
 		};
 
 		this._handleResize = this._handleResize.bind(this);
@@ -346,7 +345,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 							style="${styleMap(tabsContainerListStyles)}">
 							${repeat(this._tabInfos, (tabInfo) => tabInfo.id, (tabInfo) => html`
 								<d2l-tab-internal
-								  .selected="${tabInfo.selected ? 'true' : 'false'}"
+								  .selected="${tabInfo.selected}"
 									.controlsPanel="${tabInfo.id}"
 									.activeFocusable="${tabInfo.activeFocusable}"
 									data-state="${tabInfo.state}"
@@ -499,7 +498,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	async _focusSelected() {
-		const selectedTab = this.shadowRoot?.querySelector('d2l-tab-internal[selected="true"]');
+		const selectedTab = this.shadowRoot?.querySelector('d2l-tab-internal[selected]');
 		if (!selectedTab) return;
 		const selectedTabInfo = this._getTabInfo(selectedTab.controlsPanel);
 		await this._updateScrollPosition(selectedTabInfo);

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -279,7 +279,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 			await this.updateComplete;
 
 			if (!this._scrollCollapsed) {
-				return this._updateScrollPosition(tabInfo);
+				await this._updateScrollPosition(tabInfo);
 			} else {
 				const measures = this._getMeasures();
 				const newTranslationValue = this._calculateScrollPosition(tabInfo, measures);
@@ -291,12 +291,11 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 				}
 
 				const expanded = await this._tryExpandTabsContainer(measures);
-				if (expanded) {
-					return;
-				} else {
-					return this._updateScrollPosition(tabInfo);
+				if (!expanded) {
+					await this._updateScrollPosition(tabInfo);
 				}
 			}
+			return tab.shadowRoot.querySelector('[role="tab"]');
 		};
 
 		this._handleResize = this._handleResize.bind(this);
@@ -345,10 +344,12 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 							role="tablist"
 							style="${styleMap(tabsContainerListStyles)}">
 							${repeat(this._tabInfos, (tabInfo) => tabInfo.id, (tabInfo) => html`
-								<d2l-tab-internal aria-selected="${tabInfo.selected ? 'true' : 'false'}"
+								<d2l-tab-internal
+								  selected="${tabInfo.selected ? 'true' : 'false'}"
 									.controlsPanel="${tabInfo.id}"
+									.activeFocusable="${tabInfo.activeFocusable}"
 									data-state="${tabInfo.state}"
-									tabindex="${tabInfo.activeFocusable ? 0 : -1}"
+									href="${tabInfo.href}"
 									text="${tabInfo.text}">
 								</d2l-tab-internal>
 							`)}
@@ -497,9 +498,8 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	async _focusSelected() {
-		const selectedTab = this.shadowRoot && this.shadowRoot.querySelector('d2l-tab-internal[aria-selected="true"]');
+		const selectedTab = this.shadowRoot && this.shadowRoot.querySelector('d2l-tab-internal[selected="true"]');
 		if (!selectedTab) return;
-
 		const selectedTabInfo = this._getTabInfo(selectedTab.controlsPanel);
 		await this._updateScrollPosition(selectedTabInfo);
 
@@ -590,6 +590,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 			const tabInfo = {
 				id: panel.id,
 				text: panel.text,
+				href: panel.href,
 				selected: panel.selected,
 				state: state
 			};
@@ -809,7 +810,9 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	_setFocusable(tabInfo) {
+
 		const currentFocusable = this._tabInfos.find(ti => ti.activeFocusable);
+
 		if (currentFocusable) currentFocusable.activeFocusable = false;
 
 		tabInfo.activeFocusable = true;

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -554,7 +554,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	_handleFocusOut(e) {
-		if (e.relatedTarget && e.relatedTarget.role === 'tab') return;
+		if (e.relatedTarget?.tagName === 'D2L-TAB-INTERNAL') return;
 		this._resetFocusables();
 	}
 

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -1,6 +1,7 @@
 import '../colors/colors.js';
 import '../icons/icon.js';
 import '../../helpers/queueMicrotask.js';
+import './tab-internal.js';
 import { css, html, LitElement } from 'lit';
 import { cssEscape, findComposedAncestor } from '../../helpers/dom.js';
 import { ArrowKeysMixin } from '../../mixins/arrow-keys-mixin.js';
@@ -12,7 +13,6 @@ import { repeat } from 'lit/directives/repeat.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import { tabInternalStyles } from './tab-internal.js';
 
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
@@ -72,7 +72,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	static get styles() {
-		return [bodyCompactStyles, tabInternalStyles, css`
+		return [bodyCompactStyles, css`
 			:host {
 				--d2l-tabs-background-color: white;
 				box-sizing: border-box;

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -93,6 +93,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 				display: flex;
 			}
 			.d2l-tabs-layout-shown {
+				align-items: center;
 				display: flex;
 				max-height: 60px;
 				opacity: 1;

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -498,7 +498,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	async _focusSelected() {
-		const selectedTab = this.shadowRoot && this.shadowRoot.querySelector('d2l-tab-internal[selected="true"]');
+		const selectedTab = this.shadowRoot?.querySelector('d2l-tab-internal[selected="true"]');
 		if (!selectedTab) return;
 		const selectedTabInfo = this._getTabInfo(selectedTab.controlsPanel);
 		await this._updateScrollPosition(selectedTabInfo);

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -345,7 +345,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 							style="${styleMap(tabsContainerListStyles)}">
 							${repeat(this._tabInfos, (tabInfo) => tabInfo.id, (tabInfo) => html`
 								<d2l-tab-internal
-								  selected="${tabInfo.selected ? 'true' : 'false'}"
+								  .selected="${tabInfo.selected ? 'true' : 'false'}"
 									.controlsPanel="${tabInfo.id}"
 									.activeFocusable="${tabInfo.activeFocusable}"
 									data-state="${tabInfo.state}"

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -811,9 +811,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(FocusVisiblePolyf
 	}
 
 	_setFocusable(tabInfo) {
-
 		const currentFocusable = this._tabInfos.find(ti => ti.activeFocusable);
-
 		if (currentFocusable) currentFocusable.activeFocusable = false;
 
 		tabInfo.activeFocusable = true;

--- a/components/tabs/test/tabs.axe.js
+++ b/components/tabs/test/tabs.axe.js
@@ -9,7 +9,7 @@ describe('d2l-tabs', () => {
 			<d2l-tabs>
 				<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 				<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+				<d2l-tab-panel text="Chemistry" href="chemistry">Tab content for Chemistry</d2l-tab-panel>
 			</d2l-tabs>`);
 		await expect(el).to.be.accessible();
 	});

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -1,6 +1,6 @@
 import '../tabs.js';
 import '../tab-panel.js';
-import { fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`
@@ -8,7 +8,7 @@ const normalFixture = html`
 		<d2l-tabs>
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+			<d2l-tab-panel text="Chemistry" href="chemistry">Tab content for Chemistry</d2l-tab-panel>
 		</d2l-tabs>
 	</div>
 `;
@@ -34,6 +34,21 @@ describe('d2l-tabs', () => {
 			const panel = el.querySelectorAll('d2l-tab-panel')[1];
 			setTimeout(() => panel.selected = true);
 			await oneEvent(panel, 'd2l-tab-panel-selected');
+		});
+
+		it.only('selects panel when clicked', async() => {
+			const el = await fixture(normalFixture);
+			const panel = el.querySelectorAll('d2l-tab-panel')[1];
+			panel.click();
+			expect(panel.selected).to.be.false;
+		});
+
+		it.only('does not select href panel when clicked', async() => {
+			//const document.addEventListener('click', () => false);
+			const el = await fixture(normalFixture);
+			const hrefPanel = el.querySelectorAll('d2l-tab-panel')[2];
+			hrefPanel.click();
+			expect(hrefPanel.selected).to.be.false;
 		});
 
 		it('dispatches d2l-tab-panel-text-changed', async() => {

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -36,15 +36,14 @@ describe('d2l-tabs', () => {
 			await oneEvent(panel, 'd2l-tab-panel-selected');
 		});
 
-		it.only('selects panel when clicked', async() => {
+		it('selects panel when clicked', async() => {
 			const el = await fixture(normalFixture);
 			const panel = el.querySelectorAll('d2l-tab-panel')[1];
 			panel.click();
 			expect(panel.selected).to.be.false;
 		});
 
-		it.only('does not select href panel when clicked', async() => {
-			//const document.addEventListener('click', () => false);
+		it('does not select href panel when clicked', async() => {
 			const el = await fixture(normalFixture);
 			const hrefPanel = el.querySelectorAll('d2l-tab-panel')[2];
 			hrefPanel.click();

--- a/index.html
+++ b/index.html
@@ -17,8 +17,9 @@
 		}
 	</style>
 	<script>
-	  const pathParts = location.pathname.split('/').slice(0, -1);
-	  if (history.state) history.replaceState(history.state, '', `${pathParts.join('/')}/${pathParts.at(-2)}.html`), history.go();
+		const pathParts = location.pathname.split('/').slice(0, -1);
+		if (history.state) history.replaceState(history.state, '', `${pathParts.join('/')}/${pathParts.at(-2)}.html`), history.go();
+		else if (pathParts.length) history.replaceState('', '', '/');
 	</script>
 </head>
 <body class="d2l-typography">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 	</style>
 	<script>
 	  const pathParts = location.pathname.split('/').slice(0, -1);
-	  if (history.state) history.replaceState({}, '', `${pathParts.join('/')}/${pathParts.at(-2)}.html`), history.go();
+	  if (history.state) history.replaceState(history.state, '', `${pathParts.join('/')}/${pathParts.at(-2)}.html`), history.go();
 	</script>
 </head>
 <body class="d2l-typography">

--- a/index.html
+++ b/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<link rel="stylesheet" href="components/demo/styles.css" type="text/css">
+	<link rel="stylesheet" href="/components/demo/styles.css" type="text/css">
 	<script type="module">
-		import './components/colors/colors.js';
-		import './components/typography/typography.js';
-		import './index.js';
+		/* eslint-disable import/no-absolute-path, indent */
+		import '/components/colors/colors.js';
+		import '/components/typography/typography.js';
+		import '/index.js';
 	</script>
 	<title>core-ui</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,6 +16,10 @@
 			padding: 0 30px;
 		}
 	</style>
+	<script>
+	  const pathParts = location.pathname.split('/').slice(0, -1);
+	  if (history.state) history.replaceState({}, '', `${pathParts.join('/')}/${pathParts.at(-2)}.html`), history.go();
+	</script>
 </head>
 <body class="d2l-typography">
 

--- a/mixins/arrow-keys-mixin.js
+++ b/mixins/arrow-keys-mixin.js
@@ -44,7 +44,7 @@ export const ArrowKeysMixin = superclass => class extends superclass {
 
 	async _focus(elem) {
 		if (elem) {
-			elem = await this.arrowKeysOnBeforeFocus?.(elem) || elem;
+			this.arrowKeysOnBeforeFocus && await this.arrowKeysOnBeforeFocus(elem);
 			elem.focus();
 		}
 	}

--- a/mixins/arrow-keys-mixin.js
+++ b/mixins/arrow-keys-mixin.js
@@ -44,7 +44,7 @@ export const ArrowKeysMixin = superclass => class extends superclass {
 
 	async _focus(elem) {
 		if (elem) {
-			if (this.arrowKeysOnBeforeFocus) await this.arrowKeysOnBeforeFocus(elem);
+			elem = await this.arrowKeysOnBeforeFocus?.(elem) || elem;
 			elem.focus();
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:eslint": "eslint . --ext .js,.html --ignore-path .gitignore",
     "lint:lit": "lit-analyzer \"{components,controllers,directives,helpers,mixins,templates,test,tools}/**/*.js\" --strict --rules.no-unknown-tag-name off",
     "lint:style": "stylelint \"**/*.{js,html}\" --ignore-path .gitignore",
-    "start": "web-dev-server --node-resolve --watch --open",
+    "start": "web-dev-server --app-index index.html --node-resolve --watch --open",
     "test": "npm run lint && npm run test:translations && npm run test:headless && npm run test:axe",
     "test:axe": "web-test-runner --group aXe",
     "test:headless": "web-test-runner --group default",


### PR DESCRIPTION
In order to support deep linking to tabs within single-page apps, `d2l-tabs` needs to support using anchors for tabs.

- Moves the actual tab inside tab-internal shadow DOM
- If an `href` is provided use an anchor for the tab
- Do not select the tab or dispatch an event when clicked
- Adds basic support for SPA routing to all demos, if applied

I have another branch that uses the host itself as its `renderRoot` (so attaches the template to the light dom) that would allow us to use `aria-controls` correctly, but since we don't use it at all now (and `ARIAMixin` is gaining support for element references soon-ish) I left this in the shadow DOM.

[US148994](https://rally1.rallydev.com/#/?detail=/userstory/686279846799&fdp=true): Add support for anchor tabs to d2l-tabs