### PR TITLE
Add a section "announcing dialog text"

### DIFF
--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -276,7 +276,7 @@ When using `d2l-dialog` or `d2l-dialog-fullscreen` the dialog text will not be a
 To announce the dialog text, use one of the following methods:
 
 1. Use `d2l-dialog-confirm` instead
-2. Add `describe-content="true"`
+2. Add `describe-content="true"` (if using `d2l-dialog`)
 3. Set `autofocus` on the first text element (see above for details)
 
 <!-- docs: start hidden content -->

--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -257,15 +257,27 @@ document.querySelector('#open').addEventListener('click', () => {
 });
 ```
 
-## Focus Management
+## Accessibility
+
+### Focus Management
 
 When opened, focus will be automatically placed within the dialog. The element to be focused will either be the content element having the optional `autofocus` attribute, or a focusable element identified by the dialog depending on the type of dialog. For `d2l-dialog` and `d2l-dialog-fullscreen`, the first focusable element will be focused. For `d2l-dialog-confirm`, the least destructive action will be focused, which is assumed to be the first non-primary button in the footer.
 
-### Specifying an `autofocus` Element (Optional)
+#### Specifying an `autofocus` Element (Optional)
 
 To specify which element should be focused, add the `autofocus` attribute to that element. An element with the `autofocus` attribute will receive focus if the element has a `tabindex` value of `0` or `-1`, or is a naturally focusable element (e.g. button).
 
 Note that the element must be in the dialog content's DOM scope and not within another component's Shadow DOM.
+
+### Announcing the dialog text
+
+When using `d2l-dialog` or `d2l-dialog-fullscreen` the dialog text will not be announced by screen readers. Screen readers will announce the presence of a dialog, the dialog title, and the currently focused element. For example, the general dialog example at the top of this page reads "Dialog Title dialog. clickable Done button.". The text "Some dialog content" is not announced.
+
+To announce the dialog text, use one of the following methods:
+
+1. Use `d2l-dialog-confirm` instead
+2. Add `describe-content="true"`
+3. Set `autofocus` on the first text element (see above for details)
 
 <!-- docs: start hidden content -->
 ## Future Improvements


### PR DESCRIPTION
[US148599](https://rally1.rallydev.com/#/?detail=/userstory/685344794269&fdp=true): Update Daylight Core UI docs for accessibility

Add a section to the `d2l-dialog` page about how to use `describe-content` to make sure the text content is announced.

**Context**
Updating as a result of https://github.com/BrightspaceUI/core/issues/3156, in particular https://github.com/BrightspaceUI/core/issues/3156#issuecomment-1380700267. This change will hopefully prevent any such confusion in the future.

Also see the recommendation from @geurts 
https://github.com/BrightspaceUI/core/issues/3156#issuecomment-1423478779