### PR TITLE
Alternative custom empty state approach

### DIFF
--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -154,6 +154,7 @@ The filter will announce changes to filter selections, search results, and when 
 
 ### Events
 * `d2l-filter-change`: dispatched when any filter value has changed (may contain info about multiple dimensions and multiple changes in each)
+* `d2l-filter-dimension-empty-state-action`: dispatched when an empty state action button is clicked
 * `d2l-filter-dimension-first-open`: dispatched when a dimension is opened for the first time (if there is only one dimension, this will be dispatched when the dropdown is first opened)
 * `d2l-filter-dimension-search`: dispatched when a dimension that supports searching and has the "manual" search-type is searched
 
@@ -257,6 +258,43 @@ Note that when using multiple filter dimensions, the counts should be updated wh
   </d2l-filter-dimension-set>
 </d2l-filter>
 ```
+
+## Dimension Set Empty State [d2l-filter-dimension-set-empty-state]
+
+The `d2l-filter-dimension-set-empty-state` component allows you to customize the empty state components that are rendered in [d2l-filter-dimension-set](#d2l-filter-dimension-set). When placed in the `d2l-filter-dimension-set` empty state slots, it will replace the component's default empty state. This component can be placed in either the `set-empty-state` or the `search-empty-state` slots.
+
+<!-- docs: demo live name:d2l-filter-dimension-set-value align:start autoOpen:true autoSize:false size:large -->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/filter/filter.js';
+  import '@brightspace-ui/core/components/filter/filter-dimension-set.js';
+  import '@brightspace-ui/core/components/filter/filter-dimension-set-empty-state.js';
+  import '@brightspace-ui/core/components/filter/filter-dimension-set-value.js';
+</script>
+<d2l-filter>
+  <d2l-filter-dimension-set key="course" text="Course" >
+    <d2l-filter-dimension-set-value key="art" text="Art" count="1" selected></d2l-filter-dimension-set-value>
+    <d2l-filter-dimension-set-value key="astronomy" text="Astronomy" count="3" disabled></d2l-filter-dimension-set-value>
+    <d2l-filter-dimension-set-value key="biology" text="Biology" count="5"></d2l-filter-dimension-set-value>
+	<d2l-filter-dimension-set-empty-state slot="search-empty-state" description="Search returned no results." action-text="Add a course"></d2l-filter-dimension-set-empty-state>
+	<d2l-filter-dimension-set-empty-state slot="set-empty-state" description="There are no available items." action-text="Add a course"></d2l-filter-dimension-set-empty-state>
+  </d2l-filter-dimension-set>
+</d2l-filter>
+<script>
+	document.querySelector('#filter-single').addEventListener('d2l-filter-dimension-empty-state-action', e => {
+			console.log(`Filter dimension empty state action clicked:\nkey: ${e.detail.key}\ntype: ${e.detail.type}`);
+		});
+</script>
+```
+<!-- docs: start hidden content -->
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `action-href` | String | The href that will be used for the empty state action. When set with action-text, d2l-filter will render a link action. |
+| `action-text` | String | The text that will be displayed in the empty state action. When set, d2l-filter renders a button action, or a link if action-href is also defined. |
+| `description` | String, required | The text that is displayed in the empty state description |
+<!-- docs: end hidden content -->
 
 ## Tags for Applied Filters [d2l-filter-tags]
 

--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -263,7 +263,7 @@ Note that when using multiple filter dimensions, the counts should be updated wh
 
 The `d2l-filter-dimension-set-empty-state` component allows you to customize the empty state components that are rendered in [d2l-filter-dimension-set](#d2l-filter-dimension-set). When placed in the `d2l-filter-dimension-set` empty state slots, it will replace the component's default empty state. This component can be placed in either the `set-empty-state` or the `search-empty-state` slots.
 
-<!-- docs: demo live name:d2l-filter-dimension-set-value align:start autoOpen:true autoSize:false size:large -->
+<!-- docs: demo live name:d2l-filter-dimension-set-empty-state align:start autoOpen:true autoSize:false size:large -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/filter/filter.js';

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -73,6 +73,7 @@
 						<d2l-filter-dimension-set-value key="physics" text="Physics" count="1012"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="stats" text="Statistics" count="2"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="writerscraft" text="Writer's Craft"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-empty-state slot="search-empty-state" description="Search returned no results." action-text="Do something" action-href="https://d2l.com/"></d2l-filter-dimension-set-empty-state>
 					</d2l-filter-dimension-set>
 					<d2l-filter-dimension-set key="role" text="Role">
 						<d2l-filter-dimension-set-value key="admin" text="Admin" count="0"></d2l-filter-dimension-set-value>
@@ -129,7 +130,7 @@
 		</d2l-demo-snippet>
 	</d2l-demo-page>
 
-<script type="module">
+	<script type="module">
 		document.addEventListener('d2l-filter-change', e => {
 			if (e.detail.dimensions.length === 1) {
 				console.log(`Filter selection(s) changed for dimension "${e.detail.dimensions[0].dimensionKey}":`, e.detail.dimensions[0].changes); // eslint-disable-line no-console
@@ -148,7 +149,7 @@
 		});
 
 		document.querySelector('#filter-single').addEventListener('d2l-filter-dimension-empty-state-action', e => {
-			console.log(e);
+			console.log(`Filter dimension empty state action clicked:\nkey: ${e.detail.key}\ntype: ${e.detail.type}`);
 		});
 
 		requestAnimationFrame(() => {

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -8,6 +8,7 @@
 		import '../../button/button.js';
 		import '../../filter/filter.js';
 		import '../../filter/filter-dimension-set.js';
+		import '../../filter/filter-dimension-set-empty-state.js';
 		import '../../filter/filter-dimension-set-value.js';
 		import './filter-search-demo.js';
 	</script>
@@ -24,7 +25,7 @@
 			<template>
 				<d2l-filter>
 					<d2l-filter-dimension-set key="course" text="Course" select-all>
-						<d2l-filter-dimension-set-value key="art" text="Art" count="12"></d2l-filter-dimension-set-value>
+						<!-- <d2l-filter-dimension-set-value key="art" text="Art" count="12"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="astronomy" text="Astronomy" count="2" selected></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="biology" text="Biology" count="15"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="chemistry" text="Chemistry" count="1"disabled></d2l-filter-dimension-set-value>
@@ -33,8 +34,10 @@
 						<d2l-filter-dimension-set-value key="how-to" text="How To Write a How To Article With a Flashy Title" count="100"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="math" text="Math" count="50"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="physics" text="Physics" count="23"></d2l-filter-dimension-set-value>
-						<d2l-filter-dimension-set-value key="stats" text="Statistics" count="333"></d2l-filter-dimension-set-value>
-						<d2l-filter-dimension-set-value key="writerscraft" text="Writer's Craft" count="2211"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="stats" text="Statistics" count="333"></d2l-filter-dimension-set-value> -->
+						<!-- <d2l-filter-dimension-set-value key="writerscraft" text="Writer's Craft" count="2211"></d2l-filter-dimension-set-value> -->
+						<d2l-filter-dimension-set-empty-state slot="search-empty-state" description="Search returned no results." action-text="Do something"></d2l-filter-dimension-set-empty-state>
+						<d2l-filter-dimension-set-empty-state slot="set-empty-state" description="There are no available items." action-text="Add an item"></d2l-filter-dimension-set-empty-state>
 					</d2l-filter-dimension-set>
 				</d2l-filter>
 			</template>
@@ -126,7 +129,7 @@
 		</d2l-demo-snippet>
 	</d2l-demo-page>
 
-	<script type="module">
+<script type="module">
 		document.addEventListener('d2l-filter-change', e => {
 			if (e.detail.dimensions.length === 1) {
 				console.log(`Filter selection(s) changed for dimension "${e.detail.dimensions[0].dimensionKey}":`, e.detail.dimensions[0].changes); // eslint-disable-line no-console

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -23,9 +23,9 @@
 		<h2>Single Set Dimension</h2>
 		<d2l-demo-snippet>
 			<template>
-				<d2l-filter>
+				<d2l-filter id="filter-single">
 					<d2l-filter-dimension-set key="course" text="Course" select-all>
-						<!-- <d2l-filter-dimension-set-value key="art" text="Art" count="12"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="art" text="Art" count="12"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="astronomy" text="Astronomy" count="2" selected></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="biology" text="Biology" count="15"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="chemistry" text="Chemistry" count="1"disabled></d2l-filter-dimension-set-value>
@@ -34,8 +34,8 @@
 						<d2l-filter-dimension-set-value key="how-to" text="How To Write a How To Article With a Flashy Title" count="100"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="math" text="Math" count="50"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="physics" text="Physics" count="23"></d2l-filter-dimension-set-value>
-						<d2l-filter-dimension-set-value key="stats" text="Statistics" count="333"></d2l-filter-dimension-set-value> -->
-						<!-- <d2l-filter-dimension-set-value key="writerscraft" text="Writer's Craft" count="2211"></d2l-filter-dimension-set-value> -->
+						<d2l-filter-dimension-set-value key="stats" text="Statistics" count="333"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="writerscraft" text="Writer's Craft" count="2211"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-empty-state slot="search-empty-state" description="Search returned no results." action-text="Do something"></d2l-filter-dimension-set-empty-state>
 						<d2l-filter-dimension-set-empty-state slot="set-empty-state" description="There are no available items." action-text="Add an item"></d2l-filter-dimension-set-empty-state>
 					</d2l-filter-dimension-set>
@@ -145,6 +145,10 @@
 
 		document.addEventListener('d2l-filter-dimension-first-open', e => {
 			console.log(`Filter dimension opened for the first time: ${e.detail.key}`);
+		});
+
+		document.querySelector('#filter-single').addEventListener('d2l-filter-dimension-empty-state-action', e => {
+			console.log(e.detail);
 		});
 
 		requestAnimationFrame(() => {

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -148,7 +148,7 @@
 		});
 
 		document.querySelector('#filter-single').addEventListener('d2l-filter-dimension-empty-state-action', e => {
-			console.log(e.detail);
+			console.log(e);
 		});
 
 		requestAnimationFrame(() => {

--- a/components/filter/filter-dimension-set-empty-state.js
+++ b/components/filter/filter-dimension-set-empty-state.js
@@ -47,7 +47,8 @@ class FilterDimensionSetEmptyState extends LitElement {
 			/** @ignore */
 			this.dispatchEvent(new CustomEvent('d2l-filter-dimension-set-empty-state-change', {
 				bubbles: true,
-				composed: false
+				composed: false,
+				detail: { changes: changes }
 			}));
 		}
 	}

--- a/components/filter/filter-dimension-set-empty-state.js
+++ b/components/filter/filter-dimension-set-empty-state.js
@@ -33,26 +33,6 @@ class FilterDimensionSetEmptyState extends LitElement {
 		this.description = '';
 	}
 
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		const changes = new Map();
-		changedProperties.forEach((oldValue, prop) => {
-			if (oldValue === undefined) return;
-
-			if (prop === 'actionHref' || prop === 'actionText' || prop === 'description') {
-				changes.set(prop, this[prop]);
-			}
-		});
-		if (changes.size > 0) {
-			/** @ignore */
-			this.dispatchEvent(new CustomEvent('d2l-filter-dimension-set-empty-state-change', {
-				bubbles: true,
-				composed: false,
-				detail: { changes: changes }
-			}));
-		}
-	}
 }
 
 customElements.define('d2l-filter-dimension-set-empty-state', FilterDimensionSetEmptyState);

--- a/components/filter/filter-dimension-set-empty-state.js
+++ b/components/filter/filter-dimension-set-empty-state.js
@@ -2,23 +2,24 @@ import { LitElement } from 'lit';
 
 /**
  * A component to customize the empty state parameters for a particular filter-dimension-set.
+ * This component does not render anything, but instead gathers data needed for the d2l-filter.
  */
 class FilterDimensionSetEmptyState extends LitElement {
 
 	static get properties() {
 		return {
 			/**
-			 * Count for the value in the list. If no count is provided, no count will be displayed
+			 * The href that will be used for the empty state action. When set with action-text, d2l-filter will render a link action.
 			 * @type {string}
 			 */
 			actionHref: { type: String, attribute: 'action-href' },
 			/**
-			 * Whether this value in the filter is disabled or not
-			 * @type {boolean}
+			 * The text that will be displayed in the empty state action. When set, d2l-filter renders a button action, or a link if action-href is also defined.
+			 * @type {string}
 			 */
 			actionText: { type: String, attribute: 'action-text' },
 			/**
-			 * REQUIRED: The text that is displayed for the value
+			 * REQUIRED: The text that is displayed in the empty state description
 			 * @type {string}
 			 */
 			description: { type: String }
@@ -39,7 +40,7 @@ class FilterDimensionSetEmptyState extends LitElement {
 		changedProperties.forEach((oldValue, prop) => {
 			if (oldValue === undefined) return;
 
-			if (prop === 'actionHref' || prop === 'actionText' || prop === 'description' || prop === 'type') {
+			if (prop === 'actionHref' || prop === 'actionText' || prop === 'description') {
 				changes.set(prop, this[prop]);
 			}
 		});

--- a/components/filter/filter-dimension-set-empty-state.js
+++ b/components/filter/filter-dimension-set-empty-state.js
@@ -1,0 +1,56 @@
+import { LitElement } from 'lit';
+
+/**
+ * A component to customize the empty state parameters for a particular filter-dimension-set.
+ */
+class FilterDimensionSetEmptyState extends LitElement {
+
+	static get properties() {
+		return {
+			/**
+			 * Count for the value in the list. If no count is provided, no count will be displayed
+			 * @type {string}
+			 */
+			actionHref: { type: String, attribute: 'action-href' },
+			/**
+			 * Whether this value in the filter is disabled or not
+			 * @type {boolean}
+			 */
+			actionText: { type: String, attribute: 'action-text' },
+			/**
+			 * REQUIRED: The text that is displayed for the value
+			 * @type {string}
+			 */
+			description: { type: String }
+		};
+	}
+
+	constructor() {
+		super();
+		this.actionHref = '';
+		this.actionText = '';
+		this.description = '';
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		const changes = new Map();
+		changedProperties.forEach((oldValue, prop) => {
+			if (oldValue === undefined) return;
+
+			if (prop === 'actionHref' || prop === 'actionText' || prop === 'description' || prop === 'type') {
+				changes.set(prop, this[prop]);
+			}
+		});
+		if (changes.size > 0) {
+			/** @ignore */
+			this.dispatchEvent(new CustomEvent('d2l-filter-dimension-set-empty-state-change', {
+				bubbles: true,
+				composed: false
+			}));
+		}
+	}
+}
+
+customElements.define('d2l-filter-dimension-set-empty-state', FilterDimensionSetEmptyState);

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -146,16 +146,6 @@ class FilterDimensionSet extends LitElement {
 		return nodes.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-value');
 	}
 
-	_handleDimensionSetSearchEmptyStateChange(e) {
-		e.stopPropagation();
-		this._dispatchEvent('d2l-filter-dimension-empty-state-change', { dimensionKey: this.key, type: EmptyStateType.Search, changes: e.detail.changes });
-	}
-
-	_handleDimensionSetSetEmptyStateChange(e) {
-		e.stopPropagation();
-		this._dispatchEvent('d2l-filter-dimension-empty-state-change', { dimensionKey: this.key, type: EmptyStateType.Set, changes: e.detail.changes });
-	}
-
 	_handleDimensionSetValueDataChange(e) {
 		e.stopPropagation();
 		this._dispatchEvent('d2l-filter-dimension-data-change', { dimensionKey: this.key, valueKey: e.detail.valueKey, changes: e.detail.changes });
@@ -163,12 +153,12 @@ class FilterDimensionSet extends LitElement {
 
 	_handleSearchEmptyStateSlotChange(e) {
 		if (!this._searchEmptyStateSlot) this._searchEmptyStateSlot = e.target;
-		this._dispatchEvent('d2l-filter-dimension-empty-state-slot-change', { dimensionKey: this.key, type: EmptyStateType.Search });
+		this._dispatchEvent('d2l-filter-dimension-data-change', { dimensionKey: this.key, changes: new Map([['searchEmptyState', this.getSearchEmptyState()]]) });
 	}
 
 	_handleSetEmptyStateSlotChange(e) {
 		if (!this._setEmptyStateSlot) this._setEmptyStateSlot = e.target;
-		this._dispatchEvent('d2l-filter-dimension-empty-state-slot-change', { dimensionKey: this.key, type: EmptyStateType.Set });
+		this._dispatchEvent('d2l-filter-dimension-data-change', { dimensionKey: this.key, changes: new Map([['setEmptyState', this.getSearchEmptyState()]]) });
 	}
 
 	_handleSlotChange(e) {

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -97,57 +97,15 @@ class FilterDimensionSet extends LitElement {
 		}
 	}
 
-	_dispatchDataChangeEvent(eventDetail) {
-		/** @ignore */
-		this.dispatchEvent(new CustomEvent('d2l-filter-dimension-data-change', {
-			detail: eventDetail,
-			bubbles: true,
-			composed: false
-		}));
+	getSearchEmptyState() {
+		return this._getEmptyState(this._searchEmptyStateSlot);
 	}
 
-	_dispatchEmptyStateChangeEvent(eventDetail) {
-		/** @ignore */
-		this.dispatchEvent(new CustomEvent('d2l-filter-dimension-empty-state-change', {
-			detail: eventDetail,
-			bubbles: true,
-			composed: false
-		}));
+	getSetEmptyState() {
+		return this._getEmptyState(this._setEmptyStateSlot);
 	}
 
-	_getEmptyStateSlottedNode(emptyStateSlot) {
-		if (!emptyStateSlot) return null;
-		const nodes = emptyStateSlot.assignedNodes({ flatten: true });
-		return nodes.find((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-empty-state');
-	}
-
-	_getSearchEmptyState() {
-		const searchEmptyState = this._getEmptyStateSlottedNode(this._searchEmptyStateSlot);
-		if (!searchEmptyState) return null;
-		return {
-			actionHref: searchEmptyState.actionHref,
-			actionText: searchEmptyState.actionText,
-			description: searchEmptyState.description
-		};
-	}
-
-	_getSetEmptyState() {
-		const setEmptyState = this._getEmptyStateSlottedNode(this._setEmptyStateSlot);
-		if (!setEmptyState) return null;
-		return {
-			actionHref: setEmptyState.actionHref,
-			actionText: setEmptyState.actionText,
-			description: setEmptyState.description
-		};
-	}
-
-	_getSlottedNodes() {
-		if (!this._slot) return [];
-		const nodes = this._slot.assignedNodes({ flatten: true });
-		return nodes.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-value');
-	}
-
-	_getValues() {
+	getValues() {
 		const valueNodes = this._getSlottedNodes();
 		const values = valueNodes.map(value => {
 			return {
@@ -160,35 +118,63 @@ class FilterDimensionSet extends LitElement {
 		});
 		return values;
 	}
+
+	_dispatchEvent(eventName, eventDetail) {
+		/** @ignore */
+		this.dispatchEvent(new CustomEvent(eventName, {
+			detail: eventDetail,
+			bubbles: true,
+			composed: false
+		}));
+	}
+
+	_getEmptyState(emptyStateSlot) {
+		if (!emptyStateSlot) return null;
+		const nodes = emptyStateSlot.assignedNodes({ flatten: true });
+		const emptyState = nodes.find((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-empty-state');
+		if (!emptyState) return null;
+		return {
+			actionHref: emptyState.actionHref,
+			actionText: emptyState.actionText,
+			description: emptyState.description
+		};
+	}
+
+	_getSlottedNodes() {
+		if (!this._slot) return [];
+		const nodes = this._slot.assignedNodes({ flatten: true });
+		return nodes.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-value');
+	}
+
 	_handleDimensionSetSearchEmptyStateChange(e) {
 		e.stopPropagation();
-		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Search, changes: e.detail.changes });
+		this._dispatchEvent('d2l-filter-dimension-empty-state-change', { dimensionKey: this.key, type: EmptyStateType.Search, changes: e.detail.changes });
 	}
 
 	_handleDimensionSetSetEmptyStateChange(e) {
 		e.stopPropagation();
-		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Set, changes: e.detail.changes });
+		this._dispatchEvent('d2l-filter-dimension-empty-state-change', { dimensionKey: this.key, type: EmptyStateType.Set, changes: e.detail.changes });
 	}
 
 	_handleDimensionSetValueDataChange(e) {
 		e.stopPropagation();
-		this._dispatchDataChangeEvent({ dimensionKey: this.key, valueKey: e.detail.valueKey, changes: e.detail.changes });
+		this._dispatchEvent('d2l-filter-dimension-data-change', { dimensionKey: this.key, valueKey: e.detail.valueKey, changes: e.detail.changes });
 	}
 
 	_handleSearchEmptyStateSlotChange(e) {
 		if (!this._searchEmptyStateSlot) this._searchEmptyStateSlot = e.target;
-		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Search });
+		this._dispatchEvent('d2l-filter-dimension-empty-state-slot-change', { dimensionKey: this.key, type: EmptyStateType.Search });
 	}
 
 	_handleSetEmptyStateSlotChange(e) {
 		if (!this._setEmptyStateSlot) this._setEmptyStateSlot = e.target;
-		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Set });
+		this._dispatchEvent('d2l-filter-dimension-empty-state-slot-change', { dimensionKey: this.key, type: EmptyStateType.Set });
 	}
 
 	_handleSlotChange(e) {
 		if (!this._slot) this._slot = e.target;
-		const values = this._getValues();
-		this._dispatchDataChangeEvent({ dimensionKey: this.key, changes: new Map([['values', values]]) });
+		const values = this.getValues();
+		this._dispatchEvent('d2l-filter-dimension-data-change', { dimensionKey: this.key, changes: new Map([['values', values]]) });
 	}
 
 }

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -1,16 +1,16 @@
 import { html, LitElement } from 'lit';
 
-const EmptyStateType = {
-	Search: 'Search',
-	Set: 'Set'
+export const EmptyStateType = {
+	Search: 'search',
+	Set: 'set'
 };
 
 /**
  * A component to represent the main filter dimension type - a set of possible values that can be selected.
  * This component does not render anything, but instead gathers data needed for the d2l-filter.
  * @slot - For d2l-filter-dimension-set-value components
- * @slot - The empty state that is displayed when the search returns no results
- * @slot - The empty state that is displayed when the dimension-set has no values
+ * @slot search-empty-state - The empty state that is displayed when the search returns no results
+ * @slot set-empty-state - The empty state that is displayed when the dimension-set has no values
  */
 class FilterDimensionSet extends LitElement {
 
@@ -115,8 +115,14 @@ class FilterDimensionSet extends LitElement {
 		}));
 	}
 
+	_getEmptyStateSlottedNode(emptyStateSlot) {
+		if (!emptyStateSlot) return null;
+		const nodes = emptyStateSlot.assignedNodes({ flatten: true });
+		return nodes.find((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-empty-state');
+	}
+
 	_getSearchEmptyState() {
-		const searchEmptyState = this._getSearchEmptyStateSlottedNode();
+		const searchEmptyState = this._getEmptyStateSlottedNode(this._searchEmptyStateSlot);
 		if (!searchEmptyState) return null;
 		return {
 			actionHref: searchEmptyState.actionHref,
@@ -125,27 +131,14 @@ class FilterDimensionSet extends LitElement {
 		};
 	}
 
-	_getSearchEmptyStateSlottedNode() {
-		if (!this._searchEmptyStateSlot) return null;
-		const nodes = this._searchEmptyStateSlot.assignedNodes({ flatten: true });
-		return nodes.find((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-empty-state');
-	}
-
 	_getSetEmptyState() {
-		const setEmptyState = this._getSetEmptyStateSlottedNode();
+		const setEmptyState = this._getEmptyStateSlottedNode(this._setEmptyStateSlot);
 		if (!setEmptyState) return null;
 		return {
 			actionHref: setEmptyState.actionHref,
 			actionText: setEmptyState.actionText,
 			description: setEmptyState.description
 		};
-	}
-
-	_getSetEmptyStateSlottedNode() {
-		if (!this._setEmptyStateSlot) return null;
-		const nodes = this._setEmptyStateSlot.assignedNodes({ flatten: true });
-		return nodes.find((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-empty-state');
-
 	}
 
 	_getSlottedNodes() {
@@ -167,17 +160,14 @@ class FilterDimensionSet extends LitElement {
 		});
 		return values;
 	}
-
-	_handleDimensionSetEmptyStateChange(e, type) {
-		e.stopPropagation();
-		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: type, changes: e.detail.changes });
-	}
 	_handleDimensionSetSearchEmptyStateChange(e) {
-		this._handleDimensionSetEmptyStateChange(e, EmptyStateType.Search);
+		e.stopPropagation();
+		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Search, changes: e.detail.changes });
 	}
 
 	_handleDimensionSetSetEmptyStateChange(e) {
-		this._handleDimensionSetEmptyStateChange(e, EmptyStateType.Set);
+		e.stopPropagation();
+		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Set, changes: e.detail.changes });
 	}
 
 	_handleDimensionSetValueDataChange(e) {
@@ -187,13 +177,11 @@ class FilterDimensionSet extends LitElement {
 
 	_handleSearchEmptyStateSlotChange(e) {
 		if (!this._searchEmptyStateSlot) this._searchEmptyStateSlot = e.target;
-		const searchEmptyState = this._getSearchEmptyState();
 		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Search });
 	}
 
 	_handleSetEmptyStateSlotChange(e) {
 		if (!this._setEmptyStateSlot) this._setEmptyStateSlot = e.target;
-		const setEmptyState = this._getSetEmptyState();
 		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Set });
 	}
 

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -170,7 +170,7 @@ class FilterDimensionSet extends LitElement {
 
 	_handleDimensionSetEmptyStateChange(e, type) {
 		e.stopPropagation();
-		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: type });
+		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: type, changes: e.detail.changes });
 	}
 	_handleDimensionSetSearchEmptyStateChange(e) {
 		this._handleDimensionSetEmptyStateChange(e, EmptyStateType.Search);

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -93,7 +93,7 @@ class FilterDimensionSet extends LitElement {
 		});
 
 		if (changes.size > 0) {
-			this._dispatchDataChangeEvent({ dimensionKey: this.key, changes: changes });
+			this._dispatchEvent('d2l-filter-dimension-data-change', { dimensionKey: this.key, changes: changes });
 		}
 	}
 

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -1,9 +1,16 @@
 import { html, LitElement } from 'lit';
 
+const EmptyStateType = {
+	Search: 'Search',
+	Set: 'Set'
+};
+
 /**
  * A component to represent the main filter dimension type - a set of possible values that can be selected.
  * This component does not render anything, but instead gathers data needed for the d2l-filter.
  * @slot - For d2l-filter-dimension-set-value components
+ * @slot - The empty state that is displayed when the search returns no results
+ * @slot - The empty state that is displayed when the dimension-set has no values
  */
 class FilterDimensionSet extends LitElement {
 
@@ -55,6 +62,8 @@ class FilterDimensionSet extends LitElement {
 		this.selectionSingle = false;
 		this.text = '';
 		this.valueOnlyActiveFilterText = false;
+		this._searchEmptyStatesSlot = null;
+		this._setEmptyStatesSlot = null;
 		this._slot = null;
 	}
 
@@ -64,7 +73,11 @@ class FilterDimensionSet extends LitElement {
 	}
 
 	render() {
-		return html`<slot @slotchange="${this._handleSlotChange}"></slot>`;
+		return html`
+			<slot @slotchange="${this._handleSlotChange}"></slot>
+			<slot name="search-empty-state" @d2l-filter-dimension-set-empty-state-change="${this._handleDimensionSetSearchEmptyStateChange}" @slotchange="${this._handleSearchEmptyStateSlotChange}"></slot>
+			<slot name="set-empty-state" @d2l-filter-dimension-set-empty-state-change="${this._handleDimensionSetSetEmptyStateChange}" @slotchange="${this._handleSetEmptyStateSlotChange}"></slot>
+		`;
 	}
 
 	updated(changedProperties) {
@@ -93,6 +106,48 @@ class FilterDimensionSet extends LitElement {
 		}));
 	}
 
+	_dispatchEmptyStateChangeEvent(eventDetail) {
+		/** @ignore */
+		this.dispatchEvent(new CustomEvent('d2l-filter-dimension-empty-state-change', {
+			detail: eventDetail,
+			bubbles: true,
+			composed: false
+		}));
+	}
+
+	_getSearchEmptyState() {
+		const searchEmptyState = this._getSearchEmptyStateSlottedNode();
+		if (!searchEmptyState) return null;
+		return {
+			actionHref: searchEmptyState.actionHref,
+			actionText: searchEmptyState.actionText,
+			description: searchEmptyState.description
+		};
+	}
+
+	_getSearchEmptyStateSlottedNode() {
+		if (!this._searchEmptyStateSlot) return null;
+		const nodes = this._searchEmptyStateSlot.assignedNodes({ flatten: true });
+		return nodes.find((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-empty-state');
+	}
+
+	_getSetEmptyState() {
+		const setEmptyState = this._getSetEmptyStateSlottedNode();
+		if (!setEmptyState) return null;
+		return {
+			actionHref: setEmptyState.actionHref,
+			actionText: setEmptyState.actionText,
+			description: setEmptyState.description
+		};
+	}
+
+	_getSetEmptyStateSlottedNode() {
+		if (!this._setEmptyStateSlot) return null;
+		const nodes = this._setEmptyStateSlot.assignedNodes({ flatten: true });
+		return nodes.find((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'd2l-filter-dimension-set-empty-state');
+
+	}
+
 	_getSlottedNodes() {
 		if (!this._slot) return [];
 		const nodes = this._slot.assignedNodes({ flatten: true });
@@ -113,9 +168,33 @@ class FilterDimensionSet extends LitElement {
 		return values;
 	}
 
+	_handleDimensionSetEmptyStateChange(e, type) {
+		e.stopPropagation();
+		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: type });
+	}
+	_handleDimensionSetSearchEmptyStateChange(e) {
+		this._handleDimensionSetEmptyStateChange(e, EmptyStateType.Search);
+	}
+
+	_handleDimensionSetSetEmptyStateChange(e) {
+		this._handleDimensionSetEmptyStateChange(e, EmptyStateType.Set);
+	}
+
 	_handleDimensionSetValueDataChange(e) {
 		e.stopPropagation();
 		this._dispatchDataChangeEvent({ dimensionKey: this.key, valueKey: e.detail.valueKey, changes: e.detail.changes });
+	}
+
+	_handleSearchEmptyStateSlotChange(e) {
+		if (!this._searchEmptyStateSlot) this._searchEmptyStateSlot = e.target;
+		const searchEmptyState = this._getSearchEmptyState();
+		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Search });
+	}
+
+	_handleSetEmptyStateSlotChange(e) {
+		if (!this._setEmptyStateSlot) this._setEmptyStateSlot = e.target;
+		const setEmptyState = this._getSetEmptyState();
+		this._dispatchEmptyStateChangeEvent({ dimensionKey: this.key, type: EmptyStateType.Set });
 	}
 
 	_handleSlotChange(e) {

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -189,8 +189,6 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-		this.addEventListener('d2l-filter-dimension-empty-state-change', this._handleDimensionEmptyStateChange);
-		this.addEventListener('d2l-filter-dimension-empty-state-slot-change', this._handleDimensionEmptyStateSlotChange);
 		this.addEventListener('d2l-filter-dimension-data-change', this._handleDimensionDataChange);
 
 		// Prevent these events from bubbling out of the filter
@@ -430,7 +428,6 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 		if (this._isDimensionEmpty(dimension)) {
 			const classes = {
-				'd2l-body-small': true,
 				'd2l-filter-dimension-info-message': true
 			};
 			return dimension.setEmptyState
@@ -449,7 +446,6 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		if (dimension.searchValue && dimension.searchValue !== '') {
 			const count = dimension.values.reduce((total, value) => { return !value.hidden ? total + 1 : total; }, 0);
 			const classes = {
-				'd2l-body-small': true,
 				'd2l-filter-dimension-info-message': true,
 				'd2l-offscreen': count !== 0
 			};
@@ -623,34 +619,6 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		if (shouldResizeDropdown) {
 			this._requestDropdownResize();
 		}
-	}
-
-	_handleDimensionEmptyStateChange(e) {
-		e.stopPropagation();
-
-		const dimension = this._dimensions.find(dimension => dimension.key === e.detail.dimensionKey);
-		let shouldUpdate = false;
-		let emptyState = null;
-		if (e.detail.type === EmptyStateType.Search) emptyState = dimension.searchEmptyState;
-		else if (e.detail.type === EmptyStateType.Set) emptyState = dimension.setEmptyState;
-		if (!emptyState) return;
-
-		e.detail.changes.forEach((newValue, prop) => {
-			if (emptyState[prop] === newValue) return;
-
-			emptyState[prop] = newValue;
-			shouldUpdate = true;
-		});
-
-		if (shouldUpdate)  this.requestUpdate();
-	}
-
-	_handleDimensionEmptyStateSlotChange(e) {
-		e.stopPropagation();
-		const dimension = this._dimensions.find(dimension => dimension.key === e.detail.dimensionKey);
-		if (e.detail.type === EmptyStateType.Search) dimension.searchEmptyState = e.target.getSearchEmptyState();
-		else if (e.detail.type === EmptyStateType.Set) dimension.setEmptyState = e.target.getSetEmptyState();
-		this.requestUpdate();
 	}
 
 	_handleDimensionHide() {

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -39,6 +39,7 @@ const SET_DIMENSION_ID_PREFIX = 'list-';
  * This component is in charge of all rendering.
  * @slot - Dimension components used by the filter to construct the different dimensions locally
  * @fires d2l-filter-change - Dispatched when a dimension's value(s) have changed
+ * @fires d2l-filter-dimension-empty-state-action - Dispatched when an empty state action button is clicked
  * @fires d2l-filter-dimension-first-open - Dispatched when a dimension is opened for the first time
  * @fires d2l-filter-dimension-search - Dispatched when a dimension that supports searching and has the "manual" search-type is searched
  */
@@ -383,7 +384,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		`;
 	}
 
-	_createEmptyState(emptyState, classes) {
+	_createEmptyState(emptyState, classes, dimensionKey, type) {
 		let emptyStateAction = nothing;
 		if (emptyState.actionText && emptyState.actionHref) {
 			emptyStateAction = html`
@@ -395,7 +396,10 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		}
 		else if (emptyState.actionText) {
 			emptyStateAction = html`
-				<d2l-empty-state-action-button text="${emptyState.actionText}"></d2l-empty-state-action-button>
+				<d2l-empty-state-action-button
+					@d2l-empty-state-action="${e => this._handleEmptyStateAction(e, dimensionKey, type)}"
+					text="${emptyState.actionText}">
+				</d2l-empty-state-action-button>
 			`;
 		}
 		return html`
@@ -420,7 +424,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				'd2l-filter-dimension-info-message': true
 			};
 			return dimension.setEmptyState
-				? this._createEmptyState(dimension.setEmptyState, classes)
+				? this._createEmptyState(dimension.setEmptyState, classes, dimension.key, 'Set')
 				: html`
 					<d2l-empty-state-simple
 						class="${classMap(classes)}"
@@ -438,7 +442,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 			};
 
 			searchResults = dimension.searchEmptyState
-				? this._createEmptyState(dimension.searchEmptyState, classes)
+				? this._createEmptyState(dimension.searchEmptyState, classes, dimension.key, 'Search')
 				: html`
 					<d2l-empty-state-simple
 						class="${classMap(classes)}"
@@ -607,7 +611,24 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 	}
 
 	_handleDimensionEmptyStateChange(e) {
-		console.log(e);
+		e.stopPropagation();
+
+		const dimension = this._dimensions.find(dimension => dimension.key === e.detail.dimensionKey);
+		let emptyState = null;
+		if (e.detail.type === 'Search') emptyState = dimension.searchEmptyState;
+		else if (e.detail.type === 'Set') emptyState = dimension.setEmptyState;
+		if (!emptyState) return;
+
+		let shouldUpdate = false;
+
+		e.detail.changes.forEach((newValue, prop) => {
+			if (emptyState[prop] === newValue) return;
+
+			emptyState[prop] = newValue;
+			shouldUpdate = true;
+		});
+
+		if (shouldUpdate)  this.requestUpdate();
 	}
 
 	_handleDimensionHide() {
@@ -648,6 +669,15 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 			this._dispatchDimensionFirstOpenEvent(this._dimensions[0].key);
 		}
 		this._stopPropagation(e);
+	}
+
+	_handleEmptyStateAction(e, dimensionKey, type) {
+		this.dispatchEvent(new CustomEvent('d2l-filter-dimension-empty-state-action', {
+			detail: {
+				key: dimensionKey,
+				type: type
+			}
+		}));
 	}
 
 	_handleSearch(e) {

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -22,6 +22,7 @@ import { bodyCompactStyles, bodySmallStyles, bodyStandardStyles } from '../typog
 import { css, html, LitElement, nothing } from 'lit';
 import { announce } from '../../helpers/announce.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { EmptyStateType } from './filter-dimension-set.js';
 import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { formatNumber } from '@brightspace-ui/intl/lib/number.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -424,7 +425,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				'd2l-filter-dimension-info-message': true
 			};
 			return dimension.setEmptyState
-				? this._createEmptyState(dimension.setEmptyState, classes, dimension.key, 'Set')
+				? this._createEmptyState(dimension.setEmptyState, classes, dimension.key, EmptyStateType.Set)
 				: html`
 					<d2l-empty-state-simple
 						class="${classMap(classes)}"
@@ -442,7 +443,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 			};
 
 			searchResults = dimension.searchEmptyState
-				? this._createEmptyState(dimension.searchEmptyState, classes, dimension.key, 'Search')
+				? this._createEmptyState(dimension.searchEmptyState, classes, dimension.key, EmptyStateType.Search)
 				: html`
 					<d2l-empty-state-simple
 						class="${classMap(classes)}"
@@ -615,8 +616,8 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 		const dimension = this._dimensions.find(dimension => dimension.key === e.detail.dimensionKey);
 		let emptyState = null;
-		if (e.detail.type === 'Search') emptyState = dimension.searchEmptyState;
-		else if (e.detail.type === 'Set') emptyState = dimension.setEmptyState;
+		if (e.detail.type === EmptyStateType.Search) emptyState = dimension.searchEmptyState;
+		else if (e.detail.type === EmptyStateType.Set) emptyState = dimension.setEmptyState;
 		if (!emptyState) return;
 
 		let shouldUpdate = false;

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -5,6 +5,7 @@ import '../button/button-subtle.js';
 import '../dropdown/dropdown-button-subtle.js';
 import '../dropdown/dropdown-content.js';
 import '../dropdown/dropdown-menu.js';
+import '../empty-state/empty-state-simple.js';
 import '../hierarchical-view/hierarchical-view.js';
 import '../inputs/input-search.js';
 import '../list/list.js';
@@ -143,7 +144,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 			}
 
 			.d2l-filter-dimension-info-message {
-				padding: 0.9rem 0;
+				margin: 0.3rem;
 				text-align: center;
 			}
 
@@ -389,9 +390,10 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 		if (this._isDimensionEmpty(dimension)) {
 			return html`
-				<p class="d2l-filter-dimension-info-message d2l-body-small" role="alert">
-					${this.localize('components.filter.noFilters')}
-				</p>
+				<d2l-empty-state-simple
+					class="d2l-filter-dimension-info-message d2l-body-small"
+					description="${this.localize('components.filter.noFilters')}">
+				</d2l-empty-state-simple>
 			`;
 		}
 
@@ -405,9 +407,10 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 			};
 
 			searchResults = html`
-				<p class="${classMap(classes)}" role="alert">
-					${this.localize('components.filter.searchResults', { number: count })}
-				</p>
+				<d2l-empty-state-simple
+					class="${classMap(classes)}"
+					description="${this.localize('components.filter.searchResults', { number: count })}">
+				</d2l-empty-state-simple>
 			`;
 
 			if (count === 0) return searchResults;

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -391,7 +391,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		if (this._isDimensionEmpty(dimension)) {
 			return html`
 				<d2l-empty-state-simple
-					class="d2l-filter-dimension-info-message d2l-body-small"
+					class="d2l-filter-dimension-info-message"
 					description="${this.localize('components.filter.noFilters')}">
 				</d2l-empty-state-simple>
 			`;
@@ -402,7 +402,6 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 			const count = dimension.values.reduce((total, value) => { return !value.hidden ? total + 1 : total; }, 0);
 			const classes = {
 				'd2l-filter-dimension-info-message': true,
-				'd2l-body-small': true,
 				'd2l-offscreen': count !== 0
 			};
 

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -147,8 +147,11 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				color: var(--d2l-color-chromite);
 			}
 
+			.d2l-empty-state-container {
+				padding: 0.3rem;
+			}
+
 			.d2l-filter-dimension-info-message {
-				margin: 0.3rem;
 				text-align: center;
 			}
 
@@ -187,6 +190,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 		this.addEventListener('d2l-filter-dimension-empty-state-change', this._handleDimensionEmptyStateChange);
+		this.addEventListener('d2l-filter-dimension-empty-state-slot-change', this._handleDimensionEmptyStateSlotChange);
 		this.addEventListener('d2l-filter-dimension-data-change', this._handleDimensionDataChange);
 
 		// Prevent these events from bubbling out of the filter
@@ -398,17 +402,21 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		else if (emptyState.actionText) {
 			emptyStateAction = html`
 				<d2l-empty-state-action-button
-					@d2l-empty-state-action="${e => this._handleEmptyStateAction(e, dimensionKey, type)}"
+					@d2l-empty-state-action="${this._handleEmptyStateAction}"
+					data-dimension-key="${dimensionKey}"
+					data-type="${type}"
 					text="${emptyState.actionText}">
 				</d2l-empty-state-action-button>
 			`;
 		}
 		return html`
-			<d2l-empty-state-simple
-				class="${classMap(classes)}"
-				description="${emptyState.description}">
-				${emptyStateAction}
-			</d2l-empty-state-simple>
+			<div class="d2l-empty-state-container">
+				<d2l-empty-state-simple
+					class="${classMap(classes)}"
+					description="${emptyState.description}">
+					${emptyStateAction}
+				</d2l-empty-state-simple>
+			</div>
 		`;
 	}
 
@@ -422,15 +430,18 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 		if (this._isDimensionEmpty(dimension)) {
 			const classes = {
+				'd2l-body-small': true,
 				'd2l-filter-dimension-info-message': true
 			};
 			return dimension.setEmptyState
 				? this._createEmptyState(dimension.setEmptyState, classes, dimension.key, EmptyStateType.Set)
 				: html`
-					<d2l-empty-state-simple
-						class="${classMap(classes)}"
-						description="${this.localize('components.filter.noFilters')}">
-					</d2l-empty-state-simple>
+					<div class="d2l-empty-state-container">
+						<d2l-empty-state-simple
+							class="${classMap(classes)}"
+							description="${this.localize('components.filter.noFilters')}">
+						</d2l-empty-state-simple>
+					</div>
 				`;
 		}
 
@@ -438,6 +449,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		if (dimension.searchValue && dimension.searchValue !== '') {
 			const count = dimension.values.reduce((total, value) => { return !value.hidden ? total + 1 : total; }, 0);
 			const classes = {
+				'd2l-body-small': true,
 				'd2l-filter-dimension-info-message': true,
 				'd2l-offscreen': count !== 0
 			};
@@ -445,10 +457,12 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 			searchResults = dimension.searchEmptyState
 				? this._createEmptyState(dimension.searchEmptyState, classes, dimension.key, EmptyStateType.Search)
 				: html`
-					<d2l-empty-state-simple
-						class="${classMap(classes)}"
-						description="${this.localize('components.filter.searchResults', { number: count })}">
-					</d2l-empty-state-simple>
+					<div class="d2l-empty-state-container">
+						<d2l-empty-state-simple
+							class="${classMap(classes)}"
+							description="${this.localize('components.filter.searchResults', { number: count })}">
+						</d2l-empty-state-simple>
+					</div>
 				`;
 
 			if (count === 0) return searchResults;
@@ -615,12 +629,11 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		e.stopPropagation();
 
 		const dimension = this._dimensions.find(dimension => dimension.key === e.detail.dimensionKey);
+		let shouldUpdate = false;
 		let emptyState = null;
 		if (e.detail.type === EmptyStateType.Search) emptyState = dimension.searchEmptyState;
 		else if (e.detail.type === EmptyStateType.Set) emptyState = dimension.setEmptyState;
 		if (!emptyState) return;
-
-		let shouldUpdate = false;
 
 		e.detail.changes.forEach((newValue, prop) => {
 			if (emptyState[prop] === newValue) return;
@@ -630,6 +643,14 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		});
 
 		if (shouldUpdate)  this.requestUpdate();
+	}
+
+	_handleDimensionEmptyStateSlotChange(e) {
+		e.stopPropagation();
+		const dimension = this._dimensions.find(dimension => dimension.key === e.detail.dimensionKey);
+		if (e.detail.type === EmptyStateType.Search) dimension.searchEmptyState = e.target.getSearchEmptyState();
+		else if (e.detail.type === EmptyStateType.Set) dimension.setEmptyState = e.target.getSetEmptyState();
+		this.requestUpdate();
 	}
 
 	_handleDimensionHide() {
@@ -672,12 +693,9 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		this._stopPropagation(e);
 	}
 
-	_handleEmptyStateAction(e, dimensionKey, type) {
+	_handleEmptyStateAction(e) {
 		this.dispatchEvent(new CustomEvent('d2l-filter-dimension-empty-state-action', {
-			detail: {
-				key: dimensionKey,
-				type: type
-			}
+			detail: { key: e.target.getAttribute('data-dimension-key'), type: e.target.getAttribute('data-type') }
 		}));
 	}
 
@@ -722,15 +740,16 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				text: dimension.text,
 				type: type
 			};
+
 			switch (type) {
 				case 'd2l-filter-dimension-set': {
 					info.searchType = dimension.searchType;
 					info.selectionSingle = dimension.selectionSingle;
 					if (dimension.selectAll && !dimension.selectionSingle) info.selectAllIdPrefix = SET_DIMENSION_ID_PREFIX;
-					info.searchEmptyState = dimension._getSearchEmptyState();
-					info.setEmptyState = dimension._getSetEmptyState();
+					info.searchEmptyState = dimension.getSearchEmptyState();
+					info.setEmptyState = dimension.getSetEmptyState();
 					info.valueOnlyActiveFilterText = dimension.valueOnlyActiveFilterText;
-					const values = dimension._getValues();
+					const values = dimension.getValues();
 					info.values = values;
 					break;
 				}

--- a/components/filter/test/filter-dimension-set-empty-state.test.js
+++ b/components/filter/test/filter-dimension-set-empty-state.test.js
@@ -4,7 +4,7 @@ import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { spy } from 'sinon';
 
 const emptyStateFixture = html`
-	<d2l-filter-dimension-set-empty-state action-href="https://d2l.com" action-text="Link text" description="Empty state description"></d2l-filter-dimension-set-empty-state>
+	<d2l-filter-dimension-set-empty-state action-href="https://d2l.com/" action-text="Link text" description="Empty state description"></d2l-filter-dimension-set-empty-state>
 `;
 
 describe('d2l-filter-dimension-set-empty-state', () => {

--- a/components/filter/test/filter-dimension-set-empty-state.test.js
+++ b/components/filter/test/filter-dimension-set-empty-state.test.js
@@ -1,0 +1,35 @@
+import '../filter-dimension-set-empty-state.js';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { spy } from 'sinon';
+
+const emptyStateFixture = html`
+	<d2l-filter-dimension-set-empty-state action-href="https://d2l.com" action-text="Link text" description="Empty state description"></d2l-filter-dimension-set-empty-state>
+`;
+
+describe('d2l-filter-dimension-set-empty-state', () => {
+
+	it('should construct', () => {
+		runConstructor('d2l-filter-dimension-set-empty-state');
+	});
+
+	describe('empty-state change', () => {
+		[
+			{ property: 'actionHref', value: 'https://google.ca' },
+			{ property: 'actionText', value: 'Click me' },
+			{ property: 'description', value: 'Changed empty state description' }
+		].forEach(condition => {
+			it(`fires data change event when its ${condition.property} data changes`, async() => {
+				const elem = await fixture(emptyStateFixture);
+				const eventSpy = spy(elem, 'dispatchEvent');
+				if (condition.property === 'actionHref' || condition.property === 'actionText' || condition.property === 'description') elem[condition.property] = condition.value;
+
+				const e = await oneEvent(elem, 'd2l-filter-dimension-set-empty-state-change');
+				expect(e.detail.changes.size).to.equal(1);
+				expect(e.detail.changes.get(condition.property)).to.equal(condition.value);
+				expect(eventSpy).to.be.calledOnce;
+			});
+		});
+	});
+
+});

--- a/components/filter/test/filter-dimension-set.test.js
+++ b/components/filter/test/filter-dimension-set.test.js
@@ -1,5 +1,6 @@
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
+import '../filter-dimension-set-empty-state.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { spy } from 'sinon';
@@ -8,6 +9,14 @@ const dimensionfixture = html`
 	<d2l-filter-dimension-set key="dim" text="Dim">
 		<d2l-filter-dimension-set-value key="1" text="Value 1"></d2l-filter-dimension-set-value>
 		<d2l-filter-dimension-set-value key="2" text="Value 2"></d2l-filter-dimension-set-value>
+	</d2l-filter-dimension-set>`;
+
+const emptyStateDimensionFixture = html`
+	<d2l-filter-dimension-set key="dim" text="Dim">
+		<d2l-filter-dimension-set-value key="1" text="Value 1"></d2l-filter-dimension-set-value>
+		<d2l-filter-dimension-set-value key="2" text="Value 2"></d2l-filter-dimension-set-value>
+		<d2l-filter-dimension-set-empty-state id="search-empty-state" slot="search-empty-state" description="Empty state description"></d2l-filter-dimension-set-empty-state>
+		<d2l-filter-dimension-set-empty-state id="set-empty-state" slot="set-empty-state" description="Empty state description" action-text="Action text" action-href="https://d2l.com"></d2l-filter-dimension-set-empty-state>
 	</d2l-filter-dimension-set>`;
 
 describe('d2l-filter-dimension-set', () => {
@@ -32,6 +41,7 @@ describe('d2l-filter-dimension-set', () => {
 			expect(values[1].key).to.equal('2');
 			expect(values[2].key).to.equal('newValue');
 		});
+
 	});
 
 	describe('data change', () => {
@@ -61,6 +71,32 @@ describe('d2l-filter-dimension-set', () => {
 			expect(e.detail.valueKey).to.equal('2');
 			expect(e.detail.changes.size).to.equal(1);
 			expect(e.detail.changes.get('selected')).to.be.true;
+			expect(eventSpy).to.be.calledOnce;
+		});
+
+		it('fires empty state change event when data changes in search empty state', async() => {
+			const elem = await fixture(emptyStateDimensionFixture);
+			const eventSpy = spy(elem, 'dispatchEvent');
+			const searchEmptyState = elem.querySelector('#search-empty-state');
+			setTimeout(() => searchEmptyState.actionText = 'Changed!');
+
+			const e = await oneEvent(elem, 'd2l-filter-dimension-empty-state-change');
+			expect(e.detail.dimensionKey).to.equal('dim');
+			expect(e.detail.changes.size).to.equal(1);
+			expect(e.detail.changes.get('actionText')).to.equal('Changed!');
+			expect(eventSpy).to.be.calledOnce;
+		});
+
+		it('fires empty state change event when data changes in set empty state', async() => {
+			const elem = await fixture(emptyStateDimensionFixture);
+			const eventSpy = spy(elem, 'dispatchEvent');
+			const setEmptyState = elem.querySelector('#set-empty-state');
+			setTimeout(() => setEmptyState.description = 'Changed!');
+
+			const e = await oneEvent(elem, 'd2l-filter-dimension-empty-state-change');
+			expect(e.detail.dimensionKey).to.equal('dim');
+			expect(e.detail.changes.size).to.equal(1);
+			expect(e.detail.changes.get('description')).to.equal('Changed!');
 			expect(eventSpy).to.be.calledOnce;
 		});
 	});

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -1,5 +1,6 @@
 import '../filter.js';
 import '../filter-dimension-set.js';
+import '../filter-dimension-set-empty-state.js';
 import '../filter-dimension-set-value.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { spy, stub } from 'sinon';
@@ -17,6 +18,28 @@ const singleSetDimensionSingleSelectionFixture = html`
 		<d2l-filter-dimension-set key="dim" text="Dim" selection-single>
 			<d2l-filter-dimension-set-value key="1" text="Value 1" selected></d2l-filter-dimension-set-value>
 			<d2l-filter-dimension-set-value key="2" text="Value 2"></d2l-filter-dimension-set-value>
+		</d2l-filter-dimension-set>
+	</d2l-filter>`;
+const singleSetLinkSearchEmptyStateDimensionFixture = html`
+	<d2l-filter>
+		<d2l-filter-dimension-set key="dim" text="Dim" select-all>
+			<d2l-filter-dimension-set-value key="1" text="Value 1" selected></d2l-filter-dimension-set-value>
+			<d2l-filter-dimension-set-value key="2" text="Value 2"></d2l-filter-dimension-set-value>
+			<d2l-filter-dimension-set-empty-state slot="search-empty-state" description="Test description" action-text="Click me" action-href="https://d2l.com"></d2l-filter-dimension-set-empty-state>
+		</d2l-filter-dimension-set>
+	</d2l-filter>`;
+const singleSetSearchEmptyStateDimensionFixture = html`
+<d2l-filter>
+	<d2l-filter-dimension-set key="dim" text="Dim" select-all>
+		<d2l-filter-dimension-set-value key="1" text="Value 1" selected></d2l-filter-dimension-set-value>
+		<d2l-filter-dimension-set-value key="2" text="Value 2"></d2l-filter-dimension-set-value>
+		<d2l-filter-dimension-set-empty-state slot="search-empty-state" description="Test description" action-text="Click me"></d2l-filter-dimension-set-empty-state>
+	</d2l-filter-dimension-set>
+</d2l-filter>`;
+const singleSetSetEmptyStateDimensionFixture = html`
+	<d2l-filter>
+		<d2l-filter-dimension-set key="dim" text="Dim" select-all>
+			<d2l-filter-dimension-set-empty-state slot="set-empty-state" description="Test description" action-text="Click me"></d2l-filter-dimension-set-empty-state>
 		</d2l-filter-dimension-set>
 	</d2l-filter>`;
 const multiDimensionFixture = html`
@@ -61,15 +84,26 @@ describe('d2l-filter', () => {
 			expect(elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message').description).to.include('No available filters');
 		});
 
-		it('set dimension - no search results', async() => {
-			const elem = await fixture(singleSetDimensionFixture);
+		it('set dimension - custom empty state', async() => {
+			const elem = await fixture(singleSetSetEmptyStateDimensionFixture);
+			const emptyState = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
+			const emptyStateAction = emptyState.querySelector('d2l-empty-state-action-button');
+			expect(emptyState.description).to.equal('Test description');
+			expect(emptyStateAction.text).to.equal('Click me');
+		});
+
+		it('set dimension - custom no search results', async() => {
+			const elem = await fixture(singleSetLinkSearchEmptyStateDimensionFixture);
 			elem._handleSearch({ detail: { value: 'no results' } });
 			elem.requestUpdate();
 			await elem.updateComplete;
 
-			const infoMessage = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
-			expect(infoMessage.description).to.include('No search results');
-			expect(infoMessage.classList.contains('d2l-offscreen')).to.be.false;
+			const emptyState = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
+			const emptyStateAction = emptyState.querySelector('d2l-empty-state-action-link');
+			expect(emptyState.description).to.equal('Test description');
+			expect(emptyStateAction.text).to.equal('Click me');
+			expect(emptyStateAction.href).to.equal('https://d2l.com');
+			expect(emptyState.classList.contains('d2l-offscreen')).to.be.false;
 		});
 
 		it('set dimension - search results (offscreen)', async() => {
@@ -500,6 +534,38 @@ describe('d2l-filter', () => {
 				setTimeout(() => dimensions[0].click());
 				await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
 				expect(eventSpy).to.be.calledTwice;
+			});
+
+			describe('d2l-filter-dimension-empty-state', () => {
+				it('Fires empty state action when search empty state action is clicked', async() => {
+					const elem = await fixture(singleSetSearchEmptyStateDimensionFixture);
+					elem._handleSearch({ detail: { value: 'no results' } });
+					elem.requestUpdate();
+					await elem.updateComplete;
+
+					const eventSpy = spy(elem, 'dispatchEvent');
+					const emptyState = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
+					const emptyStateAction = emptyState.querySelector('d2l-empty-state-action-button');
+
+					setTimeout(() => emptyStateAction.dispatchEvent(new CustomEvent('d2l-empty-state-action')));
+					const e = await oneEvent(elem, 'd2l-filter-dimension-empty-state-action');
+					expect(e.detail.key).to.equal('dim');
+					expect(e.detail.type).to.equal('search');
+					expect(eventSpy).to.be.calledOnce;
+				});
+
+				it('Fires empty state action when set empty state action is clicked', async() => {
+					const elem = await fixture(singleSetSetEmptyStateDimensionFixture);
+					const eventSpy = spy(elem, 'dispatchEvent');
+					const emptyState = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
+					const emptyStateAction = emptyState.querySelector('d2l-empty-state-action-button');
+
+					setTimeout(() => emptyStateAction.dispatchEvent(new CustomEvent('d2l-empty-state-action')));
+					const e = await oneEvent(elem, 'd2l-filter-dimension-empty-state-action');
+					expect(e.detail.key).to.equal('dim');
+					expect(e.detail.type).to.equal('set');
+					expect(eventSpy).to.be.calledOnce;
+				});
 			});
 		});
 

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -58,7 +58,7 @@ describe('d2l-filter', () => {
 	describe('info messages', () => {
 		it('set dimension - empty state', async() => {
 			const elem = await fixture('<d2l-filter><d2l-filter-dimension-set key="dim"></d2l-filter-dimension-set></d2l-filter>');
-			expect(elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message').textContent).to.include('No available filters');
+			expect(elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message').description).to.include('No available filters');
 		});
 
 		it('set dimension - no search results', async() => {
@@ -68,7 +68,7 @@ describe('d2l-filter', () => {
 			await elem.updateComplete;
 
 			const infoMessage = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
-			expect(infoMessage.textContent).to.include('No search results');
+			expect(infoMessage.description).to.include('No search results');
 			expect(infoMessage.classList.contains('d2l-offscreen')).to.be.false;
 		});
 
@@ -79,14 +79,14 @@ describe('d2l-filter', () => {
 			await elem.updateComplete;
 
 			const infoMessage = elem.shadowRoot.querySelector('.d2l-filter-dimension-info-message');
-			expect(infoMessage.textContent).to.include('1 search result');
+			expect(infoMessage.description).to.include('1 search result');
 			expect(infoMessage.classList.contains('d2l-offscreen')).to.be.true;
 
 			elem._handleSearch({ detail: { value: 'value' } });
 			elem.requestUpdate();
 			await elem.updateComplete;
 
-			expect(infoMessage.textContent).to.include('2 search results');
+			expect(infoMessage.description).to.include('2 search results');
 			expect(infoMessage.classList.contains('d2l-offscreen')).to.be.true;
 		});
 	});

--- a/components/filter/test/filter.visual-diff.html
+++ b/components/filter/test/filter.visual-diff.html
@@ -10,6 +10,7 @@
 			import '../../../test/typography-preload.js';
 			import '../filter.js';
 			import '../filter-dimension-set.js';
+			import '../filter-dimension-set-empty-state.js';
 			import '../filter-dimension-set-value.js';
 		</script>
 		<title>d2l-filter</title>
@@ -42,6 +43,13 @@
 				</d2l-filter>
 			</div>
 			<div class="visual-diff">
+				<d2l-filter id="single-set-custom-empty">
+					<d2l-filter-dimension-set key="course" text="Course">
+						<d2l-filter-dimension-set-empty-state slot="set-empty-state" description="No courses." action-text="Add a Course"></d2l-filter-dimension-set-empty-state>
+					</d2l-filter-dimension-set>
+				</d2l-filter>
+			</div>
+			<div class="visual-diff">
 				<d2l-filter id="single-set-single-selection">
 					<d2l-filter-dimension-set key="course" text="Semester" selection-single>
 						<d2l-filter-dimension-set-value key="fall" text="Fall"></d2l-filter-dimension-set-value>
@@ -71,6 +79,7 @@
 						<d2l-filter-dimension-set-value key="english" text="English" count="1012"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="how-to" text="How To Write a How To Article With a Flashy Title" count="12"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="math" text="Math" count="10968"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-empty-state slot="search-empty-state" description="No search results." action-text="Go here" action-href="https://d2l.com/"></d2l-filter-dimension-set-empty-state>
 					</d2l-filter-dimension-set>
 				</d2l-filter>
 			</div>

--- a/components/filter/test/filter.visual-diff.js
+++ b/components/filter/test/filter.visual-diff.js
@@ -48,6 +48,7 @@ describe('d2l-filter', () => {
 
 			[
 				'empty',
+				'custom-empty',
 				'single-selection',
 				'single-selection-select-all',
 				'multi-selection',
@@ -255,6 +256,8 @@ describe('d2l-filter', () => {
 			});
 
 			[
+				'empty',
+				'custom-empty',
 				'single-selection-select-all',
 				'multi-selection-no-search',
 				'multi-selection-no-search-select-all',


### PR DESCRIPTION
This is a branch off of #3317 to try out a different approach to adding custom empty states.

The code needs to be cleaned up but the main things to have a look at in this PR: 
`d2l-filter-dimension-set-empty-state`:
    - Removed the change events to clean up code. We could add this back to listen to changes to the component properties in the future if a consumer needed it
`d2l-filter-dimension-set`:
    - Removed the `d2l-filter-empty-state-change` and `d2l-filter-empty-state-slot-change` events. When the empty state slots change, it regrabs the EmptyState for that slot and dispatches the existing `d2l-filter-dimension-change` event.
`d2l-filter`:
    - Since we removed the empty state change events we can remove the handlers here and the `d2l-filter-dimension-data-change` handler handles the empty state changes without any updates to it.
 
It worked pretty seamlessly. I really like this approach and it cleans it up a lot. I think it would be a good idea to pivot to this.