### PR TITLE
fix: Improve CSS transitions for dialogs

### DIFF
--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -84,10 +84,21 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 				dialog.d2l-dialog-outer,
 				div.d2l-dialog-outer {
+					animation: d2l-dialog-fullscreen-close 200ms ease-out;
 					border-radius: 8px;
 					margin: 1.5rem;
 					top: 0;
 					width: auto;
+				}
+
+				@keyframes d2l-dialog-fullscreen-close {
+					0% { opacity: 1; transform: translateY(0); }
+					100% { opacity: 0; transform: translateY(-50px) scale(0.97); }
+				}
+
+				@keyframes d2l-dialog-fullscreen-open {
+					0% { opacity: 0; transform: translateY(-50px) scale(0.97); }
+					100% { opacity: 1; transform: translateY(0); }
 				}
 
 				dialog.d2l-dialog-outer.d2l-dialog-fullscreen-within,
@@ -113,7 +124,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 				:host([_state="showing"]) dialog.d2l-dialog-outer,
 				:host([_state="showing"]) div.d2l-dialog-outer {
-					animation: d2l-dialog-open 400ms ease-out;
+					animation: d2l-dialog-fullscreen-open 400ms ease-out;
 				}
 
 				:host([_state="showing"]) dialog::backdrop {

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -84,7 +84,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 				dialog.d2l-dialog-outer,
 				div.d2l-dialog-outer {
-					animation: d2l-dialog-fullscreen-close 200ms ease-out;
+					animation: d2l-dialog-fullscreen-close 200ms ease-in;
 					border-radius: 8px;
 					margin: 1.5rem;
 					top: 0;

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -84,21 +84,10 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 				dialog.d2l-dialog-outer,
 				div.d2l-dialog-outer {
-					animation: d2l-dialog-fullscreen-close 200ms ease-out;
 					border-radius: 8px;
 					margin: 1.5rem;
 					top: 0;
 					width: auto;
-				}
-
-				@keyframes d2l-dialog-fullscreen-close {
-					0% { opacity: 1; transform: translateY(0); }
-					100% { opacity: 0; transform: translateY(-50px) scale(0.97); }
-				}
-
-				@keyframes d2l-dialog-fullscreen-open {
-					0% { opacity: 0; transform: translateY(-50px) scale(0.97); }
-					100% { opacity: 1; transform: translateY(0); }
 				}
 
 				dialog.d2l-dialog-outer.d2l-dialog-fullscreen-within,
@@ -124,7 +113,7 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 
 				:host([_state="showing"]) dialog.d2l-dialog-outer,
 				:host([_state="showing"]) div.d2l-dialog-outer {
-					animation: d2l-dialog-fullscreen-open 400ms ease-out;
+					animation: d2l-dialog-open 400ms ease-out;
 				}
 
 				:host([_state="showing"]) dialog::backdrop {

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -21,7 +21,7 @@ export const dialogStyles = css`
 	}
 
 	.d2l-dialog-outer {
-		animation: d2l-dialog-close 200ms ease-out;
+		animation: d2l-dialog-close 200ms ease-in;
 		background-color: white;
 		border: 1px solid var(--d2l-color-mica);
 		border-radius: 8px;
@@ -43,11 +43,11 @@ export const dialogStyles = css`
 
 	@keyframes d2l-dialog-close {
 		0% { opacity: 1; transform: translateY(0); }
-		100% { opacity: 0; transform: translateY(-50px) scale(0.97); }
+		100% { opacity: 0; transform: translateY(-50px); }
 	}
 
 	@keyframes d2l-dialog-open {
-		0% { opacity: 0; transform: translateY(-50px) scale(0.97); }
+		0% { opacity: 0; transform: translateY(-50px); }
 		100% { opacity: 1; transform: translateY(0); }
 	}
 
@@ -75,11 +75,12 @@ export const dialogStyles = css`
 		/* cannot use variables inside of ::backdrop : https://github.com/whatwg/fullscreen/issues/124 */
 		background-color: #f9fbff;
 		opacity: 0;
-		transition: opacity 200ms ease-out;
+		transition: opacity 200ms ease-in;
 	}
 
 	:host([_state="showing"]) dialog::backdrop {
 		opacity: 0.7;
+		transition-timing-function: ease-out;
 	}
 
 	d2l-focus-trap {

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -42,13 +42,13 @@ export const dialogStyles = css`
 	}
 
 	@keyframes d2l-dialog-close {
-		0% { transform: translateY(0); }
-		100% { transform: translateY(-50px); }
+		0% { opacity: 1; transform: translateY(0); }
+		100% { opacity: 0; transform: translateY(-50px) scale(0.97); }
 	}
 
 	@keyframes d2l-dialog-open {
-		0% { transform: translateY(-50px); }
-		100% { transform: translateY(0); }
+		0% { opacity: 0; transform: translateY(-50px) scale(0.97); }
+		100% { opacity: 1; transform: translateY(0); }
 	}
 
 	.d2l-dialog-outer.d2l-dialog-outer-nested-showing {


### PR DESCRIPTION
A few CSS transition tweaks for the dialog open/close, coming from design feedback from Jeff.

Rally: https://rally1.rallydev.com/#/?detail=/defect/685414266339&fdp=true
