### PR TITLE
fix: filter empty state documentation

### DIFF
--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -271,6 +271,10 @@ The `d2l-filter-dimension-set-empty-state` component allows you to customize the
   import '@brightspace-ui/core/components/filter/filter-dimension-set.js';
   import '@brightspace-ui/core/components/filter/filter-dimension-set-empty-state.js';
   import '@brightspace-ui/core/components/filter/filter-dimension-set-value.js';
+
+  document.querySelector('d2l-filter').addEventListener('d2l-filter-dimension-empty-state-action', e => {
+      console.log(`Filter dimension empty state action clicked:\nkey: ${e.detail.key}\ntype: ${e.detail.type}`);
+    });
 </script>
 <d2l-filter>
   <d2l-filter-dimension-set key="course" text="Course" >

--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -281,11 +281,6 @@ The `d2l-filter-dimension-set-empty-state` component allows you to customize the
     <d2l-filter-dimension-set-empty-state slot="set-empty-state" description="There are no available items." action-text="Add a course"></d2l-filter-dimension-set-empty-state>
   </d2l-filter-dimension-set>
 </d2l-filter>
-<script>
-    document.querySelector('#filter-single').addEventListener('d2l-filter-dimension-empty-state-action', e => {
-            console.log(`Filter dimension empty state action clicked:\nkey: ${e.detail.key}\ntype: ${e.detail.type}`);
-        });
-</script>
 ```
 <!-- docs: start hidden content -->
 ### Properties


### PR DESCRIPTION
This extra `<script>` block was breaking the filter empty state demo and needed to be combined into a single `<script>` block. Can't verify this due to PATs being blocked on BrightspaceUI which prevents us from running the repo locally, but this should fix the issue.