### PR TITLE
fix: Move dialog full-height to an internal class

### DIFF
--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -32,9 +32,10 @@ class DialogFullscreen extends LocalizeCoreElement(AsyncContainerMixin(DialogMix
 			 * The preferred width (unit-less) for the dialog. Maximum 1170.
 			 */
 			width: { type: Number },
-			_hasFooterContent: { type: Boolean, attribute: false },
-			_icon: { type: String, attribute: false },
-			_headerStyle: { type: String, attribute: false },
+			_autoSize: { state: true }, /* DE52039 This is only redefined here to suppress a lit-analyzer linting issue */
+			_hasFooterContent: { state: true },
+			_icon: { state: true },
+			_headerStyle: { state: true },
 		};
 	}
 

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -42,22 +42,22 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			 * The optional title for the dialog
 			 */
 			titleText: { type: String, attribute: 'title-text' },
-			_autoSize: { type: Boolean, attribute: 'auto-size', reflect: true },
-			_fullHeight: { type: Boolean, attribute: 'full-height', reflect: true },
-			_fullscreenWithin: { type: Number },
-			_height: { type: Number },
+			_autoSize: { state: true },
+			_fullHeight: { state: true },
+			_fullscreenWithin: { state: true },
+			_height: { state: true },
 			_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
-			_left: { type: Number },
-			_margin: { type: Object },
-			_nestedShowing: { type: Boolean },
-			_overflowBottom: { type: Boolean },
-			_overflowTop: { type: Boolean },
-			_parentDialog: { type: Object },
-			_scroll: { type: Boolean },
+			_left: { state: true },
+			_margin: { state: true },
+			_nestedShowing: { state: true },
+			_overflowBottom: { state: true },
+			_overflowTop: { state: true },
+			_parentDialog: { state: true },
+			_scroll: { state: true },
 			_state: { type: String, reflect: true },
-			_top: { type: Number },
-			_width: { type: Number },
-			_useNative: { type: Boolean }
+			_top: { state: true },
+			_width: { state: true },
+			_useNative: { state: true }
 		};
 	}
 
@@ -451,6 +451,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 		const dialogOuterClasses = {
 			'd2l-dialog-outer': true,
+			'd2l-dialog-outer-full-height': this._autoSize && this._fullHeight,
 			'd2l-dialog-outer-overflow-bottom': this._overflowBottom,
 			'd2l-dialog-outer-overflow-top': this._overflowTop,
 			'd2l-dialog-outer-nested': !this._useNative && this._parentDialog,

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -31,11 +31,6 @@ export const dialogStyles = css`
 		top: 75px;
 	}
 
-	:host([auto-size][full-height]) > .d2l-dialog-outer {
-		bottom: 1.5rem;
-		top: 1.5rem;
-	}
-
 	:host([_state="showing"]) > .d2l-dialog-outer {
 		/* must target direct child to avoid ancestor from interfering with closing child dialogs in Legacy-Edge */
 		animation: d2l-dialog-open 200ms ease-out;
@@ -49,6 +44,11 @@ export const dialogStyles = css`
 	@keyframes d2l-dialog-open {
 		0% { opacity: 0; transform: translateY(-50px); }
 		100% { opacity: 1; transform: translateY(0); }
+	}
+
+	.d2l-dialog-outer.d2l-dialog-outer-full-height {
+		bottom: 1.5rem;
+		top: 1.5rem;
 	}
 
 	.d2l-dialog-outer.d2l-dialog-outer-nested-showing {


### PR DESCRIPTION
This PR moves the dialog full-height behaviour to an internal class, instead of sprouting the `full-height` attribute on the component; recommended by @dbatiste. There should be no functional changes.

Rally: https://rally1.rallydev.com/#/?detail=/defect/685414266339&fdp=true
