### PR TITLE
fix: hide events from Daylight Site

### DIFF
--- a/components/inputs/input-color.js
+++ b/components/inputs/input-color.js
@@ -347,6 +347,7 @@ class InputColor extends FocusMixin(FormElementMixin(LocalizeCoreElement(LitElem
 
 	_handleClose() {
 		this._opened = false;
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-input-color-close', { bubbles: false, composed: false }
 		));
@@ -384,6 +385,7 @@ class InputColor extends FocusMixin(FormElementMixin(LocalizeCoreElement(LitElem
 
 	_handleOpenDropdown() {
 		this._opened = true;
+		/** @ignore */
 		this.dispatchEvent(new CustomEvent(
 			'd2l-input-color-open', { bubbles: false, composed: false }
 		));


### PR DESCRIPTION
These events are only used internally by the MVC code, and will go away when the palette can be rendered as a component.