### PR TITLE
ignore untranslated warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:axe": "web-test-runner --group aXe",
     "test:headless": "web-test-runner --group default",
     "test:headless:watch": "web-test-runner --group default --watch",
-    "test:translations": "mfv -e -s en -p ./lang/"
+    "test:translations": "mfv -e -s en -p ./lang/ -i untranslated"
   },
   "files": [
     "custom-elements.json",


### PR DESCRIPTION
Now that `en-GB` is a thing, we're getting an untranslated warning for every line. This disables the warnings as they're not particularly useful anyway.