### PR TITLE
Fix custom filter empty state screenreader bug

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -475,7 +475,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				'd2l-empty-state-container': true,
 				'd2l-offscreen': count !== 0
 			};
-			const emptyState = dimension.searchEmptyState
+			const emptyState = dimension.searchEmptyState && count === 0
 				? this._createEmptyState(dimension.searchEmptyState, dimension.key, EmptyStateType.Search)
 				: html`
 					<d2l-empty-state-simple


### PR DESCRIPTION
In the filter component when the search does not return empty, the search empty state is rendered off-screen so that a screenreader message is still read. In the default case, the description will switch to something like "3 search results" instead of "No results".

The custom empty state was using the same message both when the search is empty and when it is not. This PR adds a check so that the custom empty state description is used when shown on-screen and the default description is used when the search is non-empty and the empty state is rendered off-screen.