### PR TITLE
fix: Failing list visual-diff

### DIFF
--- a/components/list/test/list.visual-diff.js
+++ b/components/list/test/list.visual-diff.js
@@ -144,7 +144,7 @@ describe('d2l-list', () => {
 			{ name: 'not selected hover', selector: '#selectable', action: () => hover('#selectable [selectable]') },
 			{ name: 'selection-disabled hover', selector: '#selectable', action: () => hover('#selectable [selectable][selection-disabled]') },
 			{ name: 'button selection-disabled hover', selector: '#selectableButton', action: () => hover('#selectableButton [selectable][selection-disabled]') },
-			{ name: 'button selection-disabled button-disabled hover', selector: '#selectableButton', action: () => hover('#selectableButton [selectable][selection-disabled][button-disabled') },
+			{ name: 'button selection-disabled button-disabled hover', selector: '#selectableButton', action: () => hover('#selectableButton [selectable][selection-disabled][button-disabled]') },
 			{ name: 'selected', selector: '#selectableSelected' },
 			{ name: 'selected focus', selector: '#selectableSelected', action: () => focusInput('#selectableSelected [selectable]') },
 			{ name: 'selected hover', selector: '#selectableSelected', action: () => hover('#selectableSelected [selectable]') },


### PR DESCRIPTION
There's a failing visual-diff test `d2l-list-selectable-button-selection-disabled-button-disabled-hover` that's being orphaned:

https://github.com/BrightspaceUI/core/pull/3375/files
https://github.com/BrightspaceUI/core/pull/3377/files

This PR hopefully fixes it!