### PR TITLE
feat: Add aria-label for table-controls

### DIFF
--- a/components/table/table-controls.js
+++ b/components/table/table-controls.js
@@ -30,6 +30,10 @@ class TableControls extends SelectionControls {
 		`];
 	}
 
+	_getSelectionControlsLabel() {
+		return this.localize('components.table-controls.label');
+	}
+
 	_renderSelection() {
 		return html`
 			<d2l-selection-summary

--- a/components/table/test/table.test.js
+++ b/components/table/test/table.test.js
@@ -37,10 +37,10 @@ describe('d2l-table-controls', () => {
 		runConstructor('d2l-table-controls');
 	});
 
-	// it('should override default SelectionControls label', async() => {
-	// 	const el = await fixture(html`<d2l-table-controls></d2l-table-controls>`);
-	// 	const section = el.shadowRoot.querySelector('section');
-	// 	expect(section.getAttribute('aria-label')).to.equal('Table controls');
-	// });
+	it('should override default SelectionControls label', async() => {
+		const el = await fixture(html`<d2l-table-controls></d2l-table-controls>`);
+		const section = el.shadowRoot.querySelector('section');
+		expect(section.getAttribute('aria-label')).to.equal('Actions for table');
+	});
 
 });

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "مرئي.",
 	"components.switch.hidden": "مخفي",
 	"components.switch.conditions": "يجب استيفاء الشروط",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "التمرير إلى الأمام",
 	"components.tabs.previous": "التمرير إلى الخلف",
 	"components.tag-list.clear": "انقر فوق، أو اضغط على مسافة للخلف، أو اضغط على مفتاح حذف لإزالة العنصر {value}",

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Gweladwy.",
 	"components.switch.hidden": "Cudd",
 	"components.switch.conditions": "Rhaid bodloni’r amodau",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Sgrolio Ymlaen",
 	"components.tabs.previous": "Sgrolio Yn Ôl",
 	"components.tag-list.clear": "Cliciwch, pwyswch yn ôl, neu pwyswch y bysell dileu i dynnu’r eitem {value}",

--- a/lang/da.js
+++ b/lang/da.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Synlig.",
 	"components.switch.hidden": "Skjult",
 	"components.switch.conditions": "Betingelserne skal være opfyldt",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Rul frem",
 	"components.tabs.previous": "Rul tilbage",
 	"components.tag-list.clear": "Klik, tryk på tilbagetasten, eller tryk på slettasten for at fjerne element {value}",

--- a/lang/de.js
+++ b/lang/de.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Sichtbar.",
 	"components.switch.hidden": "Ausgeblendet",
 	"components.switch.conditions": "Bedingungen müssen erfüllt sein",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Weiterblättern",
 	"components.tabs.previous": "Zurückblättern",
 	"components.tag-list.clear": "Klicken Sie, drücken Sie die Rücktaste, oder drücken Sie die Entfernen-Taste, um das Element {value} zu entfernen",

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Visible.",
 	"components.switch.hidden": "Hidden",
 	"components.switch.conditions": "Conditions must be met",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Scroll Forward",
 	"components.tabs.previous": "Scroll Backward",
 	"components.tag-list.clear": "Click, press backspace, or press delete key to remove item {value}",

--- a/lang/en.js
+++ b/lang/en.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Visible.",
 	"components.switch.hidden": "Hidden",
 	"components.switch.conditions": "Conditions must be met",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Scroll Forward",
 	"components.tabs.previous": "Scroll Backward",
 	"components.tag-list.clear": "Click, press backspace, or press delete key to remove item {value}",

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Visible.", // mfv-translated
 	"components.switch.hidden": "Oculto",
 	"components.switch.conditions": "Deben cumplirse las condiciones",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Desplazarse hacia delante",
 	"components.tabs.previous": "Desplazarse hacia atrás",
 	"components.tag-list.clear": "Haga clic, pulse Retroceso o pulse la tecla Supr para eliminar el elemento {value}",

--- a/lang/es.js
+++ b/lang/es.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Visible.", // mfv-translated
 	"components.switch.hidden": "Oculto",
 	"components.switch.conditions": "Se deben cumplir las condiciones",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Desplazarse hacia adelante",
 	"components.tabs.previous": "Desplazarse hacia atrás",
 	"components.tag-list.clear": "Haga clic, presione Retroceso o presione la tecla Suprimir para eliminar el elemento {value}",

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Visible.", // mfv-translated
 	"components.switch.hidden": "Masqué",
 	"components.switch.conditions": "Les conditions doivent être remplies",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Faire défiler vers l'avant",
 	"components.tabs.previous": "Faire défiler vers l'arrière",
 	"components.tag-list.clear": "Cliquez sur l’élément, appuyez sur la touche Retour arrière ou sur la touche Suppr pour supprimer l’élément {value}",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Visible.", // mfv-translated
 	"components.switch.hidden": "Masqué(e)",
 	"components.switch.conditions": "Les conditions doivent être remplies",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Défilement avant",
 	"components.tabs.previous": "Défilement arrière",
 	"components.tag-list.clear": "Cliquez sur le bouton, appuyez sur retour arrière ou appuyez sur la touche de suppression pour supprimer l’élément {value}",

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "दृश्यमान।",
 	"components.switch.hidden": "छुपा हुआ",
 	"components.switch.conditions": "शर्तें पूरी होनी चाहिए",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "आगे स्क्रॉल करें",
 	"components.tabs.previous": "पीछे स्क्रॉल करें",
 	"components.tag-list.clear": "{value} को हटाने के लिए क्लिक करें, बैकस्पेस दबाएँ, या हटाएँ कुंजी को दबाएँ",

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "表示。",
 	"components.switch.hidden": "非表示",
 	"components.switch.conditions": "条件が一致する必要があります",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "前方にスクロール",
 	"components.tabs.previous": "後方にスクロール",
 	"components.tag-list.clear": "クリックする、Backspace キーを押す、または Delete キーを押すと項目 {value} が削除されます",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "표시.",
 	"components.switch.hidden": "숨김",
 	"components.switch.conditions": "조건을 충족해야 합니다",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "앞으로 스크롤",
 	"components.tabs.previous": "뒤로 스크롤",
 	"components.tag-list.clear": "항목 {value}을(를) 제거하려면 클릭하거나, 백스페이스 또는 삭제 키를 누릅니다.",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Zichtbaar.",
 	"components.switch.hidden": "Verborgen",
 	"components.switch.conditions": "Er moet aan de voorwaarden worden voldaan",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Naar voren scrollen",
 	"components.tabs.previous": "Naar achteren scrollen",
 	"components.tag-list.clear": "Klik, druk op Backspace of druk op de Delete-toets om item {value} te verwijderen",

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Visível.",
 	"components.switch.hidden": "Oculto",
 	"components.switch.conditions": "As condições devem ser atendidas",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Ir para frente",
 	"components.tabs.previous": "Ir para trás",
 	"components.tag-list.clear": "Clique em, pressione Backspace ou pressione a tecla Delete para remover o item {value}",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Synlig.",
 	"components.switch.hidden": "Dold",
 	"components.switch.conditions": "Villkoren måste uppfyllas",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Bläddra framåt",
 	"components.tabs.previous": "Bläddra bakåt",
 	"components.tag-list.clear": "Klicka, tryck på backstegstangenten eller Delete-tangenten för att ta bort objektet {value}",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "Görünür.",
 	"components.switch.hidden": "Gizli",
 	"components.switch.conditions": "Koşullar karşılanmalıdır",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "İleri Kaydır",
 	"components.tabs.previous": "Geri Kaydır",
 	"components.tag-list.clear": "Öğe {value} değerini kaldırmak için tıklatın, geri al tuşuna veya sil tuşuna basın",

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "可见。",
 	"components.switch.hidden": "隐藏",
 	"components.switch.conditions": "必须符合条件",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "向前滚动",
 	"components.tabs.previous": "向后滚动",
 	"components.tag-list.clear": "单击、按退格键或按 Delete 键以移除项目 {value}",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -106,6 +106,7 @@ export default {
 	"components.switch.visibleWithPeriod": "可見。",
 	"components.switch.hidden": "隱藏",
 	"components.switch.conditions": "必須符合條件",
+	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "向前捲動",
 	"components.tabs.previous": "向後捲動",
 	"components.tag-list.clear": "按一下、按下退格鍵或按下刪除鍵以移除項目 {value}",


### PR DESCRIPTION
This PR adds a unique aria-label for `d2l-table-controls`, overriding the default one provided on `d2l-selection-controls`.

Rally: https://rally1.rallydev.com/#/?detail=/userstory/673796873161&fdp=true
