### PR TITLE
replace forceFocusVisible() with focusWithKeyboard()

### DIFF
--- a/components/button/test/button-icon.visual-diff.html
+++ b/components/button/test/button-icon.visual-diff.html
@@ -5,8 +5,6 @@
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../button-icon.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-button-icon</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/button/test/button-icon.visual-diff.js
+++ b/components/button/test/button-icon.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focus, focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-button-icon', () => {
 
@@ -35,8 +34,8 @@ describe('d2l-button-icon', () => {
 					const selector = `#${entry.category}`;
 
 					if (name === 'hover') await page.hover(selector);
-					else if (name === 'focus') await page.$eval(selector, (elem) => forceFocusVisible(elem));
-					else if (name === 'click') await page.$eval(selector, (elem) => elem.focus());
+					else if (name === 'focus') await focusWithKeyboard(page, selector);
+					else if (name === 'click') await focus(page, selector);
 
 					const rectId = (name.indexOf('disabled') !== -1) ? name : entry.category;
 					const rect = await visualDiff.getRect(page, `#${rectId}`);

--- a/components/button/test/button-icon.visual-diff.js
+++ b/components/button/test/button-icon.visual-diff.js
@@ -1,4 +1,4 @@
-import { focus, focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
+import { focusWithKeyboard, focusWithMouse, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
 
 describe('d2l-button-icon', () => {
@@ -35,7 +35,7 @@ describe('d2l-button-icon', () => {
 
 					if (name === 'hover') await page.hover(selector);
 					else if (name === 'focus') await focusWithKeyboard(page, selector);
-					else if (name === 'click') await focus(page, selector);
+					else if (name === 'click') await focusWithMouse(page, selector);
 
 					const rectId = (name.indexOf('disabled') !== -1) ? name : entry.category;
 					const rect = await visualDiff.getRect(page, `#${rectId}`);

--- a/components/button/test/button-subtle.visual-diff.html
+++ b/components/button/test/button-subtle.visual-diff.html
@@ -5,8 +5,6 @@
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../button-subtle.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-button-subtle</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/button/test/button-subtle.visual-diff.js
+++ b/components/button/test/button-subtle.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focus, focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-button-subtle', () => {
 
@@ -39,9 +38,9 @@ describe('d2l-button-subtle', () => {
 							if (name === 'hover') {
 								await page.hover(selector);
 							} else if (name === 'focus') {
-								await page.$eval(selector, (elem) => forceFocusVisible(elem));
+								await focusWithKeyboard(page, selector);
 							} else if (name === 'click') {
-								await page.$eval(selector, (elem) => elem.focus());
+								await focus(page, selector);
 							}
 
 							const rectId = `${type}-${(name.indexOf('disabled') !== -1 || name.indexOf('icon') !== -1) ? name : entry.category}`;

--- a/components/button/test/button-subtle.visual-diff.js
+++ b/components/button/test/button-subtle.visual-diff.js
@@ -1,4 +1,4 @@
-import { focus, focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
+import { focusWithKeyboard, focusWithMouse, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
 
 describe('d2l-button-subtle', () => {
@@ -40,7 +40,7 @@ describe('d2l-button-subtle', () => {
 							} else if (name === 'focus') {
 								await focusWithKeyboard(page, selector);
 							} else if (name === 'click') {
-								await focus(page, selector);
+								await focusWithMouse(page, selector);
 							}
 
 							const rectId = `${type}-${(name.indexOf('disabled') !== -1 || name.indexOf('icon') !== -1) ? name : entry.category}`;

--- a/components/button/test/button.visual-diff.html
+++ b/components/button/test/button.visual-diff.html
@@ -5,8 +5,6 @@
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../button.js';
-			import { forceFocusVisible } from '../../../helpers/focus.js';
-			window.forceFocusVisible = forceFocusVisible;
 		</script>
 		<title>d2l-button</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/button/test/button.visual-diff.js
+++ b/components/button/test/button.visual-diff.js
@@ -1,4 +1,4 @@
-import { focus, focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
+import { focusWithKeyboard, focusWithMouse, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
 
 describe('d2l-button', () => {
@@ -34,7 +34,7 @@ describe('d2l-button', () => {
 					} else if (name === 'focus') {
 						await focusWithKeyboard(page, selector);
 					} else if (name === 'click') {
-						await focus(page, selector);
+						await focusWithMouse(page, selector);
 					}
 
 					const rectId = (name.indexOf('disabled') !== -1) ? name : entry.category;

--- a/components/button/test/button.visual-diff.js
+++ b/components/button/test/button.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focus, focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-button', () => {
 
@@ -33,9 +32,9 @@ describe('d2l-button', () => {
 					if (name === 'hover') {
 						await page.hover(selector);
 					} else if (name === 'focus') {
-						await page.$eval(selector, (elem) => forceFocusVisible(elem));
+						await focusWithKeyboard(page, selector);
 					} else if (name === 'click') {
-						await page.$eval(selector, (elem) => elem.focus());
+						await focus(page, selector);
 					}
 
 					const rectId = (name.indexOf('disabled') !== -1) ? name : entry.category;

--- a/components/card/card-footer-link.js
+++ b/components/card/card-footer-link.js
@@ -2,6 +2,7 @@ import '../colors/colors.js';
 import '../count-badge/count-badge-icon.js';
 import '../icons/icon.js';
 import { css, html, LitElement } from 'lit';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
@@ -10,7 +11,7 @@ import { RtlMixin } from '../../mixins/rtl-mixin.js';
  * An icon link that can be placed in the `footer` slot.
  * @slot tooltip - slot for the link tooltip
  */
-class CardFooterLink extends RtlMixin(LitElement) {
+class CardFooterLink extends FocusMixin(RtlMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -98,6 +99,10 @@ class CardFooterLink extends RtlMixin(LitElement) {
 		super();
 		this.download = false;
 		this.secondaryCountType = 'notification';
+	}
+
+	static get focusElementSelector() {
+		return 'a';
 	}
 
 	render() {

--- a/components/card/test/card-footer-link.visual-diff.html
+++ b/components/card/test/card-footer-link.visual-diff.html
@@ -6,8 +6,6 @@
 		import '../../typography/typography.js';
 		import '../../tooltip/tooltip.js';
 		import '../card-footer-link.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-card-footer-link</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/card/test/card-footer-link.visual-diff.js
+++ b/components/card/test/card-footer-link.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-card-footer-link', () => {
 
@@ -23,11 +22,11 @@ describe('d2l-card-footer-link', () => {
 
 	[
 		{ name: 'no-secondary', selector: '#no-secondary' },
-		{ name: 'no-secondary-focus', selector: '#no-secondary-focus', action: (selector) => page.$eval(selector, (elem) => forceFocusVisible(elem)) },
+		{ name: 'no-secondary-focus', selector: '#no-secondary-focus', action: (selector) => focusWithKeyboard(page, selector) },
 		{ name: 'secondary-notification', selector: '#secondary-notification' },
-		{ name: 'secondary-notification-focus', selector: '#secondary-notification-focus', action: (selector) => page.$eval(selector, (elem) => forceFocusVisible(elem)) },
+		{ name: 'secondary-notification-focus', selector: '#secondary-notification-focus', action: (selector) => focusWithKeyboard(page, selector) },
 		{ name: 'secondary-count', selector: '#secondary-count' },
-		{ name: 'secondary-count-focus', selector: '#secondary-count-focus', action: (selector) => page.$eval(selector, (elem) => forceFocusVisible(elem)) }
+		{ name: 'secondary-count-focus', selector: '#secondary-count-focus', action: (selector) => focusWithKeyboard(page, selector) }
 	].forEach((info) => {
 
 		it(info.name, async function() {

--- a/components/card/test/card.visual-diff.html
+++ b/components/card/test/card.visual-diff.html
@@ -10,8 +10,6 @@
 		import '../../tooltip/tooltip.js';
 		import '../../typography/typography.js';
 		import '../card.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-card</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/card/test/card.visual-diff.js
+++ b/components/card/test/card.visual-diff.js
@@ -1,7 +1,6 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, focusWithMouse, VisualDiff } from '@brightspace-ui/visual-diff';
 import { open } from '../../dropdown/test/dropdown-helper.js';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-card', () => {
 
@@ -28,14 +27,14 @@ describe('d2l-card', () => {
 		{ name: 'align-center', selector: '#align-center' },
 		{ name: 'badge', selector: '#badge' },
 		{ name: 'actions', selector: '#actions' },
-		{ name: 'actions-focus', selector: '#actions', action: (selector) => page.$eval(`${selector} > d2l-button-icon`, (elem) => forceFocusVisible(elem)) },
+		{ name: 'actions-focus', selector: '#actions', action: (selector) => focusWithKeyboard(page, `${selector} > d2l-button-icon`) },
 		{ name: 'actions-rtl', selector: '#actions-rtl' },
-		{ name: 'no-link-focus', selector: '#header-content', action: (selector) => page.$eval(selector, (elem) => elem.focus()) },
+		{ name: 'no-link-focus', selector: '#header-content', action: (selector) => focusWithMouse(page, selector) },
 		{ name: 'subtle', selector: '#subtle' },
 		{ name: 'link', selector: '#link' },
-		{ name: 'link-focus', selector: '#link', action: (selector) => page.$eval(selector, (elem) => elem.focus()) },
-		{ name: 'link-actions-focus', selector: '#link', action: (selector) => page.$eval(`${selector} > d2l-button-icon`, (elem) => forceFocusVisible(elem)) },
-		{ name: 'link-footer-focus', selector: '#link', action: (selector) => page.$eval(`${selector} > d2l-button`, (elem) => forceFocusVisible(elem)) },
+		{ name: 'link-focus', selector: '#link', action: (selector) => focusWithMouse(page, selector) },
+		{ name: 'link-actions-focus', selector: '#link', action: (selector) => focusWithKeyboard(page, `${selector} > d2l-button-icon`) },
+		{ name: 'link-footer-focus', selector: '#link', action: (selector) => focusWithKeyboard(page, `${selector} > d2l-button`) },
 		{ name: 'with-dropdown', selector: '#with-dropdown', margin: 20 },
 		{ name: 'with-dropdown-open', selector: '#with-dropdown', margin: 20, action: (selector) => open(page, `${selector} d2l-dropdown-more`) },
 		{ name: 'with-dropdown-adjacent-hover', selector: '#with-dropdown-adjacent-hover', margin: 20, action: async(selector) => {
@@ -43,7 +42,7 @@ describe('d2l-card', () => {
 			return page.hover(`${selector} #hover-target`);
 		} },
 		{ name: 'with-tooltip', selector: '#with-tooltip', margin: 20 },
-		{ name: 'with-tooltip-focus', selector: '#with-tooltip', margin: 20, action: (selector) => page.$eval(`${selector} #shiny-button`, (elem) => forceFocusVisible(elem)) }
+		{ name: 'with-tooltip-focus', selector: '#with-tooltip', margin: 20, action: (selector) => focusWithKeyboard(page, `${selector} #shiny-button`) }
 	].forEach((info) => {
 
 		it(info.name, async function() {

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -4,6 +4,7 @@ import '../expand-collapse/expand-collapse-content.js';
 import { css, html, LitElement } from 'lit';
 import { heading1Styles, heading2Styles, heading3Styles, heading4Styles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import { RtlMixin } from '../../mixins/rtl-mixin.js';
 
@@ -25,7 +26,7 @@ const defaultHeading = 3;
  * @fires d2l-collapsible-panel-expand - Dispatched when the panel is expanded
  * @fires d2l-collapsible-panel-collapse - Dispatched when the panel is collapsed
  */
-class CollapsiblePanel extends RtlMixin(LitElement) {
+class CollapsiblePanel extends FocusMixin(RtlMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -269,6 +270,10 @@ class CollapsiblePanel extends RtlMixin(LitElement) {
 		this._focused = false;
 		this._hasSummary = false;
 		this._scrolled = false;
+	}
+
+	static get focusElementSelector() {
+		return 'button.d2l-offscreen';
 	}
 
 	disconnectedCallback() {

--- a/components/collapsible-panel/test/collapsible-panel.visual-diff.html
+++ b/components/collapsible-panel/test/collapsible-panel.visual-diff.html
@@ -13,8 +13,6 @@
 		import '../../typography/typography.js';
 		import '../collapsible-panel.js';
 		import '../collapsible-panel-summary-item.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-collapsible-panel</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/collapsible-panel/test/collapsible-panel.visual-diff.js
+++ b/components/collapsible-panel/test/collapsible-panel.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-collapsible-panel', () => {
 
@@ -20,8 +19,8 @@ describe('d2l-collapsible-panel', () => {
 
 	after(async() => await browser.close());
 
-	function focusElement(selector) {
-		return page.$eval(selector, (elem) => forceFocusVisible(elem));
+	async function focusElement(selector) {
+		return focusWithKeyboard(page, `${selector} > d2l-collapsible-panel`);
 	}
 
 	function expandPanel(selector) {

--- a/components/collapsible-panel/test/collapsible-panel.visual-diff.js
+++ b/components/collapsible-panel/test/collapsible-panel.visual-diff.js
@@ -19,7 +19,7 @@ describe('d2l-collapsible-panel', () => {
 
 	after(async() => await browser.close());
 
-	async function focusElement(selector) {
+	function focusElement(selector) {
 		return focusWithKeyboard(page, `${selector} > d2l-collapsible-panel`);
 	}
 

--- a/components/count-badge/test/count-badge-icon.visual-diff.html
+++ b/components/count-badge/test/count-badge-icon.visual-diff.html
@@ -5,8 +5,6 @@
 	<script type="module">
 		import '../count-badge-icon.js';
 		import '../../typography/typography.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-count-badge-icon</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/count-badge/test/count-badge-icon.visual-diff.js
+++ b/components/count-badge/test/count-badge-icon.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-count-badge-icon', () => {
 
@@ -49,7 +48,7 @@ describe('d2l-count-badge-icon', () => {
 	].forEach((testName) => {
 		it(`${testName} focused`, async function() {
 			const selector = `#${testName}`;
-			await page.$eval(selector, (elem) => forceFocusVisible(elem));
+			await focusWithKeyboard(page, selector);
 			const rect = await visualDiff.getRect(page, selector);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
@@ -61,7 +60,7 @@ describe('d2l-count-badge-icon', () => {
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 		it('tooltip appears on focus-visible', async function() {
-			await page.$eval('#tooltip-icon', (elem) => forceFocusVisible(elem));
+			await focusWithKeyboard(page, '#tooltip-icon');
 			await page.waitForTimeout(50);
 			const rect = await getRect(page, '#tooltip-icon');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });

--- a/components/count-badge/test/count-badge.visual-diff.html
+++ b/components/count-badge/test/count-badge.visual-diff.html
@@ -5,8 +5,6 @@
 	<script type="module">
 		import '../count-badge.js';
 		import '../../typography/typography.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-count-badge</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/count-badge/test/count-badge.visual-diff.js
+++ b/components/count-badge/test/count-badge.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-count-badge', () => {
 
@@ -53,7 +52,7 @@ describe('d2l-count-badge', () => {
 	].forEach((testName) => {
 		it(`${testName} focused`, async function() {
 			const selector = `#${testName}`;
-			await page.$eval(selector, (elem) => forceFocusVisible(elem));
+			await focusWithKeyboard(page, selector);
 			const rect = await visualDiff.getRect(page, selector);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
@@ -65,7 +64,7 @@ describe('d2l-count-badge', () => {
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 		it('appears on focus-visible', async function() {
-			await page.$eval('#tooltip', (elem) => forceFocusVisible(elem));
+			await focusWithKeyboard(page, '#tooltip');
 			await page.waitForTimeout(50);
 			const rect = await getRect(page, '#tooltip');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });

--- a/components/inputs/test/input-search.visual-diff.html
+++ b/components/inputs/test/input-search.visual-diff.html
@@ -6,8 +6,6 @@
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-search.js';
-			import { forceFocusVisible } from '../../../helpers/focus.js';
-			window.forceFocusVisible = forceFocusVisible;
 		</script>
 		<title>d2l-input-search visual-diff tests</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/inputs/test/input-search.visual-diff.js
+++ b/components/inputs/test/input-search.visual-diff.js
@@ -57,13 +57,13 @@ describe('d2l-input-search', () => {
 	});
 
 	it('focus-search-button', async function() {
-		await focusWithKeyboard(page, 'pierce/#no-value > d2l-button-icon[icon="tier1:search"]');
+		await focusWithKeyboard(page, ['#no-value', 'd2l-button-icon[icon="tier1:search"]']);
 		const rect = await visualDiff.getRect(page, '#no-value');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('focus-clear-button', async function() {
-		await focusWithKeyboard(page, 'pierce/#has-value > d2l-button-icon[icon="tier1:close-default"]');
+		await focusWithKeyboard(page, ['#has-value', 'd2l-button-icon[icon="tier1:close-default"]']);
 		const rect = await visualDiff.getRect(page, '#has-value');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});

--- a/components/inputs/test/input-search.visual-diff.js
+++ b/components/inputs/test/input-search.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-input-search', () => {
 
@@ -58,21 +57,13 @@ describe('d2l-input-search', () => {
 	});
 
 	it('focus-search-button', async function() {
-		await page.evaluateHandle(() => {
-			forceFocusVisible(
-				document.querySelector('#no-value').shadowRoot.querySelector('d2l-button-icon[icon="tier1:search"]')
-			);
-		});
+		await focusWithKeyboard(page, ['#no-value', 'd2l-button-icon[icon="tier1:search"]']);
 		const rect = await visualDiff.getRect(page, '#no-value');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('focus-clear-button', async function() {
-		await page.evaluateHandle(() => {
-			forceFocusVisible(
-				document.querySelector('#has-value').shadowRoot.querySelector('d2l-button-icon[icon="tier1:close-default"]')
-			);
-		});
+		await focusWithKeyboard(page, ['#has-value', 'd2l-button-icon[icon="tier1:close-default"]']);
 		const rect = await visualDiff.getRect(page, '#has-value');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});

--- a/components/inputs/test/input-search.visual-diff.js
+++ b/components/inputs/test/input-search.visual-diff.js
@@ -57,13 +57,13 @@ describe('d2l-input-search', () => {
 	});
 
 	it('focus-search-button', async function() {
-		await focusWithKeyboard(page, ['#no-value', 'd2l-button-icon[icon="tier1:search"]']);
+		await focusWithKeyboard(page, 'pierce/#no-value > d2l-button-icon[icon="tier1:search"]');
 		const rect = await visualDiff.getRect(page, '#no-value');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('focus-clear-button', async function() {
-		await focusWithKeyboard(page, ['#has-value', 'd2l-button-icon[icon="tier1:close-default"]']);
+		await focusWithKeyboard(page, 'pierce/#has-value > d2l-button-icon[icon="tier1:close-default"]');
 		const rect = await visualDiff.getRect(page, '#has-value');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});

--- a/components/list/test/list-item-drag-handle.visual-diff.html
+++ b/components/list/test/list-item-drag-handle.visual-diff.html
@@ -4,8 +4,6 @@
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<script type="module">
 			import '../list-item-drag-handle.js';
-			import { forceFocusVisible } from '../../../helpers/focus.js';
-			window.forceFocusVisible = forceFocusVisible;
 		</script>
 		<title>d2l-list-item-drag-handle</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/list/test/list-item-drag-handle.visual-diff.js
+++ b/components/list/test/list-item-drag-handle.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 function itWithReload(name, test, getPage) {
 	return it(name, async function() {
@@ -14,10 +13,6 @@ describe('d2l-list-item-drag-handle', () => {
 	const visualDiff = new VisualDiff('list-item-drag-handle', import.meta.url);
 
 	let browser, page;
-
-	const focusMethod = (selector) => {
-		return page.$eval(selector, (item) => { forceFocusVisible(item); });
-	};
 
 	before(async() => {
 		browser = await puppeteer.launch();
@@ -37,7 +32,7 @@ describe('d2l-list-item-drag-handle', () => {
 		});
 
 		it('focus', async function() {
-			await focusMethod('d2l-list-item-drag-handle');
+			await focusWithKeyboard(page, 'd2l-list-item-drag-handle');
 			const rect = await visualDiff.getRect(page, '#drag-handle');
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});

--- a/components/list/test/list.visual-diff.html
+++ b/components/list/test/list.visual-diff.html
@@ -20,8 +20,6 @@
 			import '../list-item.js';
 			import '../list-item-button.js';
 			import '../list-item-content.js';
-			import { forceFocusVisible } from '../../../helpers/focus.js';
-			window.forceFocusVisible = forceFocusVisible;
 		</script>
 		<title>d2l-list</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/list/test/list.visual-diff.js
+++ b/components/list/test/list.visual-diff.js
@@ -1,8 +1,7 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import { hide, show } from '../../tooltip/test/tooltip-helper.js';
 import { open, reset } from '../../dropdown/test/dropdown-helper.js';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-list', () => {
 
@@ -18,10 +17,6 @@ describe('d2l-list', () => {
 		return page.$eval(selector, (item) => {
 			item.focus();
 		});
-	};
-
-	const forceFocusMethod = (selector) => {
-		return page.$eval(selector, (item) => forceFocusVisible(item));
 	};
 
 	const focusInput = (selector) => {
@@ -172,7 +167,7 @@ describe('d2l-list', () => {
 		] },
 		{ category: 'draggable', tests: [
 			{ name: 'default', selector: '#draggable' },
-			{ name: 'focus', selector: '#draggable', action: () => forceFocusMethod('#draggable [key="1"]') },
+			{ name: 'focus', selector: '#draggable', action: () => focusWithKeyboard(page, '#draggable [key="1"]') },
 			{ name: 'hover', selector: '#draggable', action: () => hover('#draggable [key="1"]') },
 			{ name: 'selectable', selector: '#draggableSelectable' },
 			{ name: 'selectable focus', selector: '#draggableSelectable', action: () => focusInput('#draggableSelectable [key="1"]') },

--- a/components/paging/test/pager-load-more.visual-diff.html
+++ b/components/paging/test/pager-load-more.visual-diff.html
@@ -6,8 +6,6 @@
 		import '../../typography/typography.js';
 		import './pageable-component.js';
 		import '../pager-load-more.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-pager-load-more</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/paging/test/pager-load-more.visual-diff.js
+++ b/components/paging/test/pager-load-more.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-pager-load-more', () => {
 
@@ -42,7 +41,7 @@ describe('d2l-pager-load-more', () => {
 			{ name: 'item-count', selector: '#item-count' },
 			{ name: 'no-item-count', selector: '#no-item-count' },
 			{ name: 'hover', selector: '#item-count', action: selector => page.hover(`${selector} d2l-pager-load-more`) },
-			{ name: 'focus', selector: '#item-count', action: selector => page.$eval(selector, elem => forceFocusVisible(elem.querySelector('d2l-pager-load-more'))) },
+			{ name: 'focus', selector: '#item-count', action: selector => focusWithKeyboard(page, `${selector} d2l-pager-load-more`) },
 		].forEach(runTest);
 
 	});

--- a/components/switch/test/switch.visual-diff.html
+++ b/components/switch/test/switch.visual-diff.html
@@ -9,8 +9,6 @@
 	<script type="module">
 		import '../../typography/typography.js';
 		import '../switch.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-switch</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/switch/test/switch.visual-diff.js
+++ b/components/switch/test/switch.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-switch', () => {
 
@@ -38,7 +37,7 @@ describe('d2l-switch', () => {
 
 			[
 				{ name: 'off', selector: '#off' },
-				{ name: 'off-focus', selector: '#off', action: (selector) => page.$eval(selector, (elem) => forceFocusVisible(elem)) },
+				{ name: 'off-focus', selector: '#off', action: (selector) => focusWithKeyboard(page, selector) },
 				{ name: 'off-disabled', selector: '#off-disabled' },
 				{ name: 'off-hover', selector: '#off',
 					action: async(selector) => {
@@ -47,7 +46,7 @@ describe('d2l-switch', () => {
 					}
 				},
 				{ name: 'on', selector: '#on' },
-				{ name: 'on-focus', selector: '#on', action: (selector) => page.$eval(selector, (elem) => forceFocusVisible(elem)) },
+				{ name: 'on-focus', selector: '#on', action: (selector) => focusWithKeyboard(page, selector) },
 				{ name: 'on-hover', selector: '#on',
 					action: async(selector) => {
 						const d2lSwitch = await getSwitch(selector);

--- a/components/tabs/test/tabs.visual-diff.html
+++ b/components/tabs/test/tabs.visual-diff.html
@@ -11,8 +11,6 @@
 		import '../../button/button.js';
 		import '../tabs.js';
 		import '../tab-panel.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-tabs</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/components/tabs/test/tabs.visual-diff.js
+++ b/components/tabs/test/tabs.visual-diff.js
@@ -118,13 +118,13 @@ describe('d2l-tabs', () => {
 
 				it('focus next', async function() {
 					const rect = await visualDiff.getRect(page, '#focus-next');
-					await focusWithKeyboard(page, ['#focus-next', '.d2l-tabs-scroll-next-container > button']);
+					await focusWithKeyboard(page, 'pierce/#focus-next > .d2l-tabs-scroll-next-container > button');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 				});
 
 				it('focus previous', async function() {
 					const rect = await visualDiff.getRect(page, '#focus-previous');
-					await focusWithKeyboard(page, ['#focus-previous', '.d2l-tabs-scroll-previous-container > button']);
+					await focusWithKeyboard(page, 'pierce/#focus-previous > .d2l-tabs-scroll-previous-container > button');
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 				});
 			});

--- a/components/tabs/test/tabs.visual-diff.js
+++ b/components/tabs/test/tabs.visual-diff.js
@@ -1,6 +1,5 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-tabs', () => {
 
@@ -118,20 +117,14 @@ describe('d2l-tabs', () => {
 				});
 
 				it('focus next', async function() {
-					await page.$eval('#focus-next', (elem) => {
-						const buttonElement = elem.shadowRoot.querySelector('.d2l-tabs-scroll-next-container > button');
-						forceFocusVisible(buttonElement);
-					});
 					const rect = await visualDiff.getRect(page, '#focus-next');
+					await focusWithKeyboard(page, ['#focus-next', '.d2l-tabs-scroll-next-container > button']);
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 				});
 
 				it('focus previous', async function() {
 					const rect = await visualDiff.getRect(page, '#focus-previous');
-					await page.$eval('#focus-previous', (elem) => {
-						const buttonElement = elem.shadowRoot.querySelector('.d2l-tabs-scroll-previous-container > button');
-						forceFocusVisible(buttonElement);
-					});
+					await focusWithKeyboard(page, ['#focus-previous', '.d2l-tabs-scroll-previous-container > button']);
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 				});
 			});

--- a/components/tabs/test/tabs.visual-diff.js
+++ b/components/tabs/test/tabs.visual-diff.js
@@ -118,13 +118,13 @@ describe('d2l-tabs', () => {
 
 				it('focus next', async function() {
 					const rect = await visualDiff.getRect(page, '#focus-next');
-					await focusWithKeyboard(page, 'pierce/#focus-next > .d2l-tabs-scroll-next-container > button');
+					await focusWithKeyboard(page, ['#focus-next', '.d2l-tabs-scroll-next-container > button']);
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 				});
 
 				it('focus previous', async function() {
 					const rect = await visualDiff.getRect(page, '#focus-previous');
-					await focusWithKeyboard(page, 'pierce/#focus-previous > .d2l-tabs-scroll-previous-container > button');
+					await focusWithKeyboard(page, ['#focus-previous', '.d2l-tabs-scroll-previous-container > button']);
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 				});
 			});

--- a/components/tooltip/test/tooltip-help.visual-diff.html
+++ b/components/tooltip/test/tooltip-help.visual-diff.html
@@ -5,8 +5,6 @@
 	<script type="module">
 		import '../../../test/typography-preload.js';
 		import '../tooltip-help.js';
-		import { forceFocusVisible } from '../../../helpers/focus.js';
-		window.forceFocusVisible = forceFocusVisible;
 	</script>
 	<title>d2l-tooltip-help</title>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1.0">

--- a/components/tooltip/test/tooltip-help.visual-diff.js
+++ b/components/tooltip/test/tooltip-help.visual-diff.js
@@ -1,7 +1,6 @@
-/*global forceFocusVisible */
+import { focusWithKeyboard, VisualDiff } from '@brightspace-ui/visual-diff';
 import { getRect, show } from './tooltip-helper.js';
 import puppeteer from 'puppeteer';
-import VisualDiff from '@brightspace-ui/visual-diff';
 
 describe('d2l-tooltip-help', () => {
 
@@ -41,16 +40,16 @@ describe('d2l-tooltip-help', () => {
 			});
 
 			if (testCase.focus) {
-				await page.$eval(tooltipHelpSelector, (elem) => forceFocusVisible(elem));
+				await focusWithKeyboard(page, tooltipHelpSelector);
 			}
 			if (testCase.hover) {
 				await page.hover(tooltipHelpSelector);
+				if (!testCase.focus) {
+					await openEvent;
+				}
 			}
 			if (testCase.click) {
 				await page.click(tooltipHelpSelector);
-			}
-
-			if (testCase.focus || testCase.hover || testCase.click) {
 				await openEvent;
 			}
 
@@ -96,7 +95,7 @@ describe('d2l-tooltip-help', () => {
 					});
 				});
 
-				await page.$eval(`${selector} d2l-tooltip-help`, (elem) => forceFocusVisible(elem));
+				await focusWithKeyboard(page, `${selector} d2l-tooltip-help`);
 				await openEvent;
 
 				const rect = await visualDiff.getRect(page, selector);
@@ -119,7 +118,7 @@ describe('d2l-tooltip-help', () => {
 		it(testCase.case, async function() {
 
 			if (testCase.focus) {
-				await page.$eval(tooltipHelpSelectorSkeleton, (elem) => forceFocusVisible(elem));
+				await focusWithKeyboard(page, tooltipHelpSelectorSkeleton);
 			}
 			if (testCase.hover) {
 				await page.hover(tooltipHelpSelectorSkeleton);


### PR DESCRIPTION
In our visual-diff tests, using `forceFocusVisible` to test focus state isn't actually necessary now that we have the `focusWithKeyboard` visual-diff helper. In fact, it's dangerous because that only exercises the `.focus-visible` CSS class, and not the actual `:focus-visible` pseudo-class.

In a follow-up PR, I'll be updating visual-diff tests that are using `focus()` to test either `:focus-visible` or "focus with a mouse" to use `focusWithKeyboard` or `focusWithMouse`.