### PR TITLE
Separate localize and localizeHTML completely; Allow all non-lit html…

### DIFF
--- a/helpers/localize.js
+++ b/helpers/localize.js
@@ -7,18 +7,18 @@ const markupError = `localizeHTML() rich-text replacements must use markup templ
 const acceptedTagsRegex = new RegExp(`<(?!/?(${acceptedTags.join('|')}))`);
 
 export function validateMarkup(content, applyRegex) {
-	if (content.map) return content.map(item => validateMarkup(item, applyRegex));
-
-	if (content._markup) return content;
-	if (content.constructor !== String) throw markupError;
-	if (applyRegex && acceptedTagsRegex.test(content)) throw markupError;
-
+	if (content) {
+		if (content.map) return content.map(item => validateMarkup(item, applyRegex));
+		if (content._markup) return content;
+		if (Object.hasOwn(content, '_$litType$')) throw markupError;
+		if (applyRegex && content.constructor === String && acceptedTagsRegex.test(content)) throw markupError;
+	}
 	return content;
 }
 
-export function markup(str, ...parts) {
-	validateMarkup(str, true) && validateMarkup(parts, true);
-	return { ...html(str, ...parts), _markup: true };
+export function markup(strings, ...expressions) {
+	validateMarkup(strings, true) && validateMarkup(expressions, true);
+	return { ...html(strings, ...expressions), _markup: true };
 }
 
 export const linkGenerator = ({ href, target }) => {

--- a/mixins/demo/localize-mixin-mission.js
+++ b/mixins/demo/localize-mixin-mission.js
@@ -6,8 +6,11 @@ class Mission extends LocalizeDynamicMixin(LitElement) {
 
 	static get localizeConfig() {
 		const langResources = {
-			'en': { mission: '<p><link1>Transforming</link1> the way</p><link2> <b>{name}</b></link2> learns. \'<div></div>\'' },
-			'fr': { mission: '<p><link1>Transformer</link1> la façon dont</p><link2> \'<br>\'\'</br>\' <b>{name}</b></link2> apprend' }
+			'en': {
+				mission: '<p><link1>Transforming</link1> the way</p><link2> <b>{name}</b></link2> learns. \'<div></div>\'',
+				a: '{a, select, true {T <i>{c}</i>} false {F - {b, date, medium}} other {O - {a}}}'
+			},
+			'fr': { mission: '<p><link1>Transformer</link1> la façon dont</p><link2> <br></br> <b>{name}</b></link2> apprend' }
 		};
 		return {
 			importFunc: async lang => langResources[lang]
@@ -22,8 +25,16 @@ class Mission extends LocalizeDynamicMixin(LitElement) {
 			link1: linkGenerator({ href: 'https://wikipedia.org/wiki/Culture_change', target: '_blank' }),
 			link2: chunks => markup`<d2l-link href="https://wikipedia.org/wiki/Earth" target="_blank"><em>${chunks}</em> ${surnameMarkup}</d2l-link>`
 		};
+		let a;
 		return html`
 			${this.localizeHTML('mission', replacements)}
+			<div>1. ${this.localizeHTML('a', { a })}</div>
+			<div>2. ${this.localizeHTML('a', { a: null })}</div>
+			<div>3. ${this.localizeHTML('a', { a: 1 })}</div>
+			<div>4. ${this.localizeHTML('a', { a: {} })}</div>
+			<div>5. ${this.localizeHTML('a', { a: false, b: new Date() })}</div>
+			<div>6. ${this.localizeHTML('a', { a: true, c: [1, 2, 3] })}</div>
+			<div>7. ${this.localizeHTML('a', { a: true, c: markup`<b>test</b>` })}</div>
 		`;
 	}
 }


### PR DESCRIPTION
_One_ more for the stack.

- Separates localize and localizeHTML completely to avoid messiness/allowing default elements in `localize`
- Allows all non-lit types to be passes as replacement params
- Catches all `localize`/`localizeHTML` errors so as not to block `render`
- Fixes some naming