### PR TITLE
remove forceFocusVisible from scroll-wrapper test

### DIFF
--- a/components/scroll-wrapper/demo/scroll-wrapper-test.js
+++ b/components/scroll-wrapper/demo/scroll-wrapper-test.js
@@ -1,6 +1,5 @@
 import '../scroll-wrapper.js';
 import { css, html, LitElement } from 'lit';
-import { forceFocusVisible } from '../../../helpers/focus.js';
 import { RtlMixin } from '../../../mixins/rtl-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -53,7 +52,7 @@ class TestScrollWrapper extends RtlMixin(LitElement) {
 	}
 
 	focus() {
-		if (this.shadowRoot) forceFocusVisible(this.shadowRoot.querySelector('d2l-scroll-wrapper')._container);
+		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-scroll-wrapper')._container.focus();
 	}
 
 }


### PR DESCRIPTION
Missed this earlier. This test element is being focused on from visual-diff tests that are now using the `focusWithKeyboard()` helper, so there should be no need to `forceFocusVisible` from there.