### PR TITLE
fix: remove forceFocusVisible

### DIFF
--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -117,7 +117,6 @@ class ButtonIcon extends ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(
 					--d2l-icon-fill-color: var(--d2l-button-icon-fill-color-hover, var(--d2l-color-tungsten));
 					background-color: var(--d2l-button-icon-background-color-hover);
 				}
-				button.force-dialog-focus-visible,
 				button:${unsafeCSS(getFocusPseudoClass())} {
 					box-shadow: var(--d2l-button-icon-focus-box-shadow);
 				}

--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -117,7 +117,7 @@ class ButtonIcon extends ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(
 					--d2l-icon-fill-color: var(--d2l-button-icon-fill-color-hover, var(--d2l-color-tungsten));
 					background-color: var(--d2l-button-icon-background-color-hover);
 				}
-				button.focus-visible,
+				button.force-dialog-focus-visible,
 				button:${unsafeCSS(getFocusPseudoClass())} {
 					box-shadow: var(--d2l-button-icon-focus-box-shadow);
 				}

--- a/components/button/button-styles.js
+++ b/components/button/button-styles.js
@@ -22,7 +22,7 @@ export const buttonStyles = css`
 		white-space: nowrap;
 		width: auto;
 	}
-	button.focus-visible, /* still required for when forceFocusVisible is used programatically */
+	button.force-dialog-focus-visible,
 	button:${unsafeCSS(getFocusPseudoClass())} {
 		box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
 	}

--- a/components/button/button-styles.js
+++ b/components/button/button-styles.js
@@ -22,7 +22,6 @@ export const buttonStyles = css`
 		white-space: nowrap;
 		width: auto;
 	}
-	button.force-dialog-focus-visible,
 	button:${unsafeCSS(getFocusPseudoClass())} {
 		box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
 	}

--- a/components/count-badge/count-badge-icon.js
+++ b/components/count-badge/count-badge-icon.js
@@ -25,8 +25,6 @@ class CountBadgeIcon extends FocusMixin(CountBadgeMixin(LitElement)) {
 	static get styles() {
 		return [super.styles, css`
 		:host([focus-ring]) d2l-icon,
-		:host(.focus-visible) d2l-icon,
-		d2l-icon.focus-visible,
 		:host(:${unsafeCSS(getFocusPseudoClass())}) d2l-icon,
 		d2l-icon:${unsafeCSS(getFocusPseudoClass())} {
 			box-shadow: 0 0 0 2px var(--d2l-color-celestine);

--- a/components/count-badge/count-badge.js
+++ b/components/count-badge/count-badge.js
@@ -11,8 +11,6 @@ class CountBadge extends FocusMixin(CountBadgeMixin(LitElement)) {
 	static get styles() {
 		return [super.styles, css`
 		:host([focus-ring]) .d2l-count-badge-wrapper,
-		:host(.focus-visible) .d2l-count-badge-wrapper,
-		.d2l-count-badge-wrapper.focus-visible,
 		:host(:${unsafeCSS(getFocusPseudoClass())}) .d2l-count-badge-wrapper,
 		.d2l-count-badge-wrapper:${unsafeCSS(getFocusPseudoClass())} {
 			box-shadow: 0 0 0 2px var(--d2l-color-celestine);

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -105,7 +105,7 @@ class DialogConfirm extends DialogMixin(LitElement) {
 			const node = nodes[i];
 			if (node.nodeType !== Node.ELEMENT_NODE) continue;
 			if (!node.hasAttribute('primary')) {
-				this._forceDialogFocusVisible(node);
+				this._focusElemOrDescendant(node);
 				return;
 			}
 		}

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -1,7 +1,6 @@
 import { css, html, LitElement } from 'lit';
 import { DialogMixin } from './dialog-mixin.js';
 import { dialogStyles } from './dialog-styles.js';
-import { forceFocusVisible } from '../../helpers/focus.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { heading3Styles } from '../typography/styles.js';
 
@@ -106,7 +105,7 @@ class DialogConfirm extends DialogMixin(LitElement) {
 			const node = nodes[i];
 			if (node.nodeType !== Node.ELEMENT_NODE) continue;
 			if (!node.hasAttribute('primary')) {
-				forceFocusVisible(node);
+				this._forceDialogFocusVisible(node);
 				return;
 			}
 		}

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -3,7 +3,7 @@ import '../../helpers/viewport-size.js';
 import { allowBodyScroll, preventBodyScroll } from '../backdrop/backdrop.js';
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
-import { getComposedActiveElement, getFirstFocusableDescendant, getNextFocusable, isFocusable, isFocusVisibleApplied } from '../../helpers/focus.js';
+import { getComposedActiveElement, getFirstFocusableDescendant, getNextFocusable, isFocusable } from '../../helpers/focus.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit';
@@ -417,8 +417,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			// edge case: no children were focused, try again after one redraw
 			const activeElement = getComposedActiveElement();
 			if (!activeElement
-			|| !isComposedAncestor(dialog, activeElement)
-			|| !isFocusVisibleApplied(activeElement)) {
+			|| !isComposedAncestor(dialog, activeElement)) {
 				// wait till the dialog is visible for Safari
 				requestAnimationFrame(() => this._focusInitial());
 			}

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -423,7 +423,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			const activeElement = getComposedActiveElement();
 			if (!activeElement
 			|| !isComposedAncestor(dialog, activeElement)
-			|| !isFocusVisibleApplied(activeElement)) {
+			|| (!isFocusVisibleApplied(activeElement) && !activeElement.classList.contains('force-dialog-focus-visible'))) {
 				// wait till the dialog is visible for Safari
 				requestAnimationFrame(() => this._focusInitial());
 			}

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -231,16 +231,8 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		if (this._opener && this._opener.focus) {
 			// wait for inactive focus trap
 			requestAnimationFrame(() => {
-				let focusable = this._opener;
+				this._tryApplyFocus(this._opener);
 				this._opener = null;
-				if (!isFocusable(focusable)) {
-					focusable = findComposedAncestor(focusable, (node) => (isFocusable(node) || getFirstFocusableDescendant(node) !== null));
-					if (focusable === null) return;
-					if (!isFocusable(focusable)) {
-						focusable = getFirstFocusableDescendant(focusable);
-					}
-				}
-				if (isFocusable(focusable)) focusable.focus();
 			});
 		}
 	}
@@ -513,6 +505,17 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 				<d2l-backdrop for-target="${this._dialogId}" ?shown="${this._state === 'showing'}"></d2l-backdrop>`}
 		`;
 
+	}
+
+	_tryApplyFocus(focusable) {
+		if (!isFocusable(focusable)) {
+			focusable = findComposedAncestor(focusable, (node) => (isFocusable(node) || getFirstFocusableDescendant(node) !== null));
+			if (focusable === null) return;
+			if (!isFocusable(focusable)) {
+				focusable = getFirstFocusableDescendant(focusable);
+			}
+		}
+		if (isFocusable(focusable)) focusable.focus();
 	}
 
 	_updateOverflow() {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -201,13 +201,20 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		return autofocusElement;
 	}
 
+	_focusElemOrDescendant(elem) {
+		if (!isFocusable(elem, false, false)) {
+			elem = getFirstFocusableDescendant(elem);
+		}
+		if (elem) elem.focus();
+	}
+
 	_focusFirst() {
 		if (!this.shadowRoot) return;
 		const content = this.shadowRoot.querySelector('.d2l-dialog-content');
 		if (content) {
 			const elementToFocus = this._findAutofocusElement(content) ?? getNextFocusable(content);
 			if (isComposedAncestor(this.shadowRoot.querySelector('.d2l-dialog-inner'), elementToFocus)) {
-				this._forceDialogFocusVisible(elementToFocus);
+				this._focusElemOrDescendant(elementToFocus);
 				return;
 			}
 		}
@@ -219,7 +226,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		const header = this.shadowRoot.querySelector('.d2l-dialog-header');
 		if (header) {
 			const firstFocusable = getNextFocusable(header);
-			if (firstFocusable) this._forceDialogFocusVisible(firstFocusable);
+			if (firstFocusable) this._focusElemOrDescendant(firstFocusable);
 		}
 	}
 
@@ -235,18 +242,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 				this._opener = null;
 			});
 		}
-	}
-
-	_forceDialogFocusVisible(elem) {
-		if (!isFocusable(elem, false, false)) {
-			elem = getFirstFocusableDescendant(elem);
-		}
-		if (!elem) return;
-		if (elem.tagName === 'BUTTON') {
-			elem.addEventListener('blur', () => elem.classList.remove('force-dialog-focus-visible'), { once: true });
-			elem.classList.add('force-dialog-focus-visible');
-		}
-		elem.focus();
 	}
 
 	_getHeight() {
@@ -423,7 +418,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			const activeElement = getComposedActiveElement();
 			if (!activeElement
 			|| !isComposedAncestor(dialog, activeElement)
-			|| (!isFocusVisibleApplied(activeElement) && !activeElement.classList.contains('force-dialog-focus-visible'))) {
+			|| !isFocusVisibleApplied(activeElement)) {
 				// wait till the dialog is visible for Safari
 				requestAnimationFrame(() => this._focusInitial());
 			}

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -246,7 +246,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			elem.addEventListener('blur', () => elem.classList.remove('force-dialog-focus-visible'), { once: true });
 			elem.classList.add('force-dialog-focus-visible');
 		}
-		if (elem) elem.focus();
+		elem.focus();
 	}
 
 	_getHeight() {

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -101,7 +101,6 @@ export const htmlBlockContentStyles = css`
 		color: var(--d2l-color-celestine-minus-1, #004489);
 		text-decoration: underline;
 	}
-	a.focus-visible,
 	a:${unsafeCSS(getFocusPseudoClass())} {
 		border-radius: 2px;
 		outline: 2px solid var(--d2l-color-celestine, #006fbf);

--- a/components/inputs/input-color.js
+++ b/components/inputs/input-color.js
@@ -213,7 +213,6 @@ class InputColor extends FocusMixin(FormElementMixin(LocalizeCoreElement(LitElem
 				.readonly-wrapper:focus {
 					outline: none;
 				}
-				.readonly-wrapper.focus-visible,
 				.readonly-wrapper:${unsafeCSS(getFocusPseudoClass())} {
 					box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
 				}

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -20,7 +20,6 @@ export const linkStyles = css`
 		color: var(--d2l-color-celestine-minus-1);
 		text-decoration: underline;
 	}
-	.d2l-link.focus-visible,
 	.d2l-link:${unsafeCSS(getFocusPseudoClass())} {
 		border-radius: 2px;
 		outline: 2px solid var(--d2l-color-celestine);

--- a/components/menu/menu-item-styles.js
+++ b/components/menu/menu-item-styles.js
@@ -21,8 +21,6 @@ export const menuItemStyles = css`
 		color: var(--d2l-menu-foreground-color-hover);
 	}
 
-	:host(.focus-visible),
-	:host([first].focus-visible),
 	:host(:${unsafeCSS(getFocusPseudoClass())}),
 	:host([first]:${unsafeCSS(getFocusPseudoClass())}) {
 		border-radius: 6px;
@@ -38,7 +36,6 @@ export const menuItemStyles = css`
 		opacity: 0.75;
 	}
 
-	:host([disabled].focus-visible),
 	:host([disabled]:${unsafeCSS(getFocusPseudoClass())}) {
 		cursor: default;
 		opacity: 0.75;

--- a/components/scroll-wrapper/scroll-wrapper.js
+++ b/components/scroll-wrapper/scroll-wrapper.js
@@ -59,7 +59,6 @@ class ScrollWrapper extends RtlMixin(LitElement) {
 				overflow-x: auto;
 				overflow-y: var(--d2l-scroll-wrapper-overflow-y, visible);
 			}
-			.d2l-scroll-wrapper-container.focus-visible,
 			.d2l-scroll-wrapper-container:${unsafeCSS(getFocusPseudoClass())} {
 				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine), 0 2px 12px 0 rgba(0, 0, 0, 0.15);
 			}

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -59,7 +59,6 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 				padding: 0.1rem;
 				vertical-align: middle;
 			}
-			.d2l-switch-container.focus-visible,
 			.d2l-switch-container:${unsafeCSS(getFocusPseudoClass())} {
 				border-color: var(--d2l-color-celestine);
 			}

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -63,7 +63,6 @@ class Tab extends RtlMixin(LitElement) {
 				margin-left: 0.6rem;
 				margin-right: 0;
 			}
-			:host(.focus-visible) > .d2l-tab-text,
 			:host(:${unsafeCSS(getFocusPseudoClass())}) > .d2l-tab-text {
 				border-radius: 0.3rem;
 				box-shadow: 0 0 0 2px var(--d2l-color-celestine);

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -182,16 +182,13 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(RtlMixin(LitElement))) {
 				border: 0;
 			}
 			.d2l-tabs-scroll-button[disabled]:hover,
-			.d2l-tabs-scroll-button[disabled].focus-visible,
 			.d2l-tabs-scroll-button[disabled]:${unsafeCSS(getFocusPseudoClass())} {
 				background-color: transparent;
 			}
 			.d2l-tabs-scroll-button:hover,
-			.d2l-tabs-scroll-button.focus-visible,
 			.d2l-tabs-scroll-button:${unsafeCSS(getFocusPseudoClass())} {
 				background-color: var(--d2l-color-gypsum);
 			}
-			.d2l-tabs-scroll-button.focus-visible,
 			.d2l-tabs-scroll-button:${unsafeCSS(getFocusPseudoClass())} {
 				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
 			}

--- a/components/tag-list/demo/tag-list.html
+++ b/components/tag-list/demo/tag-list.html
@@ -82,7 +82,7 @@
 							e.target.removeChild(tag);
 						});
 						// consumer must move focus someplace logical
-						if (nextFocusable) nextFocusable.focus();
+						nextFocusable?.focus();
 					});
 				</script>
 			</d2l-demo-snippet>

--- a/components/tag-list/demo/tag-list.html
+++ b/components/tag-list/demo/tag-list.html
@@ -68,7 +68,7 @@
 					<d2l-tag-list-item text="Example 9"></d2l-tag-list-item>
 				</d2l-tag-list>
 				<script type="module">
-					import { forceFocusVisible, getNextFocusable } from '../../../helpers/focus.js';
+					import { getNextFocusable } from '../../../helpers/focus.js';
 
 					document.addEventListener('d2l-tag-list-item-clear', (e) => {
 						e.target.parentNode.removeChild(e.target);
@@ -82,7 +82,7 @@
 							e.target.removeChild(tag);
 						});
 						// consumer must move focus someplace logical
-						forceFocusVisible(nextFocusable);
+						if (nextFocusable) nextFocusable.focus();
 					});
 				</script>
 			</d2l-demo-snippet>

--- a/components/tooltip/tooltip-help.js
+++ b/components/tooltip/tooltip-help.js
@@ -60,7 +60,6 @@ class TooltipHelp extends SkeletonMixin(FocusMixin(LitElement)) {
 			#d2l-tooltip-help-text:focus {
 				outline-style: none;
 			}
-			#d2l-tooltip-help-text.focus-visible,
 			#d2l-tooltip-help-text:${unsafeCSS(getFocusPseudoClass())} {
 				border-radius: 0.05rem;
 				outline: 2px solid var(--d2l-color-celestine);

--- a/directives/animate/animate.js
+++ b/directives/animate/animate.js
@@ -1,5 +1,5 @@
 import { directive, PartType } from 'lit/directive.js';
-import { getComposedActiveElement, getNextFocusable, isFocusVisibleApplied } from '../../helpers/focus.js';
+import { getComposedActiveElement, getNextFocusable, isFocusVisibleSupported } from '../../helpers/focus.js';
 import { AsyncDirective } from 'lit/async-directive.js';
 import { isComposedAncestor } from '../../helpers/dom.js';
 import { noChange } from 'lit';
@@ -9,6 +9,11 @@ const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const showTransitionDuration = 300;
 const hideTransitionDuration = 200;
 const moveYValue = 20;
+
+function isFocusVisibleApplied(node) {
+	if (!node) return false;
+	return isFocusVisibleSupported() && node.parentNode?.querySelector(':focus-visible') === node;
+}
 
 class AnimationState {
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -148,9 +148,6 @@ getPreviousFocusableAncestor(node, includeHidden, includeTabbablesOnly)
 // returns true/false whether the element is focusable
 isFocusable(node, includeHidden, includeTabbablesOnly, includeDisabled)
 
-// returns true/false whether the element has :focus-visible applied
-isFocusVisibleApplied(node)
-
 // returns true/false whether the :focus-visible is supported
 isFocusVisibleSupported()
 ```

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -120,9 +120,6 @@ Focus helper functions to easily select focusable DOM nodes
 ```js
 import { ... } from '@brightspace-ui/core/helpers/focus.js';
 
-// focuses on an element and forces a visible focus ring
-forceFocusVisible(node);
-
 // gets the active element, including shadow DOM active elements
 getComposedActiveElement()
 
@@ -130,9 +127,9 @@ getComposedActiveElement()
 getFirstFocusableDescendant(node, includeHidden, predicate, includeTabbablesOnly)
 
 // gets the focus pseudo-class to used in selectors (focus-visible if supported, or focus)
-// Always also include `.focus-visible` as a selector, to support `forceFocusVisible`. Usage:
+// Usage:
 //	css`
-//		some-element.focus-visible, some-element:${unsafeCSS(getFocusPseudoClass())} { ... }
+//		some-element:${unsafeCSS(getFocusPseudoClass())} { ... }
 //	`
 getFocusPseudoClass()
 
@@ -151,15 +148,11 @@ getPreviousFocusableAncestor(node, includeHidden, includeTabbablesOnly)
 // returns true/false whether the element is focusable
 isFocusable(node, includeHidden, includeTabbablesOnly, includeDisabled)
 
-// returns true/false whether the element has :focus-visible or .focus-visible applied
+// returns true/false whether the element has :focus-visible applied
 isFocusVisibleApplied(node)
 
 // returns true/false whether the :focus-visible is supported
 isFocusVisibleSupported()
-
-// returns true and focuses on node or its nearest focusable ancestor;
-// or false if node and its ancestors are not focusable
-tryApplyFocus(node)
 ```
 
 ## Gesture - Swipe

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -176,7 +176,6 @@ export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDi
 
 export function isFocusVisibleApplied(node) {
 	if (!node) return false;
-	if (node.classList.contains('focus-visible')) return true;
 	return isFocusVisibleSupported() && node.parentNode?.querySelector(':focus-visible') === node;
 }
 

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -174,11 +174,6 @@ export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDi
 
 }
 
-export function isFocusVisibleApplied(node) {
-	if (!node) return false;
-	return isFocusVisibleSupported() && node.parentNode?.querySelector(':focus-visible') === node;
-}
-
 let _isFocusVisibleSupported;
 
 export function isFocusVisibleSupported() {

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -13,18 +13,6 @@ const focusableElements = {
 	textarea: true
 };
 
-export function forceFocusVisible(elem, includeTabbablesOnly) {
-	if (!isFocusable(elem, false, includeTabbablesOnly)) {
-		elem = getFirstFocusableDescendant(elem);
-	}
-	if (!elem) return;
-	elem.addEventListener('blur', () => {
-		elem.classList.remove('focus-visible');
-	}, { once: true });
-	elem.classList.add('focus-visible');
-	elem.focus();
-}
-
 export function getComposedActiveElement() {
 	let node = document.activeElement;
 
@@ -209,17 +197,4 @@ export function isFocusVisibleSupported() {
 	}
 
 	return _isFocusVisibleSupported;
-}
-
-export function tryApplyFocus(elem) {
-	if (isFocusable(elem)) {
-		forceFocusVisible(elem);
-		return true;
-	}
-	const focusable = findComposedAncestor(elem, (node) => (isFocusable(node) || getFirstFocusableDescendant(node) !== null));
-	if (focusable) {
-		forceFocusVisible(focusable);
-		return true;
-	}
-	return false;
 }

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -1,4 +1,4 @@
-import { findComposedAncestor, getComposedChildren, getComposedParent, getNextAncestorSibling, getPreviousAncestorSibling, isVisible } from './dom.js';
+import { getComposedChildren, getComposedParent, getNextAncestorSibling, getPreviousAncestorSibling, isVisible } from './dom.js';
 
 const focusableElements = {
 	a: true,

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -1,5 +1,4 @@
 import { defineCE, expect, fixture, html } from '@open-wc/testing';
-import { focusWithKeyboard, focusWithMouse } from '../../tools/web-test-runner-helpers.js';
 import {
 	getComposedActiveElement,
 	getFirstFocusableDescendant,
@@ -7,8 +6,7 @@ import {
 	getNextFocusable,
 	getPreviousFocusable,
 	getPreviousFocusableAncestor,
-	isFocusable,
-	isFocusVisibleApplied
+	isFocusable
 } from '../focus.js';
 import { LitElement } from 'lit';
 
@@ -375,30 +373,6 @@ describe('focus', () => {
 		it('returns false for comment node', () => {
 			const commentNode = elem.querySelector('button').nextSibling.nextSibling;
 			expect(isFocusable(commentNode)).to.be.false;
-		});
-
-	});
-
-	describe('isFocusVisibleApplied', () => {
-
-		let button;
-		beforeEach(async() => {
-			const elem = await fixture(focusableFixture);
-			button = elem.querySelector('button');
-		});
-
-		it('returns false on an unfocused element', async() => {
-			expect(isFocusVisibleApplied(button)).to.be.false;
-		});
-
-		it('returns false on a mouse-mode focused element', async() => {
-			await focusWithMouse(button);
-			expect(isFocusVisibleApplied(button)).to.be.false;
-		});
-
-		it('returns true on a keyboard-mode focused element', async() => {
-			await focusWithKeyboard(button);
-			expect(isFocusVisibleApplied(button)).to.be.true;
 		});
 
 	});

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -1,7 +1,6 @@
 import { defineCE, expect, fixture, html } from '@open-wc/testing';
 import { focusWithKeyboard, focusWithMouse } from '../../tools/web-test-runner-helpers.js';
 import {
-	forceFocusVisible,
 	getComposedActiveElement,
 	getFirstFocusableDescendant,
 	getLastFocusableDescendant,
@@ -9,8 +8,7 @@ import {
 	getPreviousFocusable,
 	getPreviousFocusableAncestor,
 	isFocusable,
-	isFocusVisibleApplied,
-	tryApplyFocus
+	isFocusVisibleApplied
 } from '../focus.js';
 import { LitElement } from 'lit';
 
@@ -420,40 +418,6 @@ describe('focus', () => {
 			expect(isFocusVisibleApplied(button)).to.be.true;
 		});
 
-		it('returns true on a forceFocusVisible element', async() => {
-			await focusWithMouse(button);
-			forceFocusVisible(button);
-			expect(isFocusVisibleApplied(button)).to.be.true;
-		});
-
-	});
-
-	describe('tryApplyFocus', () => {
-
-		it('returns true on single focusable element', async() => {
-			const elem = await fixture(focusableFixture);
-			expect(tryApplyFocus(elem.querySelector('button'))).to.be.true;
-		});
-
-		it('returns false on non-existent element', async() => {
-			const elem = await fixture(focusableFixture);
-			expect(tryApplyFocus(elem.querySelector('#nonExistentDiv'))).to.be.false;
-		});
-
-		it('returns true on element with focusable parent', async() => {
-			const elem = await fixture(focusableAncestorFixture);
-			expect(tryApplyFocus(elem.querySelector('div'))).to.be.true;
-		});
-
-		it('returns true on element with focusable grandparent', async() => {
-			const elem = await fixture(focusableAncestorFixture);
-			expect(tryApplyFocus(elem.querySelector('button'))).to.be.true;
-		});
-
-		it('returns true on element with focusable sibling of parent', async() => {
-			const elem = await fixture(parentSiblingFocusableAncestorFixture);
-			expect(tryApplyFocus(elem.querySelector('button'))).to.be.true;
-		});
 	});
 
 });

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -75,23 +75,6 @@ const focusableFixture = html`
 		</div>
 	</div>
 `;
-const focusableAncestorFixture = html`
-	<a>
-		<div>
-			<button disabled></button>
-		</div>
-	</a>
-`;
-const parentSiblingFocusableAncestorFixture = html`
-	<div>
-		<div>
-			<iframe></iframe>
-			<div>
-				<button disabled></button>
-			</div>
-		</div>
-	</div>
-`;
 const focusableNotTabbableFixture = html`
 	<div>
 		<div id="not-focusable" class="same-class"></div>

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -742,8 +742,6 @@ class TemplatePrimarySecondary extends RtlMixin(LocalizeCoreElement(LitElement))
 				display: inline-block;
 				width: 0.1rem;
 			}
-			.d2l-template-primary-secondary-divider.focus-visible .d2l-template-primary-secondary-divider-handle-right,
-			.d2l-template-primary-secondary-divider.focus-visible .d2l-template-primary-secondary-divider-handle-left,
 			.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-right,
 			.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-left {
 				display: block;
@@ -777,8 +775,6 @@ class TemplatePrimarySecondary extends RtlMixin(LocalizeCoreElement(LitElement))
 				background-color: var(--d2l-color-mica);
 				box-shadow: none;
 			}
-			:host([resizable]) .d2l-template-primary-secondary-divider.focus-visible,
-			:host([resizable][dir="rtl"]) .d2l-template-primary-secondary-divider.focus-visible,
 			:host([resizable]) .d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())},
 			:host([resizable][dir="rtl"]) .d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} {
 				background-color: var(--d2l-color-celestine);
@@ -789,8 +785,6 @@ class TemplatePrimarySecondary extends RtlMixin(LocalizeCoreElement(LitElement))
 			.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-line::after {
 				background-color: var(--d2l-color-ferrite);
 			}
-			.d2l-template-primary-secondary-divider.focus-visible .d2l-template-primary-secondary-divider-handle-line::before,
-			.d2l-template-primary-secondary-divider.focus-visible .d2l-template-primary-secondary-divider-handle-line::after,
 			.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-line::before,
 			.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-line::after {
 				background-color: white;
@@ -919,14 +913,12 @@ class TemplatePrimarySecondary extends RtlMixin(LocalizeCoreElement(LitElement))
 					height: 1rem;
 					width: 2.2rem;
 				}
-				.d2l-template-primary-secondary-divider.focus-visible .d2l-template-primary-secondary-divider-handle,
 				.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle {
 					box-shadow: none;
 					height: 1.2rem;
 					right: 17px;
 					width: 2.6rem;
 				}
-				:host([dir="rtl"]) .d2l-template-primary-secondary-divider.focus-visible .d2l-template-primary-secondary-divider-handle,
 				:host([dir="rtl"]) .d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle {
 					left: 17px;
 					right: auto;
@@ -935,7 +927,6 @@ class TemplatePrimarySecondary extends RtlMixin(LocalizeCoreElement(LitElement))
 					color: white;
 					display: block;
 				}
-				.d2l-template-primary-secondary-divider.focus-visible .d2l-template-primary-secondary-divider-handle-mobile,
 				.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-mobile {
 					box-shadow: 0 0 0 0.1rem white, 0 0 0 0.2rem var(--d2l-color-celestine);
 					right: 0.2rem;


### PR DESCRIPTION
This removes `forceFocusVisible` from the last usage in dialogs, and removes it entirely as something core supports. `tryApplyFocus` also goes away as it was using `forceFocusVisible` and was only used in 1 place in dialogs.

For dialogs specifically, we'd still like a focus ring when a dialog opens and focus gets placed on one of the buttons. To accomplish this, I've created a dialog-specific implementation in the dialog mixin, and used a `.force-dialog-focus-visible` CSS class to be very explicit about what we're doing.

Once this merges, I'll remove the `.focus-visible` CSS class from any other repos that were using it.