### PR TITLE
fix: move `more-less` to its own README file

### DIFF
--- a/components/expand-collapse/README.md
+++ b/components/expand-collapse/README.md
@@ -1,4 +1,8 @@
-# Expand Collapse Content [d2l-expand-collapse-content]
+# Collapsible Content
+
+This component allows content to be collapsed and expanded within your web application.
+
+## Expand Collapse Content [d2l-expand-collapse-content]
 
 The `d2l-expand-collapse-content` element can be used to create expandable and collapsible content. This component only provides the logic to expand and collapse the content; controlling when and how it expands or collapses is the responsibility of the user.
 

--- a/components/expand-collapse/README.md
+++ b/components/expand-collapse/README.md
@@ -1,10 +1,8 @@
-# Collapsible Content
-
-This component allows content to be collapsed and expanded within your web application.
-
-## Expand Collapse Content [d2l-expand-collapse-content]
+# Expand Collapse Content
 
 The `d2l-expand-collapse-content` element can be used to create expandable and collapsible content. This component only provides the logic to expand and collapse the content; controlling when and how it expands or collapses is the responsibility of the user.
+
+## Expand Collapse Content [d2l-expand-collapse-content]
 
 <!-- docs: demo live name:d2l-expand-collapse-content autoSize:false display:block size:small -->
 ```html

--- a/components/expand-collapse/README.md
+++ b/components/expand-collapse/README.md
@@ -1,6 +1,4 @@
-# Collapsible Containers
-
-## Expand Collapse Content [d2l-expand-collapse-content]
+# Expand Collapse Content [d2l-expand-collapse-content]
 
 The `d2l-expand-collapse-content` element can be used to create expandable and collapsible content. This component only provides the logic to expand and collapse the content; controlling when and how it expands or collapses is the responsibility of the user.
 
@@ -40,29 +38,3 @@ The `d2l-expand-collapse-content` element can be used to create expandable and c
 
 To make your usage of `d2l-expand-collapse-content` accessible, the [`aria-expanded` attribute](https://www.w3.org/TR/wai-aria/#aria-expanded) should be added to the element that controls expanding and collapsing the content with `"true"` or `"false"` to indicate that the content is expanded or collapsed.
 
-## More-Less [d2l-more-less]
-
-The `d2l-more-less` element can be used to minimize the display of long content, while providing a way to reveal the full content.
-
-<!-- docs: demo live name:d2l-more-less -->
-```html
-<script type="module">
-  import '@brightspace-ui/core/components/more-less/more-less.js';
-</script>
-<d2l-more-less>
-	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-</d2l-more-less>
-```
-
-<!-- docs: start hidden content -->
-### Properties
-
-| Property | Type | Description |
-|---|---|---|
-| `blur-color` | String | Gradient HEX formatted color of the blurring effect (defaults to white). |
-| `expanded` | Boolean | Specifies the expanded/collapsed state of the content |
-| `h-align` | String | A value of `text` aligns the leading edge of text |
-| `height` | String, default: `'4em'` | Maximum height of the content when in "less" mode. The `d2l-more-less` element itself will take up additional vertical space for the fading effect as well as the more/less button itself. |
-| `inactive` | Boolean | Whether the component is active or inactive |
-<!-- docs: end hidden content -->

--- a/components/more-less/README.md
+++ b/components/more-less/README.md
@@ -1,10 +1,8 @@
-# Minimize long content
-
-This component assists in minimizing long content and a way to reveal it.
-
-## More-Less [d2l-more-less]
+# More/Less
 
 The `d2l-more-less` element can be used to minimize the display of long content, while providing a way to reveal the full content.
+
+## More-Less [d2l-more-less]
 
 <!-- docs: demo live name:d2l-more-less -->
 ```html

--- a/components/more-less/README.md
+++ b/components/more-less/README.md
@@ -1,4 +1,8 @@
-# More-Less [d2l-more-less]
+# Minimize long content
+
+This component assists in minimizing long content and a way to reveal it.
+
+## More-Less [d2l-more-less]
 
 The `d2l-more-less` element can be used to minimize the display of long content, while providing a way to reveal the full content.
 

--- a/components/more-less/README.md
+++ b/components/more-less/README.md
@@ -1,3 +1,26 @@
-# More-Less
+# More-Less [d2l-more-less]
 
-See [more-less](https://github.com/BrightspaceUI/core/tree/main/components/expand-collapse/README.md#more-less-d2l-more-less).
+The `d2l-more-less` element can be used to minimize the display of long content, while providing a way to reveal the full content.
+
+<!-- docs: demo live name:d2l-more-less -->
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/more-less/more-less.js';
+</script>
+<d2l-more-less>
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</d2l-more-less>
+```
+
+<!-- docs: start hidden content -->
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `blur-color` | String | Gradient HEX formatted color of the blurring effect (defaults to white). |
+| `expanded` | Boolean | Specifies the expanded/collapsed state of the content |
+| `h-align` | String | A value of `text` aligns the leading edge of text |
+| `height` | String, default: `'4em'` | Maximum height of the content when in "less" mode. The `d2l-more-less` element itself will take up additional vertical space for the fading effect as well as the more/less button itself. |
+| `inactive` | Boolean | Whether the component is active or inactive |
+<!-- docs: end hidden content -->


### PR DESCRIPTION
Very simple restructuring of READMEs.
[US147050](https://rally1.rallydev.com/#/?detail=/userstory/675147239973&fdp=true): Collapsible Panel > Refactor the "Collapsible Container" docs