### PR TITLE
[DE52324] Update CSS to allow _focusing attribute to be elevated to a…

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -108,9 +108,12 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				display: none;
 			}
 
-			:host([_tooltip-showing]),
-			:host([_dropdown-open]) {
+			:host([_dropdown-open]),
+			:host([_focusing]) {
 				z-index: 10; /* must be greater than adjacent selected items (if this is increased, d2l-collapsible-panel must be updated too) */
+			}
+			:host([_tooltip-showing]) {
+				z-index: 20; /* must be greater than adjacent selected items (if this is increased, d2l-collapsible-panel must be updated too) */
 			}
 			:host([_fullscreen-within]) {
 				position: fixed; /* required for Safari */


### PR DESCRIPTION
… z-index of 10. Changed _tooltip-showing attribute to be elevated to a z-index of 20.

Rally ticket: https://rally1.rallydev.com/#/10153049633d/dashboard?detail=%2Fdefect%2F689632043385

Allow a `d2l-list-item` with a `_focusing` attribute to be elevated to a higher relative `z-index`. This ensures that the list item has a higher `z-index` than other list items. This means that opened dialogs (emoji editor, attributes and Delete Criterion Row) will be higher `z-index` than other elements and the grayed out background correctly grays out other list items and the rest of the page.

