### PR TITLE
fix: Flaky list-controls visual diff

### DIFF
--- a/components/list/test/list.visual-diff.js
+++ b/components/list/test/list.visual-diff.js
@@ -46,11 +46,9 @@ describe('d2l-list', () => {
 	};
 
 	const scrollTo = (selector, y) => {
-		return page.$eval(selector, (container, y) => {
-			return new Promise(resolve => {
-				container.scrollTo(0, y);
-				setTimeout(resolve, 400);
-			});
+		return page.$eval(selector, (element, y) => {
+			element.scrollIntoView();
+			element.scrollTo(0, y);
 		}, y);
 	};
 
@@ -70,6 +68,7 @@ describe('d2l-list', () => {
 
 	beforeEach(async() => {
 		await visualDiff.resetFocus(page);
+		await page.mouse.move(-1, -1);
 	});
 
 	after(async() => await browser.close());


### PR DESCRIPTION
This should fix the common flaky test `d2l-list-controls-sticky-top` (e.g. [here](https://github.com/BrightspaceUI/core/pull/3433/files)).

The cause of the flake is that an underline appears whenever the controls are offscreen, e.g. if the tests have scrolled down for some other test. This fix always scrolls it into view before capturing.

I also had to move the mouse because tests that use `hover()` move the mouse on the screen and then leave it there, which was causing hover styles to appear on this list!