### PR TITLE
Update the demo-snippet demo flex item to remove implicit min-width.

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -50,6 +50,7 @@ class DemoSnippet extends LitElement {
 			}
 			.d2l-demo-snippet-demo {
 				flex: 1 1 auto;
+				min-width: 0;
 				position: relative;
 			}
 			:host([full-width]) .d2l-demo-snippet-demo-wrapper.fullscreen .d2l-demo-snippet-demo {


### PR DESCRIPTION
This PR updates the `d2l-demo-snippet`'s demo flex item to not use the implicit `min-width` as determined by its contents so that it doesn't unexpectedly push other flex items out of their containing blocks.

**Before:**
![image](https://user-images.githubusercontent.com/9042472/228419755-57d51335-72aa-44b6-8b53-57e70fab2ed5.png)

**After:**
![image](https://user-images.githubusercontent.com/9042472/228419789-d47bfb71-d6b0-4e14-ad9d-2c1fe94216c4.png)
