### PR TITLE
fix: Safari list drag-and-drop

### DIFF
--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -738,7 +738,6 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 
 	_onHostDragEnter(e) {
 		const dragState = getDragState();
-		if (this === dragState.dragTarget) return;
 
 		// check if any of the drag targets are ancestors of the drop target
 		const invalidDropTarget = dragState.dragTargets.find(dragTarget => {

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -105,6 +105,7 @@ class DragState {
 
 	_cleanUpOnLeave() {
 		if (!this._activeDropTarget) return;
+		this._activeDropTarget._draggingOver = false;
 		this._activeDropTarget._dropLocation = dropLocation.void;
 		this._activeDropTarget._inTopArea = false;
 		this._activeDropTarget._inBottomArea = false;
@@ -363,7 +364,6 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 
 	firstUpdated(changedProperties) {
 		this.addEventListener('dragenter', this._onHostDragEnter.bind(this));
-		this.addEventListener('dragleave', this._onHostDragLeave.bind(this));
 		super.firstUpdated(changedProperties);
 	}
 
@@ -745,7 +745,10 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 			return isComposedAncestor(dragTarget, this);
 		});
 
-		if (invalidDropTarget) return;
+		if (invalidDropTarget) {
+			dragState.clear();
+			return;
+		}
 
 		// assert that both the source and target are from the same list - may allow this in the future
 		const targetRoot = dragState.dragTargets[0] && dragState.dragTargets[0]._getRootList();
@@ -754,10 +757,6 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		dragState.addDropTarget(this);
 		this._draggingOver = true;
 		e.dataTransfer.dropEffect = 'move';
-	}
-
-	_onHostDragLeave() {
-		this._draggingOver = false;
 	}
 
 	_onTouchCancel() {
@@ -798,7 +797,6 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		if (!listItem) return;
 		// simulate host dragenter
 		if (listItem !== this && this._currentTouchListItem !== listItem) {
-			this._currentTouchListItem.dispatchEvent(createDragEvent('dragleave'));
 			listItem.dispatchEvent(createDragEvent('dragenter'));
 			this._currentTouchListItem = listItem;
 		}


### PR DESCRIPTION
This PR fixes a defect where list drag-and-drop was broken in Safari. This was a regression introduced [here](https://github.com/BrightspaceUI/core/commit/e24344da7f99b89619d4b1ec32a71f4b4118679d) as part of #3046 (expand/collapse list). Turns out Safari is a bit different in how it triggers `'dragleave'`, which was causing the drop-target to continually be rendered and derendered.

The solution is to clean up where the `_draggingOver` state is being updated - we've moved it inside of the `DragState` class, and also now trigger a cleanup whenever the drop-target becomes invalid (e.g. when an item is hovering over itself).

Joint effort with @svanherk @oelhanafey @dbatiste. Tested on Chrome (Windows + Mac) and Safari.

Rally: https://rally1.rallydev.com/#/?detail=/defect/694750082045&fdp=true
