### PR TITLE
feat: upgrade intl-messageformat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,3 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "@formatjs/intl-pluralrules"
-      - dependency-name: "intl-messageformat"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@formatjs/intl-pluralrules": "^1",
         "@open-wc/dedupe-mixin": "^1",
         "ifrau": "^0.40",
-        "intl-messageformat": "^7",
+        "intl-messageformat": "^10",
         "lit": "^2",
         "prismjs": "^1",
         "resize-observer-polyfill": "^1"
@@ -796,19 +796,54 @@
         "@types/chai": "^4.2.12"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.14.3.tgz",
+      "integrity": "sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.0.1.tgz",
+      "integrity": "sha512-M2GgV+qJn5WJQAYewz7q2Cdl6fobQa69S1AzSM2y0P68ZDbK5cWrJIcPCO395Of1ksftGZoOt4LYCO/j9BKBSA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
+      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/icu-skeleton-parser": "1.3.18",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.3.18",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.18.tgz",
+      "integrity": "sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.32.tgz",
+      "integrity": "sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@formatjs/intl-pluralrules": {
       "version": "1.5.9",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
       "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
-      "dependencies": {
-        "@formatjs/intl-utils": "^2.3.0"
-      }
-    },
-    "node_modules/@formatjs/intl-unified-numberformat": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.7.tgz",
-      "integrity": "sha512-KnWgLRHzCAgT9eyt3OS34RHoyD7dPDYhRcuKn+/6Kv2knDF8Im43J6vlSW6Hm1w63fNq3ZIT1cFk7RuVO3Psag==",
-      "deprecated": "We have renamed the package to @formatjs/intl-numberformat",
       "dependencies": {
         "@formatjs/intl-utils": "^2.3.0"
       }
@@ -5563,27 +5598,15 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/intl-format-cache": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.3.1.tgz",
-      "integrity": "sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
-    },
     "node_modules/intl-messageformat": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-7.8.4.tgz",
-      "integrity": "sha512-yS0cLESCKCYjseCOGXuV4pxJm/buTfyCJ1nzQjryHmSehlptbZbn9fnlk1I9peLopZGGbjj46yHHiTAEZ1qOTA==",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.3.3.tgz",
+      "integrity": "sha512-un/f07/g2e/3Q8e1ghDKET+el22Bi49M7O/rHxd597R+oLpPOMykSv5s51cABVfu3FZW+fea4hrzf2MHu1W4hw==",
       "dependencies": {
-        "intl-format-cache": "^4.2.21",
-        "intl-messageformat-parser": "^3.6.4"
-      }
-    },
-    "node_modules/intl-messageformat-parser": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.6.4.tgz",
-      "integrity": "sha512-RgPGwue0mJtoX2Ax8EmMzJzttxjnva7gx0Q7mKJ4oALrTZvtmCeAw5Msz2PcjW4dtCh/h7vN/8GJCxZO1uv+OA==",
-      "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
-      "dependencies": {
-        "@formatjs/intl-unified-numberformat": "^3.2.0"
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/fast-memoize": "2.0.1",
+        "@formatjs/icu-messageformat-parser": "2.3.0",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/ip": {
@@ -10349,6 +10372,11 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@formatjs/intl-pluralrules": "^1",
     "@open-wc/dedupe-mixin": "^1",
     "ifrau": "^0.40",
-    "intl-messageformat": "^7",
+    "intl-messageformat": "^10",
     "lit": "^2",
     "prismjs": "^1",
     "resize-observer-polyfill": "^1"


### PR DESCRIPTION
We'd like to use the latest `intl-messageformat` library in order to leverage version 8's ability to do rich formatting. The release of this PR into BSI will need to be coordinated with [a similar change in `@brightspace-ui/localize-behavior`](https://github.com/BrightspaceUI/localize-behavior/pull/38). No [other BSI things](https://github.com/search?type=code&q=saved%3A%22D2L+Code%22+%22intl-messageformat%22+path%3A%2F%5Epackage.json%2F&saved_searches=%5B%7B%22name%22%3A%22D2L+Code%22%2C%22query%22%3A%22org%3ABrightspace+OR+org%3ABrightspaceUI+OR+org%3ABrightspaceHypermediaComponents+OR+org%3ABrightspaceUILabs%22%7D%5D&expanded_query=org%3ABrightspace+org%3ABrightspaceUI+org%3ABrightspaceHypermediaComponents+org%3ABrightspaceUILabs+%22intl-messageformat%22+path%3A%2F%5Epackage.json%2F) depend on it directly.

Looking through [the CHANGELOG](https://github.com/formatjs/formatjs/blob/main/packages/intl-messageformat/CHANGELOG.md), I don't see any breaking changes that are particularly concerning in versions 8, 9 or 10.