### PR TITLE
Revert "[DE52324] Update CSS to allow _focusing attribute to be elevated to a…"

### DIFF
--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -135,7 +135,7 @@ class CollapsiblePanel extends FocusMixin(RtlMixin(LitElement)) {
 				box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
 				position: sticky;
 				top: 0;
-				z-index: 12; /* must be greater greater than list-items with open dropdowns or tooltips */
+				z-index: 11; /* must be greater greater than list-items with open dropdowns or tooltips */
 			}
 			.d2l-collapsible-panel.focused.scrolled .d2l-collapsible-panel-header {
 				top: 2px;

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -108,12 +108,9 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				display: none;
 			}
 
-			:host([_dropdown-open]),
-			:host([_focusing]) {
+			:host([_tooltip-showing]),
+			:host([_dropdown-open]) {
 				z-index: 10; /* must be greater than adjacent selected items (if this is increased, d2l-collapsible-panel must be updated too) */
-			}
-			:host([_tooltip-showing]) {
-				z-index: 11; /* must be greater than adjacent selected items (if this is increased, d2l-collapsible-panel must be updated too) */
 			}
 			:host([_fullscreen-within]) {
 				position: fixed; /* required for Safari */


### PR DESCRIPTION
Reverts BrightspaceUI/core#3426

Reverting these changes as per Mango's standup discussion as they end up creating a very undesirable/unusable experience in Firefox.