### PR TITLE
Dispatch d2l-list-item-selected when Enter is pressed

### DIFF
--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -132,7 +132,7 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 	_onCheckboxKeyDown(e) {
 		// handle the enter key
 		if (e.keyCode !== 13) return;
-		this.selected = !this.selected;
+		this.setSelected(!this.selected);
 	}
 
 	_onMouseEnterSelection() {


### PR DESCRIPTION
[DE52824](https://rally1.rallydev.com/#/?detail=/defect/695920026421&fdp=true)

This PR fixes an issue in the `list-item-checkbox-mixin` where the pressing the ENTER key on the action area was changing the selection value but not dispatching the `d2l-list-item-selected` event. Added a unit test to cover this case.