### PR TITLE
DE52025 - Unset list item outside control width

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -100,7 +100,6 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			}
 			::slotted([slot="outside-control"]) {
 				grid-column: outside-control-start / outside-control-end;
-				width: fit-content;
 			}
 
 			::slotted([slot="expand-collapse"]) {


### PR DESCRIPTION
Rally: [DE52025](https://rally1.rallydev.com/#/?detail=/defect/685395612691&fdp=true)

Some recent styling changes broke drag and drop in rubrics. It's a specific issue with the `drag-target-handle-only` attribute (of which Mango is currently the only consumer) where the drag target gets pushed out to a width of zero because of the use of `fit-content` between two containers taking up the `outside-control` slot. I don't have any way of knowing why the default width was originally set, but without it I don't see any glaring issues; I'm assuming the grid cell defaults to the content width in this scenario i.e. the size of the drag handle.

I've tested the fix with list-drag-and-drop, list-expand-collapse, and rubrics. Let me know if there are any specific integration points we would need to consider for this change.

### Before
![Rubrics drag and drop before DE52025 fix](https://user-images.githubusercontent.com/11915922/229866738-cd855a60-48d0-48cb-ba5b-b5734c433d65.gif)

### After
![Rubrics drag and drop after DE52025 fix](https://user-images.githubusercontent.com/11915922/229866756-b01d1ef9-b5d2-47e5-9e59-f5044ca52947.gif)