### PR TITLE
Fix z-indices of upper layer components

### DIFF
--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -42,7 +42,7 @@ class FloatingButtons extends RtlMixin(LitElement) {
 				position: -webkit-sticky;
 				position: sticky;
 				right: 0;
-				z-index: 999;
+				z-index: 997;
 			}
 
 			:host([_floating][always-float]) {

--- a/components/dropdown/dropdown-content-styles.js
+++ b/components/dropdown/dropdown-content-styles.js
@@ -244,7 +244,7 @@ export const dropdownContentStyles = css`
 		height: 100vh;
 		position: fixed;
 		top: 0;
-		z-index: 998;
+		z-index: 1000;
 	}
 
 	:host([data-mobile][mobile-tray="right"]) .d2l-dropdown-content-width {
@@ -253,7 +253,7 @@ export const dropdownContentStyles = css`
 		height: 100vh;
 		position: fixed;
 		top: 0;
-		z-index: 998;
+		z-index: 1000;
 	}
 
 	:host([data-mobile][mobile-tray="bottom"]) .d2l-dropdown-content-width {
@@ -261,7 +261,7 @@ export const dropdownContentStyles = css`
 		border-bottom-right-radius: 0;
 		left: 0;
 		position: fixed;
-		z-index: 998;
+		z-index: 1000;
 	}
 
 	:host([data-mobile][mobile-tray="right"][opened]) .d2l-dropdown-content-width {

--- a/components/dropdown/dropdown-content-styles.js
+++ b/components/dropdown/dropdown-content-styles.js
@@ -18,7 +18,7 @@ export const dropdownContentStyles = css`
 		text-align: left;
 		top: calc(100% + var(--d2l-dropdown-verticaloffset, 16px));
 		width: 100%;
-		z-index: 1000; /* position on top of floating buttons */
+		z-index: 998; /* position on top of floating buttons */
 	}
 
 	:host([theme="dark"]) {
@@ -244,7 +244,7 @@ export const dropdownContentStyles = css`
 		height: 100vh;
 		position: fixed;
 		top: 0;
-		z-index: 1000;
+		z-index: 998;
 	}
 
 	:host([data-mobile][mobile-tray="right"]) .d2l-dropdown-content-width {
@@ -253,7 +253,7 @@ export const dropdownContentStyles = css`
 		height: 100vh;
 		position: fixed;
 		top: 0;
-		z-index: 1000;
+		z-index: 998;
 	}
 
 	:host([data-mobile][mobile-tray="bottom"]) .d2l-dropdown-content-width {
@@ -261,7 +261,7 @@ export const dropdownContentStyles = css`
 		border-bottom-right-radius: 0;
 		left: 0;
 		position: fixed;
-		z-index: 1000;
+		z-index: 998;
 	}
 
 	:host([data-mobile][mobile-tray="right"][opened]) .d2l-dropdown-content-width {

--- a/components/list/list-item-drag-image.js
+++ b/components/list/list-item-drag-image.js
@@ -88,7 +88,7 @@ class ListItemDragImage extends LocalizeCoreElement(SkeletonMixin(RtlMixin(LitEl
 				position: absolute;
 				text-align: center;
 				top: 30px;
-				z-index: 1000; /* must be higher than the skeleton z-index (999) */
+				z-index: 998; /* must be higher than the skeleton z-index */
 			}
 			:host([dir="rtl"]) .count {
 				left: 14px;

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -114,7 +114,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			}
 			:host([_fullscreen-within]) {
 				position: fixed; /* required for Safari */
-				z-index: 1000; /* must be greater than floating workflow buttons */
+				z-index: 998; /* must be greater than floating workflow buttons */
 			}
 
 			:host([dragging]) d2l-list-item-generic-layout {

--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -28,7 +28,7 @@ export const skeletonStyles = css`
 		position: absolute;
 		right: 0;
 		top: 0;
-		z-index: 999;
+		z-index: 997;
 	}
 	@media (prefers-reduced-motion: reduce) {
 		:host([skeleton]) .d2l-skeletize::before {


### PR DESCRIPTION
[DE52725](https://rally1.rallydev.com/#/?detail=/defect/694583527535&fdp=true)

This PR fixes a defect where dropdowns with `no-auto-close` would stay open when a dialog opened and since their z-indices were higher than `backdrop` they would not be faded with the rest of the background.

`d2l-backdrop` has `z-index: 999` which is shared by many components. I'm proposing to change the upper layer of our web components to `z-index: 998` and then have the backdrop layer 1 higher. If we need to put something higher than the upper level in the future, then we can push those components down a layer and still use `z-index: 998` as the upper layer.

Proposed layers:
```
...
upperLayer - 2: 996
upperLayer - 1: 997
upperLayer: 998
backdropLayer: 999
dialogLayer: 1000
tooltipLayer: 1001
```

Alternatively, if it is more understandable, we could push everything above and including the backdrop up a layer, so the upper layer is `z-index: 999` but I'm worried that that might put some components outside of core in the backdrop that previously weren't.