### PR TITLE
fix: updateComplete typo in dialog-mixin

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -412,7 +412,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 			await this._updateSize();
 			this._state = 'showing';
-			await this._updateComplete;
+			await this.updateComplete;
 
 			// edge case: no children were focused, try again after one redraw
 			const activeElement = getComposedActiveElement();


### PR DESCRIPTION
Small PR fixing what appears to be a typo in dialog-mixin, since `_updateComplete` doesn't exist.