### PR TITLE
Put mixins in their place (part 2)

### DIFF
--- a/mixins/arrow-keys-mixin.js
+++ b/mixins/arrow-keys-mixin.js
@@ -1,0 +1,1 @@
+export { ArrowKeysMixin } from './arrow-keys/arrow-keys-mixin.js';

--- a/mixins/focus-mixin.js
+++ b/mixins/focus-mixin.js
@@ -1,0 +1,1 @@
+export { FocusMixin } from './focus/focus-mixin.js';

--- a/mixins/labelled-mixin.js
+++ b/mixins/labelled-mixin.js
@@ -1,0 +1,1 @@
+export { LabelMixin, LabelledMixin } from './labelled/labelled-mixin.js';

--- a/mixins/provider-mixin.js
+++ b/mixins/provider-mixin.js
@@ -1,0 +1,1 @@
+export { provideInstance, ProviderMixin, requestInstance, RequesterMixin } from './provider/provider-mixin.js';

--- a/mixins/rtl-mixin.js
+++ b/mixins/rtl-mixin.js
@@ -1,0 +1,1 @@
+export { RtlMixin } from './rtl/rtl-mixin.js';

--- a/mixins/theme-mixin.js
+++ b/mixins/theme-mixin.js
@@ -1,0 +1,1 @@
+export { ThemeMixin } from './theme/theme-mixin.js';

--- a/mixins/visible-on-ancestor-mixin.js
+++ b/mixins/visible-on-ancestor-mixin.js
@@ -1,0 +1,1 @@
+export { VisibleOnAncestorMixin, visibleOnAncestorStyles } from './visible-on-ancestor/visible-on-ancestor-mixin.js';


### PR DESCRIPTION
Looks like we need to do this in two parts in order to preserve history. I'll merge part 1 but not release, then merge part 2 shortly after.

Part 1: move the mixin files into their own directories and adjust all paths within core
Part 2: restore the original mixin files but just have them export from the new location