### PR TITLE
fix: remove unused exports

### DIFF
--- a/mixins/arrow-keys-mixin.js
+++ b/mixins/arrow-keys-mixin.js
@@ -1,1 +1,0 @@
-export { ArrowKeysMixin } from './arrow-keys/arrow-keys-mixin.js';

--- a/mixins/localize-static-mixin.js
+++ b/mixins/localize-static-mixin.js
@@ -1,1 +1,0 @@
-export { LocalizeStaticMixin } from './localize/localize-mixin.js';

--- a/mixins/theme-mixin.js
+++ b/mixins/theme-mixin.js
@@ -1,1 +1,0 @@
-export { ThemeMixin } from './theme/theme-mixin.js';

--- a/mixins/visible-on-ancestor-mixin.js
+++ b/mixins/visible-on-ancestor-mixin.js
@@ -1,1 +1,0 @@
-export { VisibleOnAncestorMixin, visibleOnAncestorStyles } from './visible-on-ancestor/visible-on-ancestor-mixin.js';


### PR DESCRIPTION
I've adjusted the places that were using these to use the new locations. The rest have far too many references to realistically update for the time being.