### PR TITLE
Fix localizeHTML validation

### DIFF
--- a/mixins/localize/localize-mixin.js
+++ b/mixins/localize/localize-mixin.js
@@ -136,7 +136,7 @@ export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinC
 		const translatedMessage = new IntlMessageFormat(value, language);
 		let formattedMessage = value;
 		try {
-			formattedMessage = translatedMessage.format({
+			const unvalidated = translatedMessage.format({
 				b: chunks => localizeMarkup`<b>${chunks}</b>`,
 				br: () => localizeMarkup`<br>`,
 				em: chunks => localizeMarkup`<em>${chunks}</em>`,
@@ -145,7 +145,8 @@ export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinC
 				strong: chunks => localizeMarkup`<strong>${chunks}</strong>`,
 				...params
 			});
-			validateMarkup(formattedMessage);
+			validateMarkup(unvalidated);
+			formattedMessage = unvalidated;
 		} catch (e) {
 			console.error(e);
 		}

--- a/mixins/localize/test/localize-mixin.test.js
+++ b/mixins/localize/test/localize-mixin.test.js
@@ -379,7 +379,7 @@ describe('LocalizeMixin', () => {
 			expect(renderToElem(defaultTags)).lightDom.to.equal('This is <strong>important</strong>, this is <strong><em>very important</em></strong>');
 			expect(renderToElem(manual)).lightDom.to.equal('This is <d2l-link href="http://d2l.com">a link</d2l-link>');
 			expect(renderToElem(disallowed)).lightDom.to.equal('This is &lt;link&gt;replaceable&lt;/link&gt;');
-			expect(renderToElem(badTemplate)).lightDom.to.equal('This is replaceable');
+			expect(renderToElem(badTemplate)).lightDom.to.equal('This is &lt;link&gt;replaceable&lt;/link&gt;');
 			expect(renderToElem(tooltip)).lightDom.to.equal('This is a <d2l-tooltip-help inherit-font-style="" text="tooltip-help">Tooltip text</d2l-tooltip-help> within a sentence');
 			expect(renderToElem(boldItalic)).lightDom.to.equal('This is <b>bold</b> but not important, this is <i>italic</i> but not emphasized');
 			expect(renderToElem(pluralLink)).lightDom.to.equal('You have milk in your cart. <d2l-link href="checkout">Checkout</d2l-link>');


### PR DESCRIPTION
Setting `formattedMessage` before top-level validation allowed `html` template errors to be logged but the result was still returned.

Anything inside a `localizeMarkup` template fails validation while formatting, meaning they are caught before `formattedMessage` was set.