### PR TITLE
Fix d2l-input-text value update

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -599,7 +599,6 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		if (!input) return;
 
 		this.setValidity({ tooShort: this.minlength && this.value.length > 0 && this.value.length < this.minlength });
-		this.requestValidate(false);
 		this.setFormValue(this.value);
 
 		// Can't bind to input's value as Safari moves the cursor each time an
@@ -610,6 +609,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			input.value = this.value;
 		}
 
+		this.requestValidate(false);
 	}
 
 	_suppressEvent(e) {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -589,7 +589,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		this.focus();
 	}
 
-	_setValue(val, updateInput) {
+	async _setValue(val, updateInput) {
 
 		const oldVal = this.value;
 		this._prevValue = (oldVal === undefined) ? '' : oldVal;
@@ -606,6 +606,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		// input's value gets set from render(). So we manually reach in
 		// and update it when source of the change isn't the input itself.
 		if (updateInput) {
+			await this.updateComplete;
 			input.value = this.value;
 		}
 

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -491,6 +491,13 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 					const tooltip = this.shadowRoot.querySelector('d2l-tooltip');
 					tooltip.updatePosition();
 				}
+			} else if (prop === 'type') {
+				const input = this.shadowRoot?.querySelector('.d2l-input');
+				setTimeout(() => {
+					if (input && this.value !== input.value) {
+						this._setValue(input.value, false);
+					}
+				}, 0);
 			}
 		});
 	}

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -230,6 +230,7 @@ describe('d2l-input-text', () => {
 			const elem = await fixture(normalFixture);
 			elem.required = true;
 			elem.value = 'hi';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.be.empty;
@@ -239,6 +240,7 @@ describe('d2l-input-text', () => {
 			const elem = await fixture(normalFixture);
 			elem.minlength = 10;
 			elem.value = 'only nine';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.contain('label must be at least 10 characters');
@@ -248,6 +250,7 @@ describe('d2l-input-text', () => {
 			const elem = await fixture(normalFixture);
 			elem.minlength = 10;
 			elem.value = 'more than nine';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.be.empty;
@@ -265,6 +268,7 @@ describe('d2l-input-text', () => {
 			const elem = await fixture(normalFixture);
 			elem.type = 'url';
 			elem.value = 'not a url';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.contain('URL is not valid');
@@ -274,6 +278,7 @@ describe('d2l-input-text', () => {
 			const elem = await fixture(normalFixture);
 			elem.type = 'url';
 			elem.value = 'https://aurl.ataninvalidtldthatdoesntactuallyexist';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.empty;
@@ -283,6 +288,7 @@ describe('d2l-input-text', () => {
 			const elem = await fixture(normalFixture);
 			elem.type = 'email';
 			elem.value = 'not an email';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.contain('Email is not valid');
@@ -292,6 +298,7 @@ describe('d2l-input-text', () => {
 			const elem = await fixture(normalFixture);
 			elem.type = 'email';
 			elem.value = 'anemail@somedomain.ataninvalidtldthatdoesntactuallyexist';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.empty;
@@ -302,6 +309,7 @@ describe('d2l-input-text', () => {
 			elem.type = 'number';
 			elem.min = '10';
 			elem.value = '9';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.contain('Number must be greater than or equal to 10.');
@@ -312,6 +320,7 @@ describe('d2l-input-text', () => {
 			elem.type = 'number';
 			elem.max = '100';
 			elem.value = '110';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.contain('Number must be less than or equal to 100.');
@@ -323,6 +332,7 @@ describe('d2l-input-text', () => {
 			elem.min = '10';
 			elem.max = '100';
 			elem.value = '55';
+			await elem.updateComplete;
 
 			const errors = await elem.validate();
 			expect(errors).to.be.empty;
@@ -339,6 +349,18 @@ describe('d2l-input-text', () => {
 	});
 
 	describe('value', () => {
+
+		it('should update after other properties are updated', async() => {
+			const elem = await fixture(html`<d2l-input-text label="label" type="number" value="1"></d2l-input-text>`);
+			const input = getInput(elem);
+			elem.type = 'text';
+			elem.value = 'Text';
+			expect(input.type).to.equal('number');
+			expect(input.value).to.equal('1');
+			await elem.updateComplete;
+			expect(input.type).to.equal('text');
+			expect(input.value).to.equal('Text');
+		});
 
 		it('should fire uncomposed "change" event when input value changes', async() => {
 			const elem = await fixture(normalFixture);

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -382,6 +382,15 @@ describe('d2l-input-text', () => {
 			expect(elem.value).to.equal('hello');
 		});
 
+		it('should change "value" property when input value is removed by type change', async() => {
+			const elem = await fixture(normalFixture);
+			elem.value = 'hello';
+			elem.type = 'number';
+			await elem.updateComplete;
+			await aTimeout(1);
+			expect(elem.value).to.equal('');
+		});
+
 		it('should NOT fire "change" event because of blur event', async() => {
 			const elem = await fixture(normalFixture);
 			let fired = false;


### PR DESCRIPTION
Currently, if a `d2l-input-text` element's properties are changed, the `value` is updated outside of the lit update cycle, beating other properties, like `type`. If the previous (yet un-updated) `type` and the new `value` are not compatible (e.g. `number`, `"Text"`, respectively), the `input` will not only fail to update its `value` but will remove its current `value`.

Waiting for `updateComplete` to update the `value` ensures compatibility.

You can see this on the [S3 version](https://pr-3503-brightspace-ui-core.d2l.dev/mixins/localize/demo/localize-mixin.html) of #3503 in the Localize Mixin Sandbox demo by loading the Nested template, and then immediately loading the Ordinal template.