### PR TITLE
Update d2l-tooltip to not dispatch the hide event when first rendering.

### DIFF
--- a/components/tooltip/demo/tooltip.html
+++ b/components/tooltip/demo/tooltip.html
@@ -198,6 +198,11 @@
 			</template>
 		</d2l-demo-snippet>
 
+		<script>
+			document.addEventListener('d2l-tooltip-show', e => console.log('d2l-tooltip-show', e.target));
+			document.addEventListener('d2l-tooltip-hide', e => console.log('d2l-tooltip-hide', e.target));
+		</script>
+
 	</d2l-demo-page>
 
 </body>

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -447,6 +447,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		this._isFocusing = false;
 		this._isHovering = false;
 		this._resizeRunSinceTruncationCheck = false;
+		this._showing = false;
 		this._viewportMargin = defaultViewportMargin;
 	}
 

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -447,7 +447,6 @@ class Tooltip extends RtlMixin(LitElement) {
 		this._isFocusing = false;
 		this._isHovering = false;
 		this._resizeRunSinceTruncationCheck = false;
-		this._showing = false;
 		this._viewportMargin = defaultViewportMargin;
 	}
 
@@ -460,7 +459,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		if (oldVal !== val) {
 			this._showing = val;
 			this.requestUpdate('showing', oldVal);
-			this._showingChanged(val);
+			this._showingChanged(val, oldVal !== undefined); // don't dispatch hide event when initializing
 		}
 	}
 
@@ -883,7 +882,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		}
 	}
 
-	async _showingChanged(newValue) {
+	async _showingChanged(newValue, dispatch) {
 		clearTimeout(this._hoverTimeout);
 		clearTimeout(this._longPressTimeout);
 		if (newValue) {
@@ -896,9 +895,11 @@ class Tooltip extends RtlMixin(LitElement) {
 			this.setAttribute('aria-hidden', 'false');
 			await this.updateComplete;
 			await this.updatePosition();
-			this.dispatchEvent(new CustomEvent(
-				'd2l-tooltip-show', { bubbles: true, composed: true }
-			));
+			if (dispatch) {
+				this.dispatchEvent(new CustomEvent(
+					'd2l-tooltip-show', { bubbles: true, composed: true }
+				));
+			}
 
 			if (this.announced && !this._isInteractive(this._target)) announce(this.innerText);
 		} else {
@@ -909,9 +910,11 @@ class Tooltip extends RtlMixin(LitElement) {
 				clearDismissible(this._dismissibleId);
 				this._dismissibleId = null;
 			}
-			this.dispatchEvent(new CustomEvent(
-				'd2l-tooltip-hide', { bubbles: true, composed: true }
-			));
+			if (dispatch) {
+				this.dispatchEvent(new CustomEvent(
+					'd2l-tooltip-hide', { bubbles: true, composed: true }
+				));
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR updates the `d2l-tooltip` to not dispatch events when first initialing its `showing` property. This avoids `d2l-tooltip-hide` from being dispatched when the element is initialized.

Initially I tried to just set `this._showing = false` in the `constructor`, however this results in `aria-hidden` not being initialized correctly on the host since `_showingChanged` wouldn't get called initially.

Confirmed that `d2l-tooltip-show` is still dispatched when `force-show` is used, which effectively shows the tooltip upon first rendering. It is important that this event is still dispatched initially, since list-items rely on it to track whether or not tooltips are open, even though `force-show` is discouraged in that context.