### PR TITLE
Add skeleton to list-item-content

### DIFF
--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -1,17 +1,17 @@
 import '../colors/colors.js';
 import { bodyCompactStyles, bodySmallStyles } from '../typography/styles.js';
 import { css, html, LitElement } from 'lit';
-
+import { SkeletonMixin, skeletonStyles } from '../skeleton/skeleton-mixin.js';
 /**
  * A component for consistent layout of primary and secondary text in a list item.
  * @slot - Primary text of the list item
  * @slot secondary - Secondary text of the list item
  * @slot supporting-info - Information that supports the list item
  */
-class ListItemContent extends LitElement {
+class ListItemContent extends SkeletonMixin(LitElement) {
 
 	static get styles() {
-		return [ bodySmallStyles, bodyCompactStyles, css`
+		return [ bodySmallStyles, bodyCompactStyles, skeletonStyles, css`
 			:host {
 				min-width: 0;
 			}
@@ -52,9 +52,11 @@ class ListItemContent extends LitElement {
 
 	render() {
 		return html`
-			<div class="d2l-list-item-content-text d2l-body-compact"><div><slot></slot></div></div>
-			<div class="d2l-list-item-content-text-secondary d2l-body-small"><slot name="secondary"></slot></div>
-			<div class="d2l-list-item-content-text-supporting-info d2l-body-small"><slot name="supporting-info"></slot></div>
+			<div class="${this.skeleton ? 'd2l-skeletize' : ''}">
+				<div class="d2l-list-item-content-text d2l-body-compact"><div><slot></slot></div></div>
+				<div class="d2l-list-item-content-text-secondary d2l-body-small"><slot name="secondary"></slot></div>
+				<div class="d2l-list-item-content-text-supporting-info d2l-body-small"><slot name="supporting-info"></slot></div>
+			</div>
 		`;
 	}
 

--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -2,6 +2,7 @@ import '../colors/colors.js';
 import { bodyCompactStyles, bodySmallStyles } from '../typography/styles.js';
 import { css, html, LitElement } from 'lit';
 import { SkeletonMixin, skeletonStyles } from '../skeleton/skeleton-mixin.js';
+
 /**
  * A component for consistent layout of primary and secondary text in a list item.
  * @slot - Primary text of the list item

--- a/components/list/test/list.visual-diff.html
+++ b/components/list/test/list.visual-diff.html
@@ -197,6 +197,20 @@
 		</div>
 
 		<div style="width: 400px;">
+			<div class="visual-diff" id="itemContentSkeleton">
+				<d2l-list>
+					<d2l-list-item>
+						<d2l-list-item-content skeleton>
+							<div>Item 1</div>
+							<div slot="secondary">Secondary Info for item 1</div>
+							<div slot="supporting-info">Supporting info for item 1</div>
+						</d2l-list-item-content>
+					</d2l-list-item>
+				</d2l-list>
+			</div>
+		</div>
+
+		<div style="width: 400px;">
 			<div class="visual-diff" id="itemContentNoPadding">
 				<d2l-list>
 					<d2l-list-item padding-type="none">

--- a/components/list/test/list.visual-diff.js
+++ b/components/list/test/list.visual-diff.js
@@ -96,6 +96,7 @@ describe('d2l-list', () => {
 		] },
 		{ category: 'item-content', tests: [
 			{ name: 'all', selector: '#itemContent' },
+			{ name: 'skeleton', selector: '#itemContentSkeleton' },
 			{ name: 'no padding', selector: '#itemContentNoPadding' },
 			{ name: 'long wrapping', selector: '#itemContentLongWrap' },
 			{ name: 'long single line ellipsis', selector: '#itemContentLongSingleLineEllipsis' },


### PR DESCRIPTION
[DE52725](https://rally1.rallydev.com/#/?detail=/defect/694583527535&fdp=true)

This PR proposes the addition of the skeleton-mixin to list-item-content. This would allow consumers to skeletize all the contents of list items.

It's not an ideal skeleton style, since it creates a big grey box over all of the content. But a consumer has tried to do this [here](https://github.com/BrightspaceHypermediaComponents/activities/blob/bdb49a2011acf877108b7f70a58d9d72a3bfee34/components/d2l-activity-editor/d2l-activity-discussion-editor/d2l-activity-discussion-topic-manage-restrictions-dialog.js#L63), by copying and pasting the skeleton styles from core. This means it will not be responsive to changes to the mixin and will have to be updated in both places.

I don't love this. My thoughts are that this is not the expected use case of skeleton and we should encourage consumers to create their own skeleton content for situations like this which will result in a nicer looking skeleton.

In standup, we brought up the idea of expand/collapse being a potential use case. I think this fits better as part of the `d2l-list-item` skeleton. Currently, the skeleton for `d2l-list-item` will disable expand/collapse but does not skeletize the expand/collapse icon. We could expand those styles to also skeletize the icon.

![Screen Shot 2023-04-17 at 11 51 35 AM](https://user-images.githubusercontent.com/12901943/232541389-ff10634e-043c-4de5-969c-9e3791cd50ea.png)
