### PR TITLE
fix: Event subscription before registry is ready

### DIFF
--- a/components/paging/pageable-mixin.js
+++ b/components/paging/pageable-mixin.js
@@ -56,12 +56,13 @@ export const PageableMixin = superclass => class extends CollectionMixin(supercl
 		this._itemShowingCount = this._getItemShowingCount();
 	}
 
-	_updatePageableSubscriber(subscriber) {
+	_updatePageableSubscriber(subscriber, doUpdate = true) {
+		if (doUpdate) this._updateItemShowingCount();
 		subscriber._pageableInfo = { itemShowingCount: this._itemShowingCount, itemCount: this.itemCount };
 	}
 
 	_updatePageableSubscribers(subscribers) {
-		subscribers.forEach(subscriber => this._updatePageableSubscriber(subscriber));
+		subscribers.forEach(subscriber => this._updatePageableSubscriber(subscriber, false));
 	}
 
 };

--- a/components/selection/demo/selection.html
+++ b/components/selection/demo/selection.html
@@ -170,8 +170,8 @@
 									<li><d2l-selection-input key="tom" label="Tomato"></d2l-selection-input>Tomato</li>
 									<li><d2l-selection-input key="onion" label="Onion"></d2l-selection-input>Onion</li>
 								</ul>
-								<d2l-pager-load-more has-more page-size="1"></d2l-pager-load-more>
 							</d2l-demo-selection-pageable>
+							<d2l-pager-load-more has-more page-size="1" pageable-for="collection-1"></d2l-pager-load-more>
 							<d2l-selection-action selection-for="collection-1" text="Save" requires-selection></d2l-selection-action>
 						</div>
 

--- a/controllers/subscriber/subscriberControllers.js
+++ b/controllers/subscriber/subscriberControllers.js
@@ -137,7 +137,7 @@ export class EventSubscriberController extends BaseSubscriber {
 	}
 
 	hostConnected() {
-		this._subscriptionComplete = this._keepTrying(() => this._subscribe(), 20, 100);
+		this._subscriptionComplete = this._keepTrying(() => this._subscribe(), 40, 400);
 	}
 
 	hostDisconnected() {

--- a/controllers/subscriber/subscriberControllers.js
+++ b/controllers/subscriber/subscriberControllers.js
@@ -211,8 +211,10 @@ export class IdSubscriberController extends BaseSubscriber {
 
 		if (this._registries.get(registryId) === registryComponent) return registryComponent;
 
-		if (registryComponent) this._subscribe(registryComponent, registryId);
-		else {
+		if (registryComponent) {
+			const success = this._subscribe(registryComponent, registryId);
+			if (!success && this._options.onError) this._options.onError(registryId);
+		} else {
 			this._registries.delete(registryId);
 			this._registryControllers.delete(registryId);
 			if (this._options.onUnsubscribe) this._options.onUnsubscribe(registryId);

--- a/controllers/subscriber/test/subscriberControllers.test.js
+++ b/controllers/subscriber/test/subscriberControllers.test.js
@@ -276,7 +276,7 @@ describe('EventSubscriberController', () => {
 	it('Call onError if we did not find a registry component', () => {
 		const subscriber = elem.querySelector('#error');
 
-		clock.tick(100);
+		clock.tick(400);
 		expect(subscriber._onSubscribeRegistries).to.eql([]);
 		expect(subscriber._onErrorRegistryIds).to.eql([ undefined ]);
 	});
@@ -285,7 +285,7 @@ describe('EventSubscriberController', () => {
 		const subscriber = elem.querySelector('#delayed');
 		expect(subscriber._onSubscribeRegistries).to.eql([]);
 
-		clock.tick(100);
+		clock.tick(40);
 		expect(subscriber._onSubscribeRegistries).to.eql([ elem.querySelector('#registry-wrapper').shadowRoot.querySelector('#registry-shadow') ]);
 		expect(subscriber._onErrorRegistryIds).to.eql([]);
 	});


### PR DESCRIPTION
While backporting the table-load-more to some consumers, I found a strange race condition that was preventing the load-more pager from subscribing to the table. This PR fixes that race condition.

In short:

- in the backport, the pager is being rendered **before** the table-wrapper
- this is because it's being passed as a slot to a component that internally renders the table-wrapper
    - so the outer component renders the pager first, then the inner component renders table-wrapper and slots the pager in place
- that means when the subscription event fires, there's nothing to catch it!

I chatted with @dbatiste and we landed on this fix: keep firing the subscription event until it's caught, for some fixed amount of time. In my testing 20ms was usually enough, I've set the retry window to 100ms but we can make it larger if we want.

Also, this fix was surprisingly similar to one already in place for the ID subscriber, so I combined the approaches and added unit tests for both.

Rally: https://rally1.rallydev.com/#/?detail=/userstory/656749937623&fdp=true
