### PR TITLE
fix: Initializing itemShowingCount for pageables

### DIFF
--- a/components/paging/pageable-mixin.js
+++ b/components/paging/pageable-mixin.js
@@ -21,8 +21,8 @@ export const PageableMixin = superclass => class extends CollectionMixin(supercl
 		});
 	}
 
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
+	connectedCallback() {
+		super.connectedCallback();
 		this._updateItemShowingCount();
 	}
 
@@ -56,13 +56,12 @@ export const PageableMixin = superclass => class extends CollectionMixin(supercl
 		this._itemShowingCount = this._getItemShowingCount();
 	}
 
-	_updatePageableSubscriber(subscriber, doUpdate = true) {
-		if (doUpdate) this._updateItemShowingCount();
+	_updatePageableSubscriber(subscriber) {
 		subscriber._pageableInfo = { itemShowingCount: this._itemShowingCount, itemCount: this.itemCount };
 	}
 
 	_updatePageableSubscribers(subscribers) {
-		subscribers.forEach(subscriber => this._updatePageableSubscriber(subscriber, false));
+		subscribers.forEach(subscriber => this._updatePageableSubscriber(subscriber));
 	}
 
 };


### PR DESCRIPTION
Another small change - as part of #3533 I made a fix to how pageable initializes `itemShowingCount`, I'd like to switch it with a slightly different fix here.

The previous fix (reprocessing `_getItemShowingCount` on each subscription) could have a performance concern if there's a lot of subscribers, removing it again and switching to `connectedCallback` should be sufficient. Not a big deal, but I wanted to make the change while it's on my mind.