### PR TITLE
fix: demo RTL border

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -67,7 +67,7 @@ class DemoSnippet extends LitElement {
 				padding: 0;
 			}
 			.d2l-demo-snippet-settings {
-				border-left: 1px solid var(--d2l-color-mica);
+				border-inline-start: 1px solid var(--d2l-color-mica);
 				flex: 0 0 auto;
 				padding: 6px;
 			}


### PR DESCRIPTION
I noticed that the demo snippet's border doesn't show up when the whole page is in RTL mode:

Before:
<img width="916" alt="Screenshot 2023-04-20 at 9 39 39 AM" src="https://user-images.githubusercontent.com/5491151/233384242-cb72c2c4-0216-41b9-bf78-80ea5a44be5c.png">

After:
<img width="914" alt="Screenshot 2023-04-20 at 9 40 30 AM" src="https://user-images.githubusercontent.com/5491151/233384406-c4f0f4bd-f3d7-434f-b4b6-130f5a46a445.png">
