### PR TITLE
Correcting "Ferrite" to "Tungsten"

### DIFF
--- a/components/icons/README.md
+++ b/components/icons/README.md
@@ -15,7 +15,7 @@ For preset icons, import and use the `<d2l-icon>` web component with the `icon` 
 <d2l-icon icon="tier1:gear"></d2l-icon>
 ```
 
-The `icon` attribute value is of the form `<category-name>:<icon-name>`. The icon will automatically be the correct color (ferrite) and size based on its category.
+The `icon` attribute value is of the form `<category-name>:<icon-name>`. The icon will automatically be the correct color (Tungsten) and size based on its category.
 
 **Note:** Always choose the icon whose native size best matches your desired icon size, ideally exactly.
 
@@ -48,7 +48,7 @@ Ensure that the SVG is formatted according to [the rules outlined below](#svg-fo
 
 ## Overriding the Color
 
-To change an icon's color from ferrite to something else, simply set it from CSS:
+To change an icon's color from Tungsten to something else, simply set it from CSS:
 
 ```html
 <d2l-icon icon="tier3:alert" style="color: red;"></d2l-icon>


### PR DESCRIPTION
We darkened Ferrite and a few of the other dark grey colours a while back, and opted to keep icons at #494C4E which became the new Tungsten. We missed updating this in the documentation.