### PR TITLE
Update d2l-input-date to not use a live region

### DIFF
--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -278,7 +278,6 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 				<d2l-input-text
 					?novalidate="${this.noValidate}"
 					aria-invalid="${this.invalid ? 'true' : 'false'}"
-					atomic="true"
 					@blur="${this._handleInputTextBlur}"
 					@change="${this._handleChange}"
 					class="d2l-dropdown-opener"
@@ -291,7 +290,6 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 					label="${ifDefined(this.label)}"
 					?label-hidden="${this.labelHidden || this.labelledBy}"
 					.labelRequired="${false}"
-					live="assertive"
 					@mouseup="${this._handleMouseup}"
 					placeholder="${shortDateFormat}"
 					?required="${this.required}"

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -39,12 +39,6 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			 */
 			ariaInvalid: { type: String, attribute: 'aria-invalid' },
 			/**
-			 * ADVANCED: Specifies whether or not the screen reader should always present changes to the live region as a whole.
-			 * This only applies if live is set to polite or assertive.
-			 * @type {string}
-			 */
-			atomic: { type: String },
-			/**
 			 * Specifies which types of values can be autofilled by the browser
 			 * @type {string}
 			 */
@@ -79,11 +73,6 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			 * @type {boolean}
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
-			 * ADVANCED: Set the priority with which screen readers should treat updates to the input's live text region
-			 * @type {string}
-			 */
-			live: { type: String },
 			/**
 			 * For number inputs, maximum value
 			 * @type {string}
@@ -426,12 +415,10 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		const input = html`
 			<div class="d2l-input-container">
 				<div class="d2l-input-text-container d2l-skeletize" style="${styleMap(inputContainerStyles)}">
-					<input aria-atomic="${ifDefined(this.atomic)}"
-						aria-describedby="${ifDefined(this.description ? this._descriptionId : undefined)}"
+					<input aria-describedby="${ifDefined(this.description ? this._descriptionId : undefined)}"
 						aria-haspopup="${ifDefined(this.ariaHaspopup)}"
 						aria-invalid="${ifDefined(ariaInvalid)}"
 						aria-label="${ifDefined(this._getAriaLabel())}"
-						aria-live="${ifDefined(this.live)}"
 						aria-required="${ifDefined(ariaRequired)}"
 						?required="${this.required}"
 						autocomplete="${ifDefined(this.autocomplete)}"


### PR DESCRIPTION
[DE52693](https://rally1.rallydev.com/#/?detail=/defect/694283108021&fdp=true)

This PR updates `d2l-input-date` to not use a live region on its `d2l-input-text`. The live region causes the value of the input to be announced, sometimes when we don't expect it to, such as when delayed HM components initialize the value. It's especially weird because the value is announced without a label, so there's basically no context to the announcement. This can be confusing when the page first loads. Likewise, the value could be announced without its label being read randomly if something changes the value - in such case, the app should be taking more control over the announcement via focus or using the `announce` helper. It also results in the value being announced twice upon selecting a date and closing the dropdown - once before the normal announcement, and then as part of the normal announcement when focus is returned to the input. We should just rely on the normal announcement.

The original reason for these properties is outlined [in this PR](https://github.com/BrightspaceUI/core/pull/590). The rationale was based on Carin's feedback that she preferred the value to be announced first upon selecting a date and closing the dropdown.

This PR also removes `atomic` and `live` properties from `d2l-input-text` since I don't think we or anyone else should be doing this. They are currently used in two places : `d2l-input-date` (this change removes that case), and [an LCS widget](https://github.com/Brightspace/lcs-aau-instructor-check-in-widget/blob/main/src/shared/custom_widgets/instructor_check_in_widget/components/lcs-instructor-check-in-widget.js#L1382) which is locked into a specific version. I've reached out to @Chebsi about this widget.