### PR TITLE
Focus the select-all checkbox when select-all-pages is clicked so focus isn't lost

### DIFF
--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -133,6 +133,15 @@ export const SelectionMixin = superclass => class extends RtlMixin(CollectionMix
 		this._updateSelectionObservers();
 	}
 
+	_focusSelectAll() {
+		for (let observer of this._selectionObservers.values()){
+			if (observer.tagName === 'D2L-SELECTION-SELECT-ALL') {
+				observer.focus();
+				break;
+			}
+		}
+	}
+
 	_handleRadioKeyDown(e) {
 		// check composed path for radio (e.target could be d2l-list-item or other element due to retargeting)
 		if (!e.composedPath()[0].classList.contains('d2l-selection-input-radio')) return;

--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -134,7 +134,7 @@ export const SelectionMixin = superclass => class extends RtlMixin(CollectionMix
 	}
 
 	_focusSelectAll() {
-		for (let observer of this._selectionObservers.values()){
+		for (const observer of this._selectionObservers.values()) {
 			if (observer.tagName === 'D2L-SELECTION-SELECT-ALL') {
 				observer.focus();
 				break;

--- a/components/selection/selection-select-all-pages.js
+++ b/components/selection/selection-select-all-pages.js
@@ -40,7 +40,10 @@ class SelectAllPages extends FocusMixin(LocalizeCoreElement(SelectionObserverMix
 	}
 
 	_handleClick() {
-		if (this._provider) this._provider.setSelectionForAll(true, true);
+		if (!this._provider) return;
+
+		this._provider.setSelectionForAll(true, true);
+		this._provider._focusSelectAll();
 	}
 
 }


### PR DESCRIPTION
[DE52842](https://rally1.rallydev.com/#/?detail=/defect/696182478911&fdp=true)

This PR applies focus to the `d2l-selection-select-all` checkbox when the `d2l-selection-select-all-pages` button is clicked so that focus isn't lost when the button is hidden/removed from view.