### PR TITLE
Update the d2l-meter-* demos and tests.

### DIFF
--- a/components/meter/README.md
+++ b/components/meter/README.md
@@ -41,7 +41,14 @@ Linear meters show a horizontal progress bar.
 <script type="module">
   import '@brightspace-ui/core/components/meter/meter-linear.js';
 </script>
-<d2l-meter-linear value="3" max="10"></d2l-meter-linear>
+<style>
+  d2l-meter-linear {
+    width: 170px;
+  }
+</style>
+<d2l-meter-linear value="8" max="10" text="Activities"></d2l-meter-linear>
+<d2l-meter-linear value="8" max="10" text="Activities: {x/y}" percent></d2l-meter-linear>
+<d2l-meter-linear value="8" max="10" text-inline text="Activities"></d2l-meter-linear>
 ```
 
 <!-- docs: start hidden content -->

--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -10,6 +10,21 @@
 			import '../meter-radial.js';
 			import '../meter-circle.js';
 		</script>
+		<style>
+			d2l-demo-snippet > div > div {
+				padding: 1rem;
+			}
+			d2l-meter-linear {
+				width: 250px;
+			}
+			d2l-meter-linear, d2l-meter-radial, d2l-meter-circle {
+				margin-bottom: 1rem;
+			}
+			.dark-background {
+				background-color: var(--d2l-color-celestine);
+			}
+
+		</style>
 	</head>
 	<body unresolved>
 
@@ -17,48 +32,72 @@
 
 			<h2>Meter Linear</h2>
 
-			<d2l-demo-snippet>
+			<d2l-demo-snippet no-padding>
 				<template>
-					<d2l-meter-linear value="2" max="15" style="width: 250px;" text="Activities" text-inline></d2l-meter-linear>
-					<d2l-meter-linear value="3" max="6" style="width: 200px;" text="Visited: {x/y}" percent></d2l-meter-linear>
-					<div style="background-color: darkblue;">
-						<d2l-meter-linear value="2" max="15" style="width: 250px;" text="Activities" text-inline foreground-light></d2l-meter-linear>
-						<d2l-meter-linear value="3" max="6" style="width: 200px;" text="Visited: {x/y}" percent foreground-light></d2l-meter-linear>
+					<div>
+						<d2l-meter-linear value="2" max="15" text-inline></d2l-meter-linear>
+						<d2l-meter-linear value="2" max="15" text-inline percent></d2l-meter-linear>
+						<d2l-meter-linear value="2" max="15" text-inline text="Activities"></d2l-meter-linear>
+						<d2l-meter-linear value="2" max="15" text-inline text="Activities" percent></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6"></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" percent></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" text="Visited: {x/y}" percent></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" text="Visited: {%}"></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" text="You're doing great!" percent></d2l-meter-linear>
+					</div>
+					<div class="dark-background">
+						<d2l-meter-linear value="2" max="15" foreground-light text-inline></d2l-meter-linear>
+						<d2l-meter-linear value="2" max="15" foreground-light text-inline percent></d2l-meter-linear>
+						<d2l-meter-linear value="2" max="15" foreground-light text-inline text="Activities"></d2l-meter-linear>
+						<d2l-meter-linear value="2" max="15" foreground-light text-inline text="Activities" percent></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" foreground-light></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" foreground-light percent></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" foreground-light text="Visited: {x/y}" percent></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" foreground-light text="Visited: {%}"></d2l-meter-linear>
+						<d2l-meter-linear value="3" max="6" foreground-light text="You're doing great!" percent></d2l-meter-linear>
 					</div>
 				</template>
 			</d2l-demo-snippet>
 
 			<h2>Meter Radial</h2>
 
-			<d2l-demo-snippet>
+			<d2l-demo-snippet no-padding>
 				<template>
-					<d2l-meter-radial value="5" max="13"></d2l-meter-radial>
-					<d2l-meter-radial value="10" max="10"></d2l-meter-radial>
-					<d2l-meter-radial value="0" max="10"></d2l-meter-radial>
-					<d2l-meter-radial value="19" max="26" style="width: 25%;"></d2l-meter-radial>
-					<d2l-meter-radial value="5" max="10" text="Completed"></d2l-meter-radial>
-					<div style="background-color: darkgreen;">
-						<d2l-meter-radial value="5" max="13" foreground-light></d2l-meter-radial>
-						<d2l-meter-radial value="10" max="10" foreground-light></d2l-meter-radial>
+					<div>
+						<d2l-meter-radial value="0" max="10"></d2l-meter-radial>
+						<d2l-meter-radial value="5" max="13"></d2l-meter-radial>
+						<d2l-meter-radial value="5" max="13" percent></d2l-meter-radial>
+						<d2l-meter-radial value="10" max="10"></d2l-meter-radial>
+						<d2l-meter-radial value="5" max="10" text="Completed"></d2l-meter-radial>
+						<d2l-meter-radial value="19" max="26" style="width: 25%;"></d2l-meter-radial>
+					</div>
+					<div class="dark-background">
 						<d2l-meter-radial value="0" max="10" foreground-light></d2l-meter-radial>
-						<d2l-meter-radial value="19" max="26" style="width: 25%;" foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="5" max="13" foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="5" max="13" percent foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="10" max="10" foreground-light></d2l-meter-radial>
 						<d2l-meter-radial value="5" max="10" text="Completed" foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="19" max="26" style="width: 25%;" foreground-light></d2l-meter-radial>
 					</div>
 				</template>
 			</d2l-demo-snippet>
 
 			<h2>Meter Circle</h2>
 
-			<d2l-demo-snippet>
+			<d2l-demo-snippet no-padding>
 				<template>
-					<d2l-meter-circle value="1" max="13"></d2l-meter-circle>
-					<d2l-meter-circle value="10" max="10"></d2l-meter-circle>
-					<d2l-meter-circle value="0" max="10"></d2l-meter-circle>
-					<d2l-meter-circle value="19" max="26" style="width: 25%;"></d2l-meter-circle>
-					<div style="background-color: darkred;">
-						<d2l-meter-circle value="1" max="13" foreground-light></d2l-meter-circle>
-						<d2l-meter-circle value="10" max="10" foreground-light></d2l-meter-circle>
+					<div>
+						<d2l-meter-circle value="0" max="10"></d2l-meter-circle>
+						<d2l-meter-circle value="5" max="13"></d2l-meter-circle>
+						<d2l-meter-circle value="5" max="13" percent></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10"></d2l-meter-circle>
+						<d2l-meter-circle value="19" max="26" style="width: 25%;"></d2l-meter-circle>
+					</div>
+					<div class="dark-background">
 						<d2l-meter-circle value="0" max="10" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="5" max="13" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="5" max="13" percent foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10" foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="19" max="26" style="width: 25%;" foreground-light></d2l-meter-circle>
 					</div>
 				</template>

--- a/components/meter/meter-mixin.js
+++ b/components/meter/meter-mixin.js
@@ -17,7 +17,7 @@ export const MeterMixin = superclass => class extends LocalizeCoreElement(superc
 			 */
 			percent: { type: Boolean },
 			/**
-			 * Context information for the meter
+			 * Context information for the meter. If the text contains {%} or {x/y}, they will be replaced with a percentage or fraction respectively.
 			 * @type {string}
 			 */
 			text: { type: String },

--- a/components/meter/test/meter-circle.visual-diff.html
+++ b/components/meter/test/meter-circle.visual-diff.html
@@ -10,52 +10,51 @@
 	<title>d2l-meter-circle</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta charset="UTF-8">
+	<style>
+		.dark-background {
+			background-color: var(--d2l-color-celestine);
+			padding: 1rem;
+		}
+		.visual-diff {
+			width: 90px;
+		}
+	</style>
 </head>
 <body class="d2l-typography">
-	<div class="visual-diff" style="width: 90px;">
+
+	<div class="visual-diff">
 		<d2l-meter-circle id="no-progress" value="0" max="10"></d2l-meter-circle>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-circle id="has-progress" value="16" max="47"></d2l-meter-circle>
+	<div class="visual-diff">
+		<d2l-meter-circle id="progress" value="16" max="47"></d2l-meter-circle>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-circle id="completed" value="5" max="5"></d2l-meter-circle>
+	<div class="visual-diff">
+		<d2l-meter-circle id="progress-rtl" dir="rtl" value="16" max="47"></d2l-meter-circle>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
+	<div class="visual-diff">
+		<d2l-meter-circle id="complete" value="5" max="5"></d2l-meter-circle>
+	</div>
+	<div class="visual-diff">
+		<d2l-meter-circle id="percent" value="16" max="47" percent></d2l-meter-circle>
+	</div>
+	<div class="visual-diff">
+		<d2l-meter-circle id="percent-rtl" dir="rtl" value="16" max="47" percent></d2l-meter-circle>
+	</div>
+	<div class="visual-diff">
 		<d2l-meter-circle id="round-to-zero" value="0.004" max="100"></d2l-meter-circle>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
+	<div class="visual-diff">
 		<d2l-meter-circle id="max-zero-with-value" value="10" max="0"></d2l-meter-circle>
 	</div>
-	<!-- Test scaled versions-->
-	<div class="visual-diff" style="width: 170px;">
-		<d2l-meter-circle id="no-progress-scaled" value="0" max="10"  style="width: 300%;"></d2l-meter-circle>
+	<div class="visual-diff dark-background">
+		<d2l-meter-circle id="foreground-light" value="16" max="47" foreground-light></d2l-meter-circle>
 	</div>
-	<div class="visual-diff" style="width: 170px;">
-		<d2l-meter-circle id="has-progress-scaled" value="7" max="10"  style="width: 450%;"></d2l-meter-circle>
+	<div class="visual-diff">
+		<d2l-meter-circle id="scaled-larger" value="16" max="47" style="width: 300%;"></d2l-meter-circle>
 	</div>
-	<div class="visual-diff" style="width: 170px;">
-		<d2l-meter-circle id="completed-scaled" value="10" max="10"  style="width: 30%;"></d2l-meter-circle>
+	<div class="visual-diff">
+		<d2l-meter-circle id="scaled-smaller" value="16" max="47" style="width: 30%;"></d2l-meter-circle>
 	</div>
-	<!-- Test rtl versions -->
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-circle dir="rtl" id="no-progress-rtl" value="0" max="10"></d2l-meter-circle>
-	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-circle dir="rtl" id="has-progress-rtl" value="16" max="47"></d2l-meter-circle>
-	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-circle dir="rtl" id="completed-rtl" value="5" max="5"></d2l-meter-circle>
-	</div>
-	<!-- Test foreground-light versions-->
-	<div class="visual-diff" style="background-color: darkblue; width: 90px;">
-		<d2l-meter-circle id="no-progress-light" value="0" max="10" foreground-light></d2l-meter-circle>
-	</div>
-	<div class="visual-diff" style="background-color: darkgreen; width: 90px;">
-		<d2l-meter-circle id="has-progress-light" value="16" max="47" foreground-light></d2l-meter-circle>
-	</div>
-	<div class="visual-diff" style="background-color: darkred; width: 90px;">
-		<d2l-meter-circle id="completed-light" value="5" max="5" foreground-light></d2l-meter-circle>
-	</div>
+
 </body>
 </html>

--- a/components/meter/test/meter-circle.visual-diff.js
+++ b/components/meter/test/meter-circle.visual-diff.js
@@ -17,23 +17,20 @@ describe('d2l-meter-circle', () => {
 	after(async() => await browser.close());
 
 	[
-		{ title: 'no-progress', fixture: '#no-progress' },
-		{ title: 'has-progress', fixture: '#has-progress' },
-		{ title: 'completed', fixture: '#completed' },
-		{ title: 'round-to-zero', fixture: '#round-to-zero' },
-		{ title: 'max-zero-with-value', fixture: '#max-zero-with-value' },
-		{ title: 'no-progress-scaled', fixture: '#no-progress-scaled' },
-		{ title: 'has-progress-scaled', fixture: '#has-progress-scaled' },
-		{ title: 'completed-scaled', fixture: '#completed-scaled' },
-		{ title: 'no-progress-rtl', fixture: '#no-progress-rtl' },
-		{ title: 'has-progress-rtl', fixture: '#has-progress-rtl' },
-		{ title: 'completed-rtl', fixture: '#completed-rtl' },
-		{ title: 'no-progress-light', fixture: '#no-progress-light' },
-		{ title: 'has-progress-light', fixture: '#has-progress-light' },
-		{ title: 'completed-light', fixture: '#completed-light' }
-	].forEach((testData) => {
-		it(testData.title, async function() {
-			const rect = await visualDiff.getRect(page, testData.fixture);
+		'no-progress',
+		'progress',
+		'progress-rtl',
+		'complete',
+		'percent',
+		'percent-rtl',
+		'round-to-zero',
+		'max-zero-with-value',
+		'foreground-light',
+		'scaled-larger',
+		'scaled-smaller'
+	].forEach(name => {
+		it(name, async function() {
+			const rect = await visualDiff.getRect(page, `#${name}`);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 	});

--- a/components/meter/test/meter-linear.visual-diff.html
+++ b/components/meter/test/meter-linear.visual-diff.html
@@ -9,54 +9,88 @@
 	<title>d2l-meter-linear</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta charset="UTF-8">
+	<style>
+		.dark-background {
+			background-color: var(--d2l-color-celestine);
+			padding: 1rem;
+		}
+		.visual-diff {
+			width: 250px;
+		}
+	</style>
 </head>
 <body class="d2l-typography">
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear id="no-progress" value="0" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>
+
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-no-progress" value="0" max="10"></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear id="has-progress" value="3" max="10" text="Activities" text-inline percent></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-progress" value="4" max="10"></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear id="completed" value="10" max="10" text="{%} Activities"></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-complete" value="10" max="10"></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear id="max-zero-value-zero" value="0" max="0" text="Visited: {x/y}" percent></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-percent" value="4" max="10" percent></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear id="round-to-zero" value="0.004" max="100" text="Visited: {x/y}" percent></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-text" value="4" max="10" text="You're doing great!"></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear id="over-100" value="15" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-text-fraction" value="4" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear id="max-zero-with-value" value="10" max="0" text="Visited: {x/y}" percent></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-text-percent" value="4" max="10" text="Visited: {%}"></d2l-meter-linear>
 	</div>
-	<!-- rtl versions-->
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear dir="rtl" id="no-progress-rtl" value="0" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>
+	<div class="visual-diff dark-background">
+		<d2l-meter-linear id="normal-foreground-light" value="4" max="10" text="Visited: {%}" foreground-light></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear dir="rtl" id="has-progress-rtl" value="3" max="10" text="Activities" text-inline percent></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-text-fraction-rtl" dir="rtl" value="4" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear dir="rtl" id="completed-rtl" value="10" max="10" text="{%} Activities"></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-text-percent-rtl" dir="rtl" value="4" max="10" text="Visited: {%}"></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="width: 250px;">
-		<d2l-meter-linear dir="rtl" id="over-100-rtl" value="15" max="10" text="{%} Activities"></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-max-zero-value-zero" value="0" max="0" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
-	<!-- Test foreground-light versions-->
-	<div class="visual-diff" style="background-color: darkblue; width: 90px;">
-		<d2l-meter-linear id="no-progress-light" value="0" max="10" foreground-light></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-round-to-zero" value="0.004" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="background-color: darkgreen; width: 90px;">
-		<d2l-meter-linear id="has-progress-light" value="16" max="47" foreground-light></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-over-100" value="15" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="background-color: darkred; width: 90px;">
-		<d2l-meter-linear id="completed-light" value="5" max="5" foreground-light></d2l-meter-linear>
+	<div class="visual-diff">
+		<d2l-meter-linear id="normal-max-zero-with-value" value="5" max="0" text="Visited: {x/y}" percent></d2l-meter-linear>
 	</div>
-	<div class="visual-diff" style="background-color: darkred; width: 90px;">
-		<d2l-meter-linear id="over-100-light" value="15" max="10" foreground-light></d2l-meter-linear>
+
+	<div class="visual-diff">
+		<d2l-meter-linear id="text-inline-no-progress" value="0" max="10" text-inline></d2l-meter-linear>
 	</div>
+	<div class="visual-diff">
+		<d2l-meter-linear id="text-inline-progress" value="4" max="10" text-inline></d2l-meter-linear>
+	</div>
+	<div class="visual-diff">
+		<d2l-meter-linear id="text-inline-complete" value="10" max="10" text-inline></d2l-meter-linear>
+	</div>
+	<div class="visual-diff">
+		<d2l-meter-linear id="text-inline-percent" value="4" max="10" text-inline percent></d2l-meter-linear>
+	</div>
+	<div class="visual-diff">
+		<d2l-meter-linear id="text-inline-text-fraction" value="4" max="10" text-inline text="Visited"></d2l-meter-linear>
+	</div>
+	<div class="visual-diff">
+		<d2l-meter-linear id="text-inline-text-percent" value="4" max="10" text-inline text="Visited" percent></d2l-meter-linear>
+	</div>
+	<div class="visual-diff dark-background">
+		<d2l-meter-linear id="text-inline-foreground-light" value="4" max="10" text-inline text="Visited" percent foreground-light></d2l-meter-linear>
+	</div>
+	<div class="visual-diff">
+		<d2l-meter-linear id="text-inline-text-fraction-rtl" dir="rtl" value="4" max="10" text-inline text="Visited"></d2l-meter-linear>
+	</div>
+	<div class="visual-diff">
+		<d2l-meter-linear id="text-inline-text-percent-rtl" dir="rtl" value="4" max="10" text-inline text="Visited" percent></d2l-meter-linear>
+	</div>
+
 </body>
 </html>

--- a/components/meter/test/meter-linear.visual-diff.js
+++ b/components/meter/test/meter-linear.visual-diff.js
@@ -17,25 +17,34 @@ describe('d2l-meter-linear', () => {
 	after(async() => await browser.close());
 
 	[
-		{ title: 'no-progress', fixture: '#no-progress' },
-		{ title: 'has-progress', fixture: '#has-progress' },
-		{ title: 'completed', fixture: '#completed' },
-		{ title: 'max-zero-value-zero', fixture: '#max-zero-value-zero' },
-		{ title: 'round-to-zero', fixture: '#round-to-zero' },
-		{ title: 'over-100', fixture: '#over-100' },
-		{ title: 'max-zero-with-value', fixture: '#max-zero-with-value' },
-		{ title: 'no-progress-rtl', fixture: '#no-progress-rtl' },
-		{ title: 'has-progress-rtl', fixture: '#has-progress-rtl' },
-		{ title: 'completed-rtl', fixture: '#completed-rtl' },
-		{ title: 'over-100-rtl', fixture: '#over-100-rtl' },
-		{ title: 'no-progress-light', fixture: '#no-progress-light' },
-		{ title: 'has-progress-light', fixture: '#has-progress-light' },
-		{ title: 'completed-light', fixture: '#completed-light' },
-		{ title: 'over-100-light', fixture: '#over-100-light' }
-	].forEach((testData) => {
-		it(testData.title, async function() {
-			const rect = await visualDiff.getRect(page, testData.fixture);
+		'normal-no-progress',
+		'normal-progress',
+		'normal-complete',
+		'normal-percent',
+		'normal-text',
+		'normal-text-fraction',
+		'normal-text-percent',
+		'normal-foreground-light',
+		'normal-text-fraction-rtl',
+		'normal-text-percent-rtl',
+		'normal-max-zero-value-zero',
+		'normal-round-to-zero',
+		'normal-over-100',
+		'normal-max-zero-with-value',
+		'text-inline-no-progress',
+		'text-inline-progress',
+		'text-inline-complete',
+		'text-inline-percent',
+		'text-inline-text-fraction',
+		'text-inline-text-percent',
+		'text-inline-foreground-light',
+		'text-inline-text-fraction-rtl',
+		'text-inline-text-percent-rtl'
+	].forEach(name => {
+		it(name, async function() {
+			const rect = await visualDiff.getRect(page, `#${name}`);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 	});
+
 });

--- a/components/meter/test/meter-radial.visual-diff.html
+++ b/components/meter/test/meter-radial.visual-diff.html
@@ -10,52 +10,60 @@
 	<title>d2l-meter-radial</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta charset="UTF-8">
+	<style>
+		.dark-background {
+			background-color: var(--d2l-color-celestine);
+			padding: 1rem;
+		}
+		.visual-diff {
+			width: 90px;
+		}
+		d2l-meter-radial {
+			display: block;
+		}
+	</style>
 </head>
 <body class="d2l-typography">
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-radial id="no-progress" value="0" max="10" style="display: block;"></d2l-meter-radial>
+
+	<div class="visual-diff">
+		<d2l-meter-radial id="no-progress" value="0" max="10"></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-radial id="has-progress" value="16" max="47" style="display: block;" text="Completed"></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="progress" value="16" max="47"></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-radial id="completed" value="256" max="256" style="display: block;"></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="progress-rtl" dir="rtl" value="16" max="47"></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-radial id="round-to-zero" value="0.004" max="100" style="display: block;"></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="complete" value="256" max="256"></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-radial id="max-zero-with-value" value="10" max="0" style="display: block;"></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="percent" value="16" max="47" percent></d2l-meter-radial>
 	</div>
-	<!-- Test scaled versions-->
-	<div class="visual-diff" style="width: 170px;">
-		<d2l-meter-radial id="no-progress-scaled" value="0" max="10"  style="width: 300%;" text="Completed"></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="percent-rtl" dir="rtl" value="16" max="47" percent></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="width: 170px;">
-		<d2l-meter-radial id="has-progress-scaled" value="7" max="10"  style="width: 450%;"></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="text" value="10" max="10" percent text="Completed"></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="width: 170px;">
-		<d2l-meter-radial id="completed-scaled" value="10" max="10"  style="width: 30%;"></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="text-rtl" dir="rtl" value="10" max="10" percent text="Completed"></d2l-meter-radial>
 	</div>
-	<!-- rtl versions-->
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-radial dir="rtl" id="no-progress-rtl" value="0" max="10"  style="width: 300%;" text="Completed"></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="round-to-zero" value="0.004" max="100" percent></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-radial dir="rtl" id="has-progress-rtl" value="7" max="10"  style="width: 450%;"></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="max-zero-with-value" value="10" max="0"></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="width: 90px;">
-		<d2l-meter-radial dir="rtl" id="completed-rtl" value="10" max="10"  style="width: 30%;"></d2l-meter-radial>
+	<div class="visual-diff dark-background">
+		<d2l-meter-radial id="foreground-light" value="16" max="47" foreground-light text="Keep going!"></d2l-meter-radial>
 	</div>
-	<!-- Test foreground-light versions-->
-	<div class="visual-diff" style="background-color: darkblue; width: 90px;">
-		<d2l-meter-radial id="no-progress-light" value="0" max="10" foreground-light></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="scaled-larger" value="16" max="47" text="Keep going!" style="width: 300%;"></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="background-color: darkgreen; width: 90px;">
-		<d2l-meter-radial id="has-progress-light" value="16" max="47" foreground-light></d2l-meter-radial>
+	<div class="visual-diff">
+		<d2l-meter-radial id="scaled-smaller" value="16" max="47" style="width: 30%;"></d2l-meter-radial>
 	</div>
-	<div class="visual-diff" style="background-color: darkred; width: 90px;">
-		<d2l-meter-radial id="completed-light" value="5" max="5" foreground-light></d2l-meter-radial>
-	</div>
+
 </body>
 </html>

--- a/components/meter/test/meter-radial.visual-diff.js
+++ b/components/meter/test/meter-radial.visual-diff.js
@@ -17,23 +17,22 @@ describe('d2l-meter-radial', () => {
 	after(async() => await browser.close());
 
 	[
-		{ title: 'no-progress', fixture: '#no-progress' },
-		{ title: 'has-progress', fixture: '#has-progress' },
-		{ title: 'completed', fixture: '#completed' },
-		{ title: 'round-to-zero', fixture: '#round-to-zero' },
-		{ title: 'max-zero-with-value', fixture: '#max-zero-with-value' },
-		{ title: 'no-progress-scaled', fixture: '#no-progress-scaled' },
-		{ title: 'has-progress-scaled', fixture: '#has-progress-scaled' },
-		{ title: 'completed-scaled', fixture: '#completed-scaled' },
-		{ title: 'no-progress-rtl', fixture: '#no-progress-rtl' },
-		{ title: 'has-progress-rtl', fixture: '#has-progress-rtl' },
-		{ title: 'completed-rtl', fixture: '#completed-rtl' },
-		{ title: 'no-progress-light', fixture: '#no-progress-light' },
-		{ title: 'has-progress-light', fixture: '#has-progress-light' },
-		{ title: 'completed-light', fixture: '#completed-light' }
-	].forEach((testData) => {
-		it(testData.title, async function() {
-			const rect = await visualDiff.getRect(page, testData.fixture);
+		'no-progress',
+		'progress',
+		'progress-rtl',
+		'complete',
+		'percent',
+		'percent-rtl',
+		'text',
+		'text-rtl',
+		'round-to-zero',
+		'max-zero-with-value',
+		'foreground-light',
+		'scaled-larger',
+		'scaled-smaller'
+	].forEach(name => {
+		it(name, async function() {
+			const rect = await visualDiff.getRect(page, `#${name}`);
 			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		});
 	});


### PR DESCRIPTION
This PR makes a few updates for the meter demos and tests:

* Update the demo page to include more cases to make it easier to test the different ways it can be used
* Revamp the `d2l-meter-*` visual-diff tests to include more cases and remove diffs not adding value
* Update the Daylight demo for `d2l-meter-linear` to include three different ways it can be used per Jeff's request
* Fix the Daylight demo for `d2l-meter-linear` to properly render when `text-inline` is specified