### PR TITLE
Try to fix flaky list test

### DIFF
--- a/components/list/test/list.visual-diff.js
+++ b/components/list/test/list.visual-diff.js
@@ -53,13 +53,6 @@ describe('d2l-list', () => {
 		}, y);
 	};
 
-	const wait = (selector, milliseconds) => {
-		return page.$eval(selector, async(elem, milliseconds) => {
-			await elem.updateComplete;
-			await new Promise(resolve => setTimeout(resolve, milliseconds));
-		}, milliseconds);
-	};
-
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await visualDiff.createPage(browser, { viewport: { width: 1000, height: 8500 } });
@@ -187,7 +180,11 @@ describe('d2l-list', () => {
 		{ category: 'nested', tests: [
 			{ name: 'none-selected', selector: '#nested-none-selected' },
 			{ name: 'some-selected', selector: '#nested-some-selected' },
-			{ name: 'all-selected', selector: '#nested-all-selected', action: () => wait('#nested-all-selected d2l-list-controls', 100) }
+			{ name: 'all-selected', selector: '#nested-all-selected', action: async() => await page.waitForFunction(() => {
+				const listControls = document.querySelector('#nested-all-selected d2l-list-controls');
+				const selectionSummary = listControls.shadowRoot.querySelector('d2l-selection-summary');
+				return selectionSummary._summary === '5 selected';
+			}) }
 		] },
 		{ category: 'expand-collapse', tests: [
 			{ name: 'default', selector: '#expand-collapse-default' },


### PR DESCRIPTION
I'd like to propose this "quick fix". We've seen this test flake occasionally for well over a year. I'm optimistic this would be fixed by the next version of `visual-diff` where our `fixture` waits for everything to update, so I don't mind fixing it like this for now.

I've rerun visual-diff 5 times, but the true test will be over the next few weeks. If this does show up again, then I think this might be an issue in the selection component itself.