### PR TITLE
Announce introductory text when opening single dimension

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -667,6 +667,8 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 	_handleDimensionShowStart(e) {
 		this._activeDimensionKey = e.detail.sourceView.getAttribute('data-key');
+		const dimension = this._dimensions.find(dimension => dimension.key === this._activeDimensionKey);
+		if (dimension.introductoryText) announce(dimension.introductoryText);
 		this._dispatchDimensionFirstOpenEvent(this._activeDimensionKey);
 	}
 
@@ -680,6 +682,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		this.opened = true;
 		if (this._dimensions.length === 1) {
 			this._dispatchDimensionFirstOpenEvent(this._dimensions[0].key);
+			if (this._dimensions[0].introductoryText) announce(this._dimensions[0].introductoryText);
 		}
 		this._stopPropagation(e);
 	}


### PR DESCRIPTION
[DE52350](https://rally1.rallydev.com/#/?detail=/defect/690468457635&fdp=true)

Previously, the introductory text in filter was not very accessible since it can appear before any other focusable elements which makes it easy to miss for screen reader users. This PR changes the filter component to announce the introductory text on dimension open. 

Carin and Jeff tested this out and are happy with where it ended up.