### PR TITLE
Increase CSS specificity of list extend-separator styles

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -169,7 +169,8 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			.d2l-list-item-content-extend-separators > [slot="control"] {
 				width: 3rem;
 			}
-			.d2l-list-item-content-extend-separators > [slot="content"] {
+			.d2l-list-item-content-extend-separators > [slot="content"],
+			:host([dir="rtl"]) .d2l-list-item-content-extend-separators > [slot="content"] {
 				padding-left: 0.9rem;
 				padding-right: 0.9rem;
 			}


### PR DESCRIPTION
[DE53209](https://rally1.rallydev.com/#/?detail=/defect/699523809885&fdp=true)

This extend-separators style was being overridden by a separate RTL style due to CSS specificity. Added a check for RTL to increase the specificity. This was preventing non-selectable list-items in lists with `extend-separators` from being tabbed forward in RTL.

Before:
![Screen Shot 2023-05-03 at 3 41 50 PM](https://user-images.githubusercontent.com/12901943/236029676-1567157c-af4f-40ec-aafc-ff5d738c0732.png)

After:
![Screen Shot 2023-05-03 at 3 45 53 PM](https://user-images.githubusercontent.com/12901943/236030022-f1cd169f-2c95-486d-a767-ffd9cc72ddef.png)