### PR TITLE
Add check that next focusable list item belongs to the same list

### DIFF
--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -381,7 +381,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 
 	_dispatchListItemsMove(sourceItems, targetItem, moveLocation, keyboardActive) {
 		if (!keyboardActive) keyboardActive = false;
-		const rootList = this._getRootList();
+		const rootList = this.getRootList();
 		/** @ignore */
 		rootList.dispatchEvent(new CustomEvent('d2l-list-items-move', {
 			detail: {
@@ -408,13 +408,13 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 	}
 
 	_dispatchMoveListItemFirst(moveToRoot) {
-		const list = (moveToRoot ? this._getRootList() : findComposedAncestor(this, node => node.tagName === 'D2L-LIST'));
+		const list = (moveToRoot ? this.getRootList() : findComposedAncestor(this, node => node.tagName === 'D2L-LIST'));
 		const items = list.getItems();
 		this._dispatchListItemsMove([this], items[0], moveLocations.above, true);
 	}
 
 	_dispatchMoveListItemLast(moveToRoot) {
-		const list = (moveToRoot ? this._getRootList() : findComposedAncestor(this, node => node.tagName === 'D2L-LIST'));
+		const list = (moveToRoot ? this.getRootList() : findComposedAncestor(this, node => node.tagName === 'D2L-LIST'));
 		const items = list.getItems();
 		this._dispatchListItemsMove([this], items[items.length - 1], moveLocations.below, true);
 	}
@@ -483,7 +483,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 	}
 
 	_dispatchMoveRootItem(moveAbove) {
-		const rootList = this._getRootList();
+		const rootList = this.getRootList();
 		const items = rootList.getItems();
 		const currentIndex = items.indexOf(this);
 		if (moveAbove && currentIndex !== 0) {
@@ -610,7 +610,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 			return dragImage;
 		};
 
-		const rootList = this._getRootList(this);
+		const rootList = this.getRootList(this);
 		const selectionInfo = rootList.getSelectionInfo(rootList.dragMultiple);
 		if (rootList.dragMultiple && selectionInfo.keys.length > 1) {
 			const lazyLoadListItems = this._getFlattenedListItems().lazyLoadListItems;
@@ -750,8 +750,8 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 		}
 
 		// assert that both the source and target are from the same list - may allow this in the future
-		const targetRoot = dragState.dragTargets[0] && dragState.dragTargets[0]._getRootList();
-		if (this._getRootList() !== targetRoot) return;
+		const targetRoot = dragState.dragTargets[0] && dragState.dragTargets[0].getRootList();
+		if (this.getRootList() !== targetRoot) return;
 
 		dragState.addDropTarget(this);
 		this._draggingOver = true;

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -302,7 +302,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			if (!listItem._tryFocus()) {
 				// ultimate fallback to generic method for getting next/previous focusable
 				const nextFocusable = previous ? getPreviousFocusable(listItem) : getNextFocusable(listItem);
-				if (nextFocusable && this._isContainedInSameList(curListItem, nextFocusable)) {
+				if (nextFocusable && this._isContainedInSameRootList(curListItem, nextFocusable)) {
 					nextFocusable.focus();
 				}
 			}
@@ -445,7 +445,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			this.shadowRoot.querySelector(`.d2l-cell[data-cell-num="${this._cellNum}"]`);
 	}
 
-	_isContainedInSameList(item, node) {
+	_isContainedInSameRootList(item, node) {
 		const rootList = item?.getRootList?.(item);
 		return isComposedAncestor(rootList, node);
 	}

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -301,7 +301,9 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			if (!listItem._tryFocus()) {
 				// ultimate fallback to generic method for getting next/previous focusable
 				const nextFocusable = previous ? getPreviousFocusable(listItem) : getNextFocusable(listItem);
-				if (nextFocusable) nextFocusable.focus();
+				if (nextFocusable && this._isContainedInList(listItem, nextFocusable)) {
+					nextFocusable.focus();
+				}
 			}
 		}
 
@@ -440,6 +442,11 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 	_getThisCell() {
 		return this.shadowRoot &&
 			this.shadowRoot.querySelector(`.d2l-cell[data-cell-num="${this._cellNum}"]`);
+	}
+
+	_isContainedInList(node1, node2) {
+		const list = findComposedAncestor(node1, node => node.tagName === 'D2L-LIST');
+		return isComposedAncestor(list, node2);
 	}
 
 	_onKeydown(event) {

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -283,7 +283,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 	_focusNextRow(previous = false, num = 1) {
 
-		let listItem = findComposedAncestor(this, node => node.role === 'rowgroup');
+		const curListItem = findComposedAncestor(this, node => node.role === 'rowgroup');
+		let listItem = curListItem;
 
 		while (num > 0) {
 			const tempListItem = (previous ? this._getPreviousFlattenedListItem(listItem) : this._getNextFlattenedListItem(listItem));
@@ -301,7 +302,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			if (!listItem._tryFocus()) {
 				// ultimate fallback to generic method for getting next/previous focusable
 				const nextFocusable = previous ? getPreviousFocusable(listItem) : getNextFocusable(listItem);
-				if (nextFocusable && this._isContainedInList(listItem, nextFocusable)) {
+				if (nextFocusable && this._isContainedInSameList(curListItem, nextFocusable)) {
 					nextFocusable.focus();
 				}
 			}
@@ -444,14 +445,13 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			this.shadowRoot.querySelector(`.d2l-cell[data-cell-num="${this._cellNum}"]`);
 	}
 
-	_isContainedInList(node1, node2) {
-		const list = findComposedAncestor(node1, node => node.tagName === 'D2L-LIST');
-		return isComposedAncestor(list, node2);
+	_isContainedInSameList(item, node) {
+		const rootList = item?.getRootList?.(item);
+		return isComposedAncestor(rootList, node);
 	}
 
 	_onKeydown(event) {
 		if (!this.gridActive) return;
-
 		let node = null;
 		let preventDefault = true;
 		switch (event.keyCode) {

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -439,6 +439,16 @@ export const ListItemMixin = superclass => class extends composeMixins(
 		this._tryFocus();
 	}
 
+	getRootList(node) {
+		if (!node) node = this;
+		let rootList;
+		while (node) {
+			if (node.tagName === 'D2L-LIST') rootList = node;
+			node = getComposedParent(node);
+		}
+		return rootList;
+	}
+
 	async highlight() {
 		if (this._highlight) return;
 		const elem = this.shadowRoot.querySelector('[slot="outside-control-container"]');
@@ -486,7 +496,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 
 	_getListItems(listItems, lazyLoadListItems, listItem) {
 		if (!listItem) {
-			const rootList = this._getRootList();
+			const rootList = this.getRootList();
 			const rootListItems = rootList.getItems();
 			rootListItems.forEach(listItem => this._getListItems(listItems, lazyLoadListItems, listItem));
 		} else {
@@ -541,16 +551,6 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			if (this._isListItem(previousElement)) return previousElement;
 			previousElement = previousElement.previousElementSibling;
 		}
-	}
-
-	_getRootList(node) {
-		if (!node) node = this;
-		let rootList;
-		while (node) {
-			if (node.tagName === 'D2L-LIST') rootList = node;
-			node = getComposedParent(node);
-		}
-		return rootList;
 	}
 
 	_isListItem(node) {

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -11,6 +11,15 @@ const keyCodes = Object.freeze({
 	DOWN: { name: 'down arrow', key: 40 }
 });
 
+const awaitListElementUpdates = async(rootElement, queries) => {
+	await rootElement.updateComplete;
+	for (const query of queries) {
+		const element = rootElement.querySelector(query);
+		await element.updateComplete;
+	}
+	await new Promise(resolve => requestAnimationFrame(resolve));  // US143322: Needed by Firefox
+};
+
 const selectionInputRendering = async item => {
 	return new Promise(resolve => {
 		const intervalId = setInterval(() => {
@@ -64,16 +73,16 @@ describe('d2l-list', () => {
 						</d2l-list>
 					</div>
 				`);
-				await elem.updateComplete;
-				await elem.querySelector('#L1').updateComplete;
-				await elem.querySelector('#L2').updateComplete;
-				await elem.querySelector('#L3').updateComplete;
-				await elem.querySelector('[key="L1-1"]').updateComplete;
-				await elem.querySelector('[key="L2-1"]').updateComplete;
-				await elem.querySelector('[key="L2-2"]').updateComplete;
-				await elem.querySelector('[key="L2-3"]').updateComplete;
-				await elem.querySelector('[key="L3-1"]').updateComplete;
-				await new Promise(resolve => requestAnimationFrame(resolve));  // US143322: Needed by Firefox
+				await awaitListElementUpdates(elem, [
+					'#L1',
+					'#L2',
+					'#L3',
+					'[key="L1-1"]',
+					'[key="L2-1"]',
+					'[key="L2-2"]',
+					'[key="L2-3"]',
+					'[key="L3-1"]',
+				]);
 
 				const listItem = elem.querySelector('[key="L2-2"]');
 				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
@@ -106,15 +115,15 @@ describe('d2l-list', () => {
 						</d2l-list-item>
 					</d2l-list>	
 				`);
-				await elem.updateComplete;
-				await elem.querySelector('#L2').updateComplete;
-				await elem.querySelector('#L3').updateComplete;
-				await elem.querySelector('[key="L1-1"]').updateComplete;
-				await elem.querySelector('[key="L2-1"]').updateComplete;
-				await elem.querySelector('[key="L2-2"]').updateComplete;
-				await elem.querySelector('[key="L3-1"]').updateComplete;
-				await elem.querySelector('[key="L3-2"]').updateComplete;
-				await new Promise(resolve => requestAnimationFrame(resolve));  // US143322: Needed by Firefox
+				await awaitListElementUpdates(elem, [
+					'#L2',
+					'#L3',
+					'[key="L1-1"]',
+					'[key="L2-1"]',
+					'[key="L2-2"]',
+					'[key="L3-1"]',
+					'[key="L3-2"]',
+				]);
 
 				const listItem = elem.querySelector('[key="L2-2"]');
 				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
@@ -139,10 +148,10 @@ describe('d2l-list', () => {
 					<d2l-list-item selectable key="L1-2" label="L1-2"></d2l-list-item>
 				</d2l-list>
 			`);
-			await elem.updateComplete;
-			await elem.querySelector('[key="L1-1"]').updateComplete;
-			await elem.querySelector('[key="L1-2"]').updateComplete;
-			await new Promise(resolve => requestAnimationFrame(resolve));  // US143322: Needed by Firefox
+			await awaitListElementUpdates(elem, [
+				'[key="L1-1"]',
+				'[key="L1-2"]',
+			]);
 		});
 
 		it('dispatches d2l-list-selection-changes event when selectable item is clicked', async() => {
@@ -186,12 +195,12 @@ describe('d2l-list', () => {
 					</d2l-list-item>
 				</d2l-list>
 			`);
-			await elem.updateComplete;
-			await elem.querySelector('[key="L1-1"]').updateComplete;
-			await elem.querySelector('[slot="nested"]').updateComplete;
-			await elem.querySelector('[key="L2-1"]').updateComplete;
-			await elem.querySelector('[key="L2-2"]').updateComplete;
-			await new Promise(resolve => requestAnimationFrame(resolve)); // US143322: Needed by Firefox
+			await awaitListElementUpdates(elem, [
+				'[key="L1-1"]',
+				'[slot="nested"]',
+				'[key="L2-1"]',
+				'[key="L2-2"]',
+			]);
 		});
 
 		it('dispatches d2l-list-selection-changes event when selectable leaf item is clicked', async() => {

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -7,8 +7,8 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const keyCodes = Object.freeze({
-	UP: { name: 'up arrow', key: 'ArrowUp' },
-	DOWN: { name: 'down arrow', cokeyde: 'ArrowDown' }
+	UP: { name: 'up arrow', key: 38 },
+	DOWN: { name: 'down arrow', key: 40 }
 });
 
 const selectionInputRendering = async item => {
@@ -50,20 +50,20 @@ describe('d2l-list', () => {
 		].forEach(testCase => {
 			it(`Focus stays inside the list when in grid mode after ${testCase.keyPress.name} is pressed`, async() => {
 				const elem = await fixture(html`
-				<div>
-					<d2l-list id="L1">
-						<d2l-list-item selectable key="L1-1" label="L1-1"></d2l-list-item>
-					</d2l-list>
-					<d2l-list id="L2" grid>
-						<d2l-list-item key="L2-1" label="L2-1"></d2l-list-item>
-						<d2l-list-item selectable key="L2-2" label="L2-2"></d2l-list-item>
-						<d2l-list-item key="L2-3" label="L2-3"></d2l-list-item>
-					</d2l-list>
-					<d2l-list id="L3">
-						<d2l-list-item selectable key="L3-1" label="L3-1"></d2l-list-item>
-					</d2l-list>
-				</div>
-			`);
+					<div>
+						<d2l-list id="L1">
+							<d2l-list-item selectable key="L1-1" label="L1-1"></d2l-list-item>
+						</d2l-list>
+						<d2l-list id="L2" grid>
+							<d2l-list-item key="L2-1" label="L2-1"></d2l-list-item>
+							<d2l-list-item selectable key="L2-2" label="L2-2"></d2l-list-item>
+							<d2l-list-item key="L2-3" label="L2-3"></d2l-list-item>
+						</d2l-list>
+						<d2l-list id="L3">
+							<d2l-list-item selectable key="L3-1" label="L3-1"></d2l-list-item>
+						</d2l-list>
+					</div>
+				`);
 				await elem.updateComplete;
 				await elem.querySelector('#L1').updateComplete;
 				await elem.querySelector('#L2').updateComplete;
@@ -78,14 +78,55 @@ describe('d2l-list', () => {
 				const listItem = elem.querySelector('[key="L2-2"]');
 				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
 				listItem.focus();
-
-				const event = new KeyboardEvent('keydown', { key: testCase.keyPress.key });
+				const event = new KeyboardEvent('keydown', { keyCode: testCase.keyPress.key });
 				setTimeout(() => listItemLayout.dispatchEvent(event));
 				await oneEvent(listItemLayout, 'keydown');
+
 				expect(listItem.hasAttribute('_focusing')).to.be.true;
 			});
 		});
 
+		[
+			{ keyPress: keyCodes.UP, expectedFocus: 'L1-1' },
+			{ keyPress: keyCodes.DOWN, expectedFocus: 'L3-2' }
+		].forEach(testCase => {
+			it(`Focus navigates to other nested list items when in grid mode after ${testCase.keyPress.name} is pressed`, async() => {
+				const elem = await fixture(html`
+					<d2l-list id="L1" grid>
+						<d2l-list-item selectable key="L1-1">
+							<d2l-list id="L2" slot="nested" grid>
+								<d2l-list-item key="L2-1"></d2l-list-item>
+								<d2l-list-item selectable key="L2-2">
+									<d2l-list id="L3" slot="nested" grid>
+										<d2l-list-item key="L3-1"></d2l-list-item>
+										<d2l-list-item selectable key="L3-2"></d2l-list-item>
+									</d2l-list>
+								</d2l-list-item>
+							</d2l-list>
+						</d2l-list-item>
+					</d2l-list>	
+				`);
+				await elem.updateComplete;
+				await elem.querySelector('#L2').updateComplete;
+				await elem.querySelector('#L3').updateComplete;
+				await elem.querySelector('[key="L1-1"]').updateComplete;
+				await elem.querySelector('[key="L2-1"]').updateComplete;
+				await elem.querySelector('[key="L2-2"]').updateComplete;
+				await elem.querySelector('[key="L3-1"]').updateComplete;
+				await elem.querySelector('[key="L3-2"]').updateComplete;
+				await new Promise(resolve => requestAnimationFrame(resolve));  // US143322: Needed by Firefox
+
+				const listItem = elem.querySelector('[key="L2-2"]');
+				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
+				listItem.focus();
+				const event = new KeyboardEvent('keydown', { keyCode: testCase.keyPress.key });
+				setTimeout(() => listItemLayout.dispatchEvent(event));
+				await oneEvent(listItemLayout, 'keydown');
+
+				const focusedElement = elem.querySelector(`[key=${testCase.expectedFocus}`);
+				expect(focusedElement.hasAttribute('_focusing')).to.be.true;
+			});
+		});
 	});
 
 	describe('flat', () => {

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -6,6 +6,11 @@ import '../list-item-content.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
+const keyCodes = Object.freeze({
+	UP: { name: 'up arrow', key: 'ArrowUp' },
+	DOWN: { name: 'down arrow', cokeyde: 'ArrowDown' }
+});
+
 const selectionInputRendering = async item => {
 	return new Promise(resolve => {
 		const intervalId = setInterval(() => {
@@ -33,6 +38,52 @@ describe('d2l-list', () => {
 
 		it('should construct list', () => {
 			runConstructor('d2l-list');
+		});
+
+	});
+
+	describe('navigation', () => {
+
+		[
+			{ keyPress: keyCodes.UP },
+			{ keyPress: keyCodes.DOWN }
+		].forEach(testCase => {
+			it(`Focus stays inside the list when in grid mode after ${testCase.keyPress.name} is pressed`, async() => {
+				const elem = await fixture(html`
+				<div>
+					<d2l-list id="L1">
+						<d2l-list-item selectable key="L1-1" label="L1-1"></d2l-list-item>
+					</d2l-list>
+					<d2l-list id="L2" grid>
+						<d2l-list-item key="L2-1" label="L2-1"></d2l-list-item>
+						<d2l-list-item selectable key="L2-2" label="L2-2"></d2l-list-item>
+						<d2l-list-item key="L2-3" label="L2-3"></d2l-list-item>
+					</d2l-list>
+					<d2l-list id="L3">
+						<d2l-list-item selectable key="L3-1" label="L3-1"></d2l-list-item>
+					</d2l-list>
+				</div>
+			`);
+				await elem.updateComplete;
+				await elem.querySelector('#L1').updateComplete;
+				await elem.querySelector('#L2').updateComplete;
+				await elem.querySelector('#L3').updateComplete;
+				await elem.querySelector('[key="L1-1"]').updateComplete;
+				await elem.querySelector('[key="L2-1"]').updateComplete;
+				await elem.querySelector('[key="L2-2"]').updateComplete;
+				await elem.querySelector('[key="L2-3"]').updateComplete;
+				await elem.querySelector('[key="L3-1"]').updateComplete;
+				await new Promise(resolve => requestAnimationFrame(resolve));  // US143322: Needed by Firefox
+
+				const listItem = elem.querySelector('[key="L2-2"]');
+				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
+				listItem.focus();
+
+				const event = new KeyboardEvent('keydown', { key: testCase.keyPress.key });
+				setTimeout(() => listItemLayout.dispatchEvent(event));
+				await oneEvent(listItemLayout, 'keydown');
+				expect(listItem.hasAttribute('_focusing')).to.be.true;
+			});
 		});
 
 	});


### PR DESCRIPTION
[DE53222](https://rally1.rallydev.com/#/?detail=/defect/699633940503&fdp=true)

When navigating a list with arrow keys, the list item will try to focus on the next/previous list item sibling. If that list item is not focusable, it will skip the list item and focus the next focusable element.

The list does not check that the next focusable belongs to the same list. If that non-focusable element is at the start or end of the list, you are able to arrow outside of the list and not able to get back into it.

This PR adds a check to confirm that the next focusable element belongs to the same list as the currently focused element.