### PR TITLE
feat: Update documentation

### DIFF
--- a/components/collapsible-panel/README.md
+++ b/components/collapsible-panel/README.md
@@ -115,6 +115,7 @@ The `d2l-collapsible-panel` element is a container that provides specific layout
 
 | Slot | Type | Description |
 |--|--|--|
+| `before` | optional | Slot for content to be placed at the left side of the header, aligned with the title and header slot |
 | `header` | optional | Supporting header content |
 | `actions` | optional | Buttons and dropdown openers to be placed in top right corner of header |
 | `summary` | optional | Summary of the expanded content. Only accepts `d2l-collapsible-panel-summary-item` |
@@ -132,6 +133,7 @@ The `d2l-collapsible-panel` element is a container that provides specific layout
 | `no-sticky` | Boolean | Disables sticky positioning for the header |
 | `padding-type` | String | Optionally set horizontal padding of inline panels |
 | `panel-title` | String | The title of the panel |
+| `skeleton` | Boolean | Renders the panel title and the expand/collapse icon as skeleton loaders |
 | `type` | String | The type of collapsible panel |
 <!-- docs: end hidden content -->
 

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -20,8 +20,8 @@ const defaultHeading = 3;
 
 /**
  * A container with a title that can be expanded/collapsed to show/hide content.
- * @slot header - Slot for supporting header content
  * @slot before - Slot for content to be placed at the left side of the header, aligned with the title and header slot
+ * @slot header - Slot for supporting header content
  * @slot summary - Slot for the summary of the expanded content. Only accepts `d2l-collapsible-panel-summary-item`
  * @slot default - Slot for the expanded content
  * @slot actions - Slot for buttons and dropdown openers to be placed in top right corner of header


### PR DESCRIPTION
Update documentation to include the new `before` slot and the `skeleton` property.