### PR TITLE
Selected-first double list for filter-dimension-set

### DIFF
--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -195,6 +195,7 @@ The `d2l-filter-dimension-set` component is the main dimension type that will wo
 | `loading` | Boolean | Whether the values for this dimension are still loading and a loading spinner should be displayed |
 | `search-type` | String, default: `automatic` | `automatic` provides basic case-insensitive text comparison searching, `none` disables the search input, and `manual` fires an event for the consumer to handle the search and pass the keys of the values to be displayed |
 | `select-all` | Boolean | Whether to show a select all checkbox and selection summary for this dimension  |
+| `selected-first` | Boolean | Whether to render the selected items at the top of the filter  |
 | `selection-single` | Boolean | Whether only one value can be selected at a time for this dimension  |
 | `text` | String, required | Text for the dimension in the menu |
 | `value-only-active-filter-text` | Boolean | Whether to hide the dimension in the text sent to active filter subscribers |

--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -189,6 +189,7 @@ The `d2l-filter-dimension-set` component is the main dimension type that will wo
 
 | Property | Type | Description |
 |---|---|---|
+| `header-text` | String | The header text to display as the list header |
 | `introductory-text` | String | The introductory text to display at the top of the filter dropdown |
 | `key` | String, required | Unique identifier for the dimension |
 | `loading` | Boolean | Whether the values for this dimension are still loading and a loading spinner should be displayed |

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -24,7 +24,7 @@
 		<d2l-demo-snippet>
 			<template>
 				<d2l-filter id="filter-single">
-					<d2l-filter-dimension-set key="course" introductory-text="Filter content by courses. Start typing any course name to explore." text="Course" select-all>
+					<d2l-filter-dimension-set key="course" introductory-text="Filter content by courses. Start typing any course name to explore." header-text="Skills Promoted at Your Company" text="Course" select-all>
 						<d2l-filter-dimension-set-value key="art" text="Art" count="12"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="astronomy" text="Astronomy" count="2" selected></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="biology" text="Biology" count="15"></d2l-filter-dimension-set-value>
@@ -61,7 +61,7 @@
 		<d2l-demo-snippet>
 			<template>
 				<d2l-filter>
-					<d2l-filter-dimension-set key="course" introductory-text="Filter content by courses. Start typing any course name to explore." text="Course" select-all>
+					<d2l-filter-dimension-set key="course" introductory-text="Filter content by courses. Start typing any course name to explore." header-text="Skills Promoted at Your Company" text="Course" select-all>
 						<d2l-filter-dimension-set-value key="art" text="Art" count="0"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="astronomy" text="Astronomy" count="1" selected></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="biology" text="Biology" count="-12"></d2l-filter-dimension-set-value>

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -12,6 +12,11 @@ class FilterDimensionSet extends LitElement {
 	static get properties() {
 		return {
 			/**
+			 * The header text to display as the list header
+			 * @type {string}
+			 */
+			headerText: { type: String, attribute: 'header-text' },
+			/**
 			 * The introductory text to display at the top of the filter dropdown
 			 * @type {string}
 			 */
@@ -56,6 +61,7 @@ class FilterDimensionSet extends LitElement {
 
 	constructor() {
 		super();
+		this.headerText = '';
 		this.introductoryText = '';
 		this.loading = false;
 		this.searchType = 'automatic';

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -42,6 +42,11 @@ class FilterDimensionSet extends LitElement {
 			 */
 			selectAll: { type: Boolean, attribute: 'select-all' },
 			/**
+			 * Whether to render the selected items at the top of the filter
+			 * @type {boolean}
+			 */
+			selectedFirst: { type: Boolean, attribute: 'selected-first' },
+			/**
 			 * Whether only one value can be selected at a time for this dimension
 			 * @type {boolean}
 			 */
@@ -66,6 +71,7 @@ class FilterDimensionSet extends LitElement {
 		this.loading = false;
 		this.searchType = 'automatic';
 		this.selectAll = false;
+		this.selectedFirst = false;
 		this.selectionSingle = false;
 		this.text = '';
 		this.valueOnlyActiveFilterText = false;

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -12,6 +12,11 @@ class FilterDimensionSet extends LitElement {
 	static get properties() {
 		return {
 			/**
+			 * The introductory text to display at the top of the filter dropdown
+			 * @type {string}
+			 */
+			introductoryText: { type: String, attribute: 'introductory-text' },
+			/**
 			 * REQUIRED: Unique key to represent this dimension in the filter
 			 * @type {string}
 			 */
@@ -36,11 +41,6 @@ class FilterDimensionSet extends LitElement {
 			 * @type {boolean}
 			 */
 			selectionSingle: { type: Boolean, attribute: 'selection-single' },
-			/**
-			 * The introductory text to display at the top of the filter dropdown
-			 * @type {string}
-			 */
-			introductoryText: { type: String, attribute: 'introductory-text' },
 			/**
 			 * REQUIRED: The text that is displayed for the dimension title
 			 * @type {string}

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -126,6 +126,7 @@ class FilterDimensionSet extends LitElement {
 				disabled: value.disabled,
 				key: value.key,
 				selected: value.selected,
+				selectedOnOpen: false,
 				text: value.text
 			};
 		});

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -18,7 +18,7 @@ import '../menu/menu-item.js';
 import '../selection/selection-select-all.js';
 import '../selection/selection-summary.js';
 
-import { bodyCompactStyles, bodySmallStyles, bodyStandardStyles } from '../typography/styles.js';
+import { bodyCompactStyles, bodySmallStyles, bodyStandardStyles, heading4Styles } from '../typography/styles.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { announce } from '../../helpers/announce.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -69,7 +69,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 	}
 
 	static get styles() {
-		return [bodyCompactStyles, bodySmallStyles, bodyStandardStyles, offscreenStyles, css`
+		return [bodyCompactStyles, bodySmallStyles, bodyStandardStyles, heading4Styles, offscreenStyles, css`
 			[slot="header"] {
 				padding: 0.9rem 0.3rem;
 			}
@@ -162,6 +162,11 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 			.d2l-empty-state-container {
 				padding: 0.9rem;
+			}
+
+			.list-header-text {
+				color: var(--d2l-color-ferrite);
+				margin: 0;
 			}
 
 			.d2l-filter-dimension-info-message {
@@ -487,6 +492,15 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 			if (count === 0) return searchResults;
 		}
 
+		let listHeader = nothing;
+		if (dimension.headerText && dimension.searchValue === '') {
+			listHeader = html`
+				<d2l-list-item>
+					<h4 class="d2l-heading-4 list-header-text">${dimension.headerText}</h4>
+				</d2l-list-item>
+			`;
+		}
+
 		return html`
 			${searchResults}
 			<d2l-list
@@ -496,6 +510,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				grid
 				?selection-single="${dimension.selectionSingle}"
 				separators="between">
+				${listHeader}
 				${dimension.values.map(item => html`
 					<d2l-list-item
 						?selection-disabled="${item.disabled}"
@@ -736,8 +751,10 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 			switch (type) {
 				case 'd2l-filter-dimension-set': {
+					info.headerText = dimension.headerText;
 					info.introductoryText = dimension.introductoryText;
 					info.searchType = dimension.searchType;
+					info.searchValue = '';
 					info.selectionSingle = dimension.selectionSingle;
 					if (dimension.selectAll && !dimension.selectionSingle) info.selectAllIdPrefix = SET_DIMENSION_ID_PREFIX;
 					info.searchEmptyState = dimension.getSearchEmptyState();

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -166,7 +166,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 
 			.list-header-text {
 				color: var(--d2l-color-ferrite);
-				margin: 0;
+				margin: 0.55rem 0.9rem;
 			}
 
 			.d2l-filter-dimension-info-message {
@@ -495,16 +495,14 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		let listHeader = nothing;
 		if (dimension.headerText && dimension.searchValue === '') {
 			listHeader = html`
-				<d2l-list-item>
-					<h4 class="d2l-heading-4 list-header-text">${dimension.headerText}</h4>
-				</d2l-list-item>
+				<h4 class="d2l-heading-4 list-header-text">${dimension.headerText}</h4>
 			`;
 		}
 
 		return html`
 			${searchResults}
 			<d2l-list
-				id="${SET_DIMENSION_ID_PREFIX}${dimension.key}"
+				id="${SET_DIMENSION_ID_PREFIX}${dimension.key}-selected"
 				@d2l-list-selection-change="${this._handleChangeSetDimension}"
 				extend-separators
 				grid
@@ -524,7 +522,15 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 						</div>
 					</d2l-list-item>
 				`)}
-				${listHeader}
+			</d2l-list>
+			${listHeader}
+			<d2l-list
+				id="${SET_DIMENSION_ID_PREFIX}${dimension.key}"
+				@d2l-list-selection-change="${this._handleChangeSetDimension}"
+				extend-separators
+				grid
+				?selection-single="${dimension.selectionSingle}"
+				separators="between">
 				${dimension.values.filter(item => !item.selectedOnOpen).map(item => html`
 					<d2l-list-item
 						?selection-disabled="${item.disabled}"

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -510,8 +510,22 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				grid
 				?selection-single="${dimension.selectionSingle}"
 				separators="between">
+				${dimension.values.filter(item => item.selectedOnOpen).map(item => html`
+					<d2l-list-item
+						?selection-disabled="${item.disabled}"
+						?hidden="${item.hidden}"
+						key="${item.key}"
+						label="${item.text}"
+						selectable
+						?selected="${item.selected}">
+						<div class="d2l-filter-dimension-set-value d2l-body-compact">
+							<div class="d2l-filter-dimension-set-value-text">${item.text}</div>
+							${item.count !== undefined ? html`<div class="d2l-body-small">(${formatNumber(item.count)})</div>` : nothing}
+						</div>
+					</d2l-list-item>
+				`)}
 				${listHeader}
-				${dimension.values.map(item => html`
+				${dimension.values.filter(item => !item.selectedOnOpen).map(item => html`
 					<d2l-list-item
 						?selection-disabled="${item.disabled}"
 						?hidden="${item.hidden}"
@@ -692,6 +706,11 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 	}
 
 	_handleDropdownOpen(e) {
+		for (const dimension of this._dimensions) {
+			for (const value of dimension.values) {
+				if (value.selected) value.selectedOnOpen = true;
+			}
+		}
 		this.opened = true;
 		if (this._dimensions.length === 1) {
 			this._dispatchDimensionFirstOpenEvent(this._dimensions[0].key);

--- a/components/filter/test/filter.axe.js
+++ b/components/filter/test/filter.axe.js
@@ -5,7 +5,7 @@ import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 
 const singleSetDimensionFixture = html`
 	<d2l-filter>
-		<d2l-filter-dimension-set key="dim" introductory-text="Intro" text="Dim" select-all>
+		<d2l-filter-dimension-set key="dim" introductory-text="Intro" header-text="Header" text="Dim" select-all>
 			<d2l-filter-dimension-set-value key="value-1" text="Value 1"></d2l-filter-dimension-set-value>
 			<d2l-filter-dimension-set-value key="value-2" text="Value 2" selected></d2l-filter-dimension-set-value>
 		</d2l-filter-dimension-set>
@@ -22,7 +22,7 @@ const multiDimensionFixture = html`
 		<d2l-filter-dimension-set key="1" introductory-text="Intro" text="Dim 1" select-all>
 			<d2l-filter-dimension-set-value key="1" text="Value 1"></d2l-filter-dimension-set-value>
 		</d2l-filter-dimension-set>
-		<d2l-filter-dimension-set key="2" text="Dim 2" select-all>
+		<d2l-filter-dimension-set key="2" header-text="Header" text="Dim 2" select-all>
 			<d2l-filter-dimension-set-value key="1" text="Value 1"></d2l-filter-dimension-set-value>
 		</d2l-filter-dimension-set>
 	</d2l-filter>`;

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -168,35 +168,6 @@ describe('d2l-filter', () => {
 		});
 	});
 
-	describe('introductory-text', () => {
-		it('sets introductory text on a single dimension', async() => {
-			const elem = await fixture('<d2l-filter><d2l-filter-dimension-set introductory-text="Intro" key="dim"></d2l-filter-dimension-set></d2l-filter>');
-			expect(elem._dimensions[0].introductoryText).to.equal('Intro');
-			const introText = elem.shadowRoot.querySelector('.d2l-filter-dimension-intro-text');
-			expect(introText.classList.contains('multi-dimension')).to.be.false;
-			expect(introText.textContent).to.equal('Intro');
-		});
-
-		it('sets introductory text on a dimension in a multi-dimensional filter', async() => {
-			const elem = await fixture('<d2l-filter><d2l-filter-dimension-set introductory-text="Intro" key="dim"></d2l-filter-dimension-set><d2l-filter-dimension-set introductory-text="intro" key="dim"></d2l-filter-dimension-set></d2l-filter>');
-			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
-			const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
-			await dropdownContent.updateComplete;
-			const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
-
-			elem.opened = true;
-			await oneEvent(dropdown, 'd2l-dropdown-open');
-
-			setTimeout(() => dimension.click());
-			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
-
-			expect(elem._dimensions[0].introductoryText).to.equal('Intro');
-			const introText = elem.shadowRoot.querySelector('.d2l-filter-dimension-intro-text');
-			expect(introText.classList.contains('multi-dimension')).to.be.true;
-			expect(introText.textContent).to.equal('Intro');
-		});
-	});
-
 	describe('clearing', () => {
 		it('set dimension', async() => {
 			const elem = await fixture(singleSetDimensionFixture);

--- a/components/filter/test/filter.visual-diff.html
+++ b/components/filter/test/filter.visual-diff.html
@@ -135,6 +135,16 @@
 				</d2l-filter>
 			</div>
 			<div class="visual-diff">
+				<d2l-filter id="single-set-header-text">
+					<d2l-filter-dimension-set key="course" header-text="Seasons" text="Seasons" selection-single>
+						<d2l-filter-dimension-set-value key="fall" text="Fall"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="winter" text="Winter" disabled></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="spring" text="Spring"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="summer" text="Summer"></d2l-filter-dimension-set-value>
+					</d2l-filter-dimension-set>
+				</d2l-filter>
+			</div>
+			<div class="visual-diff">
 				<d2l-filter id="single-set-press-clear">
 					<d2l-filter-dimension-set key="course" text="Course" select-all>
 						<d2l-filter-dimension-set-value key="art" text="Art" selected></d2l-filter-dimension-set-value>
@@ -170,7 +180,7 @@
 			</div>
 			<div class="visual-diff">
 				<d2l-filter id="multiple-selected">
-					<d2l-filter-dimension-set key="course" text="Course" select-all>
+					<d2l-filter-dimension-set key="course" header-text="Related Courses" text="Course" select-all>
 						<d2l-filter-dimension-set-value key="art" text="Art"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="astronomy" text="Astronomy" selected></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-value key="biology" text="Biology" disabled></d2l-filter-dimension-set-value>

--- a/components/filter/test/filter.visual-diff.js
+++ b/components/filter/test/filter.visual-diff.js
@@ -259,6 +259,7 @@ describe('d2l-filter', () => {
 
 			[
 				'introductory-text',
+				'header-text',
 				'single-selection-select-all',
 				'multi-selection-no-search',
 				'multi-selection-no-search-select-all',
@@ -320,6 +321,7 @@ describe('d2l-filter', () => {
 
 			[
 				'single-set-introductory-text',
+				'single-set-header-text',
 				'single-set-single-selection-select-all',
 				'single-set-multi-selection-no-search',
 				'single-set-multi-selection-no-search-select-all',


### PR DESCRIPTION
This PR shows how selected-first would look as two lists.

**For Testing**
On the filter test page, the single set dimension demo and the multiple dimension demo in the course dimension are using the new `selected-first` property