### PR TITLE
Select a tab that's not being removed when the selected tab is being removed.

### DIFF
--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -24,6 +24,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-tabs>
+						<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
 						<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 						<d2l-tab-panel text="Earth &amp; Planetary Sciences">Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
@@ -39,6 +40,7 @@
 				<d2l-button-subtle id="add" text="Add"></d2l-button-subtle>
 				<d2l-button-subtle id="add-selected" text="Add Selected"></d2l-button-subtle>
 				<d2l-button-subtle id="remove" text="Remove"></d2l-button-subtle>
+				<d2l-button-subtle id="remove-multiple" text="Remove Multiple"></d2l-button-subtle>
 			</div>
 			<script>
 				let newPanelId = 0;
@@ -58,10 +60,20 @@
 					if (panels.length === 1) tabs.removeChild(panels[0]);
 					else tabs.removeChild(panels[1]);
 				};
+				const removePanels = (tabs) => {
+					const panels = [...tabs.querySelectorAll('d2l-tab-panel')];
+					if (panels.length === 0) return;
+					if (panels.length === 1) tabs.removeChild(panels[0]);
+					else {
+						tabs.removeChild(panels[1]);
+						tabs.removeChild(panels[0]);
+					}
+				};
 
 				document.querySelector('#add').addEventListener('click', () => addPanel(false, document.querySelector('#withSlot').querySelector('d2l-tabs')));
 				document.querySelector('#add-selected').addEventListener('click', () => addPanel(true, document.querySelector('#withSlot').querySelector('d2l-tabs')));
 				document.querySelector('#remove').addEventListener('click', () => removePanel(document.querySelector('#withSlot').querySelector('d2l-tabs')));
+				document.querySelector('#remove-multiple').addEventListener('click', () => removePanels(document.querySelector('#withSlot').querySelector('d2l-tabs')));
 			</script>
 
 			<d2l-demo-snippet id="withSlot">

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -611,6 +611,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(RtlMixin(Lit
 				// if a tab was removed, include old info to animate it away
 				if (newTabInfos.findIndex(newInfo => newInfo.id === info.id) === -1) {
 					info.state = 'removing';
+					info.selected = false;
 					newTabInfos.splice(index, 0, info);
 				}
 			});
@@ -618,9 +619,11 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(RtlMixin(Lit
 		this._tabInfos = newTabInfos;
 
 		if (this._tabInfos.length > 0 && !selectedTabInfo) {
-			this._tabInfos[0].activeFocusable = true;
-			this._tabInfos[0].selected = true;
-			selectedTabInfo = this._tabInfos[0];
+			selectedTabInfo = this._tabInfos.find(tabInfo => tabInfo.state !== 'removing');
+			if (selectedTabInfo) {
+				selectedTabInfo.activeFocusable = true
+				selectedTabInfo.selected = true;
+			}
 		}
 
 		await this.updateComplete;


### PR DESCRIPTION
[DE53323](https://rally1.rallydev.com/#/?detail=/defect/700345601951&fdp=true)

This PR updates `d2l-tabs` to avoid a JavaScript error when removing selected tabs. Previously, the `d2l-tabs` was assuming the first tab could be safely selected, which is obviously not a safe assumption.

Error:
```
Uncaught (in promise) TypeError: Cannot set properties of undefined (setting 'selected')
    at Tabs._handleTabSelected (tabs.js:766:26)
```
