### PR TITLE
fix: handle ENTER key to toggle switch

### DIFF
--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -234,13 +234,13 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 	}
 
 	_handleKeyDown(e) {
-		// space pressed... prevent default browser scroll
-		if (e.keyCode === 32) e.preventDefault();
+		// enter/space pressed... prevent default browser scroll
+		if (e.keyCode === 13 || e.keyCode === 32) e.preventDefault();
 	}
 
 	_handleKeyUp(e) {
-		// space pressed... toggle state
-		if (e.keyCode === 32) this._toggleState();
+		// enter/space pressed... toggle state
+		if (e.keyCode === 13 || e.keyCode === 32) this._toggleState();
 	}
 
 	_handleSwitchHover() {

--- a/components/switch/test/switch.test.js
+++ b/components/switch/test/switch.test.js
@@ -2,6 +2,9 @@ import '../switch.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { sendKeys } from '@web/test-runner-commands';
+
+const switchFixture = html`<d2l-switch text="some text"></d2l-switch>`;
 
 describe('d2l-switch', () => {
 
@@ -10,7 +13,7 @@ describe('d2l-switch', () => {
 	});
 
 	it('dispatches change event', async() => {
-		const elem = await fixture(html`<d2l-switch text="some text"></d2l-switch>`);
+		const elem = await fixture(switchFixture);
 		const clickTarget = elem.shadowRoot.querySelector('.d2l-switch-container');
 		setTimeout(() => clickTarget.click());
 		const { target } = await oneEvent(elem, 'change');
@@ -18,7 +21,7 @@ describe('d2l-switch', () => {
 	});
 
 	it('renders focusable element if enabled', async() => {
-		const elem = await fixture(html`<d2l-switch text="some text"></d2l-switch>`);
+		const elem = await fixture(switchFixture);
 		expect(elem.shadowRoot.querySelector('[role="switch"]').getAttribute('tabindex')).to.equal('0');
 	});
 
@@ -28,11 +31,22 @@ describe('d2l-switch', () => {
 	});
 
 	it('delegates focus to underlying focusable', async() => {
-		const elem = await fixture(html`<d2l-switch text="some text"></d2l-switch>`);
+		const elem = await fixture(switchFixture);
 		setTimeout(() => elem.focus());
 		await oneEvent(elem, 'focus');
 		const activeElement = getComposedActiveElement();
 		expect(activeElement).to.equal(elem.shadowRoot.querySelector('[role="switch"]'));
+	});
+
+	['Space', 'Enter'].forEach((key) => {
+		it(`should toggle when ${key} is pressed`, async() => {
+			const elem = await fixture(switchFixture);
+			setTimeout(() => elem.focus());
+			await oneEvent(elem, 'focus');
+			setTimeout(() => sendKeys({ press: key }));
+			await oneEvent(elem, 'change');
+			expect(elem.on).to.be.true;
+		});
 	});
 
 });


### PR DESCRIPTION
Context from Jeff:
> We recently had a usability test participant complain that she needed to use the `space` key to activate a switch, and expected the `enter` key to work instead. Would it be problematic to allow both keys to work? [Mozilla](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role) specifies only the space key, but [the W3C](https://www.w3.org/WAI/ARIA/apg/patterns/switch/) lists the enter key as an optional additional way to activate a switch.
If it doesn’t present any additional issues, it would be nice to add support for the enter key.