### PR TITLE
Update ListItemCheckboxMixin so that Enter key does not toggle the checkbox.

### DIFF
--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -129,12 +129,6 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 		}
 	}
 
-	_onCheckboxKeyDown(e) {
-		// handle the enter key
-		if (e.keyCode !== 13) return;
-		this.setSelected(!this.selected);
-	}
-
 	_onMouseEnterSelection() {
 		this._hoveringSelection = !this.selectionDisabled;
 	}
@@ -161,7 +155,6 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 				id="${this._checkboxId}"
 				?_indeterminate="${this.selectionInfo.state === SelectionInfo.states.some}"
 				key="${this.key}"
-				@keydown="${this._onCheckboxKeyDown}"
 				label="${this.label}"
 				?selected="${this.selected}"
 				?skeleton="${this.skeleton}">

--- a/components/list/test/list-item-checkbox-mixin.test.js
+++ b/components/list/test/list-item-checkbox-mixin.test.js
@@ -88,7 +88,6 @@ describe('ListItemCheckboxMixin', () => {
 	});
 
 	describe('Dispatches custom event when action area is selected', () => {
-		const actions = [ 'click' ];
 		const cases = [{
 			input: 'selectable',
 			initial: { selectable: true, selectionDisabled: false, selected: false },
@@ -100,35 +99,22 @@ describe('ListItemCheckboxMixin', () => {
 		}];
 
 		for (const test of cases) {
-			for (const action of actions) {
-				it(`${test.input} ${action}`, async() => {
-					const element = await fixture(`<${tag} key="1234" ${test.input} label="some label"></${tag}>`);
-					Object.keys(test.initial).forEach(prop =>
-						expect(element[prop]).to.be.equal(test.initial[prop]));
-					// simulate an action area selection
-					setTimeout(() => {
-						let actionArea = null;
-						switch (action) {
-							case 'click':
-								actionArea = element.shadowRoot.querySelector('.d2l-checkbox-action');
-								actionArea.dispatchEvent(new Event('click'));
-								break;
-							case 'enter':
-								actionArea = element.shadowRoot.querySelector('d2l-selection-input');
-								actionArea.dispatchEvent(new KeyboardEvent('keydown', {
-									keyCode: 13 // Enter
-								}));
-								break;
-						}
-					});
-
-					const { detail } = await oneEvent(element, 'd2l-list-item-selected');
-					expect(detail.selected).to.equal(test.expected.selected);
-
-					Object.keys(test.expected).forEach(prop =>
-						expect(element[prop]).to.be.equal(test.expected[prop]));
+			it(`${test.input} click`, async() => {
+				const element = await fixture(`<${tag} key="1234" ${test.input} label="some label"></${tag}>`);
+				Object.keys(test.initial).forEach(prop =>
+					expect(element[prop]).to.be.equal(test.initial[prop]));
+				// simulate an action area selection
+				setTimeout(() => {
+					const actionArea = element.shadowRoot.querySelector('.d2l-checkbox-action');
+					actionArea.dispatchEvent(new Event('click'));
 				});
-			}
+
+				const { detail } = await oneEvent(element, 'd2l-list-item-selected');
+				expect(detail.selected).to.equal(test.expected.selected);
+
+				Object.keys(test.expected).forEach(prop =>
+					expect(element[prop]).to.be.equal(test.expected[prop]));
+			});
 		}
 	});
 

--- a/components/list/test/list-item-checkbox-mixin.test.js
+++ b/components/list/test/list-item-checkbox-mixin.test.js
@@ -88,7 +88,7 @@ describe('ListItemCheckboxMixin', () => {
 	});
 
 	describe('Dispatches custom event when action area is selected', () => {
-		const actions = [ 'click', 'enter' ];
+		const actions = [ 'click' ];
 		const cases = [{
 			input: 'selectable',
 			initial: { selectable: true, selectionDisabled: false, selected: false },


### PR DESCRIPTION
[DE53334](https://rally1.rallydev.com/#/?detail=/defect/700493301447&fdp=true)

This PR updates the list-item checkboxes so that `Enter` key does not toggle the checkbox. This is to make them behave the same as native checkboxes.