### PR TITLE
fix: avoid resetMouse bug by doing it ourselves

### DIFF
--- a/tools/web-test-runner-helpers.js
+++ b/tools/web-test-runner-helpers.js
@@ -1,4 +1,4 @@
-import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
 
 export const focusWithKeyboard = async(element) => {
 	await sendKeys({ press: 'Tab' });
@@ -8,5 +8,5 @@ export const focusWithKeyboard = async(element) => {
 export const focusWithMouse = async(element) => {
 	const { x, y } = element.getBoundingClientRect();
 	await sendMouse({ type: 'click', position: [Math.ceil(x), Math.ceil(y)] });
-	await resetMouse();
+	await sendMouse({ type: 'move', position: [0, 0] });
 };


### PR DESCRIPTION
This fixes the following error from occurring on our local machines when running the unit tests:
> Error while executing command reset-mouse: 'left' is not pressed.

The reason it doesn't happen in CI is because it's Puppeteer-specific and CI runs happen with Playwright.

`resetMouse` rather aggressively [just calls `mouse.up` on all 3 buttons](https://github.com/modernweb-dev/web/blob/master/packages/test-runner-commands/src/sendMousePlugin.ts#L170) regardless of whether they were pressed or not. That wasn't a problem until [Puppeteer recently decided to throw](https://github.com/puppeteer/puppeteer/pull/10021/files#r1184418245) if `up` is called on a non-down button.

This has been [raised as a defect](https://github.com/modernweb-dev/web/issues/2262) in `@web/test-runner-commands` and is awaiting triaging. Since in our case we specifically called `click` which sends the mouse down AND up commands on its own, we only need to reset the position.