### PR TITLE
reset scroll position between table visual diffs

### DIFF
--- a/components/table/test/table-test-sticky-visual-diff.js
+++ b/components/table/test/table-test-sticky-visual-diff.js
@@ -477,6 +477,108 @@ class TestTableStickyVisualDiff extends LitElement {
 					</table>
 				</d2l-table-wrapper>
 			</div>
+			<div class="d2l-visual-diff">
+				<d2l-table-wrapper type="${type}" sticky-headers id="grades-row-header">
+					<table class="d2l-table">
+						<thead>
+							<tr>
+								<th rowspan="2" class="top" sticky>Name</th>
+								<th colspan="5" style="z-index: 3">
+									Category
+									<span style="position: relative;">
+										&nbsp;&#8964;
+										<div style="background-color: blue; color: white; position: absolute; top: 20px; left: 0px; padding: 10px; width: 145px; height: 175px;">Dropdown simulator</div>
+									</span>
+								</th>
+							</tr>
+							<tr>
+								<th style="white-space: nowrap">Item 1</th>
+								<th style="white-space: nowrap">Item 2</th>
+								<th style="white-space: nowrap">Item 3</th>
+								<th style="white-space: nowrap">Item 4</th>
+								<th style="white-space: nowrap">Item 5</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th sticky style="white-space: nowrap">Albert, Eddie</th>
+								<td>5/10</td>
+								<td>9/10</td>
+								<td>3/5</td>
+								<td>9/10</td>
+								<td class="over">9/10</td>
+							</tr>
+							<tr>
+								<th sticky style="white-space: nowrap">Bedelia, Bonnie</th>
+								<td>3/10</td>
+								<td>7/10</td>
+								<td>5/5</td>
+								<td>7/10</td>
+								<td>7/10</td>
+							</tr>
+							<tr>
+								<th sticky style="white-space: nowrap">Benson, Robbie</th>
+								<td>8/10</td>
+								<td>6/10</td>
+								<td>1/5</td>
+								<td>6/10</td>
+								<td>6/10</td>
+							</tr>
+						</tbody>
+					</table>
+				</d2l-table-wrapper>
+			</div>
+			<div class="d2l-visual-diff">
+				<d2l-table-wrapper type="${type}" sticky-headers id="grades-column-header">
+					<table class="d2l-table">
+						<thead>
+							<tr>
+								<th rowspan="2" class="top" sticky>Name</th>
+								<th colspan="5">Category</th>
+							</tr>
+							<tr>
+								<th style="white-space: nowrap">Item 1</th>
+								<th style="white-space: nowrap">Item 2</th>
+								<th style="white-space: nowrap">Item 3</th>
+								<th style="white-space: nowrap">Item 4</th>
+								<th style="white-space: nowrap">Item 5</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th sticky style="white-space: nowrap; z-index: 2">
+									Albert, Eddie
+									<span style="position: relative;">
+										&nbsp;&#8964;
+										<div style="background-color: blue; color: white; position: absolute; top: 20px; left: 0px; padding: 10px; width: 145px; height: 175px;">Dropdown simulator</div>
+									</span>
+								</th>
+								<td>5/10</td>
+								<td>9/10</td>
+								<td>3/5</td>
+								<td>9/10</td>
+								<td class="over">9/10</td>
+							</tr>
+							<tr>
+								<th sticky style="white-space: nowrap">Bedelia, Bonnie</th>
+								<td>3/10</td>
+								<td>7/10</td>
+								<td>5/5</td>
+								<td>7/10</td>
+								<td>7/10</td>
+							</tr>
+							<tr>
+								<th sticky style="white-space: nowrap">Benson, Robbie</th>
+								<td>8/10</td>
+								<td>6/10</td>
+								<td>1/5</td>
+								<td>6/10</td>
+								<td>6/10</td>
+							</tr>
+						</tbody>
+					</table>
+				</d2l-table-wrapper>
+			</div>
 		`;
 	}
 

--- a/components/table/test/table.visual-diff.js
+++ b/components/table/test/table.visual-diff.js
@@ -55,6 +55,10 @@ describe('d2l-table', () => {
 
 	after(async() => await browser.close());
 
+	beforeEach(async() => {
+		await page.evaluate(() => window.scrollTo(0, 0));
+	});
+
 	['ltr', 'rtl'].forEach((dir) => {
 		describe(dir, () => {
 			['default', 'light'].forEach((type) => {
@@ -138,6 +142,21 @@ describe('d2l-table', () => {
 						].forEach((id) => {
 							['top', 'down', 'over'].forEach((position) => {
 								it(`${id}-${position}`, async function() {
+									await page.$eval('d2l-test-table-sticky-visual-diff', (wrapper, id, position) => {
+										wrapper.shadowRoot.querySelector(`#${id} .${position}`).scrollIntoView();
+									}, id, position);
+									await visualDiff.screenshotAndCompare(page, this.test.fullTitle());
+								});
+							});
+						});
+
+						[
+							'grades-row-header',
+							'grades-column-header'
+						].forEach((id) => {
+							['top', 'over'].forEach((position) => {
+								it(`${id}-${position}`, async function() {
+									await page.evaluate(() => window.scrollTo(0, 0));
 									await page.$eval('d2l-test-table-sticky-visual-diff', (wrapper, id, position) => {
 										wrapper.shadowRoot.querySelector(`#${id} .${position}`).scrollIntoView();
 									}, id, position);


### PR DESCRIPTION
By adding tests for what grades is doing, those new grades tests were affecting existing tests because they scrolled the page around. This resets the window's scroll position before each test to try and make them more isolated.

This also sets a baseline for the grades tests (which will look somewhat broken) that can be fixed as part of #3635.