### PR TITLE
Update `d2l-overflow-group` to not wrap items while resizing unless necessary.

### DIFF
--- a/components/overflow-group/overflow-group-mixin.js
+++ b/components/overflow-group/overflow-group-mixin.js
@@ -61,12 +61,9 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 				type: String,
 				attribute: 'opener-type'
 			},
-			_chompIndex: {
-				state: true
-			},
-			_mini: {
-				state: true
-			}
+			_chompIndex: { state: true },
+			_mini: { state: true },
+			_wrapping: { state: true }
 		};
 	}
 
@@ -80,7 +77,6 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 			}
 			.d2l-overflow-group-container {
 				display: flex;
-				flex-wrap: wrap;
 				justify-content: var(--d2l-overflow-group-justify-content, normal);
 			}
 			.d2l-overflow-group-container ::slotted([data-is-chomped]) {
@@ -102,6 +98,7 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 		this._mini = this.openerType === OPENER_TYPE.ICON;
 		this._overflowContainerHidden = false;
 		this._slotItems = [];
+		this._wrapping = false;
 
 		this.autoShow = false;
 		this.maxToShow = -1;
@@ -133,8 +130,9 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 		});
 
 		const containerStyles = {
-			minHeight: this.autoShow ? 'none' : `${this._itemHeight}px`,
-			maxHeight: this.autoShow ? 'none' : `${this._itemHeight}px`
+			flexWrap: this._wrapping ? 'wrap' : 'nowrap',
+			minHeight: this.autoShow ? 'none' : (this._itemHeight ? `${this._itemHeight}px` : 'auto'),
+			maxHeight: this.autoShow ? 'none' : (this._itemHeight ? `${this._itemHeight}px` : 'auto')
 		};
 
 		return html`
@@ -142,7 +140,7 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 				<slot @slotchange="${this._handleSlotChange}"></slot>
 				${overflowContainer}
 			</div>
-			<slot name="adjacent"></slot>	
+			<slot name="adjacent"></slot>
 		`;
 	}
 
@@ -255,6 +253,7 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 			}
 
 		}
+
 		// if there is at least one showing and no more to be hidden, enable collapsing overflow container to mini overflow container
 		this._overflowContainerHidden = this._itemLayouts.length === showing.count;
 		if (!this._overflowContainerHidden && (isSoftOverflowing || isForcedOverflowing)) {
@@ -275,6 +274,9 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 		}
 		const overflowOverflowing = (showing.width + this._overflowContainerWidth >= this._availableWidth);
 		const swapToMini = overflowOverflowing && !this._overflowContainerHidden;
+
+		const requiredWidth = (isSoftOverflowing || isForcedOverflowing) ? showing.width + this._overflowContainerWidth : showing.width;
+		this._wrapping = (requiredWidth > this._availableWidth);
 
 		this._mini = this.openerType === OPENER_TYPE.ICON || swapToMini;
 		this._chompIndex = this._overflowContainerHidden ? null : showing.count;


### PR DESCRIPTION
[DE53422](https://rally1.rallydev.com/#/?detail=/defect/701287303215&fdp=true)

This PR fixes an issue where items briefly wrap within the `d2l-overflow-group` during resizing, resulting in some FOUC. This happens because the browser is wrapping the items before the overflow-group chomping results are applied. 

The solution is to use use `flex-wrap: nowrap` except when we know items will wrap instead of being chomped. In practice, items are almost never expected to wrap because `min-to-show="0|1"` in the wild, and the `auto-show` attribute/`d2l-button-group-show` class is only applied to force show the item in the LMS for the primary button. Aside: we don't really support the wrapping edge case very well, but that's a separate issue.