### PR TITLE
fix: prevent dropdown from getting blocked by mobile navbar

### DIFF
--- a/components/dropdown/dropdown-content-styles.js
+++ b/components/dropdown/dropdown-content-styles.js
@@ -241,7 +241,7 @@ export const dropdownContentStyles = css`
 	:host([data-mobile][mobile-tray="left"]) .d2l-dropdown-content-width {
 		border-bottom-left-radius: 0;
 		border-top-left-radius: 0;
-		height: 100vh;
+		bottom: 0;
 		position: fixed;
 		top: 0;
 		z-index: 1000;
@@ -250,7 +250,7 @@ export const dropdownContentStyles = css`
 	:host([data-mobile][mobile-tray="right"]) .d2l-dropdown-content-width {
 		border-bottom-right-radius: 0;
 		border-top-right-radius: 0;
-		height: 100vh;
+		bottom: 0;
 		position: fixed;
 		top: 0;
 		z-index: 1000;


### PR DESCRIPTION
In mobile devices part of the dropdowns were being blocked by the navbar at the bottom. Tested solution on safari on iphone and android+chrome on sauce labs.

Rally: [DE53342](https://rally1.rallydev.com/#/?detail=/defect/700609792545&fdp=true)