### PR TITLE
Fix d2l-overflow-group chomping in RTL.

### DIFF
--- a/components/overflow-group/overflow-group-mixin.js
+++ b/components/overflow-group/overflow-group-mixin.js
@@ -61,12 +61,9 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 				type: String,
 				attribute: 'opener-type'
 			},
-			_chompIndex: {
-				state: true
-			},
-			_mini: {
-				state: true
-			}
+			_chompIndex: { state: true },
+			_mini: { state: true },
+			_wrapping: { state: true }
 		};
 	}
 
@@ -80,7 +77,6 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 			}
 			.d2l-overflow-group-container {
 				display: flex;
-				flex-wrap: wrap;
 				justify-content: var(--d2l-overflow-group-justify-content, normal);
 			}
 			.d2l-overflow-group-container ::slotted([data-is-chomped]) {
@@ -102,6 +98,7 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 		this._mini = this.openerType === OPENER_TYPE.ICON;
 		this._overflowContainerHidden = false;
 		this._slotItems = [];
+		this._wrapping = false;
 
 		this.autoShow = false;
 		this.maxToShow = -1;
@@ -133,8 +130,9 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 		});
 
 		const containerStyles = {
-			minHeight: this.autoShow ? 'none' : `${this._itemHeight}px`,
-			maxHeight: this.autoShow ? 'none' : `${this._itemHeight}px`
+			flexWrap: this._wrapping ? 'wrap' : 'nowrap',
+			minHeight: this.autoShow ? 'none' : (this._itemHeight ? `${this._itemHeight}px` : 'auto'),
+			maxHeight: this.autoShow ? 'none' : (this._itemHeight ? `${this._itemHeight}px` : 'auto')
 		};
 
 		return html`
@@ -142,7 +140,7 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 				<slot @slotchange="${this._handleSlotChange}"></slot>
 				${overflowContainer}
 			</div>
-			<slot name="adjacent"></slot>	
+			<slot name="adjacent"></slot>
 		`;
 	}
 
@@ -255,6 +253,7 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 			}
 
 		}
+
 		// if there is at least one showing and no more to be hidden, enable collapsing overflow container to mini overflow container
 		this._overflowContainerHidden = this._itemLayouts.length === showing.count;
 		if (!this._overflowContainerHidden && (isSoftOverflowing || isForcedOverflowing)) {
@@ -275,6 +274,9 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 		}
 		const overflowOverflowing = (showing.width + this._overflowContainerWidth >= this._availableWidth);
 		const swapToMini = overflowOverflowing && !this._overflowContainerHidden;
+
+		const requiredWidth = (isSoftOverflowing || isForcedOverflowing) ? showing.width + this._overflowContainerWidth : showing.width;
+		this._wrapping = (requiredWidth > this._availableWidth);
 
 		this._mini = this.openerType === OPENER_TYPE.ICON || swapToMini;
 		this._chompIndex = this._overflowContainerHidden ? null : showing.count;

--- a/components/overflow-group/overflow-group-mixin.js
+++ b/components/overflow-group/overflow-group-mixin.js
@@ -244,12 +244,10 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 				showing.count += 1;
 				itemLayout.isChomped = false;
 				itemLayout.trigger = 'soft-show';
-
 			} else {
 				isSoftOverflowing = true;
 				itemLayout.isChomped = true;
 				itemLayout.trigger = 'soft-hide';
-
 			}
 
 		}
@@ -272,6 +270,7 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 				itemLayoutOverflowing.isChomped = true;
 			}
 		}
+
 		const overflowOverflowing = (showing.width + this._overflowContainerWidth >= this._availableWidth);
 		const swapToMini = overflowOverflowing && !this._overflowContainerHidden;
 
@@ -297,8 +296,8 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 				isChomped: false,
 				isHidden: itemHidden,
 				width: Math.ceil(parseFloat(computedStyles.width) || 0)
-					+ parseInt(computedStyles.marginRight) || 0
-					+ parseInt(computedStyles.marginLeft) || 0,
+					+ (parseInt(computedStyles.marginRight) || 0)
+					+ (parseInt(computedStyles.marginLeft) || 0),
 				node: node
 			};
 		});


### PR DESCRIPTION
[DE50816](https://rally1.rallydev.com/#/?detail=/defect/668749858657&fdp=true)

This PR fixes the `d2l-overflow-group` chomping when in RTL. The root cause of this issue was that the calculation of the width of the items was incorrect - it was not correctly factoring in the size of the margin in RTL.

Due to the timing of when measurements are taken, it is necessary to test this by setting `dir="rtl"` before loading the page. If one tries to test simply by toggling to the Arabic language in the demo page, it will be using LTR measurements and not a valid test.

**Before:**
![image](https://github.com/BrightspaceUI/core/assets/9042472/99993b97-07f1-4d9c-8416-ac04ff9a6d0c)

**After:**
![image](https://github.com/BrightspaceUI/core/assets/9042472/bfa8943d-1039-4226-a780-935890ba6043)

Note: before my [previous change to how the items wrap](https://github.com/BrightspaceUI/core/pull/3650), this would have incorrectly wrapped below...

**Before:**
![image](https://github.com/BrightspaceUI/core/assets/9042472/2a8a7f9c-3c05-47c0-ae69-88474db7bc22)

**After:**
![image](https://github.com/BrightspaceUI/core/assets/9042472/d4b59c8f-7bf9-4976-84da-4b4edf0ca9ae)

