### PR TITLE
Check that next focusable is a list item

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -302,7 +302,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			if (!listItem._tryFocus()) {
 				// ultimate fallback to generic method for getting next/previous focusable
 				const nextFocusable = previous ? getPreviousFocusable(listItem) : getNextFocusable(listItem);
-				if (nextFocusable && this._isContainedInSameRootList(curListItem, nextFocusable)) {
+				const nextListItem = findComposedAncestor(nextFocusable, (node) => node.role === 'rowgroup' || node.role === 'listitem');
+				if (nextListItem && this._isContainedInSameRootList(curListItem, nextListItem)) {
 					nextFocusable.focus();
 				}
 			}

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -3,7 +3,7 @@ import '../list-controls.js';
 import '../list-item.js';
 import '../list-item-button.js';
 import '../list-item-content.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const keyCodes = Object.freeze({
@@ -87,6 +87,8 @@ describe('d2l-list', () => {
 				const listItem = elem.querySelector('[key="L2-2"]');
 				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
 				listItem.focus();
+				await waitUntil(() => listItem.hasAttribute('_focusing'), 'List item should be focused', { timeout: 3000 });
+
 				const event = new KeyboardEvent('keydown', { keyCode: testCase.keyPress.key });
 				setTimeout(() => listItemLayout.dispatchEvent(event));
 				await oneEvent(listItemLayout, 'keydown');
@@ -128,6 +130,8 @@ describe('d2l-list', () => {
 				const listItem = elem.querySelector('[key="L2-2"]');
 				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
 				listItem.focus();
+				await waitUntil(() => listItem.hasAttribute('_focusing'), 'List item should be focused', { timeout: 3000 });
+
 				const event = new KeyboardEvent('keydown', { keyCode: testCase.keyPress.key });
 				setTimeout(() => listItemLayout.dispatchEvent(event));
 				await oneEvent(listItemLayout, 'keydown');
@@ -154,6 +158,8 @@ describe('d2l-list', () => {
 			const listItem = elem.querySelector('[key="L1-2"]');
 			const listItemLayout = elem.querySelector('[key="L1-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
 			listItem.focus();
+			await waitUntil(() => listItem.hasAttribute('_focusing'), 'List item should be focused', { timeout: 3000 });
+
 			const event = new KeyboardEvent('keydown', { keyCode: keyCodes.UP.key });
 			setTimeout(() => listItemLayout.dispatchEvent(event));
 			await oneEvent(listItemLayout, 'keydown');

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -136,6 +136,30 @@ describe('d2l-list', () => {
 				expect(focusedElement.hasAttribute('_focusing')).to.be.true;
 			});
 		});
+
+		it('Focus stays in list with list controls when in grid mode when up arrow is pressed', async() => {
+			const elem = await fixture(html`
+				 <d2l-list grid>
+					<d2l-list-controls slot="controls"></d2l-list-controls>
+					<d2l-list-item key="L1-1" label="L1-1"></d2l-list-item>
+					<d2l-list-item selectable key="L1-2" label="L1-2"></d2l-list-item>
+				</d2l-list>
+			`);
+			await awaitListElementUpdates(elem, [
+				'[slot="controls"]',
+				'[key="L1-1"]',
+				'[key="L1-2"]',
+			]);
+
+			const listItem = elem.querySelector('[key="L1-2"]');
+			const listItemLayout = elem.querySelector('[key="L1-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
+			listItem.focus();
+			const event = new KeyboardEvent('keydown', { keyCode: keyCodes.UP.key });
+			setTimeout(() => listItemLayout.dispatchEvent(event));
+			await oneEvent(listItemLayout, 'keydown');
+
+			expect(listItem.hasAttribute('_focusing')).to.be.true;
+		});
 	});
 
 	describe('flat', () => {


### PR DESCRIPTION
[DE53222](https://rally1.rallydev.com/#/?detail=/defect/699633940503&fdp=true)

This is a follow-up to #3605. I added a check that it will only focus the next item if the next focusable belongs to the same list, but this doesn't account for other non list-item components that can be placed in the d2l-list like list-controls.

This PR fixes the check so it confirms that the next focusable is a list item and that list item belongs to the same list as the currently focused list item.