### PR TITLE
Add label to d2l-list

### DIFF
--- a/components/list/README.md
+++ b/components/list/README.md
@@ -135,6 +135,7 @@ The `d2l-list` is the container to create a styled list of items using `d2l-list
 |---|---|---|
 | `drag-multiple` | Boolean | Whether the user can drag multiple items |
 | `grid` | Boolean | Enables keyboard grid for supported list items. See [Accessibility](#accessibility). |
+| `label` | String | Sets an accessible label. For use when the list context is unclear. This property is only valid on top-level lists and will have no effect on nested lists. |
 | `selection-single` | Boolean | Whether to render with single selection behaviour. If `selection-single` is specified, the list-items will render with radios instead of checkboxes, and the list component will maintain a single selected item. |
 | `separators` | String | Display separators (`all` (default), `between`, `none`) |
 | `extend-separators` | Boolean | Whether to extend the separators beyond the content's edge |

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -70,7 +70,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 		this.dragMultiple = false;
 		this.extendSeparators = false;
 		this.grid = false;
-		this.label = '';
+		this.label = undefined;
 		this._listItemChanges = [];
 		this._childHasExpandCollapseToggle = false;
 
@@ -124,7 +124,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 
 	render() {
 		const role = !this.grid ? 'list' : 'application';
-		const ariaLabel = this.label && this.slot !== 'nested' ? this.label : undefined;
+		const ariaLabel = this.slot !== 'nested' ? this.label : undefined;
 		return html`
 			<slot name="controls"></slot>
 			<slot name="header"></slot>

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -1,6 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { getNextFocusable, getPreviousFocusable } from '../../helpers/focus.js';
 import { SelectionInfo, SelectionMixin } from '../selection/selection-mixin.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { PageableMixin } from '../paging/pageable-mixin.js';
 import { SubscriberRegistryController } from '../../controllers/subscriber/subscriberControllers.js';
 
@@ -37,6 +38,11 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 			 */
 			grid: { type: Boolean },
 			/**
+			 * Sets an accessible label. For use when the list context is unclear. This property is only valid on top-level lists and will have no effect on nested lists.
+			 * @type {string}
+ 			 */
+			label: { type: String },
+			/**
 			 * Display separators. Valid values are "all" (default), "between", "none"
 			 * @type {'all'|'between'|'none'}
 			 * @default "all"
@@ -64,6 +70,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 		this.dragMultiple = false;
 		this.extendSeparators = false;
 		this.grid = false;
+		this.label = '';
 		this._listItemChanges = [];
 		this._childHasExpandCollapseToggle = false;
 
@@ -117,10 +124,11 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 
 	render() {
 		const role = !this.grid ? 'list' : 'application';
+		const ariaLabel = this.label && this.slot !== 'nested' ? this.label : undefined;
 		return html`
 			<slot name="controls"></slot>
 			<slot name="header"></slot>
-			<div role="${role}">
+			<div role="${role}" aria-label="${ifDefined(ariaLabel)}">
 				<slot @keydown="${this._handleKeyDown}" @slotchange="${this._handleSlotChange}"></slot>
 			</div>
 			${this._renderPagerContainer()}

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -62,7 +62,7 @@ describe('d2l-list', () => {
 		it('should not set aria-label on list when label is not defined', async() => {
 			const elem = await fixture(html`<d2l-list></d2l-list>`);
 			const list = elem.shadowRoot.querySelector('[role="list"]');
-			expect(list.getAttribute('aria-label')).to.be.null;
+			expect(list.hasAttribute('aria-label')).to.be.false;
 		});
 
 		it('should not set aria-label on nested lists', async() => {
@@ -77,7 +77,7 @@ describe('d2l-list', () => {
 					</d2l-list>	
 				`);
 			const nestedList = elem.querySelector('#L2').shadowRoot.querySelector('[role="application"]');
-			expect(nestedList.getAttribute('aria-label')).to.be.null;
+			expect(nestedList.hasAttribute('aria-label')).to.be.false;
 		});
 
 	});

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -51,6 +51,37 @@ describe('d2l-list', () => {
 
 	});
 
+	describe('label', () => {
+
+		it('should set aria-label on list when label is defined', async() => {
+			const elem = await fixture(html`<d2l-list label="Test Label"></d2l-list>`);
+			const list = elem.shadowRoot.querySelector('[role="list"]');
+			expect(list.getAttribute('aria-label')).to.equal('Test Label');
+		});
+
+		it('should not set aria-label on list when label is not defined', async() => {
+			const elem = await fixture(html`<d2l-list></d2l-list>`);
+			const list = elem.shadowRoot.querySelector('[role="list"]');
+			expect(list.getAttribute('aria-label')).to.be.null;
+		});
+
+		it('should not set aria-label on nested lists', async() => {
+			const elem = await fixture(html`
+					<d2l-list id="L1" grid>
+						<d2l-list-item>
+							<d2l-list id="L2" slot="nested" grid label="Test Label">
+								<d2l-list-item></d2l-list-item>
+								</d2l-list-item>
+							</d2l-list>
+						</d2l-list-item>
+					</d2l-list>	
+				`);
+			const nestedList = elem.querySelector('#L2').shadowRoot.querySelector('[role="application"]');
+			expect(nestedList.getAttribute('aria-label')).to.be.null;
+		});
+
+	});
+
 	describe('navigation', () => {
 
 		[


### PR DESCRIPTION
[US152804](https://rally1.rallydev.com/#/?detail=/userstory/701306059915&fdp=true)

This PR adds the `label` property to `d2l-list` which adds an accessible label that can be used to provide additional context when it is not obvious.

Adding an `aria-label` to nested lists was causing the label to replace the child content and skip over all of the nested content. Since there doesn't seem to be a use case for labels on nested lists, we decided to only permit the property on top-level lists. Adding the property to a nested list should have no effect.