### PR TITLE
Remove initialization of list label

### DIFF
--- a/components/list/list.js
+++ b/components/list/list.js
@@ -70,7 +70,6 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 		this.dragMultiple = false;
 		this.extendSeparators = false;
 		this.grid = false;
-		this.label = undefined;
 		this._listItemChanges = [];
 		this._childHasExpandCollapseToggle = false;
 


### PR DESCRIPTION
This removes the initialization of undefined for the list label. The web-component-analyzer interprets the default value as a string `"undefined"` which is shown on the doc site. Removing the initialization entirely does not set a default in it.

We are initializing to `undefined` instead of `''` to simplify some of the code that uses it.