### PR TITLE
Update dialogs and dropdowns to stop bubbling of touchstart.

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -142,6 +142,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 	_addHandlers() {
 		window.addEventListener('resize', this._updateSize);
+		this.addEventListener('touchstart', this._handleTouchStart);
 		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-dialog-content').addEventListener('scroll', this._updateOverflow);
 	}
 
@@ -356,6 +357,12 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._useNative = false;
 	}
 
+	_handleTouchStart(e) {
+		// elements external to the dialog such as primary-secondary template should not be reacting
+		// to touchstart events originating inside the dialog or backdrop
+		e.stopPropagation();
+	}
+
 	_isCloseAborted() {
 		const abortEvent = new CustomEvent('d2l-dialog-before-close', {
 			cancelable: true,
@@ -441,6 +448,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 	_removeHandlers() {
 		window.removeEventListener('resize', this._updateSize);
+		this.removeEventListener('touchstart', this._handleTouchStart);
 		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-dialog-content').removeEventListener('scroll', this._updateOverflow);
 	}
 

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -294,6 +294,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 
 		window.addEventListener('resize', this.__onResize);
 		this.addEventListener('blur', this.__onAutoCloseFocus, true);
+		this.addEventListener('touchstart', this.__onTouchStart);
 		document.body.addEventListener('focus', this.__onAutoCloseFocus, true);
 		document.body.addEventListener('click', this.__onAutoCloseClick, true);
 		this.mediaQueryList = window.matchMedia(`(max-width: ${this.mobileBreakpointOverride - 1}px)`);
@@ -305,6 +306,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		super.disconnectedCallback();
 		if (this.mediaQueryList.removeEventListener) this.mediaQueryList.removeEventListener('change', this._handleMobileResize);
 		this.removeEventListener('blur', this.__onAutoCloseFocus);
+		this.removeEventListener('touchstart', this.__onTouchStart);
 		window.removeEventListener('resize', this.__onResize);
 		if (document.body) {
 			// DE41322: document.body can be null in some scenarios
@@ -528,6 +530,12 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 
 	__onResize() {
 		this.resize();
+	}
+
+	__onTouchStart(e) {
+		// elements external to the dropdown content such as primary-secondary template should not be reacting
+		// to touchstart events originating inside the dropdown content
+		e.stopPropagation();
 	}
 
 	async __openedChanged(newValue) {

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -77,6 +77,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.addEventListener('mouseup', this.__onMouseUp);
 		this.addEventListener('mouseenter', this.__onMouseEnter);
 		this.addEventListener('mouseleave', this.__onMouseLeave);
+		this.addEventListener('touchstart', this.__onTouchStart);
 
 		if (this.openOnHover) {
 			document.body.addEventListener('mouseup', this._onOutsideClick);
@@ -90,6 +91,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.removeEventListener('mouseup', this.__onMouseUp);
 		this.removeEventListener('mouseenter', this.__onMouseEnter);
 		this.removeEventListener('mouseleave', this.__onMouseLeave);
+		this.removeEventListener('touchstart', this.__onTouchStart);
 
 		if (this.openOnHover) {
 			document.body.removeEventListener('mouseup', this._onOutsideClick);
@@ -280,6 +282,12 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 				this.openDropdown(false);
 			}
 		} else this.toggleOpen(true);
+	}
+
+	__onTouchStart(e) {
+		// elements external to the dropdown content such as primary-secondary template should not be reacting
+		// to touchstart events originating inside the dropdown content
+		e.stopPropagation();
 	}
 
 	/* used by open-on-hover option */

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -77,7 +77,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.addEventListener('mouseup', this.__onMouseUp);
 		this.addEventListener('mouseenter', this.__onMouseEnter);
 		this.addEventListener('mouseleave', this.__onMouseLeave);
-		this.addEventListener('touchstart', this.__onTouchStart);
 
 		if (this.openOnHover) {
 			document.body.addEventListener('mouseup', this._onOutsideClick);
@@ -91,7 +90,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		this.removeEventListener('mouseup', this.__onMouseUp);
 		this.removeEventListener('mouseenter', this.__onMouseEnter);
 		this.removeEventListener('mouseleave', this.__onMouseLeave);
-		this.removeEventListener('touchstart', this.__onTouchStart);
 
 		if (this.openOnHover) {
 			document.body.removeEventListener('mouseup', this._onOutsideClick);
@@ -282,12 +280,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 				this.openDropdown(false);
 			}
 		} else this.toggleOpen(true);
-	}
-
-	__onTouchStart(e) {
-		// elements external to the dropdown content such as primary-secondary template should not be reacting
-		// to touchstart events originating inside the dropdown content
-		e.stopPropagation();
 	}
 
 	/* used by open-on-hover option */

--- a/templates/primary-secondary/demo/integration.html
+++ b/templates/primary-secondary/demo/integration.html
@@ -14,6 +14,7 @@
 			import '../../../components/collapsible-panel/collapsible-panel.js';
 			import '../../../components/collapsible-panel/collapsible-panel-summary-item.js';
 			import '../../../components/demo/demo-page.js';
+			import '../../../components/dialog/dialog.js';
 			import '../../../components/dialog/dialog-fullscreen.js';
 			import '../../../components/dropdown/dropdown-button-subtle.js';
 			import '../../../components/dropdown/dropdown-content.js';
@@ -54,6 +55,7 @@
 
 				<d2l-list item-count="50" extend-separators>
 					<d2l-list-controls slot="controls" select-all-pages-allowed>
+					<d2l-button-icon icon="tier1:gear" id="openMainDialog" text="Open"></d2l-button-icon>
 						<d2l-selection-action icon="tier1:plus-default" text="Add"></d2l-selection-action>
 						<d2l-selection-action-dropdown text="Move To" requires-selection>
 							<d2l-dropdown-menu>
@@ -194,7 +196,6 @@
 						</div>
 					</d2l-list-item>
 				</d2l-list>
-
 
 				<div style="height: 100px;"></div>
 
@@ -341,9 +342,7 @@
 					</d2l-list-item>
 				</d2l-list>
 
-			</div>
-			<div slot="secondary" style="padding: 1rem;">
-				<d2l-dialog-fullscreen id="dialogFullscreen" title-text="Fullscreen Title">
+				<d2l-dialog-fullscreen id="dialogMain" title-text="Dialog Title">
 					<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
 					<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
 					<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
@@ -353,14 +352,32 @@
 					<d2l-button slot="footer" primary data-dialog-action="save">Save</d2l-button>
 					<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
 				</d2l-dialog-fullscreen>
+
+				<script>
+					document.querySelector('#openMainDialog').addEventListener('click', () => {
+						document.querySelector('#dialogMain').opened = true;
+					});
+					document.querySelector('#dialogMain').addEventListener('d2l-dialog-close', (e) => {
+						console.log('main dialog action:', e.detail.action);
+					});
+				</script>
+
+			</div>
+			<div slot="secondary" style="padding: 1rem;">
+
 				<d2l-collapsible-panel panel-title="Availability" expanded>
 					<d2l-collapsible-panel-summary-item slot="summary" text="Availability starts 8/16/2022 and ends 8/12/2022"></d2l-collapsible-panel-summary-item>
 					<d2l-collapsible-panel-summary-item slot="summary" text="Hidden by special access"></d2l-collapsible-panel-summary-item>
-					<d2l-button-icon slot="actions" icon="tier1:gear" id="open" text="Settings"></d2l-button-icon>
+					<d2l-button-icon slot="actions" icon="tier1:gear" id="openSecondaryDialog" text="Settings"></d2l-button-icon>
 					<d2l-dropdown-more slot="actions">
 						<d2l-dropdown-menu>
 							<d2l-menu>
+								<d2l-menu-item text="Add New"></d2l-menu-item>
+								<d2l-menu-item text="Bookmark"></d2l-menu-item>
 								<d2l-menu-item text="Duplicate"></d2l-menu-item>
+								<d2l-menu-item text="Settings"></d2l-menu-item>
+								<d2l-menu-item text="Move"></d2l-menu-item>
+								<d2l-menu-item text="Publish"></d2l-menu-item>
 								<d2l-menu-item text="Delete"></d2l-menu-item>
 							</d2l-menu>
 						</d2l-dropdown-menu>
@@ -397,12 +414,24 @@
 					</div>
 					<d2l-input-textarea label="Extra Text" label-hidden rows="6" value="This is a d2l-input-textarea." style="margin-top: 1rem;"></d2l-input-textarea>
 				</d2l-collapsible-panel>
+
+				<d2l-dialog id="dialogSecondary" title-text="Dialog Title">
+					<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
+					<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
+					<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
+					<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
+					<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
+					<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
+					<d2l-button slot="footer" primary data-dialog-action="save">Save</d2l-button>
+					<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+				</d2l-dialog>
+
 				<script>
-					document.querySelector('#open').addEventListener('click', () => {
-						document.querySelector('#dialogFullscreen').opened = true;
+					document.querySelector('#openSecondaryDialog').addEventListener('click', () => {
+						document.querySelector('#dialogSecondary').opened = true;
 					});
-					document.querySelector('#dialogFullscreen').addEventListener('d2l-dialog-close', (e) => {
-						console.log('confirm action:', e.detail.action);
+					document.querySelector('#dialogSecondary').addEventListener('d2l-dialog-close', (e) => {
+						console.log('secondary dialog action:', e.detail.action);
 					});
 				</script>
 				<p>


### PR DESCRIPTION
[DE51920](https://rally1.rallydev.com/#/?detail=/defect/684873597487&fdp=true)

This PR updates `DialogMixin` and `DropdownContentMixin` to stop bubbling of the `touchstart` event so that external elements such as `d2l-template-primary-secondary` (aside panel) do not react to it when they shouldn't. Without this change, users cause the mobile secondary/aside panel to resize when they touch-start within an open dialog or dropdown nested within the panel. 

I confirmed with Jeff that we still want the `d2l-template-primary-secondary` secondary panel behaviour that resizes the panel, just not when dialogs or dropdowns are open (removing that behaviour and just targeting the divider would have been an alternative solution). 

![background-resize](https://github.com/BrightspaceUI/core/assets/9042472/c29be5d6-2ea7-4230-a150-3b537a1bacb6)



