### PR TITLE
fix: dropdown-content > show scrollbar when content changes & overflows

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -200,9 +200,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 			_closing: {
 				type: Boolean
 			},
-			_contentOverflow: {
-				type: Boolean
-			},
 			_dropdownContent: {
 				type: Boolean,
 				attribute: 'dropdown-content',
@@ -262,7 +259,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		this._bottomOverflow = false;
 		this._topOverflow = false;
 		this._closing = false;
-		this._contentOverflow = false;
 		this._hasHeader = false;
 		this._hasFooter = false;
 		this._showBackdrop = false;
@@ -704,7 +700,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 					&& headerFooterHeight < this.maxHeight
 					? this.maxHeight - headerFooterHeight - 2
 					: availableHeight - headerFooterHeight;
-				this.__toggleOverflowY(contentRect.height + headerFooterHeight > availableHeight);
 
 				// ensure the content height has updated when the __toggleScrollStyles event handler runs
 				await this.updateComplete;
@@ -721,16 +716,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		await this.updateComplete;
 
 		await adjustPosition();
-	}
-
-	__toggleOverflowY(isOverflowing) {
-		if (!this.__content) {
-			return;
-		}
-		if (!this._contentHeight) {
-			return;
-		}
-		this._contentOverflow = isOverflowing || this.__content.scrollHeight > this._contentHeight;
 	}
 
 	__toggleScrollStyles() {
@@ -809,7 +794,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		const contentStyle = {
 			...contentWidthStyle,
 			maxHeight: maxHeightOverride,
-			overflowY: this._contentOverflow ? 'auto' : 'hidden'
 		};
 
 		const closeButtonStyles = {
@@ -845,7 +829,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		const contentStyle = {
 			...contentWidthStyle,
 			maxHeight: this._contentHeight ? `${this._contentHeight}px` : '',
-			overflowY: this._contentOverflow ? 'auto' : 'hidden'
 		};
 
 		const closeButtonStyle = {
@@ -951,7 +934,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		const contentStyle = {
 			...contentWidthStyle,
 			maxHeight: maxHeightOverride,
-			overflowY: this._contentOverflow ? 'auto' : 'hidden'
 		};
 
 		const closeButtonStyles = {

--- a/components/dropdown/dropdown-content-styles.js
+++ b/components/dropdown/dropdown-content-styles.js
@@ -120,6 +120,7 @@ export const dropdownContentStyles = css`
 		box-sizing: border-box;
 		max-width: 100%;
 		outline: none;
+		overflow-y: auto;
 		padding: 1rem;
 	}
 


### PR DESCRIPTION
Currently if there is a change in the contents of a dropdown (e.g. "show more" in the minibar) the scrollbar is not showing and the content cannot be scrolled. This is because the element has a JS property that sets the css property `overflow-y` to `auto` if the content would overflow and `hidden` otherwise, and this property is only calculated when positioning the dropdown(i.e. opening it). The change removes the property, since `overflow-y: auto` already hides the scrollbar if content is not overflowing. 

Rally: [DE38937](https://rally1.rallydev.com/#/?detail=/defect/389255799860&fdp=true)