### PR TITLE
fix: resize observer for dropdown content to update `overflow-y` value

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -7,6 +7,7 @@ import { getComposedActiveElement, getFirstFocusableDescendant, getPreviousFocus
 import { classMap } from 'lit/directives/class-map.js';
 import { html } from 'lit';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
+import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { tryGetIfrauBackdropService } from '../../helpers/ifrauBackdropService.js';
@@ -325,6 +326,8 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		this.__content = this.getContentContainer();
 		this.addEventListener('d2l-dropdown-close', this.__onClose);
 		this.addEventListener('d2l-dropdown-position', this.__toggleScrollStyles);
+		const contentObserver = new ResizeObserver(this.__onContentResize.bind(this));
+		contentObserver.observe(this.__content);
 	}
 
 	updated(changedProperties) {
@@ -526,6 +529,11 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		const opener = this.__getOpener();
 		opener.getOpenerElement().focus();
 
+	}
+
+	__onContentResize(entries) {
+		if (!entries || entries.length === 0) return;
+		this.__toggleOverflowY(false);
 	}
 
 	__onResize() {


### PR DESCRIPTION
Currently if there is a change in the contents of a dropdown (e.g. "show more" in the minibar) the scrollbar is not showing and the content cannot be scrolled. This is because the element has a JS property that sets the css property overflow-y to auto if the content would overflow and hidden otherwise, and this property is only calculated when positioning the dropdown(i.e. opening it). 
The change adds a resize observer to update the property if the inner content mutates.

Rally: [DE38937](https://rally1.rallydev.com/#/?detail=/defect/389255799860&fdp=true)