### PR TITLE
Add displayAllKeys to filter search callback

### DIFF
--- a/components/filter/demo/filter-search-demo.js
+++ b/components/filter/demo/filter-search-demo.js
@@ -89,7 +89,7 @@ class FilterSearchDemo extends LitElement {
 		});
 
 		setTimeout(() => {
-			e.detail.searchCompleteCallback(keysToDisplay);
+			e.detail.searchCompleteCallback({ keysToDisplay: keysToDisplay });
 			// eslint-disable-next-line no-console
 			console.log(`Filter dimension "${e.detail.key}" searched: ${e.detail.value}`);
 		}, 2000);

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -765,8 +765,9 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				detail: {
 					key: dimension.key,
 					value: searchValue,
-					searchCompleteCallback: function(keysToDisplay) {
+					searchCompleteCallback: function({ keysToDisplay = [], displayAllKeys = false } = {}) {
 						requestAnimationFrame(() => {
+							dimension.displayAllKeys = displayAllKeys;
 							dimension.searchKeysToDisplay = keysToDisplay;
 							this._performDimensionSearch(dimension);
 							dimension.loading = false;
@@ -861,7 +862,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 		switch (dimension.type) {
 			case 'd2l-filter-dimension-set':
 				dimension.values.forEach(value => {
-					if (dimension.searchValue === '') {
+					if (dimension.searchValue === '' || dimension.displayAllKeys) {
 						value.hidden = false;
 						return;
 					}

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -406,10 +406,27 @@ describe('d2l-filter', () => {
 			setTimeout(() => elem._handleSearch({ detail: { value: 'whatever' } }));
 			const e = await oneEvent(elem, 'd2l-filter-dimension-search');
 
-			e.detail.searchCompleteCallback(['test']);
+			e.detail.searchCompleteCallback({ keysToDisplay: ['test'] });
 			await new Promise(resolve => { requestAnimationFrame(resolve); });
 			expect(elem._dimensions[0].values[0].hidden).to.be.false;
 			expect(elem._dimensions[0].values[1].hidden).to.be.true;
+		});
+
+		it('set dimension - manual search will display all keys when set in the callback', async() => {
+			const elem = await fixture(`<d2l-filter><d2l-filter-dimension-set key="dim" text="dim" search-type="manual">
+				<d2l-filter-dimension-set-value key="test" text="test"></d2l-filter-dimension-set-value>
+				<d2l-filter-dimension-set-value key="test2" text="test2"></d2l-filter-dimension-set-value>
+			</d2l-filter-dimension-set></d2l-filter>`);
+			expect(elem._dimensions[0].values[0].hidden).to.be.undefined;
+			expect(elem._dimensions[0].values[1].hidden).to.be.undefined;
+
+			setTimeout(() => elem._handleSearch({ detail: { value: 'whatever' } }));
+			const e = await oneEvent(elem, 'd2l-filter-dimension-search');
+
+			e.detail.searchCompleteCallback({ displayAllKeys: true });
+			await new Promise(resolve => { requestAnimationFrame(resolve); });
+			expect(elem._dimensions[0].values[0].hidden).to.be.false;
+			expect(elem._dimensions[0].values[1].hidden).to.be.false;
 		});
 
 		[
@@ -1126,7 +1143,7 @@ describe('d2l-filter', () => {
 			setTimeout(() => elem._handleSearch({ detail: { value: '1' } }));
 			const e = await oneEvent(elem, 'd2l-filter-dimension-search');
 
-			e.detail.searchCompleteCallback(['1']);
+			e.detail.searchCompleteCallback({ keysToDisplay: ['1'] });
 			await new Promise(requestAnimationFrame);
 			expect(elem._dimensions[0].values.length).to.equal(1);
 			expect(elem._dimensions[0].values[0].hidden).to.be.false;


### PR DESCRIPTION
This adds the ability to display all keys in the filter callback without providing the keys yourself. This will help in avoiding unnecessary API calls since we are changing search to dispatch search events when the search value is empty as well.

This was done by changing the `searchCompleteCallback` to use a deconstructed object as the parameter which allows us to use named function parameters. We would only want to pass one of `keysToDisplay` or `displayAllKeys` in the search callback and this approach allows us to maintain a single callback function.

This change would be breaking and the 2 other places that use manual search would need to be merged in close succession:
1. [my-courses](https://search.d2l.dev/xref/Brightspace/d2l-my-courses-ui/src/search-filter/d2l-my-courses-filter.js?r=a072d043#182)
2. [content-library](https://search.d2l.dev/xref/Brightspace/content-components/core/d2l-content-library-filter/d2l-content-library-filter.js?r=2425f35c#213)

There were a few approaches I considered for this but this seemed the cleanest even though it broke the existing API:

1. Add an additional boolean parameter to the callback: e.g. `searchCompleteCallback(keysToDisplay, displayAllKeys)`. The problem with this approach is that you would need to pass in something to `keysToDisplay` even when not needed and the code didn't end up very readable: `searchCompleteCallback([], true)`
3. Separate callback, `searchCompleteDisplayAllCallback()` for displaying all keys in a dimension. This works and is more readable without breaking existing functionality but adds some complexity with an additional callback in the event detail which I wanted to avoid.