### PR TITLE
skip preview site if triggered by Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         run: npx web-test-runner --config web-test-runner.config.js --group default --playwright --browsers chromium firefox webkit
   publish:
     name: Publish static site
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Pull requests triggered by Dependabot will always fail to publish the preview site due to lack of credentials.

This change will skip the publish step in this scenario, which seems like a good compromise since we rarely care about the preview site for Dependabot PRs. If the tests are passing, that should be enough.

This follows [GitHub's recommendation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions) for checking this, and by using `triggering_actor` instead of `actor` if one of us re-runs it the static site will publish.