### PR TITLE
Update d2l-input-text so validation messages are announced

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -460,7 +460,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 
 		let tooltip = nothing;
 		if (this.validationError && !this.skeleton && !this.noValidate) {
-			tooltip = html`<d2l-tooltip state="error" align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>`;
+			tooltip = html`<d2l-tooltip state="error" announced align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>`;
 		}
 
 		return html`${tooltip}${label}${input}`;


### PR DESCRIPTION
[DE53636](https://rally1.rallydev.com/#/?detail=/defect/703500672771&fdp=true)

Currently, validation messages are not announced to screen readers for the `d2l-input-text` elements. This PR adds the `announced` attribute to its usage of `d2l-tooltip` so that it will announce the message using our `announce()` helper. It does not wire it up using `for` (which would in turn use `aria-describedby`) because we do not want validation messages buried behind VoiceOver's "More Content Available" menu. 