### PR TITLE
fix: `d2l-calendar` > Use more semantic elements and roles

### DIFF
--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -468,13 +468,13 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				return html`
 					<td
 						aria-selected="${selected}"
+						aria-label="${description}"
 						data-date=${date}
 						data-month=${month}
 						data-year=${year}
 						@keydown="${this._onKeyDown}"
 						tabindex=${focused ? '0' : '-1'}>
 						<button
-							aria-label="${description}"
 							class="${classMap(classes)}"
 							@click="${this._onDateSelected}"
 							?disabled="${disabled}"

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -474,12 +474,13 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 						data-year=${year}
 						@keydown="${this._onKeyDown}"
 						tabindex=${focused ? '0' : '-1'}
-						type="button">
+					>
 						<button
 							class="${classMap(classes)}"
 							@click="${this._onDateSelected}"
 							?disabled="${disabled}"
 							tabindex="-1"
+							type="button"
 						>
 							${date}
 						</button>

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -473,15 +473,13 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 						data-year=${year}
 						@keydown="${this._onKeyDown}"
 						role="gridcell"
-						tabindex=${focused ? '0' : '-1'}
-					>
+						tabindex=${focused ? '0' : '-1'}>
 						<button
 							class="${classMap(classes)}"
 							@click="${this._onDateSelected}"
 							?disabled="${disabled}"
 							tabindex="-1"
-							type="button"
-						>
+							type="button">
 							${date}
 						</button>
 					</td>`;

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -463,7 +463,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				const month = day.getMonth();
 				const date = day.getDate();
 				const weekday = calendarData.descriptor.calendar.days.long[calendarData.daysOfWeekIndex[index]];
-				const description = `${weekday} ${date}. ${selected ? this.localize(`${this._namespace}.selected`) : this.localize(`${this._namespace}.notSelected`)} ${formatDate(day, { format: 'monthYear' })}`;
+				const description = `${weekday} ${date} ${formatDate(day, { format: 'monthYear' })}`;
 				return html`
 					<td
 						aria-label="${description}"

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -467,12 +467,11 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				// role="gridcell" used for screen reader (e.g., JAWS and VoiceOver) behavior to work properly
 				return html`
 					<td
-						aria-selected="${selected ? 'true' : 'false'}"
+						aria-selected="${selected}"
 						data-date=${date}
 						data-month=${month}
 						data-year=${year}
 						@keydown="${this._onKeyDown}"
-						role="gridcell"
 						tabindex=${focused ? '0' : '-1'}>
 						<button
 							aria-label="${description}"

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -466,7 +466,6 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				const description = `${weekday} ${date} ${formatDate(day, { format: 'monthYear' })}`;
 				return html`
 					<td
-						aria-label="${description}"
 						aria-selected="${selected ? 'true' : 'false'}"
 						data-date=${date}
 						data-month=${month}
@@ -475,6 +474,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 						role="gridcell"
 						tabindex=${focused ? '0' : '-1'}>
 						<button
+							aria-label="${description}"
 							class="${classMap(classes)}"
 							@click="${this._onDateSelected}"
 							?disabled="${disabled}"

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -464,7 +464,6 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				const date = day.getDate();
 				const weekday = calendarData.descriptor.calendar.days.long[calendarData.daysOfWeekIndex[index]];
 				const description = `${weekday} ${date}. ${selected ? this.localize(`${this._namespace}.selected`) : this.localize(`${this._namespace}.notSelected`)} ${formatDate(day, { format: 'monthYear' })}`;
-				// role="gridcell" used for screen reader (e.g., JAWS and VoiceOver) behavior to work properly
 				return html`
 					<td
 						aria-label="${description}"
@@ -473,6 +472,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 						data-month=${month}
 						data-year=${year}
 						@keydown="${this._onKeyDown}"
+						role="gridcell"
 						tabindex=${focused ? '0' : '-1'}
 					>
 						<button
@@ -520,7 +520,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 								icon="tier1:chevron-right">
 							</d2l-button-icon>
 						</div>
-						<table aria-labelledby="${labelId}" role="presentation">
+						<table aria-labelledby="${labelId}">
 							${summary}
 							<thead aria-hidden="true">
 								<tr>${weekdayHeaders}</tr>

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -467,19 +467,20 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				// role="gridcell" used for screen reader (e.g., JAWS and VoiceOver) behavior to work properly
 				return html`
 					<td
-						aria-selected="${selected}"
 						aria-label="${description}"
+						aria-selected="${selected ? 'true' : 'false'}"
 						data-date=${date}
 						data-month=${month}
 						data-year=${year}
 						@keydown="${this._onKeyDown}"
-						tabindex=${focused ? '0' : '-1'}>
+						tabindex=${focused ? '0' : '-1'}
+						type="button">
 						<button
 							class="${classMap(classes)}"
 							@click="${this._onDateSelected}"
 							?disabled="${disabled}"
 							tabindex="-1"
-							type="button">
+						>
 							${date}
 						</button>
 					</td>`;


### PR DESCRIPTION
## The issue 🐛 
The combination of Chromium and NVDA was causing `d2l-calendar` to not read dates when navigating with the calendar with arrow keys.

## The changes
* remove `role="presentation"` from the `table` element
  * this was forcing us to set our own functionality, and in some situations was preventing the screen reader from reading anything out.

## Related PR
- https://github.com/BrightspaceUI/core/pull/602

## Functionality details

<details>
<summary>Current screen reader behavior</summary>

* Windows
    * NVDA
        * Chromium 
            * tabbing in:  does not read anything 
            * moving:  does not read anything 
        * Firefox
            * tabbing in: Saturday 9. Selected. May 2020  row 2  column 7
            * moving: Friday 8. Not Selected. May 2020  not selected  column 6
    * JAWS
        * Chromium
            * tabbing in: Saturday 9. Selected. May 2020 selected contains controls
            * moving: Friday 8. Not Selected. May 2020 contains controls
        * Firefox
            * tabbing in: May 2020 table. column 6 row 1. Saturday 9. Selected. May 2020 selected contains controls
            * moving: Friday 8. Not Selected. May 2020 contains controls
* Mac
    * Voiceover
        * Chromium
            * tabbing in: Saturday 9. Selected. May 2020
            * moving: Friday 8. Not Selected. May 2020, button
        * Firefox
            * tabbing in: Entering May 2020 table. Saturday 9. Selected. May 2020, Ma 2020, table 7 columns, 6 rows
            * moving: Friday 8. Not Selected. May 2020, button, column 6 of 7
        * Safari
            * tabbing in: Entering Click on a day to select it. May 2020 table. Saturday 9. Selected. May 2020, Click on a day to select it., May 2020, table 7 columns, 7 rows
            * moving: Friday 8. Not Selected. May 2020, button, column 6 of 7
</details>

<details>
<summary>New screen reader behavior</summary>

* Windows
    * NVDA
        * Chromium
            * tabbing in: May 2020  table. Saturday 9. May 2020  row 2  column 7
            * moving around: Friday 8. May 2020  not selected  column 6
        * Firefox
            * tabbing in: May 2020  table Saturday 9 May 2020
            * moving around: Friday 8 May 2020  not selected  column 6
    * JAWS
        * Chromium
            * tabbing in: May 2020  table. column 7 row 2  Saturday 9 May 2020 selected contains controls
            * moving around: Friday 8 May 2020 contains controls
        * Firefox
            * tabbing in: May 2020  table. column 7 row 2  Saturday 9 May 2020 selected contains controls
            * moving around: Friday 8 May 2020 contains controls
* Mac
    * Voiceover
        * Chromium
            * tabbing in: Entering September 2018 table. Saturday 8 September 2018, September 2018, table 7 columns, 6 rows
            * moving around: Friday 7 September 2018, button, column 6 of 7
        * Firefox
            * tabbing in: Entering September 2018 table. Saturday 8 September 2018, September 2018, table 7 columns, 6 rows
            * moving around: Friday 7 September 2018, button, column 6 of 7
        * Safari
            * tabbing in: Entering September 2018 table. Saturday 8 September 2018, September 2018, table 7 columns, 7 rows
            * moving around:Friday 7 September 2018, button, column 6 of 7
</details>


## Rally
[DE47890](https://rally1.rallydev.com/#/15545167705d/defects?detail=%2Fdefect%2F630216629055&view=17f0e440-d291-4296-ac11-349b05e5aa0d)