### PR TITLE
fix: reserve space for last separator

### DIFF
--- a/components/list/list.js
+++ b/components/list/list.js
@@ -56,6 +56,9 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 			:host {
 				display: block;
 			}
+			:host > div {
+				padding-bottom: 2px;
+			}
 			:host([hidden]) {
 				display: none;
 			}


### PR DESCRIPTION
This change adds some padding to the end of the list in order to prevent the last separator on the list to force a scrollbar to appear.

Rally: [DE52887](https://rally1.rallydev.com/#/?detail=/defect/697344876657&fdp=true)