### PR TITLE
only use Dependabot for major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
+      # update-package-lock workflow aready handles minor/patch updates
+      - update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "@formatjs/intl-pluralrules"


### PR DESCRIPTION
Mondays can be hectic when our `update-package-lock` workflow has run over the weekend but failed due to visual-diff changes and then Dependabot kicks in and also updates everything.

This adjusts Dependabot to ignore everything except major versions, which are something `update-package-lock` ignores.

Following [these docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore).