### PR TITLE
fix: `d2l-collapsible-panel-group` > remove unnecessary `SkeletonMixin`

### DIFF
--- a/components/collapsible-panel/README.md
+++ b/components/collapsible-panel/README.md
@@ -363,7 +363,7 @@ Collapsible panels have two optional slots, `header` and `actions` that can be u
 
 Use the `d2l-collapsible-panel-group` component to automatically handle spacing and layout for multiple panels.
 
-<!-- docs: demo live -->
+<!-- docs: demo live name:d2l-collapsible-panel-group -->
 ```html
 <script type="module">
 	import '@brightspace-ui/core/components/collapsible-panel/collapsible-panel.js';

--- a/components/collapsible-panel/collapsible-panel-group.js
+++ b/components/collapsible-panel/collapsible-panel-group.js
@@ -1,12 +1,11 @@
 import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 /**
  * A component that renders a container and layout for collapsible panels
  * @slot default - Slot for panels. Only accepts `d2l-collapsible-panel`
  */
-class CollapsiblePanelGroup extends SkeletonMixin(LitElement) {
+class CollapsiblePanelGroup extends LitElement {
 
 	static get properties() {
 		return {

--- a/components/collapsible-panel/collapsible-panel-group.js
+++ b/components/collapsible-panel/collapsible-panel-group.js
@@ -14,7 +14,7 @@ class CollapsiblePanelGroup extends LitElement {
 	}
 
 	static get styles() {
-		return [super.styles, css`
+		return css`
 			:host ::slotted(*) {
 				display: none;
 			}
@@ -26,7 +26,7 @@ class CollapsiblePanelGroup extends LitElement {
 				flex-direction: column;
 				row-gap: 0.5rem;
 			}
-		`];
+		`;
 	}
 
 	constructor() {


### PR DESCRIPTION
The `SkeletonMixin` wasn't being used in this component.

Also, update the docs to show the live properties for `d2l-collapsible-panel-group`.

## Rally
[US153600](https://rally1.rallydev.com/#/15545167705d/custom/21568985922?detail=%2Fuserstory%2F703942502753)