### PR TITLE
fix: `d2l-expand-collapse-content` > set expanded state in another spot

### DIFF
--- a/components/expand-collapse/expand-collapse-content.js
+++ b/components/expand-collapse/expand-collapse-content.js
@@ -119,9 +119,7 @@ class ExpandCollapseContent extends LitElement {
 				));
 			}
 			if (reduceMotion || firstUpdate) {
-				this._state = states.EXPANDED;
-				this._height = 'auto';
-				this._eventPromiseResolve();
+				this._setExpanded();
 			} else {
 				this._state = states.PREEXPANDING;
 				await this.updateComplete;
@@ -130,6 +128,7 @@ class ExpandCollapseContent extends LitElement {
 					this._state = states.EXPANDING;
 					const content = this.shadowRoot && this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner');
 					if (content) this._height = `${content.scrollHeight}px`;
+					if (content?.scrollHeight === 0) this._setExpanded();
 				}
 			}
 		} else {
@@ -159,14 +158,17 @@ class ExpandCollapseContent extends LitElement {
 
 	_onTransitionEnd() {
 		if (this._state === states.EXPANDING) {
-			this._state = states.EXPANDED;
-			this._height = 'auto';
-			this._eventPromiseResolve();
+			this._setExpanded();
 		} else if (this._state === states.COLLAPSING) {
 			this._state = states.COLLAPSED;
 			this._eventPromiseResolve();
 		}
 	}
 
+	_setExpanded() {
+		this._state = states.EXPANDED;
+		this._height = 'auto';
+		this._eventPromiseResolve();
+	}
 }
 customElements.define('d2l-expand-collapse-content', ExpandCollapseContent);

--- a/components/expand-collapse/expand-collapse-content.js
+++ b/components/expand-collapse/expand-collapse-content.js
@@ -126,9 +126,10 @@ class ExpandCollapseContent extends LitElement {
 				await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
 				if (this._state === states.PREEXPANDING) {
 					this._state = states.EXPANDING;
-					const content = this.shadowRoot && this.shadowRoot.querySelector('.d2l-expand-collapse-content-inner');
-					if (content) this._height = `${content.scrollHeight}px`;
-					if (content?.scrollHeight === 0) this._setExpanded();
+					const content = this.shadowRoot?.querySelector('.d2l-expand-collapse-content-inner');
+					const contentHeight = content?.scrollHeight;
+					if (contentHeight) this._height = `${contentHeight}px`;
+					if (contentHeight === 0) this._setExpanded();
 				}
 			}
 		} else {


### PR DESCRIPTION
## Description

If the component is expanding but is empty, the height of the contents will be `0`, and therefore there is nothing to animate, and the `transitionend` event will not be dispatched.

This led to an issue where the component was stuck in an "expanding" state with `height: 0`.

If we detect this scenario, we simply move to the end "expanded" state with `height: auto`. Any subsequent addition of elements to the panel would then be displayed immediately.

## Rally
[DE53776](https://rally1.rallydev.com/#/15545167705d/custom/21568985922?Iteration=%2Fiteration%2F668139821167&Release=u&cpoid=15545167705&detail=%2Fdefect%2F704665648499&rankScope=%2Fiteration%2F668139821167&typeDef=7362609627)