### PR TITLE
add back web-test-runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@rollup/plugin-node-resolve": "^15",
         "@rollup/plugin-replace": "^5",
         "@web/dev-server": "^0.2",
+        "@web/test-runner": "^0.16",
         "axe-core": "^4",
         "chalk": "^5",
         "eslint": "^8",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@rollup/plugin-node-resolve": "^15",
     "@rollup/plugin-replace": "^5",
     "@web/dev-server": "^0.2",
+    "@web/test-runner": "^0.16",
     "axe-core": "^4",
     "chalk": "^5",
     "eslint": "^8",


### PR DESCRIPTION
Core should have an explicit dependency here, since it calls `web-test-runner` itself. Without it, when you link `@brightspace-ui/testing`, calling `web-test-runner` fails.