### PR TITLE
move fixture call into beforeEach

### DIFF
--- a/mixins/localize/test/localize-mixin.test.js
+++ b/mixins/localize/test/localize-mixin.test.js
@@ -358,7 +358,10 @@ describe('LocalizeMixin', () => {
 
 	describe('localizeHTML', async() => {
 
-		const elem = await fixture(`<${localizeHTMLTag}></${localizeHTMLTag}>`);
+		let elem;
+		beforeEach(async() => {
+			elem = await fixture(`<${localizeHTMLTag}></${localizeHTMLTag}>`);
+		});
 
 		const renderToElem = data => {
 			render(data, elem);


### PR DESCRIPTION
Calling the new `fixture` outside of `it`, `before` or `beforeEach` causes it to blow up when trying to reset and call into the wtr server commands. I spent a bunch of time trying to figure out why and how to detect it but came up short for now -- will spend more time later. In the meantime, just moving these tests.