### PR TITLE
switch to keyboard helpers

### DIFF
--- a/components/list/test/list-item-drag-handle.test.js
+++ b/components/list/test/list-item-drag-handle.test.js
@@ -1,19 +1,7 @@
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { dragActions } from '../list-item-drag-handle.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
-
-const keyCodes = Object.freeze({
-	END: { key: 'end', code: 35 },
-	HOME: { key: 'home', code: 36 },
-	UP: { key: 'up arrow', code: 38 },
-	DOWN: { key: 'down arrow', code: 40 },
-	SPACE: { key: 'space', code: 32 },
-	ENTER: { key: 'enter', code: 13 },
-	ESC: { key: 'escape', code: 27 },
-	TAB: { key: 'tab', code: 9 },
-	LEFT: { key: 'left arrow', code: 37 },
-	RIGHT: { key: 'right arrow', code: 39 }
-});
+import { sendKeys } from '@web/test-runner-commands';
 
 describe('ListItemDragHandle', () => {
 
@@ -36,12 +24,12 @@ describe('ListItemDragHandle', () => {
 		});
 
 		[
-			{ keyPress: keyCodes.ENTER },
-			{ keyPress: keyCodes.SPACE }
+			{ keyPress: 'Enter' },
+			{ keyPress: ' ' }
 		].forEach(testCase => {
-			it(`Dispatch drag handle action event for ${dragActions.active} when ${testCase.keyPress.key} is pressed.`, async() => {
+			it(`Dispatch drag handle action event for "${dragActions.active}" when "${testCase.keyPress}" is pressed.`, async() => {
 				const actionArea = element.shadowRoot.querySelector('button');
-				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress.code));
+				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress));
 				const e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
 				expect(e.detail.action).to.equal(dragActions.active);
 			});
@@ -61,37 +49,37 @@ describe('ListItemDragHandle', () => {
 		});
 
 		[
-			{ keyPress: keyCodes.UP, result: dragActions.up },
-			{ keyPress: keyCodes.DOWN, result: dragActions.down },
-			{ keyPress: keyCodes.HOME, result: dragActions.first },
-			{ keyPress: keyCodes.END, result: dragActions.last },
-			{ keyPress: keyCodes.RIGHT, result: dragActions.nest },
-			{ keyPress: keyCodes.LEFT, result: dragActions.unnest }
+			{ keyPress: 'ArrowUp', result: dragActions.up },
+			{ keyPress: 'ArrowDown', result: dragActions.down },
+			{ keyPress: 'Home', result: dragActions.first },
+			{ keyPress: 'End', result: dragActions.last },
+			{ keyPress: 'ArrowRight', result: dragActions.nest },
+			{ keyPress: 'ArrowLeft', result: dragActions.unnest }
 		].forEach(testCase => {
-			it(`Dispatch drag handle action event for ${testCase.result} when ${testCase.keyPress.key} is pressed.`, async() => {
+			it(`Dispatch drag handle action event for "${testCase.result}" when "${testCase.keyPress}" is pressed.`, async() => {
 				const actionArea = element.shadowRoot.querySelector('d2l-button-move').shadowRoot.querySelector('button');
-				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress.code, !!testCase.shift));
+				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress, !!testCase.shift));
 				const e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
 				expect(e.detail.action).to.equal(testCase.result);
 			});
 		});
 
 		[
-			{ keyPress: keyCodes.TAB, result: dragActions.previousElement, shift: true },
-			{ keyPress: keyCodes.TAB, result: dragActions.nextElement },
-			{ keyPress: keyCodes.ESC, result: dragActions.cancel },
-			{ keyPress: keyCodes.ENTER, result: dragActions.save },
-			{ keyPress: keyCodes.SPACE, result: dragActions.save }
+			{ keyPress: 'Tab', result: dragActions.previousElement, shift: true },
+			{ keyPress: 'Tab', result: dragActions.nextElement },
+			{ keyPress: 'Escape', result: dragActions.cancel },
+			{ keyPress: 'Enter', result: dragActions.save },
+			{ keyPress: ' ', result: dragActions.save }
 		].forEach(testCase => {
-			it(`Dispatch drag handle action event for ${testCase.result} when ${testCase.keyPress.key} is pressed.`, async() => {
+			it(`Dispatch drag handle action event for "${testCase.result}" when "${testCase.keyPress}" is pressed.`, async() => {
 				const actionArea = element.shadowRoot.querySelector('d2l-button-move');
-				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress.code, !!testCase.shift));
+				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress, !!testCase.shift));
 				const e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
 				expect(e.detail.action).to.equal(testCase.result);
 			});
 		});
 
-		it(`Dispatch drag handle action event for ${dragActions.save} when element is focus out.`, async() => {
+		it(`Dispatch drag handle action event for "${dragActions.save}" when element is focus out.`, async() => {
 			const actionArea = element.shadowRoot.querySelector('d2l-button-move');
 			setTimeout(() => actionArea.dispatchEvent(new Event('focusout')));
 			const e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
@@ -100,13 +88,12 @@ describe('ListItemDragHandle', () => {
 		});
 	});
 
-	function dispatchKeyEvent(el, key, shiftKey = false) {
-		const eventObj = document.createEvent('Events');
-		eventObj.initEvent('keydown', true, true);
-		eventObj.which = key;
-		eventObj.keyCode = key;
-		eventObj.shiftKey = shiftKey;
-		el.dispatchEvent(eventObj);
+	async function dispatchKeyEvent(el, key, shiftKey = false) {
+		if (shiftKey) {
+			await sendKeys({ press: `Shift+${key}` });
+		} else {
+			await sendKeys({ press: key });
+		}
 	}
 
 });


### PR DESCRIPTION
I'm noticing some super rare flake in these tests in Firefox. I'm hoping that switching them to use the actual keyboard to trigger things instead of faking it out like it was doing will improve things.