### PR TITLE
stub console to suppress expected warnings

### DIFF
--- a/components/list/test/list-item-checkbox-mixin.test.js
+++ b/components/list/test/list-item-checkbox-mixin.test.js
@@ -1,5 +1,6 @@
 import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
 import { html, LitElement } from 'lit';
+import { restore, stub } from 'sinon';
 import { ListItemCheckboxMixin } from '../list-item-checkbox-mixin.js';
 
 const tag = defineCE(
@@ -14,7 +15,14 @@ const tag = defineCE(
 );
 
 describe('ListItemCheckboxMixin', () => {
-	// will log "ListItemCheckboxMixin requires a key."
+
+	let consoleWarnStub;
+	beforeEach(() => {
+		consoleWarnStub = stub(console, 'warn');
+	});
+
+	afterEach(() => restore());
+
 	describe('Sets selected status to undefined when no key is given', () => {
 		const cases = [
 			'selection-disabled selected',
@@ -26,6 +34,9 @@ describe('ListItemCheckboxMixin', () => {
 			it(test, async() => {
 				const element = await fixture(`<${tag} ${test} label="some label"></${tag}>`);
 				expect(element.selected).to.be.undefined;
+				if (cases.indexOf('selectable') > -1) {
+					expect(consoleWarnStub).to.be.calledWith('ListItemCheckboxMixin requires a key.');
+				}
 			});
 		}
 	});

--- a/components/list/test/list-item-expand-collapse-mixin.test.js
+++ b/components/list/test/list-item-expand-collapse-mixin.test.js
@@ -1,5 +1,6 @@
 import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
 import { html, LitElement } from 'lit';
+import { restore, stub } from 'sinon';
 import { ListItemCheckboxMixin } from '../list-item-checkbox-mixin.js';
 import { ListItemExpandCollapseMixin } from '../list-item-expand-collapse-mixin.js';
 import { ListItemMixin } from '../list-item-mixin.js';
@@ -17,10 +18,19 @@ const tag = defineCE(
 );
 
 describe('ListItemExpandCollapseMixin', () => {
+
+	let consoleWarnStub;
+	beforeEach(() => {
+		consoleWarnStub = stub(console, 'warn');
+	});
+
+	afterEach(() => restore());
+
 	it('Sets expandable to false when no key is given', async() => {
 		const element = await fixture(`<${tag} expandable></${tag}>`);
 		await element.updateComplete;
 		expect(element.expandable).to.be.false;
+		expect(consoleWarnStub).to.be.calledWith('ListItemExpandCollapseMixin requires a key.');
 	});
 
 	describe('Render expand/collapse action area when appropriate', () => {

--- a/mixins/localize/test/localize-mixin.test.js
+++ b/mixins/localize/test/localize-mixin.test.js
@@ -1,9 +1,9 @@
 import { _LocalizeMixinBase, generateLink, generateTooltipHelp, localizeMarkup, LocalizeMixin } from '../localize-mixin.js';
 import { defineCE, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { LitElement, render } from 'lit';
+import { restore, stub } from 'sinon';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { LocalizeCoreElement } from '../../../helpers/localize-core-element.js';
-import { stub } from 'sinon';
 
 const Test1LocalizeMixinBase = superclass => class extends _LocalizeMixinBase(superclass) {
 
@@ -358,10 +358,13 @@ describe('LocalizeMixin', () => {
 
 	describe('localizeHTML', async() => {
 
-		let elem;
+		let consoleErrorStub, elem;
 		beforeEach(async() => {
+			consoleErrorStub = stub(console, 'error');
 			elem = await fixture(`<${localizeHTMLTag}></${localizeHTMLTag}>`);
 		});
+
+		afterEach(() => restore());
 
 		const renderToElem = data => {
 			render(data, elem);
@@ -382,6 +385,7 @@ describe('LocalizeMixin', () => {
 			items.push('bread', 'eggs');
 			const pluralMap = elem.localizeHTML('pluralTest', { itemCount: items.length, link: generateLink({ href: 'checkout' }), html: () => items.map(i => localizeMarkup`<p>${i}</p>`) });
 
+			expect(consoleErrorStub).to.have.been.calledTwice;
 			expect(renderToElem(defaultTags)).lightDom.to.equal('This is <strong>important</strong>, this is <strong><em>very important</em></strong>');
 			expect(renderToElem(manual)).lightDom.to.equal('This is <d2l-link href="http://d2l.com">a link</d2l-link>');
 			expect(renderToElem(disallowed)).lightDom.to.equal('This is &lt;link&gt;replaceable&lt;/link&gt;');


### PR DESCRIPTION
Cleaning up some of the console warnings/errors that get spit out while our unit tests are running by stubbing them out. 

There's still a single log entry that's expected for an error being thrown in a Promise -- haven't figured out a way to catch that yet.