### PR TITLE
switch to @brightspace-ui/testing fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm run lint:style
   playwright:
     name: Accessibility and Unit Tests
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout

--- a/components/alert/test/alert-toast.axe.js
+++ b/components/alert/test/alert-toast.axe.js
@@ -1,5 +1,5 @@
 import '../alert-toast.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-alert-toast', () => {
 

--- a/components/alert/test/alert-toast.test.js
+++ b/components/alert/test/alert-toast.test.js
@@ -1,5 +1,5 @@
 import '../alert-toast.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-alert-toast', () => {

--- a/components/alert/test/alert.axe.js
+++ b/components/alert/test/alert.axe.js
@@ -1,5 +1,5 @@
 import '../alert.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-alert', () => {
 

--- a/components/alert/test/alert.test.js
+++ b/components/alert/test/alert.test.js
@@ -1,5 +1,5 @@
 import '../alert.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const alertFixture = html`

--- a/components/backdrop/test/backdrop.test.js
+++ b/components/backdrop/test/backdrop.test.js
@@ -1,5 +1,5 @@
 import '../backdrop.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const backdropFixture = html`

--- a/components/breadcrumbs/test/breadcrumbs.axe.js
+++ b/components/breadcrumbs/test/breadcrumbs.axe.js
@@ -1,7 +1,7 @@
 import '../breadcrumb.js';
 import '../breadcrumb-current-page.js';
 import '../breadcrumbs.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-breadcrumbs', () => {
 

--- a/components/button/test/button-icon.axe.js
+++ b/components/button/test/button-icon.axe.js
@@ -1,5 +1,5 @@
 import '../button-icon.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-button-icon', () => {
 

--- a/components/button/test/button-icon.test.js
+++ b/components/button/test/button-icon.test.js
@@ -1,5 +1,5 @@
 import '../button-icon.js';
-import { fixture, html, oneEvent } from '@open-wc/testing';
+import { fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-button-icon', () => {

--- a/components/button/test/button-mixin.test.js
+++ b/components/button/test/button-mixin.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture } from '@open-wc/testing';
+import { defineCE, expect, fixture } from '@brightspace-ui/testing';
 import { html, LitElement } from 'lit';
 import { ButtonMixin } from '../button-mixin.js';
 

--- a/components/button/test/button-move.axe.js
+++ b/components/button/test/button-move.axe.js
@@ -1,5 +1,5 @@
 import '../button-move.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-button-move', () => {
 

--- a/components/button/test/button-move.test.js
+++ b/components/button/test/button-move.test.js
@@ -1,4 +1,4 @@
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { keyDown } from '../../../tools/dom-test-helpers.js';
 import { moveActions } from '../button-move.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';

--- a/components/button/test/button-subtle.axe.js
+++ b/components/button/test/button-subtle.axe.js
@@ -1,5 +1,5 @@
 import '../button-subtle.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-button-subtle', () => {
 

--- a/components/button/test/button-subtle.test.js
+++ b/components/button/test/button-subtle.test.js
@@ -1,5 +1,5 @@
 import '../button-subtle.js';
-import { fixture, html, oneEvent } from '@open-wc/testing';
+import { fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-button-subtle', () => {

--- a/components/button/test/button.axe.js
+++ b/components/button/test/button.axe.js
@@ -1,5 +1,5 @@
 import '../button.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 const normalFixture = html`<d2l-button>Normal Button</d2l-button>`;
 const primaryFixture = html`<d2l-button primary>Primary Button</d2l-button>`;

--- a/components/button/test/button.test.js
+++ b/components/button/test/button.test.js
@@ -1,5 +1,5 @@
 import '../button.js';
-import { fixture, html, oneEvent } from '@open-wc/testing';
+import { fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-button', () => {

--- a/components/calendar/test/calendar.axe.js
+++ b/components/calendar/test/calendar.axe.js
@@ -1,5 +1,5 @@
 import '../calendar.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-calendar', () => {
 

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -1,4 +1,4 @@
-import { aTimeout, expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent, waitUntil } from '@brightspace-ui/testing';
 import { checkIfDatesEqual,
 	getDatesInMonthArray,
 	getNextMonth,

--- a/components/card/test/card-content-meta.axe.js
+++ b/components/card/test/card-content-meta.axe.js
@@ -1,5 +1,5 @@
 import '../card-content-meta.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-card-content-meta', () => {
 

--- a/components/card/test/card-content-title.axe.js
+++ b/components/card/test/card-content-title.axe.js
@@ -1,5 +1,5 @@
 import '../card-content-title.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-card-content-title', () => {
 

--- a/components/card/test/card-footer-link.axe.js
+++ b/components/card/test/card-footer-link.axe.js
@@ -1,5 +1,5 @@
 import '../card-footer-link.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-card-footer-link', () => {
 

--- a/components/card/test/card-loading-shimmer.axe.js
+++ b/components/card/test/card-loading-shimmer.axe.js
@@ -1,5 +1,5 @@
 import '../card-loading-shimmer.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-card-loading-shimmer', () => {
 

--- a/components/card/test/card.axe.js
+++ b/components/card/test/card.axe.js
@@ -1,5 +1,5 @@
 import '../card.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-card', () => {
 

--- a/components/card/test/card.test.js
+++ b/components/card/test/card.test.js
@@ -1,5 +1,5 @@
 import '../card.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-card', () => {

--- a/components/collapsible-panel/test/collapsible-panel.axe.js
+++ b/components/collapsible-panel/test/collapsible-panel.axe.js
@@ -1,6 +1,6 @@
 import '../collapsible-panel.js';
 import '../collapsible-panel-summary-item.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-collapsible-panel', () => {
 

--- a/components/collapsible-panel/test/collapsible-panel.test.js
+++ b/components/collapsible-panel/test/collapsible-panel.test.js
@@ -1,7 +1,7 @@
 import '../collapsible-panel.js';
 import '../collapsible-panel-summary-item.js';
 import '../collapsible-panel-group.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-collapsible-panel', () => {

--- a/components/count-badge/test/count-badge-icon.axe.js
+++ b/components/count-badge/test/count-badge-icon.axe.js
@@ -1,5 +1,5 @@
 import '../count-badge-icon.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 const countBadgeAnnounceChanges = html`
 <d2l-count-badge-icon size="small" announce-changes text="1 new notification." type="notification" number="1"></d2l-count-badge-icon>`;

--- a/components/count-badge/test/count-badge.axe.js
+++ b/components/count-badge/test/count-badge.axe.js
@@ -1,5 +1,5 @@
 import '../count-badge.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 const countBadgeTooltip = html`
 <d2l-count-badge size="small" has-tooltip text="1 new notification." type="notification" number="1"></d2l-count-badge>`;

--- a/components/description-list/test/description-list.axe.js
+++ b/components/description-list/test/description-list.axe.js
@@ -1,5 +1,5 @@
 import '../demo/description-list-test.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-d2l-wrapper', () => {
 

--- a/components/description-list/test/description-list.test.js
+++ b/components/description-list/test/description-list.test.js
@@ -1,6 +1,6 @@
 import '../description-list-wrapper.js';
 
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-dl-wrapper', () => {

--- a/components/dialog/test/dialog-confirm.test.js
+++ b/components/dialog/test/dialog-confirm.test.js
@@ -1,6 +1,6 @@
 import '../../button/button.js';
 import '../dialog-confirm.js';
-import { expect, fixture, oneEvent } from '@open-wc/testing';
+import { expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { html } from 'lit';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';

--- a/components/dialog/test/dialog.test.js
+++ b/components/dialog/test/dialog.test.js
@@ -1,5 +1,5 @@
 import '../dialog.js';
-import { expect, fixture, oneEvent } from '@open-wc/testing';
+import { expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { html } from 'lit';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
@@ -17,7 +17,8 @@ describe('d2l-dialog', () => {
 	describe('focus management', () => {
 
 		it('should focus on close button if no focusable elements inside', async() => {
-			const el = await fixture(html`<d2l-dialog opened>not focusable</d2l-dialog>`);
+			const el = await fixture(html`<d2l-dialog>not focusable</d2l-dialog>`);
+			el.opened = true;
 			await oneEvent(el, 'd2l-dialog-open');
 			expect(getComposedActiveElement().getAttribute('aria-label')).to.equal('Close this dialog');
 		});
@@ -52,16 +53,18 @@ describe('d2l-dialog', () => {
 		});
 
 		it('should not focus on an autofocus element that had not been made focusable', async() => {
-			const el = await fixture(html`<d2l-dialog opened><p autofocus>focus</p><button>focus</button></d2l-dialog>`);
-			const paragraph = el.querySelector('p');
+			const el = await fixture(html`<d2l-dialog><p autofocus>focus</p><button>focus</button></d2l-dialog>`);
+			el.opened = true;
 			await oneEvent(el, 'd2l-dialog-open');
+			const paragraph = el.querySelector('p');
 			expect(getComposedActiveElement()).to.not.equal(paragraph);
 		});
 
 		it('should not focus on a descendant autofocus element that had not been made focusable', async() => {
-			const el = await fixture(html`<d2l-dialog opened><div><p autofocus>focus</p></div><button>focus</button></d2l-dialog>`);
-			const paragraph = el.querySelector('p');
+			const el = await fixture(html`<d2l-dialog><div><p autofocus>focus</p></div><button>focus</button></d2l-dialog>`);
+			el.opened = true;
 			await oneEvent(el, 'd2l-dialog-open');
+			const paragraph = el.querySelector('p');
 			expect(getComposedActiveElement()).to.not.equal(paragraph);
 		});
 

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -1,7 +1,6 @@
 import '../dropdown.js';
 import '../dropdown-content.js';
-import { aTimeout, expect, fixture, html, nextFrame, oneEvent } from '@open-wc/testing';
-import { focusElem } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, focusElem, html, nextFrame, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`
@@ -62,7 +61,6 @@ describe('d2l-dropdown', () => {
 	beforeEach(async() => {
 		dropdown = await fixture(normalFixture);
 		content = dropdown.querySelector('d2l-dropdown-content');
-		await content.updateComplete;
 	});
 
 	describe('constructor', () => {

--- a/components/dropdown/test/dropdown-menu.test.js
+++ b/components/dropdown/test/dropdown-menu.test.js
@@ -4,7 +4,7 @@ import '../../menu/menu.js';
 import '../../menu/menu-item.js';
 import '../../menu/menu-item-link.js';
 import '../../menu/menu-item-radio.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const itemFixture = html`

--- a/components/dropdown/test/dropdown-openers.test.js
+++ b/components/dropdown/test/dropdown-openers.test.js
@@ -2,7 +2,7 @@ import '../dropdown-button-subtle.js';
 import '../dropdown-button.js';
 import '../dropdown-context-menu.js';
 import '../dropdown-more.js';
-import { fixture, html, oneEvent } from '@open-wc/testing';
+import { fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-dropdown-openers', () => {

--- a/components/empty-state/test/empty-state-illustrated.axe.js
+++ b/components/empty-state/test/empty-state-illustrated.axe.js
@@ -1,7 +1,7 @@
 import '../empty-state-action-button.js';
 import '../empty-state-action-link.js';
 import '../empty-state-illustrated.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe ('d2l-empty-state-illustrated', () => {
 

--- a/components/empty-state/test/empty-state-illustrated.test.js
+++ b/components/empty-state/test/empty-state-illustrated.test.js
@@ -1,7 +1,7 @@
 import '../empty-state-illustrated.js';
 import '../empty-state-action-button.js';
 import '../empty-state-action-link.js';
-import { fixture, oneEvent, waitUntil } from '@open-wc/testing';
+import { fixture, oneEvent, waitUntil } from '@brightspace-ui/testing';
 import { html } from 'lit';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 

--- a/components/empty-state/test/empty-state-simple.axe.js
+++ b/components/empty-state/test/empty-state-simple.axe.js
@@ -1,7 +1,7 @@
 import '../empty-state-action-button.js';
 import '../empty-state-action-link.js';
 import '../empty-state-simple.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe ('d2l-empty-state-simple', () => {
 

--- a/components/empty-state/test/empty-state-simple.test.js
+++ b/components/empty-state/test/empty-state-simple.test.js
@@ -1,7 +1,7 @@
 import '../empty-state-action-button.js';
 import '../empty-state-action-link.js';
 import '../empty-state-simple.js';
-import { fixture, oneEvent } from '@open-wc/testing';
+import { fixture, oneEvent } from '@brightspace-ui/testing';
 import { html } from 'lit';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 

--- a/components/expand-collapse/test/expand-collapse-content.test.js
+++ b/components/expand-collapse/test/expand-collapse-content.test.js
@@ -1,5 +1,5 @@
 import '../expand-collapse-content.js';
-import { fixture, html } from '@open-wc/testing';
+import { fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const collapsedContentFixture = html`<d2l-expand-collapse-content>A message.</d2l-expand-collapse-content>`;

--- a/components/filter/test/filter-dimension-set-value.test.js
+++ b/components/filter/test/filter-dimension-set-value.test.js
@@ -1,5 +1,5 @@
 import '../filter-dimension-set-value.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { spy } from 'sinon';
 

--- a/components/filter/test/filter-dimension-set.test.js
+++ b/components/filter/test/filter-dimension-set.test.js
@@ -1,7 +1,7 @@
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
 import '../filter-dimension-set-empty-state.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { spy } from 'sinon';
 

--- a/components/filter/test/filter-overflow-group.axe.js
+++ b/components/filter/test/filter-overflow-group.axe.js
@@ -2,7 +2,7 @@ import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
 import '../filter-overflow-group.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-filter-overflow-group', () => {
 

--- a/components/filter/test/filter-overflow-group.test.js
+++ b/components/filter/test/filter-overflow-group.test.js
@@ -2,7 +2,7 @@ import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
 import '../filter-overflow-group.js';
-import { aTimeout, expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent, waitUntil } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-filter-overflow-group', () => {

--- a/components/filter/test/filter-tags.axe.js
+++ b/components/filter/test/filter-tags.axe.js
@@ -2,7 +2,7 @@ import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
 import '../filter-tags.js';
-import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { expect, fixture, html, waitUntil } from '@brightspace-ui/testing';
 
 const basicFixture = html`
 	<div>

--- a/components/filter/test/filter-tags.test.js
+++ b/components/filter/test/filter-tags.test.js
@@ -2,7 +2,7 @@ import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
 import '../filter-tags.js';
-import { expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent, waitUntil } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { spy } from 'sinon';
 

--- a/components/filter/test/filter.axe.js
+++ b/components/filter/test/filter.axe.js
@@ -1,7 +1,7 @@
 import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 const singleSetDimensionFixture = html`
 	<d2l-filter>

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -2,7 +2,7 @@ import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-empty-state.js';
 import '../filter-dimension-set-value.js';
-import { expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent, waitUntil } from '@brightspace-ui/testing';
 import { spy, stub } from 'sinon';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 

--- a/components/focus-trap/test/focus-trap.test.js
+++ b/components/focus-trap/test/focus-trap.test.js
@@ -1,5 +1,5 @@
 import '../focus-trap.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';
 

--- a/components/form/test/form-element-localize-helper.test.js
+++ b/components/form/test/form-element-localize-helper.test.js
@@ -1,7 +1,7 @@
 import '../../validation/validation-custom.js';
 import './form-element.js';
 
-import { defineCE, expect, fixture } from '@open-wc/testing';
+import { defineCE, expect, fixture } from '@brightspace-ui/testing';
 import { html, LitElement } from 'lit';
 import { LocalizeCoreElement } from '../../../helpers/localize-core-element.js';
 import { localizeFormElement } from '../form-element-localize-helper.js';

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -1,6 +1,6 @@
 import '../../validation/validation-custom.js';
 import './form-element.js';
-import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { html, LitElement } from 'lit';
 
 const formTag = defineCE(

--- a/components/form/test/form-error-summary.test.js
+++ b/components/form/test/form-error-summary.test.js
@@ -1,5 +1,5 @@
 import '../form-errory-summary.js';
-import { expect, fixture } from '@open-wc/testing';
+import { expect, fixture } from '@brightspace-ui/testing';
 import { html } from 'lit';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 

--- a/components/form/test/form-helper.test.js
+++ b/components/form/test/form-helper.test.js
@@ -1,7 +1,7 @@
 import './form-element.js';
 import '../../status-indicator/status-indicator.js';
 import '../../tooltip/tooltip.js';
-import { defineCE, expect, fixture } from '@open-wc/testing';
+import { defineCE, expect, fixture } from '@brightspace-ui/testing';
 import { findFormElements, flattenMap, getFormElementData, isCustomElement, isCustomFormElement, isElement, isNativeFormElement, tryGetLabelText } from '../form-helper.js';
 import { html, LitElement } from 'lit';
 

--- a/components/form/test/form-native.test.js
+++ b/components/form/test/form-native.test.js
@@ -1,7 +1,7 @@
 import '../../validation/validation-custom.js';
 import '../form-native.js';
 import './form-element.js';
-import { expect, fixture } from '@open-wc/testing';
+import { expect, fixture } from '@brightspace-ui/testing';
 import { html } from 'lit';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 

--- a/components/form/test/form.test.js
+++ b/components/form/test/form.test.js
@@ -2,7 +2,7 @@ import '../../validation/validation-custom.js';
 import '../form.js';
 import './form-element.js';
 import './nested-form.js';
-import { expect, fixture } from '@open-wc/testing';
+import { expect, fixture } from '@brightspace-ui/testing';
 import { html } from 'lit';
 
 describe('d2l-form', () => {

--- a/components/hierarchical-view/test/hierarchical-view.test.js
+++ b/components/hierarchical-view/test/hierarchical-view.test.js
@@ -1,5 +1,5 @@
 import '../hierarchical-view.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { spy } from 'sinon';
 
@@ -24,7 +24,6 @@ describe('d2l-hierarchical-view', () => {
 		const el = await fixture(viewsFixture);
 		view1 = el.querySelector('#view1');
 		view2 = el.querySelector('#view2');
-		await oneEvent(view1, 'd2l-hierarchical-view-resize');
 	});
 
 	it('root view is initially active', () => {

--- a/components/html-block/test/html-block.axe.js
+++ b/components/html-block/test/html-block.axe.js
@@ -1,5 +1,5 @@
 import '../html-block.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-html-block', () => {
 

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -1,7 +1,8 @@
 import '../html-block.js';
-import { expect, fixture, html, oneEvent, unsafeStatic } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { provideInstance } from '../../../mixins/provider/provider-mixin.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { unsafeStatic } from 'lit/static-html.js';
 
 class TestRenderer {
 	async render(elem) {

--- a/components/icons/test/getFileIconType.test.js
+++ b/components/icons/test/getFileIconType.test.js
@@ -1,5 +1,5 @@
 import { getFileIconTypeFromExtension, getFileIconTypeFromFilename } from '../getFileIconType.js';
-import { expect } from '@open-wc/testing';
+import { expect } from '@brightspace-ui/testing';
 describe('getFileIconType', () => {
 	describe('getFileIconTypeFromExtension', () => {
 		const emptyExts = ['', ' ', '.'];

--- a/components/inputs/test/input-checkbox.axe.js
+++ b/components/inputs/test/input-checkbox.axe.js
@@ -1,5 +1,5 @@
 import '../input-checkbox.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-checkbox', () => {
 

--- a/components/inputs/test/input-checkbox.test.js
+++ b/components/inputs/test/input-checkbox.test.js
@@ -1,5 +1,5 @@
 import '../input-checkbox.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const uncheckedFixture = html`<d2l-input-checkbox aria-label="basic"></d2l-input-checkbox>`;

--- a/components/inputs/test/input-color.axe.js
+++ b/components/inputs/test/input-color.axe.js
@@ -1,5 +1,5 @@
 import '../input-color.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-color', () => {
 	it('normal', async() => {

--- a/components/inputs/test/input-color.test.js
+++ b/components/inputs/test/input-color.test.js
@@ -1,5 +1,5 @@
 import '../input-color.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-input-color', () => {

--- a/components/inputs/test/input-date-range.axe.js
+++ b/components/inputs/test/input-date-range.axe.js
@@ -1,5 +1,5 @@
 import '../input-date-range.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-date-range', () => {
 

--- a/components/inputs/test/input-date-range.test.js
+++ b/components/inputs/test/input-date-range.test.js
@@ -1,4 +1,4 @@
-import { aTimeout, expect, fixture, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { getShiftedEndDate } from '../input-date-range.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';

--- a/components/inputs/test/input-date-time-range.axe.js
+++ b/components/inputs/test/input-date-time-range.axe.js
@@ -1,5 +1,5 @@
 import '../input-date-time-range.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-input-date-time-range', () => {
 

--- a/components/inputs/test/input-date-time-range.test.js
+++ b/components/inputs/test/input-date-time-range.test.js
@@ -1,4 +1,4 @@
-import { aTimeout, expect, fixture, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { getShiftedEndDateTime } from '../input-date-time-range.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';

--- a/components/inputs/test/input-date-time.axe.js
+++ b/components/inputs/test/input-date-time.axe.js
@@ -1,5 +1,5 @@
 import '../input-date-time.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-date-time', () => {
 

--- a/components/inputs/test/input-date-time.test.js
+++ b/components/inputs/test/input-date-time.test.js
@@ -1,4 +1,4 @@
-import { aTimeout, expect, fixture, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { _formatLocalDateTimeInISO } from '../input-date-time.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';

--- a/components/inputs/test/input-date.axe.js
+++ b/components/inputs/test/input-date.axe.js
@@ -1,5 +1,5 @@
 import '../input-date.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-date', () => {
 

--- a/components/inputs/test/input-date.test.js
+++ b/components/inputs/test/input-date.test.js
@@ -1,4 +1,4 @@
-import { aTimeout, expect, fixture, oneEvent, waitUntil } from '@open-wc/testing';
+import { aTimeout, expect, fixture, oneEvent, waitUntil } from '@brightspace-ui/testing';
 import { formatISODateInUserCalDescriptor } from '../input-date.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';

--- a/components/inputs/test/input-number.axe.js
+++ b/components/inputs/test/input-number.axe.js
@@ -1,5 +1,5 @@
 import '../input-number.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-input-number', () => {
 	it('normal', async() => {

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -1,5 +1,5 @@
 import '../input-number.js';
-import { aTimeout, defineCE, expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
+import { aTimeout, defineCE, expect, fixture, html, oneEvent, waitUntil } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { LitElement } from 'lit';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';

--- a/components/inputs/test/input-percent.axe.js
+++ b/components/inputs/test/input-percent.axe.js
@@ -1,5 +1,5 @@
 import '../input-percent.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-percent', () => {
 	it('normal', async() => {

--- a/components/inputs/test/input-percent.test.js
+++ b/components/inputs/test/input-percent.test.js
@@ -1,5 +1,5 @@
 import '../input-percent.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-percent label="label"></d2l-input-percent>`;

--- a/components/inputs/test/input-search.axe.js
+++ b/components/inputs/test/input-search.axe.js
@@ -1,5 +1,5 @@
 import '../input-search.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-search', () => {
 

--- a/components/inputs/test/input-search.test.js
+++ b/components/inputs/test/input-search.test.js
@@ -1,4 +1,4 @@
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { INPUT_TIMEOUT_MS, SUPPRESS_ENTER_TIMEOUT_MS } from '../input-search.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { useFakeTimers } from 'sinon';
@@ -103,7 +103,7 @@ describe('d2l-input-search', () => {
 
 			let clock;
 			beforeEach(() => {
-				clock = useFakeTimers();
+				clock = useFakeTimers({ toFake: ['clearTimeout', 'setTimeout'] });
 			});
 
 			afterEach(() => clock.restore());

--- a/components/inputs/test/input-text.axe.js
+++ b/components/inputs/test/input-text.axe.js
@@ -1,5 +1,5 @@
 import '../input-text.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-text', () => {
 

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -1,5 +1,5 @@
 import '../input-text.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-text label="label"></d2l-input-text>`;

--- a/components/inputs/test/input-textarea.axe.js
+++ b/components/inputs/test/input-textarea.axe.js
@@ -1,5 +1,5 @@
 import '../input-textarea.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-textarea', () => {
 

--- a/components/inputs/test/input-textarea.test.js
+++ b/components/inputs/test/input-textarea.test.js
@@ -1,5 +1,5 @@
 import '../input-textarea.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-textarea label="label"></d2l-input-textarea>`;

--- a/components/inputs/test/input-time-range.axe.js
+++ b/components/inputs/test/input-time-range.axe.js
@@ -1,5 +1,5 @@
 import '../input-time-range.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-time-range', () => {
 

--- a/components/inputs/test/input-time-range.test.js
+++ b/components/inputs/test/input-time-range.test.js
@@ -1,4 +1,4 @@
-import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { formatDateInISOTime, getDateFromISOTime } from '../../../helpers/dateTime.js';
 import { getDefaultTime } from '../input-time.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';

--- a/components/inputs/test/input-time.axe.js
+++ b/components/inputs/test/input-time.axe.js
@@ -1,5 +1,5 @@
 import '../input-time.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-input-time', () => {
 

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -1,5 +1,5 @@
 import '../input-time.js';
-import { aTimeout, expect, fixture, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';

--- a/components/link/test/link.axe.js
+++ b/components/link/test/link.axe.js
@@ -1,5 +1,5 @@
 import '../link.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-link', () => {
 

--- a/components/link/test/link.test.js
+++ b/components/link/test/link.test.js
@@ -1,5 +1,5 @@
 import '../link.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-link href="https://www.d2l.com">Link Test</d2l-link>`;

--- a/components/list/test/list-item-checkbox-mixin.test.js
+++ b/components/list/test/list-item-checkbox-mixin.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { html, LitElement } from 'lit';
 import { restore, stub } from 'sinon';
 import { ListItemCheckboxMixin } from '../list-item-checkbox-mixin.js';

--- a/components/list/test/list-item-drag-handle.axe.js
+++ b/components/list/test/list-item-drag-handle.axe.js
@@ -1,5 +1,5 @@
 import '../list-item-drag-handle.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-list-item-drag-handle', () => {
 

--- a/components/list/test/list-item-drag-handle.test.js
+++ b/components/list/test/list-item-drag-handle.test.js
@@ -82,7 +82,7 @@ describe('ListItemDragHandle', () => {
 				if (e.detail.action !== testCase.result && e.detail.action === dragActions.save) {
 					element.activateKeyboardMode();
 					await element.updateComplete;
-					setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress));
+					setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress, !!testCase.shift));
 					e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
 				}
 				expect(e.detail.action).to.equal(testCase.result);

--- a/components/list/test/list-item-drag-handle.test.js
+++ b/components/list/test/list-item-drag-handle.test.js
@@ -1,7 +1,6 @@
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { clickElem, expect, fixture, focusElem, html, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
 import { dragActions } from '../list-item-drag-handle.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
-import { sendKeysElem } from '@brightspace-ui/testing';
 
 describe('ListItemDragHandle', () => {
 
@@ -13,12 +12,12 @@ describe('ListItemDragHandle', () => {
 		let element;
 		beforeEach(async() => {
 			element = await fixture(html`<d2l-list-item-drag-handle></d2l-list-item-drag-handle>`);
-			element.focus();
+			await focusElem(element);
 		});
 
 		it(`Dispatch drag handle action event for ${dragActions.active} event when clicked.`, async() => {
 			const actionArea = element.shadowRoot.querySelector('button');
-			setTimeout(() => actionArea.dispatchEvent(new Event('click')));
+			setTimeout(() => clickElem(actionArea));
 			const e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
 			expect(e.detail.action).to.equal(dragActions.active);
 		});
@@ -37,15 +36,12 @@ describe('ListItemDragHandle', () => {
 	});
 
 	describe('Events in keyboard mode', () => {
+
 		let element;
 		beforeEach(async() => {
 			element = await fixture(html`<d2l-list-item-drag-handle></d2l-list-item-drag-handle>`);
-			element.focus();
-			const actionArea = element.shadowRoot.querySelector('button');
-			setTimeout(() => {
-				actionArea.dispatchEvent(new Event('click'));
-			});
-			await oneEvent(actionArea, 'click');
+			element.activateKeyboardMode();
+			await element.updateComplete;
 		});
 
 		[
@@ -58,8 +54,15 @@ describe('ListItemDragHandle', () => {
 		].forEach(testCase => {
 			it(`Dispatch drag handle action event for "${testCase.result}" when "${testCase.keyPress}" is pressed.`, async() => {
 				const actionArea = element.shadowRoot.querySelector('d2l-button-move').shadowRoot.querySelector('button');
-				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress, !!testCase.shift));
-				const e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
+				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress));
+				let e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
+				// Firefox will trigger loss of focus randomly, so retry
+				if (e.detail.action === dragActions.save) {
+					element.activateKeyboardMode();
+					await element.updateComplete;
+					setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress));
+					e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
+				}
 				expect(e.detail.action).to.equal(testCase.result);
 			});
 		});
@@ -74,7 +77,14 @@ describe('ListItemDragHandle', () => {
 			it(`Dispatch drag handle action event for "${testCase.result}" when "${testCase.keyPress}" is pressed.`, async() => {
 				const actionArea = element.shadowRoot.querySelector('d2l-button-move');
 				setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress, !!testCase.shift));
-				const e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
+				let e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
+				// Firefox will trigger loss of focus randomly, so retry
+				if (e.detail.action !== testCase.result && e.detail.action === dragActions.save) {
+					element.activateKeyboardMode();
+					await element.updateComplete;
+					setTimeout(() => dispatchKeyEvent(actionArea, testCase.keyPress));
+					e = await oneEvent(element, 'd2l-list-item-drag-handle-action');
+				}
 				expect(e.detail.action).to.equal(testCase.result);
 			});
 		});

--- a/components/list/test/list-item-drag-mixin.test.js
+++ b/components/list/test/list-item-drag-mixin.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { dropLocation, ListItemDragDropMixin, NewPositionEventDetails } from '../list-item-drag-drop-mixin.js';
 import { html, LitElement } from 'lit';
 import { ListItemMixin } from '../list-item-mixin.js';

--- a/components/list/test/list-item-expand-collapse-mixin.test.js
+++ b/components/list/test/list-item-expand-collapse-mixin.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { html, LitElement } from 'lit';
 import { restore, stub } from 'sinon';
 import { ListItemCheckboxMixin } from '../list-item-checkbox-mixin.js';

--- a/components/list/test/list-item-generic-layout.test.js
+++ b/components/list/test/list-item-generic-layout.test.js
@@ -2,7 +2,7 @@ import '../list.js';
 import '../list-item.js';
 import '../../button/button-icon.js';
 
-import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';

--- a/components/list/test/list-item-placement-marker.axe.js
+++ b/components/list/test/list-item-placement-marker.axe.js
@@ -1,5 +1,5 @@
 import '../list-item-placement-marker.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-list-item-placement-marker', () => {
 	it('visible', async() => {

--- a/components/list/test/list-item-role-mixin.test.js
+++ b/components/list/test/list-item-role-mixin.test.js
@@ -1,5 +1,5 @@
 import '../list.js';
-import { defineCE, expect, fixture } from '@open-wc/testing';
+import { defineCE, expect, fixture } from '@brightspace-ui/testing';
 import { ListItemRoleMixin } from '../list-item-role-mixin.js';
 import { LitElement } from 'lit';
 

--- a/components/list/test/list.axe.js
+++ b/components/list/test/list.axe.js
@@ -3,7 +3,7 @@ import '../list-controls.js';
 import '../list-item.js';
 import '../list-item-button.js';
 import '../../selection/selection-action.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 const normalFixture = html`
 	<d2l-list>

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -3,8 +3,7 @@ import '../list-controls.js';
 import '../list-item.js';
 import '../list-item-button.js';
 import '../list-item-content.js';
-import { expect, fixture, html, oneEvent, waitUntil } from '@open-wc/testing';
-import { focusElem, sendKeysElem } from '@brightspace-ui/testing';
+import { expect, fixture, focusElem, html, oneEvent, sendKeysElem, waitUntil } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const awaitListElementUpdates = async(rootElement, queries) => {

--- a/components/menu/test/menu-item-checkbox.test.js
+++ b/components/menu/test/menu-item-checkbox.test.js
@@ -1,5 +1,5 @@
 import '../menu-item-checkbox.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 function dispatchItemSelectEvent(elem) {

--- a/components/menu/test/menu-item-link.test.js
+++ b/components/menu/test/menu-item-link.test.js
@@ -1,5 +1,5 @@
 import '../menu-item-link.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-menu-item-link', () => {

--- a/components/menu/test/menu-item-mixin.test.js
+++ b/components/menu/test/menu-item-mixin.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { LitElement } from 'lit';
 import { MenuItemMixin } from '../menu-item-mixin.js';
 

--- a/components/menu/test/menu-item-radio.test.js
+++ b/components/menu/test/menu-item-radio.test.js
@@ -1,5 +1,5 @@
 import '../menu-item-radio.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 function dispatchItemSelectEvent(elem) {

--- a/components/menu/test/menu-item-selectable-mixin.test.js
+++ b/components/menu/test/menu-item-selectable-mixin.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture } from '@open-wc/testing';
+import { defineCE, expect, fixture } from '@brightspace-ui/testing';
 import { LitElement } from 'lit';
 import { MenuItemSelectableMixin } from '../menu-item-selectable-mixin.js';
 

--- a/components/menu/test/menu-item-separator.test.js
+++ b/components/menu/test/menu-item-separator.test.js
@@ -1,5 +1,5 @@
 import '../menu-item-separator.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-menu-item-separator', () => {

--- a/components/menu/test/menu.axe.js
+++ b/components/menu/test/menu.axe.js
@@ -1,6 +1,6 @@
 import '../menu.js';
 import '../menu-item.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-menu', () => {
 

--- a/components/meter/test/meter-circle.axe.js
+++ b/components/meter/test/meter-circle.axe.js
@@ -1,5 +1,5 @@
 import '../meter-circle.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-meter-circle', () => {
 

--- a/components/meter/test/meter-linear.axe.js
+++ b/components/meter/test/meter-linear.axe.js
@@ -1,5 +1,5 @@
 import '../meter-linear.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-meter-linear', () => {
 

--- a/components/meter/test/meter-radial.axe.js
+++ b/components/meter/test/meter-radial.axe.js
@@ -1,5 +1,5 @@
 import '../meter-radial.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-meter-radial', () => {
 

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -11,7 +11,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 /**
  * A component used to minimize the display of long content, while providing a way to reveal the full content.
  * @slot - Default content placed inside of the component
- * @fires d2l-more-less-render - Dispatched when the component finishes rendering
  */
 class MoreLess extends LocalizeCoreElement(LitElement) {
 
@@ -147,12 +146,6 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 	}
 
 	render() {
-		requestAnimationFrame(
-			() => this.dispatchEvent(new CustomEvent('d2l-more-less-render', {
-				bubbles: false,
-				composed: false
-			}))
-		);
 		const contentClasses = {
 			'd2l-more-less-content': true,
 			'd2l-more-less-transition': this.__transitionAdded

--- a/components/more-less/test/more-less.axe.js
+++ b/components/more-less/test/more-less.axe.js
@@ -1,6 +1,6 @@
 import '../more-less.js';
-import { expect, fixture, html } from '@open-wc/testing';
-import { waitForHeight, waitForRender } from './more-less.test.js';
+import { expect, fixture, html } from '@brightspace-ui/testing';
+import { waitForHeight } from './more-less.test.js';
 
 describe('d2l-more-less', () => {
 
@@ -15,7 +15,6 @@ describe('d2l-more-less', () => {
 					<p>Mauris in libero cursus, iaculis sapien quis, semper felis. Maecenas convallis gravida libero euismod vehicula. Morbi quis lectus dui. Praesent non congue purus, at vehicula metus. Quisque vitae tempus elit. Aenean a aliquet nunc, nec blandit metus. Duis mattis odio vel erat eleifend volutpat. Cras eget augue et ligula vehicula ultrices. Ut vitae hendrerit nibh, id interdum nisl. Ut vestibulum tellus sed nulla bibendum aliquam. Maecenas quis sapien enim.</p>
 				</d2l-more-less>
 			`);
-			await waitForRender(elem);
 			await waitForHeight(elem);
 			await expect(elem).to.be.accessible();
 		});

--- a/components/more-less/test/more-less.test.js
+++ b/components/more-less/test/more-less.test.js
@@ -1,5 +1,5 @@
 import '../more-less.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 export function waitForHeight(elem) {
@@ -15,10 +15,6 @@ export function waitForHeight(elem) {
 		}
 		check();
 	});
-}
-
-export async function waitForRender(elem) {
-	await oneEvent(elem, 'd2l-more-less-render');
 }
 
 describe('d2l-more-less', () => {
@@ -40,7 +36,6 @@ describe('d2l-more-less', () => {
 					<p id="clone-target">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum elementum venenatis arcu sit amet varius. Maecenas posuere magna arcu, quis maximus odio fringilla ac. Integer ligula lorem, faucibus sit amet cursus vel, pellentesque a justo. Aliquam urna metus, molestie at tempor eget, vestibulum a purus. Donec aliquet rutrum mi. Duis ornare congue tempor. Nullam sed massa fermentum, tincidunt leo eu, vestibulum orci. Sed ultrices est in lacus venenatis, posuere suscipit arcu scelerisque. In aliquam ipsum rhoncus, lobortis ligula ut, molestie orci. Proin scelerisque tempor posuere. Phasellus consequat, lorem quis hendrerit tempor, sem lectus sagittis nunc, in tristique dui arcu non arcu. Nunc aliquam nisi et sapien commodo lacinia. <a href="javascript:void(0);">Quisque</a> iaculis orci vel odio varius porta. Fusce tincidunt dolor enim, vitae sollicitudin purus suscipit eu.</p>
 				</d2l-more-less>
 			`);
-			await waitForRender(elem);
 			await waitForHeight(elem);
 		});
 

--- a/components/object-property-list/test/object-property-list.axe.js
+++ b/components/object-property-list/test/object-property-list.axe.js
@@ -2,7 +2,7 @@ import '../object-property-list.js';
 import '../object-property-list-item.js';
 import '../object-property-list-item-link.js';
 import '../../status-indicator/status-indicator.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-object-property-list', () => {
 

--- a/components/object-property-list/test/object-property-list.test.js
+++ b/components/object-property-list/test/object-property-list.test.js
@@ -2,7 +2,7 @@ import '../object-property-list.js';
 import '../object-property-list-item.js';
 import '../object-property-list-item-link.js';
 import '../../status-indicator/status-indicator.js';
-import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const validateSeparators = (elem, count) => {

--- a/components/overflow-group/test/overflow-group.axe.js
+++ b/components/overflow-group/test/overflow-group.axe.js
@@ -2,7 +2,7 @@
 import '../overflow-group.js';
 import '../../button/button.js';
 import '../../button/button-subtle.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-overflow-group', () => {
 

--- a/components/overflow-group/test/overflow-group.test.js
+++ b/components/overflow-group/test/overflow-group.test.js
@@ -1,6 +1,6 @@
 import '../overflow-group.js';
 import '../../button/button.js';
-import { fixture, html, oneEvent } from '@open-wc/testing';
+import { fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-overflow-group', () => {

--- a/components/paging/test/pager-load-more.axe.js
+++ b/components/paging/test/pager-load-more.axe.js
@@ -1,6 +1,6 @@
 import './pageable-component.js';
 import '../pager-load-more.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 const generatePager = (hasMore, itemCount, pageSize) => fixture(html`

--- a/components/paging/test/pager-load-more.test.js
+++ b/components/paging/test/pager-load-more.test.js
@@ -1,5 +1,5 @@
 import '../pager-load-more.js';
-import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, oneEvent } from '@brightspace-ui/testing';
 import { html, LitElement } from 'lit';
 import { PageableMixin } from '../pageable-mixin.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';

--- a/components/scroll-wrapper/test/scroll-wrapper.axe.js
+++ b/components/scroll-wrapper/test/scroll-wrapper.axe.js
@@ -1,6 +1,6 @@
 
 import '../scroll-wrapper.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-scroll-wrapper', () => {
 

--- a/components/selection/test/selection.axe.js
+++ b/components/selection/test/selection.axe.js
@@ -7,7 +7,7 @@ import '../selection-input.js';
 import '../selection-select-all.js';
 import '../selection-select-all-pages.js';
 import '../selection-summary.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-selection-action', () => {
 

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -8,7 +8,7 @@ import '../selection-input.js';
 import '../selection-select-all.js';
 import '../selection-select-all-pages.js';
 import '../selection-summary.js';
-import { expect, fixture, html, nextFrame, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, nextFrame, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { SelectionInfo } from '../selection-mixin.js';
 import Sinon from 'sinon';

--- a/components/status-indicator/test/status-indicator.axe.js
+++ b/components/status-indicator/test/status-indicator.axe.js
@@ -1,5 +1,5 @@
 import '../status-indicator.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-status-indicator', () => {
 

--- a/components/status-indicator/test/status-indicator.test.js
+++ b/components/status-indicator/test/status-indicator.test.js
@@ -1,5 +1,5 @@
 import '../status-indicator.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-status-indicator', () => {

--- a/components/switch/test/switch-visibility.axe.js
+++ b/components/switch/test/switch-visibility.axe.js
@@ -1,5 +1,5 @@
 import '../switch-visibility.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-switch-visibility', () => {
 

--- a/components/switch/test/switch.axe.js
+++ b/components/switch/test/switch.axe.js
@@ -1,5 +1,5 @@
 import '../switch.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 describe('d2l-switch', () => {
 

--- a/components/switch/test/switch.test.js
+++ b/components/switch/test/switch.test.js
@@ -1,8 +1,7 @@
 import '../switch.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
-import { sendKeysElem } from '@brightspace-ui/testing';
 
 const switchFixture = html`<d2l-switch text="some text"></d2l-switch>`;
 

--- a/components/table/test/table.test.js
+++ b/components/table/test/table.test.js
@@ -1,6 +1,6 @@
 import '../table-controls.js';
 import '../table-wrapper.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-table-wrapper', () => {

--- a/components/tabs/test/tabs.axe.js
+++ b/components/tabs/test/tabs.axe.js
@@ -1,6 +1,6 @@
 import '../tabs.js';
 import '../tab-panel.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-tabs', () => {
 

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -1,6 +1,6 @@
 import '../tabs.js';
 import '../tab-panel.js';
-import { fixture, html, oneEvent } from '@open-wc/testing';
+import { fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`

--- a/components/tag-list/test/tag-list.axe.js
+++ b/components/tag-list/test/tag-list.axe.js
@@ -1,7 +1,7 @@
 import './tag-list-item-mixin-consumer.js';
 import '../tag-list.js';
 import '../tag-list-item.js';
-import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { expect, fixture, html, waitUntil } from '@brightspace-ui/testing';
 
 const basicFixture = html`
 	<d2l-tag-list description="Testing Tags">

--- a/components/tag-list/test/tag-list.test.js
+++ b/components/tag-list/test/tag-list.test.js
@@ -1,7 +1,7 @@
 import './tag-list-item-mixin-consumer.js';
 import '../tag-list.js';
 import '../tag-list-item.js';
-import { expect, fixture, html, nextFrame, oneEvent, waitUntil } from '@open-wc/testing';
+import { expect, fixture, html, nextFrame, oneEvent, waitUntil } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 

--- a/components/tooltip/test/tooltip-help.axe.js
+++ b/components/tooltip/test/tooltip-help.axe.js
@@ -1,5 +1,5 @@
 import '../tooltip-help.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 const tooltipFixture = html`<d2l-tooltip-help text="Helpful label.">Contents should elaborate on the label (be short and concise)</d2l-tooltip-help>`;
 

--- a/components/tooltip/test/tooltip.axe.js
+++ b/components/tooltip/test/tooltip.axe.js
@@ -1,5 +1,5 @@
 import '../tooltip.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-tooltip', () => {
 

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -1,6 +1,5 @@
 import '../tooltip.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
-import { focusElem } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, focusElem, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`

--- a/components/typography/test/styles.test.js
+++ b/components/typography/test/styles.test.js
@@ -1,5 +1,5 @@
 import { _isValidCssSelector } from '../styles.js';
-import { expect } from '@open-wc/testing';
+import { expect } from '@brightspace-ui/testing';
 
 describe('_isValidCssSelector', () => {
 

--- a/components/validation/test/validation-custom.test.js
+++ b/components/validation/test/validation-custom.test.js
@@ -1,5 +1,5 @@
 import '../validation-custom.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`

--- a/controllers/attributeObserver/test/htmlAttributeObserverController.test.js
+++ b/controllers/attributeObserver/test/htmlAttributeObserverController.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { HtmlAttributeObserverController } from '../htmlAttributeObserverController.js';
 import { LitElement } from 'lit';
 

--- a/controllers/subscriber/test/subscriberControllers.test.js
+++ b/controllers/subscriber/test/subscriberControllers.test.js
@@ -1,5 +1,5 @@
 
-import { defineCE, expect, fixture, nextFrame } from '@open-wc/testing';
+import { defineCE, expect, fixture, nextFrame } from '@brightspace-ui/testing';
 import { EventSubscriberController, IdSubscriberController, SubscriberRegistryController } from '../subscriberControllers.js';
 import { html, LitElement } from 'lit';
 import sinon from 'sinon';

--- a/directives/animate/test/animate.test.js
+++ b/directives/animate/test/animate.test.js
@@ -1,5 +1,4 @@
-import { clickElem, focusElem } from '@brightspace-ui/testing';
-import { expect, fixture, oneEvent } from '@open-wc/testing';
+import { clickElem, expect, fixture, focusElem, oneEvent } from '@brightspace-ui/testing';
 import { hide, show } from '../animate.js';
 import { html, LitElement } from 'lit';
 import { getComposedActiveElement } from '../../../helpers/focus.js';

--- a/directives/run-async/test/run-async.test.js
+++ b/directives/run-async/test/run-async.test.js
@@ -1,4 +1,4 @@
-import { expect, fixture } from '@open-wc/testing';
+import { expect, fixture } from '@brightspace-ui/testing';
 import { InitialStateError, runAsync } from '../run-async.js';
 import { html } from 'lit';
 

--- a/helpers/test/contrast.test.js
+++ b/helpers/test/contrast.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@open-wc/testing';
+import { expect } from '@brightspace-ui/testing';
 import { isColorAccessible } from '../contrast.js';
 
 describe('colour-contrast', () => {

--- a/helpers/test/dateTime.test.js
+++ b/helpers/test/dateTime.test.js
@@ -13,7 +13,7 @@ import { formatDateInISO,
 	parseISODate,
 	parseISODateTime,
 	parseISOTime } from '../dateTime.js';
-import { expect } from '@open-wc/testing';
+import { expect } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import sinon from 'sinon';
 

--- a/helpers/test/dismissible.test.js
+++ b/helpers/test/dismissible.test.js
@@ -1,5 +1,5 @@
 import { clearDismissible, setDismissible } from '../dismissible.js';
-import { expect } from '@open-wc/testing';
+import { expect } from '@brightspace-ui/testing';
 import { spy } from 'sinon';
 
 function pressEscape() {

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -13,7 +13,7 @@ import {
 	isVisible,
 	querySelectorComposed
 } from '../dom.js';
-import { defineCE, expect, fixture } from '@open-wc/testing';
+import { defineCE, expect, fixture } from '@brightspace-ui/testing';
 
 const testElemTag = defineCE(
 	class extends LitElement {

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture, html } from '@open-wc/testing';
+import { defineCE, expect, fixture, html } from '@brightspace-ui/testing';
 import {
 	getComposedActiveElement,
 	getFirstFocusableDescendant,

--- a/helpers/test/getLocalizeResources.test.js
+++ b/helpers/test/getLocalizeResources.test.js
@@ -1,5 +1,5 @@
 import { __clearWindowCache, getLocalizeOverrideResources } from '../getLocalizeResources.js';
-import { expect } from '@open-wc/testing';
+import { expect } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import sinon from 'sinon';
 

--- a/mixins/arrow-keys/test/arrow-keys-mixin.test.js
+++ b/mixins/arrow-keys/test/arrow-keys-mixin.test.js
@@ -1,5 +1,5 @@
 import '../demo/arrow-keys-test.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { keyDown } from '../../../tools/dom-test-helpers.js';
 

--- a/mixins/focus/test/focus-mixin.test.js
+++ b/mixins/focus/test/focus-mixin.test.js
@@ -1,5 +1,5 @@
 
-import { defineCE, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { FocusMixin } from '../focus-mixin.js';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { LitElement } from 'lit';

--- a/mixins/interactive/test/interactive-mixin.test.js
+++ b/mixins/interactive/test/interactive-mixin.test.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture, html } from '@open-wc/testing';
+import { defineCE, expect, fixture, html } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { InteractiveMixin } from '../interactive-mixin.js';
 import { keyDown } from '../../../tools/dom-test-helpers.js';

--- a/mixins/labelled/labelled-mixin.js
+++ b/mixins/labelled/labelled-mixin.js
@@ -126,6 +126,16 @@ export const LabelledMixin = superclass => class extends superclass {
 
 	}
 
+	_dispatchChangeEvent() {
+		/** @ignore */
+		this.dispatchEvent(new CustomEvent(
+			'd2l-labelled-mixin-label-change', {
+				bubbles: false,
+				composed: false
+			}
+		));
+	}
+
 	_throwError(err) {
 		if (!this.labelRequired || this._missingLabelErrorHasBeenThrown) return;
 		this._missingLabelErrorHasBeenThrown = true;
@@ -134,9 +144,14 @@ export const LabelledMixin = superclass => class extends superclass {
 
 	_updateLabelElem(labelElem) {
 
+		const oldLabelVal = this.label;
+
 		// setting textContent doesn't change labelElem but we do need to refetch the label
 		if (labelElem === this._labelElem && this._labelElem) {
 			this.label = getLabel(this._labelElem);
+			if (oldLabelVal !== this.label) {
+				this._dispatchChangeEvent();
+			}
 			return;
 		}
 
@@ -180,13 +195,9 @@ export const LabelledMixin = superclass => class extends superclass {
 		}
 
 		this.label = getLabel(this._labelElem);
-		/** @ignore */
-		this.dispatchEvent(new CustomEvent(
-			'd2l-labelled-mixin-label-elem-change', {
-				bubbles: false,
-				composed: false
-			}
-		));
+		if (oldLabelVal !== this.label) {
+			this._dispatchChangeEvent();
+		}
 
 	}
 

--- a/mixins/labelled/test/label-mixin.test.js
+++ b/mixins/labelled/test/label-mixin.test.js
@@ -1,5 +1,5 @@
 
-import { defineCE, expect, fixture, html, nextFrame, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, html, nextFrame, oneEvent } from '@brightspace-ui/testing';
 import { LabelledMixin, LabelMixin } from '../labelled-mixin.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LitElement } from 'lit';
@@ -42,7 +42,6 @@ describe('LabelMixin', () => {
 		elem = await fixture(`
 			<${labelTag} text="the label value"></${labelTag}>
 		`);
-		await elem.updateComplete;
 	});
 
 	it('reflects label value', async() => {
@@ -92,7 +91,7 @@ describe('LabelledMixin', () => {
 			const labelledElem = elem.querySelector('[labelled-by="label1"]');
 			const labelElem = elem.querySelector('#label1');
 			labelElem.textContent = 'new label value';
-			await nextFrame();
+			await oneEvent(labelledElem, 'd2l-labelled-mixin-label-change');
 			expect(labelledElem.label).to.equal('new label value');
 		});
 
@@ -104,7 +103,7 @@ describe('LabelledMixin', () => {
 			newLabelElem.id = 'label1';
 			newLabelElem.textContent = 'new label value';
 			labelElem.parentNode.replaceChild(newLabelElem, labelElem);
-			await oneEvent(labelledElem, 'd2l-labelled-mixin-label-elem-change');
+			await oneEvent(labelledElem, 'd2l-labelled-mixin-label-change');
 			expect(labelledElem.label).to.equal('new label value');
 		});
 
@@ -112,7 +111,7 @@ describe('LabelledMixin', () => {
 			elem = await fixture(nativeElemFixture);
 			const labelledElem = elem.querySelector('[labelled-by="label1"]');
 			labelledElem.labelledBy = 'label3';
-			await nextFrame();
+			await oneEvent(labelledElem, 'd2l-labelled-mixin-label-change');
 			expect(labelledElem.label).to.equal('other element');
 		});
 
@@ -138,7 +137,7 @@ describe('LabelledMixin', () => {
 			const labelledElem = elem.querySelector('[labelled-by="label2"]');
 			const labelElem = elem.querySelector('#label2');
 			labelElem.text = 'new label value';
-			await nextFrame();
+			await oneEvent(labelledElem, 'd2l-labelled-mixin-label-change');
 			expect(labelledElem.label).to.equal('new label value');
 		});
 
@@ -150,7 +149,7 @@ describe('LabelledMixin', () => {
 			newLabelElem.id = 'label2';
 			newLabelElem.text = 'new label value';
 			labelElem.parentNode.replaceChild(newLabelElem, labelElem);
-			await oneEvent(labelledElem, 'd2l-labelled-mixin-label-elem-change');
+			await oneEvent(labelledElem, 'd2l-labelled-mixin-label-change');
 			expect(labelledElem.label).to.equal('new label value');
 		});
 

--- a/mixins/localize/test/localize-mixin.test.js
+++ b/mixins/localize/test/localize-mixin.test.js
@@ -1,5 +1,5 @@
 import { _LocalizeMixinBase, generateLink, generateTooltipHelp, localizeMarkup, LocalizeMixin } from '../localize-mixin.js';
-import { defineCE, expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { defineCE, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { LitElement, render } from 'lit';
 import { restore, stub } from 'sinon';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';

--- a/mixins/rtl/test/rtl-mixin.test.js
+++ b/mixins/rtl/test/rtl-mixin.test.js
@@ -1,5 +1,5 @@
 
-import { defineCE, expect, fixture, html } from '@open-wc/testing';
+import { defineCE, expect, fixture, html } from '@brightspace-ui/testing';
 import { LitElement } from 'lit';
 import { RtlMixin } from '../rtl-mixin.js';
 

--- a/mixins/visible-on-ancestor/test/visible-on-ancestor-mixin.test.js
+++ b/mixins/visible-on-ancestor/test/visible-on-ancestor-mixin.test.js
@@ -1,6 +1,6 @@
 
 import '../../../components/button/button-icon.js';
-import { defineCE, expect, fixture, html, nextFrame } from '@open-wc/testing';
+import { defineCE, expect, fixture, html, nextFrame } from '@brightspace-ui/testing';
 import { LitElement } from 'lit';
 
 const targetTag = defineCE(

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@brightspace-ui/stylelint-config": "^0.8",
         "@brightspace-ui/testing": "^0.9",
         "@open-wc/semantic-dom-diff": "^0.20",
-        "@open-wc/testing": "^3",
         "@rollup/plugin-dynamic-import-vars": "^2",
         "@rollup/plugin-node-resolve": "^15",
         "@rollup/plugin-replace": "^5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@brightspace-ui/stylelint-config": "^0.8",
     "@brightspace-ui/testing": "^0.9",
     "@open-wc/semantic-dom-diff": "^0.20",
-    "@open-wc/testing": "^3",
     "@rollup/plugin-dynamic-import-vars": "^2",
     "@rollup/plugin-node-resolve": "^15",
     "@rollup/plugin-replace": "^5",

--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -24,7 +24,7 @@ const nonJsGlob = [
 export default {
 	input: glob.sync(jsGlob),
 	output: { dir: 'build', format: 'es', preserveModules: true },
-	external: ['puppeteer', '@brightspace-ui/visual-diff', '@open-wc/testing', 'sinon'],
+	external: ['puppeteer', '@brightspace-ui/visual-diff', '@brightspace-ui/testing', 'sinon'],
 	plugins: [
 		del({ targets: 'build' }),
 		copy({

--- a/templates/primary-secondary/test/primary-secondary.axe.js
+++ b/templates/primary-secondary/test/primary-secondary.axe.js
@@ -1,5 +1,5 @@
 import '../primary-secondary.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-template-primary-secondary', () => {
 

--- a/tools/constructor-test-helper.js
+++ b/tools/constructor-test-helper.js
@@ -1,4 +1,4 @@
-import { expect } from '@open-wc/testing';
+import { expect } from '@brightspace-ui/testing';
 
 export function runConstructor(nodeName) {
 	const ctor = customElements.get(nodeName);


### PR DESCRIPTION
The vast majority of the changes here are just adjusting the import location, however having `fixture` now wait for everything to be ready did require adjusting a few tests that were dependent on it _not_ doing that.

Once this is merged I'll do a separate pull request to remove all the test code that's manually waiting for nested element `updateComplete`s.