### PR TITLE
Remove unnecessary awaits for updateComplete

### DIFF
--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -322,7 +322,6 @@ describe('d2l-dropdown', () => {
 						</d2l-dropdown-content>
 					</d2l-dropdown>`);
 				content = dropdown.querySelector('d2l-dropdown-content');
-				await content.updateComplete;
 
 				content.setAttribute('opened', true);
 				await oneEvent(content, 'd2l-dropdown-open');
@@ -464,7 +463,6 @@ describe('d2l-dropdown', () => {
 			content = dropdown.querySelector('d2l-dropdown-content');
 			dropdownOpener = dropdown.querySelector('d2l-dropdown');
 			opener = dropdown.querySelector('.d2l-dropdown-opener');
-			await content.updateComplete;
 		});
 
 		it('gets opener when the opener has multiple classes', () => {

--- a/components/dropdown/test/dropdown-menu.test.js
+++ b/components/dropdown/test/dropdown-menu.test.js
@@ -62,7 +62,6 @@ describe('d2l-dropdown-menu', () => {
 			it(testCase.name, async() => {
 				const dropdown = await fixture(testCase.fixture);
 				const content = dropdown.querySelector('#dropdown');
-				await content.updateComplete;
 				content.setAttribute('opened', true);
 				await oneEvent(content, 'd2l-dropdown-open');
 				setTimeout(() => dropdown.querySelector('#first-item').click());

--- a/components/filter/test/filter-overflow-group.test.js
+++ b/components/filter/test/filter-overflow-group.test.js
@@ -78,7 +78,6 @@ describe('d2l-filter-overflow-group', () => {
 					</d2l-filter>
 				</d2l-filter-overflow-group>
 			`);
-			await filterOverflowGroup.updateComplete;
 			filterTags = filterOverflowGroup.querySelector('d2l-filter-tags');
 			await waitUntil(() => filterTags.filterIds, 'Filter Ids not set');
 		});

--- a/components/filter/test/filter-tags.axe.js
+++ b/components/filter/test/filter-tags.axe.js
@@ -41,7 +41,6 @@ describe('d2l-filter-tags', () => {
 	it('basic', async() => {
 		const elem = await fixture(basicFixture);
 		const filterTags = elem.querySelector('d2l-filter-tags');
-		await filterTags.updateComplete;
 		await waitUntil(() => filterTags._allActiveFilters.get('filter').length === 4, 'Active filters were not set');
 
 		await expect(elem).to.be.accessible();
@@ -49,9 +48,6 @@ describe('d2l-filter-tags', () => {
 
 	it('empty', async() => {
 		const elem = await fixture(emptyFixture);
-		const filterTags = elem.querySelector('d2l-filter-tags');
-		await filterTags.updateComplete;
-
 		await expect(elem).to.be.accessible();
 	});
 

--- a/components/filter/test/filter-tags.test.js
+++ b/components/filter/test/filter-tags.test.js
@@ -57,8 +57,6 @@ describe('d2l-filter-tags', () => {
 			const elem = await fixture(basic);
 			filter = elem.querySelector('d2l-filter');
 			filterTags = elem.querySelector('d2l-filter-tags');
-			await filter.updateComplete;
-			await filterTags.updateComplete;
 			await waitUntil(() => filterTags._allActiveFilters.get('filter').length === 3, 'Active filters were not set');
 
 			tagList = filterTags.shadowRoot.querySelector('d2l-tag-list');
@@ -164,8 +162,6 @@ describe('d2l-filter-tags', () => {
 			const elem = await fixture(twoFilters);
 			filter1 = elem.querySelector('#filter-1');
 			filterTags = elem.querySelector('d2l-filter-tags');
-			await filter1.updateComplete;
-			await filterTags.updateComplete;
 			const activeMap = filterTags._allActiveFilters;
 			await waitUntil(() => activeMap.get('filter-1').length === 1 && activeMap.get('filter-2').length === 1, 'Active filters were not set');
 

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -271,8 +271,6 @@ describe('d2l-filter', () => {
 		it('sets introductory text on a dimension in a multi-dimensional filter', async() => {
 			const elem = await fixture('<d2l-filter><d2l-filter-dimension-set introductory-text="Intro" key="dim"></d2l-filter-dimension-set><d2l-filter-dimension-set introductory-text="intro" key="dim"></d2l-filter-dimension-set></d2l-filter>');
 			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
-			const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
-			await dropdownContent.updateComplete;
 			const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
 
 			elem.opened = true;
@@ -672,8 +670,6 @@ describe('d2l-filter', () => {
 				const elem = await fixture(singleSetDimensionFixture);
 				const eventSpy = spy(elem, 'dispatchEvent');
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
-				const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-content');
-				await dropdownContent.updateComplete;
 
 				elem.opened = true;
 				const e = await oneEvent(elem, 'd2l-filter-dimension-first-open');
@@ -693,8 +689,6 @@ describe('d2l-filter', () => {
 				const elem = await fixture(multiDimensionFixture);
 				const eventSpy = spy(elem, 'dispatchEvent');
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
-				const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
-				await dropdownContent.updateComplete;
 				const dimensions = elem.shadowRoot.querySelectorAll('d2l-menu-item');
 
 				elem.opened = true;
@@ -1225,7 +1219,6 @@ describe('d2l-filter', () => {
 			const hideStub = stub(elem, '_handleDimensionHide');
 			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
 			const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-content');
-			await dropdownContent.updateComplete;
 
 			elem.opened = true;
 			await oneEvent(dropdown, 'd2l-dropdown-open');
@@ -1253,7 +1246,6 @@ describe('d2l-filter', () => {
 				const elem = await fixture(multiDimensionFixture);
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
 				const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
-				await dropdownContent.updateComplete;
 				const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
 
 				elem.opened = true;
@@ -1286,7 +1278,6 @@ describe('d2l-filter', () => {
 				const elem = await fixture(multiDimensionFixture);
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown-button-subtle');
 				const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
-				await dropdownContent.updateComplete;
 				const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
 
 				elem.opened = true;

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -42,7 +42,6 @@ describe('form-element', () => {
 	beforeEach(async() => {
 		form = await fixture(formFixture);
 		formElement = form.shadowRoot.querySelector('#my-ele');
-		await formElement.updateComplete;
 	});
 
 	describe('events', () => {

--- a/components/inputs/test/input-date-time.test.js
+++ b/components/inputs/test/input-date-time.test.js
@@ -297,7 +297,6 @@ describe('d2l-input-date-time', () => {
 			const clock = sinon.useFakeTimers({ now: newToday.getTime(), toFake: ['Date'] });
 			const elem = await fixture(basicFixture);
 			const dateInput = getChildElem(elem, 'd2l-input-date');
-			await elem.updateComplete;
 			dateInput.opened = true;
 			await oneEvent(dateInput, 'd2l-input-date-dropdown-toggle');
 			await elem.updateComplete;

--- a/components/list/test/list-item-drag-mixin.test.js
+++ b/components/list/test/list-item-drag-mixin.test.js
@@ -20,7 +20,6 @@ const tag = defineCE(
 describe('ListItemDragDropMixin', () => {
 	it('Sets draggable to false when no key is given', async() => {
 		const element = await fixture(`<${tag} draggable></${tag}>`);
-		await element.updateComplete;
 		expect(element.draggable).to.be.false;
 	});
 

--- a/components/list/test/list-item-expand-collapse-mixin.test.js
+++ b/components/list/test/list-item-expand-collapse-mixin.test.js
@@ -28,7 +28,6 @@ describe('ListItemExpandCollapseMixin', () => {
 
 	it('Sets expandable to false when no key is given', async() => {
 		const element = await fixture(`<${tag} expandable></${tag}>`);
-		await element.updateComplete;
 		expect(element.expandable).to.be.false;
 		expect(consoleWarnStub).to.be.calledWith('ListItemExpandCollapseMixin requires a key.');
 	});
@@ -72,7 +71,6 @@ describe('ListItemExpandCollapseMixin', () => {
 
 		it('Fires event on button click', async() => {
 			const element = await fixture(`<${tag} key="1234" expandable expanded></${tag}>`);
-			await element.updateComplete;
 			const button = element.shadowRoot.querySelector('d2l-button-icon');
 			expect(button).to.exist;
 			// simulate a button click
@@ -88,7 +86,6 @@ describe('ListItemExpandCollapseMixin', () => {
 
 		it('Fires event on action area click', async() => {
 			const element = await fixture(`<${tag} key="1234" expandable></${tag}>`);
-			await element.updateComplete;
 			const actionControl = element.shadowRoot.querySelector('.d2l-list-expand-collapse-action');
 			expect(actionControl).to.exist;
 			// simulate action control click

--- a/components/list/test/list-item-generic-layout.test.js
+++ b/components/list/test/list-item-generic-layout.test.js
@@ -135,9 +135,6 @@ describe('d2l-list-item-generic-layout', () => {
 	describe('grid enabling', () => {
 		it('enables grid on list-item-generic-layout elements', async() => {
 			const el = await fixture(normalFixture);
-			await el.updateComplete;
-			const items = el.getItems();
-			await Promise.all(items.map(item => item.updateComplete));
 			el.getItems().forEach(item => {
 				expect(item.shadowRoot.querySelector('d2l-list-item-generic-layout').gridActive).to.be.true;
 			});
@@ -145,9 +142,6 @@ describe('d2l-list-item-generic-layout', () => {
 
 		it('disables grid on list-item-generic-layout elements', async() => {
 			const el = await fixture(nonGridFixture);
-			await el.updateComplete;
-			const items = el.getItems();
-			await Promise.all(items.map(item => item.updateComplete));
 			el.getItems().forEach(item => {
 				expect(item.shadowRoot.querySelector('d2l-list-item-generic-layout').gridActive).to.be.undefined;
 			});
@@ -160,8 +154,6 @@ describe('d2l-list-item-generic-layout', () => {
 
 		beforeEach(async() => {
 			el = await fixture(longFixture);
-			const items = el.getItems();
-			await Promise.all(items.map(item => item.updateComplete));
 		});
 
 		const tests = [

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -6,15 +6,6 @@ import '../list-item-content.js';
 import { expect, fixture, focusElem, html, oneEvent, sendKeysElem, waitUntil } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
-const awaitListElementUpdates = async(rootElement, queries) => {
-	await rootElement.updateComplete;
-	for (const query of queries) {
-		const element = rootElement.querySelector(query);
-		await element.updateComplete;
-	}
-	await new Promise(resolve => requestAnimationFrame(resolve));  // US143322: Needed by Firefox
-};
-
 const selectionInputRendering = async item => {
 	return new Promise(resolve => {
 		const intervalId = setInterval(() => {
@@ -99,16 +90,6 @@ describe('d2l-list', () => {
 						</d2l-list>
 					</div>
 				`);
-				await awaitListElementUpdates(elem, [
-					'#L1',
-					'#L2',
-					'#L3',
-					'[key="L1-1"]',
-					'[key="L2-1"]',
-					'[key="L2-2"]',
-					'[key="L2-3"]',
-					'[key="L3-1"]',
-				]);
 
 				const listItem = elem.querySelector('[key="L2-2"]');
 				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
@@ -142,15 +123,6 @@ describe('d2l-list', () => {
 						</d2l-list-item>
 					</d2l-list>	
 				`);
-				await awaitListElementUpdates(elem, [
-					'#L2',
-					'#L3',
-					'[key="L1-1"]',
-					'[key="L2-1"]',
-					'[key="L2-2"]',
-					'[key="L3-1"]',
-					'[key="L3-2"]',
-				]);
 
 				const listItem = elem.querySelector('[key="L2-2"]');
 				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
@@ -173,11 +145,6 @@ describe('d2l-list', () => {
 					<d2l-list-item selectable key="L1-2" label="L1-2"></d2l-list-item>
 				</d2l-list>
 			`);
-			await awaitListElementUpdates(elem, [
-				'[slot="controls"]',
-				'[key="L1-1"]',
-				'[key="L1-2"]',
-			]);
 
 			const listItem = elem.querySelector('[key="L1-2"]');
 			const listItemLayout = elem.querySelector('[key="L1-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
@@ -201,10 +168,6 @@ describe('d2l-list', () => {
 					<d2l-list-item selectable key="L1-2" label="L1-2"></d2l-list-item>
 				</d2l-list>
 			`);
-			await awaitListElementUpdates(elem, [
-				'[key="L1-1"]',
-				'[key="L1-2"]',
-			]);
 		});
 
 		it('dispatches d2l-list-selection-changes event when selectable item is clicked', async() => {
@@ -248,12 +211,6 @@ describe('d2l-list', () => {
 					</d2l-list-item>
 				</d2l-list>
 			`);
-			await awaitListElementUpdates(elem, [
-				'[key="L1-1"]',
-				'[slot="nested"]',
-				'[key="L2-1"]',
-				'[key="L2-2"]',
-			]);
 		});
 
 		it('dispatches d2l-list-selection-changes event when selectable leaf item is clicked', async() => {

--- a/components/more-less/test/more-less.test.js
+++ b/components/more-less/test/more-less.test.js
@@ -2,7 +2,7 @@ import '../more-less.js';
 import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
-export function waitForHeight(elem) {
+function waitForHeight(elem) {
 	return new Promise((resolve) => {
 		function check() {
 			const content = elem.shadowRoot.querySelector('.d2l-more-less-content');

--- a/components/more-less/test/more-less.test.js
+++ b/components/more-less/test/more-less.test.js
@@ -2,7 +2,7 @@ import '../more-less.js';
 import { expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
-function waitForHeight(elem) {
+export function waitForHeight(elem) {
 	return new Promise((resolve) => {
 		function check() {
 			const content = elem.shadowRoot.querySelector('.d2l-more-less-content');

--- a/components/paging/test/pager-load-more.test.js
+++ b/components/paging/test/pager-load-more.test.js
@@ -23,7 +23,6 @@ describe('d2l-pager-load-more', () => {
 	it('dispatches d2l-pager-load-more event when clicked', async() => {
 		const el = await fixture(`<${tagName} item-count="30"><d2l-pager-load-more slot="pager" has-more page-size="5"></d2l-pager-load-more></${tagName}`);
 		const pager = el.querySelector('d2l-pager-load-more');
-		await pager.updateComplete;
 
 		setTimeout(() => pager.shadowRoot.querySelector('button').click());
 		await oneEvent(pager, 'd2l-pager-load-more');
@@ -32,7 +31,6 @@ describe('d2l-pager-load-more', () => {
 	it('does not dispatch d2l-pager-load-more event while loading', async() => {
 		const el = await fixture(`<${tagName} item-count="30"><d2l-pager-load-more slot="pager" has-more page-size="5"></d2l-pager-load-more></${tagName}`);
 		const pager = el.querySelector('d2l-pager-load-more');
-		await pager.updateComplete;
 
 		setTimeout(() => pager.shadowRoot.querySelector('button').click());
 		await oneEvent(pager, 'd2l-pager-load-more');
@@ -54,7 +52,6 @@ describe('d2l-pager-load-more', () => {
 	it('should have the right initial item counts', async() => {
 		const el = await fixture(`<${tagName} item-count="30"><d2l-pager-load-more slot="pager" has-more page-size="5"></d2l-pager-load-more></${tagName}`);
 		const pager = el.querySelector('d2l-pager-load-more');
-		await pager.updateComplete;
 
 		expect(pager._pageableInfo).to.eql({ itemCount: 30, itemShowingCount: 10 });
 	});

--- a/components/selection/test/selection.axe.js
+++ b/components/selection/test/selection.axe.js
@@ -117,7 +117,6 @@ describe('d2l-selection-select-all-pages', () => {
 
 	it('default', async() => {
 		const elem = await fixture(html`<d2l-test-selection item-count="50"><d2l-selection-select-all-pages></d2l-selection-select-all-pages><d2l-selection-input label="Input" key="key1" selected></d2l-selection-input></d2l-test-selection>`);
-		await elem.querySelector('d2l-selection-select-all-pages').updateComplete;
 		await new Promise(resolve => setTimeout(resolve, 0));
 		await expect(elem.querySelector('d2l-selection-select-all-pages')).to.be.accessible();
 	});

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -123,7 +123,6 @@ describe('d2l-selection-input', () => {
 				<d2l-selection-input key="key3" label="label3" disabled></d2l-selection-input>
 			</d2l-test-selection>
 		`);
-		await el.updateComplete;
 		await nextFrame();
 	});
 
@@ -184,7 +183,7 @@ describe('SelectionMixin', () => {
 	let el;
 
 	beforeEach(async() => {
-		el = await fixture(`
+		el = await fixture(html`
 			<d2l-test-selection>
 				<d2l-selection-select-all></d2l-selection-select-all>
 				<d2l-selection-summary></d2l-selection-summary>
@@ -194,7 +193,6 @@ describe('SelectionMixin', () => {
 				<d2l-selection-input key="key4" label="label4" disabled></d2l-selection-input>
 			</d2l-test-selection>
 		`);
-		await el.updateComplete;
 		await nextFrame();
 	});
 
@@ -302,11 +300,11 @@ describe('SelectionObserverMixin', () => {
 	let el, collection;
 
 	beforeEach(async() => {
-		el = await fixture(`
+		el = await fixture(html`
 			<div>
-				<d2l-selection-action id="obs1" selection-for="d2l-test-selection"></d2l-selection-action>
-				<d2l-selection-select-all id="obs2" selection-for="d2l-test-selection"></d2l-selection-select-all>
-				<d2l-selection-summary id="obs3" selection-for="some-other-selection"></d2l-selection-summary>
+				<d2l-selection-action selection-for="d2l-test-selection"></d2l-selection-action>
+				<d2l-selection-select-all selection-for="d2l-test-selection"></d2l-selection-select-all>
+				<d2l-selection-summary selection-for="some-other-selection"></d2l-selection-summary>
 				<d2l-test-selection id="d2l-test-selection">
 					<d2l-selection-input key="key1" label="label1"></d2l-selection-input>
 					<d2l-selection-input key="key2" label="label2" selected></d2l-selection-input>
@@ -321,15 +319,7 @@ describe('SelectionObserverMixin', () => {
 				<d2l-test-selection-observer-shadow selection-for="d2l-test-selection-2"></d2l-test-selection-observer-shadow>
 			</div>
 		`);
-		await el.querySelector('#obs1').updateComplete;
-		await el.querySelector('#obs2').updateComplete;
-		await el.querySelector('#obs3').updateComplete;
-		await el.querySelector('[key="key1"]').updateComplete;
-		await el.querySelector('[key="key2"]').updateComplete;
-		await el.querySelector('[key="key3"]').updateComplete;
 		collection = el.querySelector('#d2l-test-selection');
-		await collection.updateComplete;
-
 		await nextFrame();
 		await nextFrame(); // Limit test flake
 	});

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -1,5 +1,5 @@
 import '../tooltip.js';
-import { aTimeout, expect, fixture, focusElem, html, oneEvent } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, focusElem, html, oneEvent, sendKeys } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`
@@ -185,11 +185,7 @@ describe('d2l-tooltip', () => {
 				await oneEvent(tooltipFixture, 'd2l-tooltip-show');
 				await aTimeout();
 
-				const eventObj = document.createEvent('Events');
-				eventObj.initEvent('keydown', true, true);
-				eventObj.keyCode = 27;
-
-				setTimeout(() => document.dispatchEvent(eventObj));
+				setTimeout(() => sendKeys('press', 'Escape'));
 				await oneEvent(tooltipFixture, 'd2l-tooltip-hide');
 				expect(tooltip.showing).to.be.false;
 			});
@@ -260,10 +256,7 @@ describe('d2l-tooltip', () => {
 
 		it('should not hide when ESC key is pressed ', async() => {
 
-			const eventObj = document.createEvent('Events');
-			eventObj.initEvent('keydown', true, true);
-			eventObj.keyCode = 27;
-			document.dispatchEvent(eventObj);
+			await sendKeys('press', 'Escape');
 			await aTimeout(100);
 
 			expect(tooltip.showing).to.be.true;

--- a/controllers/subscriber/test/subscriberControllers.test.js
+++ b/controllers/subscriber/test/subscriberControllers.test.js
@@ -103,7 +103,6 @@ describe('SubscriberRegistryController', () => {
 				</${registries}>
 				<${idSubscriberSeparate} id="id" for="registry"></${idSubscriberSeparate}>
 			</div>`);
-			await elem.updateComplete;
 			registry = elem.querySelector('#registry');
 		});
 
@@ -183,7 +182,6 @@ describe('SubscriberRegistryController', () => {
 				</${registries}>
 				<${idSubscriberCombined} id="id" for="registry"></${idSubscriberCombined}>
 			</div>`);
-			await elem.updateComplete;
 			registry = elem.querySelector('#registry');
 		});
 
@@ -260,7 +258,6 @@ describe('EventSubscriberController', () => {
 			</${indirectSlotRegistries}>
 			<${eventSubscriberSeparate} id="error"></${eventSubscriberSeparate}>
 		</div>`);
-		await elem.updateComplete;
 	});
 
 	afterEach(() => {
@@ -310,7 +307,6 @@ describe('IdSubscriberController', () => {
 		beforeEach(async() => {
 			clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
 			elem = await fixture(fixtureHtml);
-			await elem.updateComplete;
 		});
 
 		afterEach(() => {
@@ -409,7 +405,6 @@ describe('IdSubscriberController', () => {
 		beforeEach(async() => {
 			clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
 			elem = await fixture(fixtureHtml);
-			await elem.updateComplete;
 		});
 
 		afterEach(() => {

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -549,26 +549,6 @@ describe('dom', () => {
 			expect(getOffsetParent(child)).to.equal(expected);
 		});
 
-		/*[
-			'direct-parent',
-			'indirect-parent',
-			'td',
-			'th',
-			'table',
-			'wrapper-inside',
-			'wrapper-passthrough',
-			'wrapper-is-parent',
-			'nested-wrapper-is-parent'
-		].forEach(fixtureName => {
-			it(fixtureName, async() => {
-				const fixt = fixture(fixtureName);
-				await fixt.updateComplete;
-				const child = fixt.querySelector('.child');
-				const expected = fixt.querySelector('.expected');
-				expect(getOffsetParent(child)).to.equal(expected);
-			});
-		});*/
-
 		it('wrapper-simple', async() => {
 			const elem = await fixture(`
 				<div>

--- a/mixins/arrow-keys/test/arrow-keys-mixin.test.js
+++ b/mixins/arrow-keys/test/arrow-keys-mixin.test.js
@@ -47,7 +47,6 @@ describe('ArrowKeysMixin', () => {
 		describe('up-down', () => {
 
 			beforeEach(async() => {
-				//simpleFixture = fixture('simpleFixture');
 				elem.arrowKeysDirection = 'updown';
 				await elem.updateComplete;
 				focusables = await elem.arrowKeysFocusablesProvider();
@@ -67,7 +66,6 @@ describe('ArrowKeysMixin', () => {
 		describe('nowrap - up-down-left-right', () => {
 
 			beforeEach(async() => {
-				//simpleFixture = fixture('simpleFixture');
 				elem.arrowKeysDirection = 'updownleftright';
 				elem.arrowKeysNoWrap = true;
 				await elem.updateComplete;

--- a/mixins/interactive/test/interactive-mixin.test.js
+++ b/mixins/interactive/test/interactive-mixin.test.js
@@ -34,7 +34,6 @@ describe('InteractiveMixin', () => {
 		beforeEach(async() => {
 			fixtureElem = await fixture(`<div role="grid"><span id="before" tabindex="0"></span><${mixinTag}></${mixinTag}><span id="after" tabindex="0"></div>`);
 			elem = fixtureElem.querySelector(mixinTag);
-			await elem.updateComplete;
 			toggle = elem.shadowRoot.querySelector('.interactive-toggle');
 		});
 


### PR DESCRIPTION
Now that everything is using the new `fixture` that automatically `await`s nested Lit components' `updateComplete`s, all of our tests that were doing that manually can... not do that.