### PR TITLE
flip sendKeysElem arguments around

### DIFF
--- a/components/list/test/list-item-drag-handle.test.js
+++ b/components/list/test/list-item-drag-handle.test.js
@@ -86,9 +86,9 @@ describe('ListItemDragHandle', () => {
 
 	async function dispatchKeyEvent(el, key, shiftKey = false) {
 		if (shiftKey) {
-			await sendKeysElem('press', `Shift+${key}`, el);
+			await sendKeysElem(el, 'press', `Shift+${key}`);
 		} else {
-			await sendKeysElem('press', key, el);
+			await sendKeysElem(el, 'press', key);
 		}
 	}
 

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -96,7 +96,7 @@ describe('d2l-list', () => {
 				await focusElem(listItem);
 				await waitUntil(() => listItem.hasAttribute('_focusing'), 'List item should be focused', { timeout: 3000 });
 
-				setTimeout(() => sendKeysElem('down', testCase.keyPress, listItemLayout));
+				setTimeout(() => sendKeysElem(listItemLayout, 'down', testCase.keyPress));
 				await oneEvent(listItemLayout, 'keydown');
 
 				expect(listItem.hasAttribute('_focusing')).to.be.true;
@@ -129,7 +129,7 @@ describe('d2l-list', () => {
 				await focusElem(listItem);
 				await waitUntil(() => listItem.hasAttribute('_focusing'), 'Initial item should be focused', { timeout: 3000 });
 
-				setTimeout(() => sendKeysElem('down', testCase.keyPress, listItemLayout));
+				setTimeout(() => sendKeysElem(listItemLayout, 'down', testCase.keyPress));
 				await oneEvent(listItemLayout, 'keydown');
 
 				const focusedElement = elem.querySelector(`[key=${testCase.expectedFocus}`);
@@ -151,7 +151,7 @@ describe('d2l-list', () => {
 			await focusElem(listItem);
 			await waitUntil(() => listItem.hasAttribute('_focusing'), 'List item should be focused', { timeout: 3000 });
 
-			setTimeout(() => sendKeysElem('down', 'ArrowUp', listItemLayout));
+			setTimeout(() => sendKeysElem(listItemLayout, 'down', 'ArrowUp'));
 			await oneEvent(listItemLayout, 'keydown');
 
 			expect(listItem.hasAttribute('_focusing')).to.be.true;

--- a/components/menu/test/menu.test.js
+++ b/components/menu/test/menu.test.js
@@ -81,42 +81,42 @@ describe('d2l-menu', () => {
 		});
 
 		it('moves focus to next focusable item when down arrow is pressed', async() => {
-			await sendKeysElem('press', 'ArrowDown', elem.querySelector('#c1'));
+			await sendKeysElem(elem.querySelector('#c1'), 'press', 'ArrowDown');
 			expect(document.activeElement).to.equal(elem.querySelector('#d1'));
 		});
 
 		it('moves focus to previous focusable item when up arrow is pressed', async() => {
-			await sendKeysElem('press', 'ArrowUp', elem.querySelector('#d1'));
+			await sendKeysElem(elem.querySelector('#d1'), 'press', 'ArrowUp');
 			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
 		});
 
 		it('moves focus to first focusable item when down arrow is pressed on last focusable item', async() => {
-			await sendKeysElem('press', 'ArrowDown', elem.querySelector('#d1'));
+			await sendKeysElem(elem.querySelector('#d1'), 'press', 'ArrowDown');
 			expect(document.activeElement).to.equal(elem.querySelector('#a1'));
 		});
 
 		it('moves focus to last focusable item when up arrow is pressed on first focusable item', async() => {
-			await sendKeysElem('press', 'ArrowUp', elem.querySelector('#a1'));
+			await sendKeysElem(elem.querySelector('#a1'), 'press', 'ArrowUp');
 			expect(document.activeElement).to.equal(elem.querySelector('#d1'));
 		});
 
 		it('sets focus to disabled menu items', async() => {
-			await sendKeysElem('press', 'ArrowDown', elem.querySelector('#a1'));
+			await sendKeysElem(elem.querySelector('#a1'), 'press', 'ArrowDown');
 			expect(document.activeElement).to.equal(elem.querySelector('#b1'));
 		});
 
 		it('sets focus to next item that starts with character pressed', async() => {
-			await sendKeysElem('press', 'c', elem.querySelector('#a1'));
+			await sendKeysElem(elem.querySelector('#a1'), 'press', 'c');
 			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
 		});
 
 		it('sets focus to next item that starts with uppercase character pressed', async() => {
-			await sendKeysElem('press', 'C', elem.querySelector('#a1'));
+			await sendKeysElem(elem.querySelector('#a1'), 'press', 'C');
 			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
 		});
 
 		it('sets focus by rolling over to beginning of menu when searching if necessary', async() => {
-			await sendKeysElem('press', 'b', elem.querySelector('#c1'));
+			await sendKeysElem(elem.querySelector('#c1'), 'press', 'b');
 			expect(document.activeElement).to.equal(elem.querySelector('#b1'));
 		});
 
@@ -175,7 +175,7 @@ describe('d2l-menu', () => {
 		});
 
 		it('shows nested menu when right arrow is pressed on opener', async() => {
-			setTimeout(() => sendKeysElem('press', 'ArrowRight', elem.querySelector('#b1')));
+			setTimeout(() => sendKeysElem(elem.querySelector('#b1'), 'press', 'ArrowRight'));
 			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
 			expect(nestedMenu.isActive()).to.be.true;
 		});
@@ -183,7 +183,7 @@ describe('d2l-menu', () => {
 		it('hides nested menu when left arrow is pressed in nested menu', async() => {
 			setTimeout(() => clickElem(elem.querySelector('#b1')));
 			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
-			setTimeout(() => sendKeysElem('press', 'ArrowLeft', elem.querySelector('#b2')));
+			setTimeout(() => sendKeysElem(elem.querySelector('#b2'), 'press', 'ArrowLeft'));
 			await oneEvent(elem, 'd2l-hierarchical-view-hide-complete');
 			expect(elem.isActive()).to.be.true;
 		});
@@ -191,7 +191,7 @@ describe('d2l-menu', () => {
 		it('hides nested menu when escape is pressed in nested menu', async() => {
 			setTimeout(() => clickElem(elem.querySelector('#b1')));
 			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
-			setTimeout(() => sendKeysElem('press', 'Escape', elem.querySelector('#b2')));
+			setTimeout(() => sendKeysElem(elem.querySelector('#b2'), 'press', 'Escape'));
 			await oneEvent(elem, 'd2l-hierarchical-view-hide-complete');
 			expect(elem.isActive()).to.be.true;
 		});

--- a/components/switch/test/switch.test.js
+++ b/components/switch/test/switch.test.js
@@ -40,7 +40,7 @@ describe('d2l-switch', () => {
 	['Space', 'Enter'].forEach((key) => {
 		it(`should toggle when ${key} is pressed`, async() => {
 			const elem = await fixture(switchFixture);
-			setTimeout(() => sendKeysElem('press', key, elem));
+			setTimeout(() => sendKeysElem(elem, 'press', key));
 			await oneEvent(elem, 'change');
 			expect(elem.on).to.be.true;
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@babel/eslint-parser": "^7",
         "@brightspace-ui/stylelint-config": "^0.8",
-        "@brightspace-ui/testing": "^0.10",
+        "@brightspace-ui/testing": "^0.11",
         "@open-wc/semantic-dom-diff": "^0.20",
         "@rollup/plugin-dynamic-import-vars": "^2",
         "@rollup/plugin-node-resolve": "^15",
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@brightspace-ui/testing": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/testing/-/testing-0.10.2.tgz",
-      "integrity": "sha512-yINV7P/I8au3o440B4yhb0opK6e1LZg1s+RunxDD5CvhY6cw9WL6R27sr8rqkO9tZPUfRb4/zcR8c3q/z2+3NA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/testing/-/testing-0.11.0.tgz",
+      "integrity": "sha512-LfHb9mw5l/vBgus2sQsYD3jnuOMFwNdCOu7hVbcSWf4GkAAFmTeyCz09CwOkveswdyXRhPheO+7wvdMQDbaGGA==",
       "dev": true,
       "dependencies": {
         "@open-wc/testing": "^3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.8",
-    "@brightspace-ui/testing": "^0.10",
+    "@brightspace-ui/testing": "^0.11",
     "@open-wc/semantic-dom-diff": "^0.20",
     "@rollup/plugin-dynamic-import-vars": "^2",
     "@rollup/plugin-node-resolve": "^15",


### PR DESCRIPTION
We updated the testing library to have `elem` be the first argument in order to be consistent with the other APIs.