### PR TITLE
Remove `z-index` and stacking contexts from list-items

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -69,7 +69,6 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 					[end actions-end];
 				grid-template-rows: [main-start] [main-end nested-start] [nested-end];
 				position: relative;
-				z-index: 0;
 			}
 
 			::slotted([slot="nested"]) {
@@ -80,7 +79,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 				grid-column: control-start / end;
 			}
 			:host(.d2l-dragging-over) ::slotted([slot="nested"]) {
-				z-index: 7; /* must be greater than item's drop-target to allow dropping onto items within nested list  */
+				order: 7; /* must be greater than item's drop-target to allow dropping onto items within nested list  */
 			}
 
 			::slotted([slot="drop-target"]) {
@@ -88,7 +87,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 				position: absolute;
 				top: 0;
 				width: 100%;
-				z-index: 6;
+				order: 6;
 			}
 
 			::slotted([slot="outside-control"]),
@@ -105,7 +104,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			::slotted([slot="expand-collapse"]) {
 				cursor: pointer;
 				grid-column: expand-collapse-start / expand-collapse-end;
-				z-index: 2;
+				order: 2;
 			}
 
 			::slotted([slot="control"]) {
@@ -124,7 +123,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			::slotted([slot="actions"]) {
 				grid-column: actions-start / actions-end;
 				justify-self: end;
-				z-index: 5;
+				order: 5;
 			}
 
 			::slotted([slot="outside-control-action"]),
@@ -134,7 +133,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			}
 			::slotted([slot="outside-control-action"]) {
 				grid-column: start / end;
-				z-index: 1;
+				order: 1;
 			}
 			:host([no-primary-action]) ::slotted([slot="outside-control-action"]) {
 				grid-column: start / outside-control-end;
@@ -143,14 +142,14 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 				grid-column: control-start / end;
 				height: 100%;
 				width: 100%;
-				z-index: 3;
+				order: 3;
 			}
 			:host([no-primary-action]) ::slotted([slot="control-action"]) {
 				grid-column: control-start / control-end;
 			}
 			::slotted([slot="content-action"]) {
 				grid-column: content-start / end;
-				z-index: 4;
+				order: 4;
 			}
 			:host([no-primary-action]) ::slotted([slot="content-action"]) {
 				display: none;

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -84,10 +84,10 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 			::slotted([slot="drop-target"]) {
 				height: 100%;
+				order: 6;
 				position: absolute;
 				top: 0;
 				width: 100%;
-				order: 6;
 			}
 
 			::slotted([slot="outside-control"]),
@@ -141,8 +141,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			::slotted([slot="control-action"]) {
 				grid-column: control-start / end;
 				height: 100%;
-				width: 100%;
 				order: 3;
+				width: 100%;
 			}
 			:host([no-primary-action]) ::slotted([slot="control-action"]) {
 				grid-column: control-start / control-end;

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -597,7 +597,6 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				align-nested="${ifDefined(this.draggable && this.selectable ? 'control' : undefined)}"
 				@focusin="${this._onFocusIn}"
 				@focusout="${this._onFocusOut}"
-				@d2l-fullscreen-within="${this._onFullscreenWithin}"
 				class="${classMap(classes)}"
 				data-breakpoint="${this._breakpoint}"
 				data-separators="${ifDefined(this._separators)}"

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -84,15 +84,12 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			paddingType: { type: String, attribute: 'padding-type' },
 			_breakpoint: { type: Number },
 			_displayKeyboardTooltip: { type: Boolean },
-			_dropdownOpen: { type: Boolean, attribute: '_dropdown-open', reflect: true },
-			_fullscreenWithin: { type: Boolean, attribute: '_fullscreen-within', reflect: true },
 			_hovering: { type: Boolean, reflect: true },
 			_hoveringPrimaryAction: { type: Boolean, attribute: '_hovering-primary-action', reflect: true },
 			_focusing: { type: Boolean, reflect: true },
 			_focusingPrimaryAction: { type: Boolean, attribute: '_focusing-primary-action', reflect: true },
 			_highlight: { type: Boolean, reflect: true },
 			_highlighting: { type: Boolean, reflect: true },
-			_tooltipShowing: { type: Boolean, attribute: '_tooltip-showing', reflect: true },
 			_hasNestedList: { state: true }
 		};
 	}
@@ -376,8 +373,6 @@ export const ListItemMixin = superclass => class extends composeMixins(
 		this._breakpoint = 0;
 		this._contentId = getUniqueId();
 		this._displayKeyboardTooltip = false;
-		this._fullscreenWithin = false;
-		this._fullscreenWithinCount = 0;
 		this._hasNestedList = false;
 	}
 
@@ -406,14 +401,6 @@ export const ListItemMixin = superclass => class extends composeMixins(
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		ro.unobserve(this);
-	}
-
-	firstUpdated(changedProperties) {
-		this.addEventListener('d2l-dropdown-open', () => this._dropdownOpen = true);
-		this.addEventListener('d2l-dropdown-close', () => this._dropdownOpen = false);
-		this.addEventListener('d2l-tooltip-show', () => this._tooltipShowing = true);
-		this.addEventListener('d2l-tooltip-hide', () => this._tooltipShowing = false);
-		super.firstUpdated(changedProperties);
 	}
 
 	updated(changedProperties) {
@@ -564,12 +551,6 @@ export const ListItemMixin = superclass => class extends composeMixins(
 
 	_onFocusOutPrimaryAction() {
 		this._focusingPrimaryAction = false;
-	}
-
-	_onFullscreenWithin(e) {
-		if (e.detail.state) this._fullscreenWithinCount += 1;
-		else this._fullscreenWithinCount -= 1;
-		this._fullscreenWithin = (this._fullscreenWithinCount > 0);
 	}
 
 	_onMouseEnter() {

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -108,15 +108,6 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				display: none;
 			}
 
-			:host([_tooltip-showing]),
-			:host([_dropdown-open]) {
-				z-index: 10; /* must be greater than adjacent selected items (if this is increased, d2l-collapsible-panel must be updated too) */
-			}
-			:host([_fullscreen-within]) {
-				position: fixed; /* required for Safari */
-				z-index: 998; /* must be greater than floating workflow buttons */
-			}
-
 			:host([dragging]) d2l-list-item-generic-layout {
 				filter: grayscale(75%);
 				opacity: 0.4;
@@ -125,10 +116,6 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				background: white;
 			}
 
-			[slot="control-container"] {
-				position: relative;
-				z-index: -1; /* must allow for interactive content to be accessible with mouse */
-			}
 			:host(:first-of-type) [slot="control-container"]::before,
 			[slot="control-container"]::after {
 				border-top: 1px solid var(--d2l-color-mica);

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -113,6 +113,11 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				background: white;
 			}
 
+			[slot="control-container"] {
+				position: relative;
+				pointer-events: none;
+			}
+
 			:host(:first-of-type) [slot="control-container"]::before,
 			[slot="control-container"]::after {
 				border-top: 1px solid var(--d2l-color-mica);

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -114,8 +114,8 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			}
 
 			[slot="control-container"] {
-				position: relative;
 				pointer-events: none;
+				position: relative;
 			}
 
 			:host(:first-of-type) [slot="control-container"]::before,


### PR DESCRIPTION
[DE52324](https://rally1.rallydev.com/#/?detail=/defect/689632043385&fdp=true): Html emoji editor can get cut off by the rubric
[US151482](https://rally1.rallydev.com/#/?detail=/userstory/698053793761&fdp=true): Spike > Update d2l-list item rendering to avoid z-index

Removes all usage of `z-index` (and any internal stacking contexts) in list items to allow all descendants, and the list item itself, to stack organically within the document. This means no more special handling is needed to support open dropdowns, tooltips, or other overflowing descendants.

CSS `order` achieves essentially the same result as `z-index`, but it is scoped to the grid items and simply re-orders them instead of continually increasing their priority compared to everything else, so there is no arms race.