### PR TITLE
Fix list-item-expand-collapse button positioning

### DIFF
--- a/components/list/list-item-expand-collapse-mixin.js
+++ b/components/list/list-item-expand-collapse-mixin.js
@@ -33,10 +33,11 @@ export const ListItemExpandCollapseMixin = superclass => class extends SkeletonM
 				--d2l-expand-collapse-slot-transition-duration: 0.3s;
 			}
 			.d2l-list-expand-collapse {
+				line-height: 0;
 				width: 0;
 			}
 			:host([dir="rtl"][_render-expand-collapse-slot]) .d2l-list-expand-collapse {
-				padding: 0.4rem 0 0 0.3rem;
+				padding: 0.55rem 0 0 0.3rem;
 			}
 			.d2l-list-expand-collapse d2l-button-icon {
 				--d2l-button-icon-min-height: 1.2rem;
@@ -47,7 +48,7 @@ export const ListItemExpandCollapseMixin = superclass => class extends SkeletonM
 				border-radius: var(--d2l-button-icon-border-radius);
 			}
 			:host([_render-expand-collapse-slot]) .d2l-list-expand-collapse {
-				padding: 0.4rem 0.3rem 0 0;
+				padding: 0.55rem 0.3rem 0 0;
 				width: 1.2rem;
 			}
 			.d2l-list-expand-collapse-action {


### PR DESCRIPTION
`0.55rem` matches various margins in `list-item-mixin` like the checkbox, which is exactly the same size, and will now line up vertically with the expand-collapse button.

Before and after:
<img width="528" alt="Screenshot 2023-06-29 at 1 54 39 PM" src="https://github.com/BrightspaceUI/core/assets/1289042/3319da27-9f0a-4a76-9df7-22b4784dfafe"><img width="528" alt="Screenshot 2023-06-29 at 1 53 36 PM" src="https://github.com/BrightspaceUI/core/assets/1289042/c09c5cb8-ff1f-4c10-8a93-080767a01a9e">
