### PR TITLE
feat: apply hover effects anywhere on the component

### DIFF
--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -25,7 +25,7 @@ export const inputStyles = css`
 		width: 100%;
 	}
 	.d2l-input,
-	:host(:hover) .d2l-input:disabled,
+	.d2l-input:hover:disabled,
 	.d2l-input:focus:disabled,
 	[aria-invalid="true"].d2l-input:disabled {
 		border-color: var(--d2l-input-border-color, var(--d2l-color-galena));
@@ -43,18 +43,14 @@ export const inputStyles = css`
 		font-size: 0.8rem;
 		font-weight: 400;
 	}
-	:host(:hover) .d2l-input,
+	.d2l-input:hover,
 	.d2l-input:focus,
 	.d2l-input-focus {
+		border-color: var(--d2l-color-celestine);
 		border-width: 2px;
 		outline-style: none;
 		outline-width: 0;
 		padding: var(--d2l-input-padding-focus, calc(0.4rem - 1px) calc(0.75rem - 1px));
-	}
-	:host(:hover) .d2l-input:not([aria-invalid="true"]),
-	.d2l-input:focus,
-	.d2l-input-focus {
-		border-color: var(--d2l-color-celestine);
 	}
 	[aria-invalid="true"].d2l-input {
 		border-color: var(--d2l-color-cinnabar);
@@ -75,13 +71,13 @@ export const inputStyles = css`
 		line-height: normal;
 	}
 	textarea.d2l-input,
-	:host(:hover) textarea.d2l-input:disabled,
+	textarea.d2l-input:hover:disabled,
 	textarea.d2l-input:focus:disabled,
 	textarea[aria-invalid="true"].d2l-input:disabled {
 		padding-bottom: 0.5rem;
 		padding-top: 0.5rem;
 	}
-	:host(:hover) textarea.d2l-input,
+	textarea.d2l-input:hover,
 	textarea.d2l-input:focus {
 		padding: var(--d2l-input-padding-focus, calc(0.75rem - 1px));
 		padding-bottom: calc(0.5rem - 1px);
@@ -94,7 +90,7 @@ export const inputStyles = css`
 		background-size: 0.8rem 0.8rem;
 		padding-right: calc(18px + 0.8rem);
 	}
-	:host(:hover) textarea.d2l-input[aria-invalid="true"],
+	textarea.d2l-input[aria-invalid="true"]:hover,
 	textarea.d2l-input[aria-invalid="true"]:focus {
 		background-position: top calc(12px - 1px) right calc(18px - 1px);
 		padding-right: calc(18px + 0.8rem - 1px);
@@ -107,7 +103,7 @@ export const inputStyles = css`
 		padding-top: 0.5rem;
 	}
 	:host([dir='rtl']) textarea.d2l-input[aria-invalid="true"]:focus,
-	:host([dir='rtl']:hover) textarea.d2l-input[aria-invalid="true"] {
+	:host([dir='rtl']) textarea.d2l-input[aria-invalid="true"]:hover {
 		background-position: top calc(12px - 1px) left calc(18px - 1px);
 		padding: var(--d2l-input-padding-focus, calc(0.75rem - 1px));
 		padding-bottom: calc(0.5rem - 1px);

--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -4,10 +4,8 @@ import { css } from 'lit';
 export const inputStyles = css`
 	.d2l-input {
 		background-color: var(--d2l-input-background-color, #ffffff);
-		border-color: var(--d2l-input-border-color, var(--d2l-color-galena));
 		border-radius: var(--d2l-input-border-radius, 0.3rem);
 		border-style: solid;
-		border-width: 1px;
 		box-shadow: inset 0 2px 0 0 rgba(177, 185, 190, 0.2); /* corundum */
 		box-sizing: border-box;
 		color: var(--d2l-color-ferrite);
@@ -21,11 +19,18 @@ export const inputStyles = css`
 		margin: 0;
 		min-height: calc(2rem + 2px);
 		min-width: calc(2rem + 1em);
-		padding: var(--d2l-input-padding, 0.4rem 0.75rem);
 		position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
 		text-align: var(--d2l-input-text-align, start);
 		vertical-align: middle;
 		width: 100%;
+	}
+	.d2l-input,
+	:host(:hover) .d2l-input:disabled,
+	.d2l-input:focus:disabled,
+	[aria-invalid="true"].d2l-input:disabled {
+		border-color: var(--d2l-input-border-color, var(--d2l-color-galena));
+		border-width: 1px;
+		padding: var(--d2l-input-padding, 0.4rem 0.75rem);
 	}
 	.d2l-input::placeholder {
 		color: var(--d2l-color-mica);
@@ -38,20 +43,20 @@ export const inputStyles = css`
 		font-size: 0.8rem;
 		font-weight: 400;
 	}
-	:host(:hover) .d2l-input:not(:disabled),
-	.d2l-input:focus:not(:disabled),
-	.d2l-input-focus:not(:disabled) {
+	:host(:hover) .d2l-input,
+	.d2l-input:focus,
+	.d2l-input-focus {
 		border-width: 2px;
 		outline-style: none;
 		outline-width: 0;
 		padding: var(--d2l-input-padding-focus, calc(0.4rem - 1px) calc(0.75rem - 1px));
 	}
-	:host(:hover) .d2l-input:not([aria-invalid="true"]):not(:disabled),
-	.d2l-input:focus:not(:disabled),
-	.d2l-input-focus:not(:disabled) {
+	:host(:hover) .d2l-input:not([aria-invalid="true"]),
+	.d2l-input:focus,
+	.d2l-input-focus {
 		border-color: var(--d2l-color-celestine);
 	}
-	.d2l-input[aria-invalid="true"]:not(:disabled) {
+	[aria-invalid="true"].d2l-input {
 		border-color: var(--d2l-color-cinnabar);
 	}
 	.d2l-input:disabled {

--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -43,14 +43,18 @@ export const inputStyles = css`
 		font-size: 0.8rem;
 		font-weight: 400;
 	}
-	.d2l-input:hover,
+	:host(:hover) .d2l-input,
 	.d2l-input:focus,
 	.d2l-input-focus {
-		border-color: var(--d2l-color-celestine);
 		border-width: 2px;
 		outline-style: none;
 		outline-width: 0;
 		padding: var(--d2l-input-padding-focus, calc(0.4rem - 1px) calc(0.75rem - 1px));
+	}
+	:host(:hover) .d2l-input:not([aria-invalid="true"]),
+	.d2l-input:focus,
+	.d2l-input-focus {
+		border-color: var(--d2l-color-celestine);
 	}
 	[aria-invalid="true"].d2l-input {
 		border-color: var(--d2l-color-cinnabar);

--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -4,8 +4,10 @@ import { css } from 'lit';
 export const inputStyles = css`
 	.d2l-input {
 		background-color: var(--d2l-input-background-color, #ffffff);
+		border-color: var(--d2l-input-border-color, var(--d2l-color-galena));
 		border-radius: var(--d2l-input-border-radius, 0.3rem);
 		border-style: solid;
+		border-width: 1px;
 		box-shadow: inset 0 2px 0 0 rgba(177, 185, 190, 0.2); /* corundum */
 		box-sizing: border-box;
 		color: var(--d2l-color-ferrite);
@@ -19,18 +21,11 @@ export const inputStyles = css`
 		margin: 0;
 		min-height: calc(2rem + 2px);
 		min-width: calc(2rem + 1em);
+		padding: var(--d2l-input-padding, 0.4rem 0.75rem);
 		position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
 		text-align: var(--d2l-input-text-align, start);
 		vertical-align: middle;
 		width: 100%;
-	}
-	.d2l-input,
-	.d2l-input:hover:disabled,
-	.d2l-input:focus:disabled,
-	[aria-invalid="true"].d2l-input:disabled {
-		border-color: var(--d2l-input-border-color, var(--d2l-color-galena));
-		border-width: 1px;
-		padding: var(--d2l-input-padding, 0.4rem 0.75rem);
 	}
 	.d2l-input::placeholder {
 		color: var(--d2l-color-mica);
@@ -43,20 +38,20 @@ export const inputStyles = css`
 		font-size: 0.8rem;
 		font-weight: 400;
 	}
-	:host(:hover) .d2l-input,
-	.d2l-input:focus,
-	.d2l-input-focus {
+	:host(:hover) .d2l-input:not(:disabled),
+	.d2l-input:focus:not(:disabled),
+	.d2l-input-focus:not(:disabled) {
 		border-width: 2px;
 		outline-style: none;
 		outline-width: 0;
 		padding: var(--d2l-input-padding-focus, calc(0.4rem - 1px) calc(0.75rem - 1px));
 	}
-	:host(:hover) .d2l-input:not([aria-invalid="true"]),
-	.d2l-input:focus,
-	.d2l-input-focus {
+	:host(:hover) .d2l-input:not([aria-invalid="true"]):not(:disabled),
+	.d2l-input:focus:not(:disabled),
+	.d2l-input-focus:not(:disabled) {
 		border-color: var(--d2l-color-celestine);
 	}
-	[aria-invalid="true"].d2l-input {
+	.d2l-input[aria-invalid="true"]:not(:disabled) {
 		border-color: var(--d2l-color-cinnabar);
 	}
 	.d2l-input:disabled {

--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -75,13 +75,13 @@ export const inputStyles = css`
 		line-height: normal;
 	}
 	textarea.d2l-input,
-	textarea.d2l-input:hover:disabled,
+	:host(:hover) textarea.d2l-input:disabled,
 	textarea.d2l-input:focus:disabled,
 	textarea[aria-invalid="true"].d2l-input:disabled {
 		padding-bottom: 0.5rem;
 		padding-top: 0.5rem;
 	}
-	textarea.d2l-input:hover,
+	:host(:hover) textarea.d2l-input,
 	textarea.d2l-input:focus {
 		padding: var(--d2l-input-padding-focus, calc(0.75rem - 1px));
 		padding-bottom: calc(0.5rem - 1px);
@@ -94,7 +94,7 @@ export const inputStyles = css`
 		background-size: 0.8rem 0.8rem;
 		padding-right: calc(18px + 0.8rem);
 	}
-	textarea.d2l-input[aria-invalid="true"]:hover,
+	:host(:hover) textarea.d2l-input[aria-invalid="true"],
 	textarea.d2l-input[aria-invalid="true"]:focus {
 		background-position: top calc(12px - 1px) right calc(18px - 1px);
 		padding-right: calc(18px + 0.8rem - 1px);
@@ -107,7 +107,7 @@ export const inputStyles = css`
 		padding-top: 0.5rem;
 	}
 	:host([dir='rtl']) textarea.d2l-input[aria-invalid="true"]:focus,
-	:host([dir='rtl']) textarea.d2l-input[aria-invalid="true"]:hover {
+	:host([dir='rtl']:hover) textarea.d2l-input[aria-invalid="true"] {
 		background-position: top calc(12px - 1px) left calc(18px - 1px);
 		padding: var(--d2l-input-padding-focus, calc(0.75rem - 1px));
 		padding-bottom: calc(0.5rem - 1px);

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -338,8 +338,9 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		if (!container) return;
 		container.removeEventListener('blur', this._handleBlur, true);
 		container.removeEventListener('focus', this._handleFocus, true);
-		container.removeEventListener('mouseover', this._handleMouseEnter);
-		container.removeEventListener('mouseout', this._handleMouseLeave);
+		this.removeEventListener('mouseover', this._handleMouseEnter);
+		this.removeEventListener('mouseout', this._handleMouseLeave);
+		this.removeEventListener('click', this._handleClick);
 	}
 
 	firstUpdated(changedProperties) {
@@ -352,8 +353,9 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		if (!container) return;
 		container.addEventListener('blur', this._handleBlur, true);
 		container.addEventListener('focus', this._handleFocus, true);
-		container.addEventListener('mouseover', this._handleMouseEnter);
-		container.addEventListener('mouseout', this._handleMouseLeave);
+		this.addEventListener('mouseover', this._handleMouseEnter);
+		this.addEventListener('mouseout', this._handleMouseLeave);
+		this.addEventListener('click', this._handleClick);
 
 		// if initially hidden then update layout when it becomes visible
 		if (typeof(IntersectionObserver) === 'function') {
@@ -540,6 +542,12 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			'change',
 			{ bubbles: true, composed: false }
 		));
+	}
+
+	_handleClick(e) {
+		const input = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
+		if (!input || e.composedPath()[0] !== this) return;
+		input.focus();
 	}
 
 	_handleFocus() {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -329,18 +329,21 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		if (this.hasAttribute('aria-label')) {
 			this.labelRequired = false;
 		}
+		this.addEventListener('mouseover', this._handleMouseEnter);
+		this.addEventListener('mouseout', this._handleMouseLeave);
+		this.addEventListener('click', this._handleClick);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		if (this._intersectionObserver) this._intersectionObserver.disconnect();
 		const container = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input-text-container');
-		if (!container) return;
-		container.removeEventListener('blur', this._handleBlur, true);
-		container.removeEventListener('focus', this._handleFocus, true);
 		this.removeEventListener('mouseover', this._handleMouseEnter);
 		this.removeEventListener('mouseout', this._handleMouseLeave);
 		this.removeEventListener('click', this._handleClick);
+		if (!container) return;
+		container.removeEventListener('blur', this._handleBlur, true);
+		container.removeEventListener('focus', this._handleFocus, true);
 	}
 
 	firstUpdated(changedProperties) {
@@ -353,9 +356,6 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		if (!container) return;
 		container.addEventListener('blur', this._handleBlur, true);
 		container.addEventListener('focus', this._handleFocus, true);
-		this.addEventListener('mouseover', this._handleMouseEnter);
-		this.addEventListener('mouseout', this._handleMouseLeave);
-		this.addEventListener('click', this._handleClick);
 
 		// if initially hidden then update layout when it becomes visible
 		if (typeof(IntersectionObserver) === 'function') {
@@ -545,7 +545,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 	}
 
 	_handleClick(e) {
-		const input = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
+		const input = this.shadowRoot?.querySelector('.d2l-input');
 		if (!input || e.composedPath()[0] !== this) return;
 		input.focus();
 	}

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -1,5 +1,6 @@
 import '../tooltip/tooltip.js';
 import { css, html, LitElement } from 'lit';
+import { classMap } from 'lit-html/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { formatNumber } from '@brightspace-ui/intl/lib/number.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
@@ -86,7 +87,8 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 			 * Value of the input
 			 * @type {string}
 			 */
-			value: { type: String }
+			value: { type: String },
+			_hovered: { type: Boolean }
 		};
 	}
 
@@ -157,6 +159,7 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 		this.value = '';
 
 		this._descriptionId = getUniqueId();
+		this._hovered = false;
 		this._textareaId = getUniqueId();
 	}
 
@@ -194,6 +197,20 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 		}
 	}
 
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.removeEventListener('mouseover', this._handleMouseEnter);
+		this.removeEventListener('mouseout', this._handleMouseLeave);
+		this.removeEventListener('click', this._handleClick);
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		this.addEventListener('mouseover', this._handleMouseEnter);
+		this.addEventListener('mouseout', this._handleMouseLeave);
+		this.addEventListener('click', this._handleClick);
+	}
+
 	render() {
 
 		// convert \n to <br> for html mirror
@@ -211,6 +228,11 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 		if (this.rows > 0) mirrorStyles.minHeight = `calc(${this.rows + 1}rem + 2px)`;
 		if (this.maxRows > 0) mirrorStyles.maxHeight = `calc(${this.maxRows + 1}rem + 2px)`;
 
+		const inputClasses = {
+			'd2l-input': true,
+			'd2l-input-focus': !this.disabled && this._hovered
+		};
+
 		const textarea = html`
 			<div class="d2l-input-textarea-container d2l-skeletize">
 				<div class="d2l-input d2l-input-textarea-mirror" style="${styleMap(mirrorStyles)}" aria-invalid="${ifDefined(ariaInvalid)}">
@@ -222,7 +244,7 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 					aria-required="${ifDefined(ariaRequired)}"
 					@blur="${this._handleBlur}"
 					@change="${this._handleChange}"
-					class="d2l-input"
+					class=${classMap(inputClasses)}
 					?disabled="${disabled}"
 					id="${this._textareaId}"
 					@input="${this._handleInput}"
@@ -307,6 +329,12 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 		));
 	}
 
+	_handleClick(e) {
+		const input = this.shadowRoot && this.shadowRoot.querySelector('textarea');
+		if (!input || e.composedPath()[0] !== this) return;
+		input.focus();
+	}
+
 	_handleInput(e) {
 		this.value = e.target.value;
 		return true;
@@ -314,6 +342,14 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 
 	_handleInvalid(e) {
 		e.preventDefault();
+	}
+
+	_handleMouseEnter() {
+		this._hovered = true;
+	}
+
+	_handleMouseLeave() {
+		this._hovered = false;
 	}
 
 }

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -88,7 +88,7 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 			 * @type {string}
 			 */
 			value: { type: String },
-			_hovered: { type: Boolean }
+			_hovered: { state: true }
 		};
 	}
 
@@ -195,6 +195,9 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 		if (this.hasAttribute('aria-label')) {
 			this.labelRequired = false;
 		}
+		this.addEventListener('mouseover', this._handleMouseEnter);
+		this.addEventListener('mouseout', this._handleMouseLeave);
+		this.addEventListener('click', this._handleClick);
 	}
 
 	disconnectedCallback() {
@@ -202,13 +205,6 @@ class InputTextArea extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMi
 		this.removeEventListener('mouseover', this._handleMouseEnter);
 		this.removeEventListener('mouseout', this._handleMouseLeave);
 		this.removeEventListener('click', this._handleClick);
-	}
-
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
-		this.addEventListener('mouseover', this._handleMouseEnter);
-		this.addEventListener('mouseout', this._handleMouseLeave);
-		this.addEventListener('click', this._handleClick);
 	}
 
 	render() {


### PR DESCRIPTION
Apply the input hover effects when hovering over anywhere on the component, not just the input or label.
Rally: [US148080](https://rally1.rallydev.com/#/?detail=/userstory/684245679355&fdp=true)