### PR TITLE
Recursively check for last item in nested lists

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -407,12 +407,17 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			if (previousElement.role === 'rowgroup') {
 
 				// this check needs to account for standard list-items as well as custom
-				const nestedList = previousElement.querySelector('[slot="nested"]') || previousElement.shadowRoot.querySelector('d2l-list');
+				let nestedList = previousElement.querySelector('[slot="nested"]') || previousElement.shadowRoot.querySelector('d2l-list');
 				if (nestedList) {
-					const nestedListItems = [...nestedList.children].filter(node => node.role === 'rowgroup');
-					if (nestedListItems && nestedListItems.length > 0) {
-						return nestedListItems[nestedListItems.length - 1];
+					let nestedListItems = [...nestedList.children].filter(node => node.role === 'rowgroup');
+
+					let lastItem;
+					while (nestedListItems?.length) {
+						lastItem = nestedListItems[nestedListItems.length - 1];
+						nestedList = lastItem.querySelector('[slot="nested"]') || lastItem.shadowRoot.querySelector('d2l-list');
+						nestedListItems = nestedList && [...nestedList.children].filter(node => node.role === 'rowgroup');
 					}
+					return lastItem;
 				}
 				return previousElement;
 


### PR DESCRIPTION
[DE53272](https://rally1.rallydev.com/#/?detail=/defect/700010022767&fdp=true): List > Grid navigation not navigating properly to deeply nested list items

When looking for the previous item to focus in grid mode, the last item should be checked recursively for nested lists.