### PR TITLE
Remove direct stylelint dependency and rely on our config's dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,7 @@
         "rollup": "^3",
         "rollup-plugin-copy": "^3",
         "rollup-plugin-delete": "^2",
-        "sinon": "^15",
-        "stylelint": "^15"
+        "sinon": "^15"
       }
     },
     "node_modules/@75lb/deep-merge": {

--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
     "rollup": "^3",
     "rollup-plugin-copy": "^3",
     "rollup-plugin-delete": "^2",
-    "sinon": "^15",
-    "stylelint": "^15"
+    "sinon": "^15"
   },
   "dependencies": {
     "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
This PR removes the direct `stylelint` dependency so that we rely only on the dependency specified by our `@brightspace-ui/stylelint-config`. Removing this dependency helps to avoid conflicts.