### PR TITLE
Move list tests to proper browser interactions

### DIFF
--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -3,28 +3,14 @@ import '../list-controls.js';
 import '../list-item.js';
 import '../list-item-button.js';
 import '../list-item-content.js';
-import { expect, fixture, focusElem, html, oneEvent, sendKeysElem, waitUntil } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, html, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
-const selectionInputRendering = async item => {
-	return new Promise(resolve => {
-		const intervalId = setInterval(() => {
-			const selectionInput = item.shadowRoot.querySelector('d2l-selection-input');
-			const inputCheckbox = selectionInput.shadowRoot.querySelector('d2l-input-checkbox');
-			if (inputCheckbox) {
-				clearInterval(intervalId);
-				resolve();
-			}
-		}, 10);
-	});
-};
-
 const clickItemInput = async item => {
-	await selectionInputRendering(item);
 	const selectionInput = item.shadowRoot.querySelector('d2l-selection-input');
 	const inputCheckbox = selectionInput.shadowRoot.querySelector('d2l-input-checkbox');
 	const input = inputCheckbox.shadowRoot.querySelector('input');
-	input.click();
+	return clickElem(input);
 };
 
 describe('d2l-list', () => {
@@ -92,14 +78,10 @@ describe('d2l-list', () => {
 				`);
 
 				const listItem = elem.querySelector('[key="L2-2"]');
-				const listItemLayout = elem.querySelector('[key="L2-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
-				await focusElem(listItem);
-				await waitUntil(() => listItem.hasAttribute('_focusing'), 'List item should be focused', { timeout: 3000 });
 
-				setTimeout(() => sendKeysElem(listItemLayout, 'down', testCase.keyPress));
-				await oneEvent(listItemLayout, 'keydown');
+				await sendKeysElem(listItem, 'press', testCase.keyPress);
 
-				expect(listItem.hasAttribute('_focusing')).to.be.true;
+				expect(elem.querySelector('[_focusing]')).to.equal(listItem);
 			});
 		});
 
@@ -117,6 +99,7 @@ describe('d2l-list', () => {
 									<d2l-list id="L3" slot="nested" grid>
 										<d2l-list-item key="L3-1" label="item"></d2l-list-item>
 										<d2l-list-item selectable key="L3-2" label="item"></d2l-list-item>
+										<d2l-list-item key="L3-3" label="item"></d2l-list-item>
 									</d2l-list>
 								</d2l-list-item>
 							</d2l-list>
@@ -124,19 +107,18 @@ describe('d2l-list', () => {
 						<d2l-list-item selectable key="L1-2" label="item"></d2l-list-item>
 					</d2l-list>	
 				`);
-
 				const listItem = elem.querySelector(`[key="${initialFocus}"]`);
-				const listItemLayout = listItem.shadowRoot.querySelector('d2l-list-item-generic-layout');
-				await focusElem(listItem);
-				await waitUntil(() => listItem.hasAttribute('_focusing'), 'Initial item should be focused', { timeout: 3000 });
-				setTimeout(() => sendKeysElem(listItemLayout, 'down', keyPress));
-				await oneEvent(listItemLayout, 'keydown');
-				const focusedElement = elem.querySelector('[key="L3-2"');
-				await waitUntil(() => focusedElement.hasAttribute('_focusing'), `${name} item should be focused`, { timeout: 3000 });
+
+				await sendKeysElem(listItem, 'press', keyPress);
+
+				const focusedElement = elem.querySelector('[_focusing]');
+				const focusTarget = elem.querySelector('[key="L3-2');
+
+				expect(focusedElement).to.equal(focusTarget);
 			});
 		});
 
-		it('Focus stays in list with list controls when in grid mode when up arrow is pressed', async() => {
+		it('Focus does not move to list controls when up arrow is pressed in grid mode', async() => {
 			const elem = await fixture(html`
 				 <d2l-list grid>
 					<d2l-list-controls slot="controls"></d2l-list-controls>
@@ -146,14 +128,11 @@ describe('d2l-list', () => {
 			`);
 
 			const listItem = elem.querySelector('[key="L1-2"]');
-			const listItemLayout = elem.querySelector('[key="L1-2"]').shadowRoot.querySelector('d2l-list-item-generic-layout');
-			await focusElem(listItem);
-			await waitUntil(() => listItem.hasAttribute('_focusing'), 'List item should be focused', { timeout: 3000 });
 
-			setTimeout(() => sendKeysElem(listItemLayout, 'down', 'ArrowUp'));
-			await oneEvent(listItemLayout, 'keydown');
+			await sendKeysElem(listItem, 'press', 'ArrowUp');
+			const focusedElement = elem.querySelector('[_focusing]');
 
-			expect(listItem.hasAttribute('_focusing')).to.be.true;
+			expect(focusedElement).to.equal(listItem);
 		});
 	});
 
@@ -170,16 +149,14 @@ describe('d2l-list', () => {
 		});
 
 		it('dispatches d2l-list-selection-changes event when selectable item is clicked', async() => {
-			setTimeout(() => clickItemInput(elem.querySelector('[key="L1-1"]')));
+			clickItemInput(elem.querySelector('[key="L1-1"]'));
 			const e = await oneEvent(elem, 'd2l-list-selection-changes');
 			expect(e.detail.length).to.equal(1);
 		});
 
 		it('dispatches d2l-list-selection-changes event with batched changes', async() => {
-			setTimeout(() => {
-				clickItemInput(elem.querySelector('[key="L1-1"]'));
-				clickItemInput(elem.querySelector('[key="L1-2"]'));
-			});
+			clickItemInput(elem.querySelector('[key="L1-1"]'));
+			clickItemInput(elem.querySelector('[key="L1-2"]'));
 			const e = await oneEvent(elem, 'd2l-list-selection-changes');
 			expect(e.detail.length).to.equal(2);
 		});
@@ -189,7 +166,7 @@ describe('d2l-list', () => {
 		});
 
 		it('getSelectedListItems returns array including selected items', async() => {
-			setTimeout(() => clickItemInput(elem.querySelector('[key="L1-1"]')));
+			clickItemInput(elem.querySelector('[key="L1-1"]'));
 			await oneEvent(elem, 'd2l-list-selection-changes');
 			expect(elem.getSelectedListItems().length).to.equal(1);
 		});
@@ -213,22 +190,20 @@ describe('d2l-list', () => {
 		});
 
 		it('dispatches d2l-list-selection-changes event when selectable leaf item is clicked', async() => {
-			setTimeout(() => clickItemInput(elem.querySelector('[key="L2-1"]')));
+			clickItemInput(elem.querySelector('[key="L2-1"]'));
 			const e = await oneEvent(elem, 'd2l-list-selection-changes');
 			expect(e.detail.length).to.equal(1);
 		});
 
 		it('dispatches d2l-list-selection-changes event with batched changes when leaf items clicked', async() => {
-			setTimeout(() => {
-				clickItemInput(elem.querySelector('[key="L2-1"]'));
-				clickItemInput(elem.querySelector('[key="L2-2"]'));
-			});
+			clickItemInput(elem.querySelector('[key="L2-1"]'));
+			clickItemInput(elem.querySelector('[key="L2-2"]'));
 			const e = await oneEvent(elem, 'd2l-list-selection-changes');
 			expect(e.detail.length).to.equal(3);
 		});
 
 		it('dispatches d2l-list-selection-changes event with batched changes when root item clicked', async() => {
-			setTimeout(() => clickItemInput(elem.querySelector('[key="L1-1"]')));
+			clickItemInput(elem.querySelector('[key="L1-1"]'));
 			const e = await oneEvent(elem, 'd2l-list-selection-changes');
 			expect(e.detail.length).to.equal(3);
 		});
@@ -238,19 +213,19 @@ describe('d2l-list', () => {
 		});
 
 		it('getSelectedListItems returns array with root selected items only', async() => {
-			setTimeout(() => clickItemInput(elem.querySelector('[key="L1-1"]')));
+			clickItemInput(elem.querySelector('[key="L1-1"]'));
 			await oneEvent(elem, 'd2l-list-selection-changes');
 			expect(elem.getSelectedListItems().length).to.equal(1);
 		});
 
 		it('getSelectedListItems returns array including nested selected items', async() => {
-			setTimeout(() => clickItemInput(elem.querySelector('[key="L1-1"]')));
+			clickItemInput(elem.querySelector('[key="L1-1"]'));
 			await oneEvent(elem, 'd2l-list-selection-changes');
 			expect(elem.getSelectedListItems(true).length).to.equal(3);
 		});
 
 		it('getSelectedListItems returns array excluding indeterminate items', async() => {
-			setTimeout(() => clickItemInput(elem.querySelector('[key="L2-1"]')));
+			clickItemInput(elem.querySelector('[key="L2-1"]'));
 			await oneEvent(elem, 'd2l-list-selection-changes');
 			expect(elem.getSelectedListItems(true).length).to.equal(1);
 		});
@@ -299,13 +274,13 @@ describe('d2l-list-item-button', () => {
 
 		it('dispatches d2l-list-item-link-click event when clicked', async() => {
 			const el = await fixture(html`<d2l-list-item action-href="javascript:void(0)" label="item"></d2l-list-item>`);
-			setTimeout(() => el.shadowRoot.querySelector('a').click());
+			clickElem(el.shadowRoot.querySelector('a'));
 			await oneEvent(el, 'd2l-list-item-link-click');
 		});
 
 		it('dispatches d2l-list-item-button-click event when clicked', async() => {
 			const el = await fixture(html`<d2l-list-item-button label="item"></d2l-list-item-button>`);
-			setTimeout(() => el.shadowRoot.querySelector('button').click());
+			clickElem(el.shadowRoot.querySelector('button'));
 			await oneEvent(el, 'd2l-list-item-button-click');
 		});
 

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -79,7 +79,7 @@ describe('d2l-list', () => {
 
 				const listItem = elem.querySelector('[key="L2-2"]');
 
-				await sendKeysElem(listItem, 'press', testCase.keyPress);
+				await sendKeysElem(listItem, 'down', testCase.keyPress);
 
 				expect(elem.querySelector('[_focusing]')).to.equal(listItem);
 			});
@@ -109,7 +109,7 @@ describe('d2l-list', () => {
 				`);
 				const listItem = elem.querySelector(`[key="${initialFocus}"]`);
 
-				await sendKeysElem(listItem, 'press', keyPress);
+				await sendKeysElem(listItem, 'down', keyPress);
 
 				const focusedElement = elem.querySelector('[_focusing]');
 				const focusTarget = elem.querySelector('[key="L3-2');
@@ -129,7 +129,7 @@ describe('d2l-list', () => {
 
 			const listItem = elem.querySelector('[key="L1-2"]');
 
-			await sendKeysElem(listItem, 'press', 'ArrowUp');
+			await sendKeysElem(listItem, 'down', 'ArrowUp');
 			const focusedElement = elem.querySelector('[_focusing]');
 
 			expect(focusedElement).to.equal(listItem);


### PR DESCRIPTION
Now that #3808 and #3798 have been merged, opening this to move list tests to proper browser interactions, which is what caught the Safari bug to begin with.