### PR TITLE
Attempt to simplify

### DIFF
--- a/components/skeleton/skeleton-group-mixin.js
+++ b/components/skeleton/skeleton-group-mixin.js
@@ -6,17 +6,17 @@ export const SkeletonGroupMixin = dedupeMixin(superclass => class extends superc
 	constructor() {
 		super();
 
-		this._readyToDisplayCached = false;
+		this._skeletonActiveCached = true;
 		this._skeletonSubscribers = new SubscriberRegistryController(this, 'skeleton', {
 			updateSubscribers: this._checkSubscribersReadyToDisplay.bind(this)
 		});
 	}
 
 	_checkSubscribersReadyToDisplay(subscribers) {
-		const readyToDisplay = ![...subscribers.values()].some(subscriber => subscriber.skeleton);
-		if (readyToDisplay !== this._readyToDisplayCached) {
-			this._readyToDisplayCached = readyToDisplay;
-			subscribers.forEach(subscriber => subscriber.changeDisplay(readyToDisplay));
+		const skeletonActive = [...subscribers.values()].some(subscriber => subscriber._skeleton);
+		if (skeletonActive !== this._skeletonActiveCached) {
+			this._skeletonActiveCached = skeletonActive;
+			subscribers.forEach(subscriber => subscriber.setSkeletonActive(skeletonActive));
 		}
 	}
 });

--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -170,7 +170,7 @@ export const SkeletonMixin = dedupeMixin(superclass => class extends RtlMixin(su
 		super();
 		this._skeleton = false;
 		this._skeletonActive = false;
-		this._waitToDisplay = false;
+		this._skeletonWait = false;
 
 		this._parentSkeleton = new EventSubscriberController(this, 'skeleton', {
 			onSubscribe: this._onSubscribe.bind(this),
@@ -186,7 +186,7 @@ export const SkeletonMixin = dedupeMixin(superclass => class extends RtlMixin(su
 		const oldVal = this._skeleton;
 		if (oldVal === val) return;
 		this._skeleton = val;
-		if (!this._waitToDisplay) {
+		if (!this._skeletonWait) {
 			this._skeletonActive = val;
 			this.requestUpdate('skeleton', oldVal);
 		} else {
@@ -203,7 +203,7 @@ export const SkeletonMixin = dedupeMixin(superclass => class extends RtlMixin(su
 	}
 
 	_onSubscribe() {
-		this._waitToDisplay = true;
+		this._skeletonWait = true;
 		if (this._skeleton !== this._skeletonActive) {
 			this._skeletonActive = true;
 			this.requestUpdate('skeleton', this._skelton);
@@ -211,7 +211,7 @@ export const SkeletonMixin = dedupeMixin(superclass => class extends RtlMixin(su
 	}
 
 	_onUnsubscribe() {
-		this._waitToDisplay = false;
+		this._skeletonWait = false;
 		if (this._skeleton !== this._skeletonActive) {
 			this._skeletonActive = this._skeleton;
 			this.requestUpdate('skeleton', this._skeleton);

--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -206,7 +206,7 @@ export const SkeletonMixin = dedupeMixin(superclass => class extends RtlMixin(su
 		this._skeletonWait = true;
 		if (this._skeleton !== this._skeletonActive) {
 			this._skeletonActive = true;
-			this.requestUpdate('skeleton', this._skelton);
+			this.requestUpdate('skeleton', this._skeleton);
 		}
 	}
 

--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -156,8 +156,7 @@ export const SkeletonMixin = dedupeMixin(superclass => class extends RtlMixin(su
 			 * Render the component as a [skeleton loader](https://github.com/BrightspaceUI/core/tree/main/components/skeleton).
 			 * @type {boolean}
 			 */
-			skeleton: { reflect: true, type: Boolean  },
-			_skeletonActive: { state: true },
+			skeleton: { reflect: true, type: Boolean  }
 		};
 	}
 
@@ -169,11 +168,9 @@ export const SkeletonMixin = dedupeMixin(superclass => class extends RtlMixin(su
 
 	constructor() {
 		super();
+		this._skeleton = false;
 		this._skeletonActive = false;
-		this._readyToDisplay = true;
 		this._waitToDisplay = false;
-
-		this.skeleton = false;
 
 		this._parentSkeleton = new EventSubscriberController(this, 'skeleton', {
 			onSubscribe: this._onSubscribe.bind(this),
@@ -187,42 +184,38 @@ export const SkeletonMixin = dedupeMixin(superclass => class extends RtlMixin(su
 
 	set skeleton(val) {
 		const oldVal = this._skeleton;
-		if (oldVal !== val) {
-			this._skeleton = val;
+		if (oldVal === val) return;
+		this._skeleton = val;
+		if (!this._waitToDisplay) {
 			this._skeletonActive = val;
 			this.requestUpdate('skeleton', oldVal);
-		}
-	}
-
-	updated(changedProperties) {
-		super.updated(changedProperties);
-		if (changedProperties.has('skeleton')) {
+		} else {
 			this._parentSkeleton._registryController?.updateSubscribers();
 		}
 	}
 
-	changeDisplay(renderContent) {
-		this._readyToDisplay = renderContent;
-		this._updateDisplayState();
+	setSkeletonActive(skeletonActive) {
+		const oldVal = this._skeletonActive;
+		if (skeletonActive !== oldVal) {
+			this._skeletonActive = skeletonActive;
+			this.requestUpdate('skeleton', oldVal);
+		}
 	}
 
 	_onSubscribe() {
 		this._waitToDisplay = true;
-		this._readyToDisplay = false;
-		this._updateDisplayState();
+		if (this._skeleton !== this._skeletonActive) {
+			this._skeletonActive = true;
+			this.requestUpdate('skeleton', this._skelton);
+		}
 	}
 
 	_onUnsubscribe() {
 		this._waitToDisplay = false;
-		this._readyToDisplay = true;
-		this._updateDisplayState();
-	}
-
-	_updateDisplayState() {
-		if (this._waitToDisplay) {
-			this._skeletonActive = !this._readyToDisplay;
-		} else {
+		if (this._skeleton !== this._skeletonActive) {
 			this._skeletonActive = this._skeleton;
+			this.requestUpdate('skeleton', this._skeleton);
 		}
 	}
+
 });


### PR DESCRIPTION
I wanted to play around with a couple ideas to simplify things:
- It should remove the need for the `_readyToDisplay` tracker
- `_skeletonActive` doesn't need to be a state property and cause re-renders
- I've renamed `updateDisplay` / `waitForDisplay` to `updateSkeletonActive` / `skeletonWait` just to align with the new terminology