### PR TITLE
POC - Migrate to subscriber controllers

### DIFF
--- a/components/form/demo/form-demo.js
+++ b/components/form/demo/form-demo.js
@@ -95,12 +95,13 @@ class FormNestedDemo extends LitElement {
 		if (this.shadowRoot) this.shadowRoot.querySelector('#root').submit();
 	}
 
+	_validateMagicWord(e) {
+		e.detail.resolve(e.detail.forElement.value === 'please');
+	}
+
 	_validatePassword(e) {
 		e.detail.resolve(e.detail.forElement.value === 'hunter2');
 	}
 
-	_validateMagicWord(e) {
-		e.detail.resolve(e.detail.forElement.value === 'please');
-	}
 }
 customElements.define('d2l-form-demo', FormNestedDemo);

--- a/components/form/demo/form-demo.js
+++ b/components/form/demo/form-demo.js
@@ -66,6 +66,12 @@ class FormNestedDemo extends LitElement {
 								</select>
 							</label>
 						</div>
+						<div class="d2l-form-demo-container">
+							<label for="native">Magic Word</label>
+							<d2l-validation-custom for="native" @d2l-validation-custom-validate=${this._validateMagicWord} failure-text="Expected please" ></d2l-validation-custom>
+							<input id="native" name="native" required type="text"></d2l-input-text>
+							
+						</div>
 					</d2l-form>
 					<d2l-form-panel-demo></d2l-form-panel-demo>
 				</div>
@@ -91,6 +97,10 @@ class FormNestedDemo extends LitElement {
 
 	_validatePassword(e) {
 		e.detail.resolve(e.detail.forElement.value === 'hunter2');
+	}
+
+	_validateMagicWord(e) {
+		e.detail.resolve(e.detail.forElement.value === 'please');
 	}
 }
 customElements.define('d2l-form-demo', FormNestedDemo);

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -180,13 +180,13 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 		if (this._selectionProvider === nestedList) return;
 
 		if (this._selectionProvider && this._selectionProvider !== nestedList) {
-			this._selectionProvider.unsubscribeObserver(this);
+			this._selectionProvider._observerController.unsubscribe(this);
 			this._selectionProvider = null;
 		}
 
 		if (nestedList) {
 			this._selectionProvider = nestedList;
-			this._selectionProvider.subscribeObserver(this);
+			this._selectionProvider._observerController.subscribe(this);
 		}
 	}
 

--- a/components/selection/selection-controls.js
+++ b/components/selection/selection-controls.js
@@ -189,7 +189,7 @@ export class SelectionControls extends PageableSubscriberMixin(SelectionObserver
 
 	_renderSelection() {
 		return html`
-			${this._provider && !this._noSelectAll ? html`<d2l-selection-select-all></d2l-selection-select-all>` : nothing}
+			${this._registry && !this._noSelectAll ? html`<d2l-selection-select-all></d2l-selection-select-all>` : nothing}
 			<d2l-selection-summary no-selection-text="${ifDefined(this._noSelectionText)}"></d2l-selection-summary>
 			${this.selectAllPagesAllowed ? html`<d2l-selection-select-all-pages></d2l-selection-select-all-pages>` : nothing}
 		`;

--- a/components/selection/selection-select-all-pages.js
+++ b/components/selection/selection-select-all-pages.js
@@ -27,23 +27,23 @@ class SelectAllPages extends FocusMixin(LocalizeCoreElement(SelectionObserverMix
 	}
 
 	render() {
-		if (!this._provider) return;
-		if (!this._provider.itemCount) return;
-		if (this._provider.selectionSingle) return;
+		if (!this._registry) return;
+		if (!this._registry.itemCount) return;
+		if (this._registry.selectionSingle) return;
 		if (this.selectionInfo.state !== SelectionInfo.states.all) return;
 
 		return html`
 			<d2l-button-subtle
 				@click="${this._handleClick}"
-				text="${this.localize('components.selection.select-all-items', 'count', this._provider.itemCount)}">
+				text="${this.localize('components.selection.select-all-items', 'count', this._registry.itemCount)}">
 			</d2l-button-subtle>`;
 	}
 
 	_handleClick() {
-		if (!this._provider) return;
+		if (!this._registry) return;
 
-		this._provider.setSelectionForAll(true, true);
-		this._provider._focusSelectAll();
+		this._registry.setSelectionForAll(true, true);
+		this._registry._focusSelectAll();
 	}
 
 }

--- a/components/selection/selection-select-all.js
+++ b/components/selection/selection-select-all.js
@@ -44,7 +44,7 @@ class SelectAll extends FocusMixin(LocalizeCoreElement(SelectionObserverMixin(Li
 	}
 
 	render() {
-		if (!this._provider || this._provider.selectionSingle) return;
+		if (!this._registry || this._registry.selectionSingle) return;
 
 		const summary = (this.selectionInfo.state === SelectionInfo.states.none ? this.localize('components.selection.select-all')
 			: this.localize('components.selection.selected', 'count', this.selectionInfo.keys.length));
@@ -62,7 +62,7 @@ class SelectAll extends FocusMixin(LocalizeCoreElement(SelectionObserverMixin(Li
 	}
 
 	_handleCheckboxChange(e) {
-		if (this._provider) this._provider.setSelectionForAll(e.target.checked, false);
+		if (this._registry) this._registry.setSelectionForAll(e.target.checked, false);
 	}
 
 }

--- a/components/selection/selection-summary.js
+++ b/components/selection/selection-summary.js
@@ -44,29 +44,29 @@ class Summary extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) {
 	}
 
 	willUpdate(changedProperties) {
-		if (changedProperties.has('_provider') || changedProperties.has('selectionInfo') || changedProperties.has('noSelectionText')) {
+		if (changedProperties.has('selectionInfo') || changedProperties.has('noSelectionText')) {
 			this._updateSelectSummary();
 		}
 	}
 
 	_updateSelectSummary() {
-		if (this._provider?.selectionSingle) {
+		if (this._registry?.selectionSingle) {
 			this._summary = null;
 			return;
 		}
 
 		let count;
-		if (this._provider && this._provider.selectionCountOverride !== undefined) {
-			count = this._provider.selectionCountOverride;
-			this._summary = this._provider.selectionCountOverride === 0 && this.noSelectionText ?
+		if (this._registry && this._registry.selectionCountOverride !== undefined) {
+			count = this._registry.selectionCountOverride;
+			this._summary = this._registry.selectionCountOverride === 0 && this.noSelectionText ?
 				this.noSelectionText : this.localize('components.selection.selected', 'count', count);
 		} else {
 			/* If lazy loading items is supported (ex. d2l-list) then check the keys to determine if the plus sign should be included.
 			 * If lazy loading is not supported (ex. d2l-table-wrapper), then skip this.
 			 */
 			let includePlus = false;
-			if (this._provider && this._provider._getLazyLoadItems) {
-				const lazyLoadListItems = this._provider._getLazyLoadItems();
+			if (this._registry && this._registry._getLazyLoadItems) {
+				const lazyLoadListItems = this._registry._getLazyLoadItems();
 				if (lazyLoadListItems.size > 0) {
 					for (const selectedItemKey of this.selectionInfo.keys) {
 						if (lazyLoadListItems.has(selectedItemKey)) {
@@ -77,8 +77,8 @@ class Summary extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) {
 				}
 			}
 
-			count = (this._provider && this.selectionInfo.state === SelectionInfo.states.allPages) ?
-				this._provider.itemCount : this.selectionInfo.keys.length;
+			count = (this._registry && this.selectionInfo.state === SelectionInfo.states.allPages) ?
+				this._registry.itemCount : this.selectionInfo.keys.length;
 
 			if (this.selectionInfo.state === SelectionInfo.states.none && this.noSelectionText) {
 				this._summary = this.noSelectionText;

--- a/components/validation/test/validation-custom.test.js
+++ b/components/validation/test/validation-custom.test.js
@@ -1,5 +1,5 @@
 import '../validation-custom.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, html } from '@brightspace-ui/testing';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`
@@ -37,19 +37,11 @@ describe('d2l-validation-custom', () => {
 
 	});
 
+	describe('subscribe', () => {
+		// to do
+	});
+
 	describe('events', () => {
-
-		it('should fire connected event', async() => {
-			const unconnectedCustom = document.createElement('d2l-validation-custom');
-			setTimeout(() => root.appendChild(unconnectedCustom), 0);
-			await oneEvent(unconnectedCustom, 'd2l-validation-custom-connected');
-		});
-
-		it('should fire disconnected event', async() => {
-			setTimeout(() => custom.remove(), 0);
-			await oneEvent(custom, 'd2l-validation-custom-disconnected');
-			expect(custom.forElement).to.be.null;
-		});
 
 		[true, false].forEach(expectedIsValid => {
 

--- a/components/validation/validation-custom-mixin.js
+++ b/components/validation/validation-custom-mixin.js
@@ -1,4 +1,4 @@
-import { isCustomFormElement } from '../form/form-helper.js';
+import { EventSubscriberController, IdSubscriberController } from '../../controllers/subscriber/subscriberControllers.js';
 
 export const ValidationCustomMixin = superclass => class extends superclass {
 
@@ -12,60 +12,34 @@ export const ValidationCustomMixin = superclass => class extends superclass {
 	constructor() {
 		super();
 		this._forElement = null;
+
+		// Will register to both the form (through the event) and the "for" element (if set and extends FormElementMixin)
+		this._eventSubscriberController = new EventSubscriberController(this, 'validation-custom', {});
+		this._idSubscriberController = new IdSubscriberController(this, 'validation-custom', {
+			idPropertyName: 'for',
+			onError: this._onError.bind(this)
+		});
 	}
 
 	get forElement() {
-		return this._forElement;
-	}
-
-	connectedCallback() {
-		super.connectedCallback();
-		this._updateForElement();
-		this.dispatchEvent(new CustomEvent('d2l-validation-custom-connected', { bubbles: true }));
-	}
-
-	disconnectedCallback() {
-		super.disconnectedCallback();
-		if (isCustomFormElement(this._forElement)) {
-			this._forElement.validationCustomDisconnected(this);
+		if (this.for) {
+			// Validation custom components only support one "for" element
+			return this._idSubscriberController.registries.length > 0 ? this._idSubscriberController.registries[0] : this._forElement;
+		} else {
+			return this._eventSubscriberController.registry;
 		}
-		this._forElement = null;
-		this.dispatchEvent(new CustomEvent('d2l-validation-custom-disconnected'));
-	}
-
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		changedProperties.forEach((_, prop) => {
-			if (prop === 'for') {
-				this._updateForElement();
-			}
-		});
 	}
 
 	async validate() {
 		throw new Error('ValidationCustomMixin requires validate to be overridden');
 	}
 
-	_updateForElement() {
-		const oldForElement = this._forElement;
-		if (this.for) {
-			const root = this.getRootNode();
-			this._forElement = root.getElementById(this.for);
-			if (!this._forElement) {
-				throw new Error(`validation-custom failed to find element with id ${this.for}`);
-			}
-		} else {
-			this._forElement = null;
-		}
-		if (this._forElement !== oldForElement) {
-			if (isCustomFormElement(oldForElement)) {
-				oldForElement.validationCustomDisconnected(this);
-			}
-			if (isCustomFormElement(this._forElement)) {
-				this._forElement.validationCustomConnected(this);
-			}
+	_onError() {
+		// If the "for" element does not extend FormElementMixin, we must find it ourselves
+		const root = this.getRootNode();
+		this._forElement = root.getElementById(this.for);
+		if (!this._forElement) {
+			throw new Error(`validation-custom failed to find element with id ${this.for}`);
 		}
 	}
-
 };


### PR DESCRIPTION
Update to https://github.com/BrightspaceUI/core/pull/1901

POC of how to migrate the form/validation, selection, and labelledby components and mixins to the subscriber controllers.
This is not thoroughly tested and variables are not well-named - this is a starting point.