### PR TITLE
DE53956 Replace optional chaining syntax for compatibility with Polymer

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -479,7 +479,7 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 					tooltip.updatePosition();
 				}
 			} else if (prop === 'type') {
-				const input = this.shadowRoot?.querySelector('.d2l-input');
+				const input = this.shadowRoot && this.shadowRoot.querySelector('.d2l-input');
 				setTimeout(() => {
 					if (input && this.value !== input.value) {
 						this._setValue(input.value, false);


### PR DESCRIPTION
[DE53956](https://rally1.rallydev.com/#/?detail=/defect/706049515503&fdp=true): [WCAG2.2] Activity Feed > Several buttons with enclosed focus not meeting Focus appearance requirements

We haven't managed to move away from Polymer yet: https://github.com/Brightspace/assignments-ui/pull/323#issuecomment-1631896201