### PR TITLE
Increase the more-less component's max height to allow room for rounding errors

### DIFF
--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -201,11 +201,13 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 	__adjustToContent_makeInactive() {
 		this.inactive = true;
 		this.expanded = false;
-		this.__maxHeight = `${this.__content.scrollHeight}px`;
+		// Include 1 px of give room to account for issues with Firefox rounding the content's scroll height
+		this.__maxHeight = `${this.__content.scrollHeight + 1}px`;
 	}
 
 	__adjustToContent_resize(contentHeight) {
-		this.__maxHeight = `${contentHeight}px`;
+		// Include 1 px of give room to account for issues with Firefox rounding the content's scroll height
+		this.__maxHeight = `${contentHeight + 1}px`;
 	}
 
 	__computeAriaExpanded() {

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -206,7 +206,7 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 	}
 
 	__adjustToContent_resize(contentHeight) {
-		// Include 1 px of give room to account for issues with Firefox rounding the content's scroll height
+		// Include 1px of given room to account for issues with Firefox rounding the content's scroll height
 		this.__maxHeight = `${contentHeight + 1}px`;
 	}
 

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -201,7 +201,7 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 	__adjustToContent_makeInactive() {
 		this.inactive = true;
 		this.expanded = false;
-		// Include 1 px of give room to account for issues with Firefox rounding the content's scroll height
+		// Include 1px of given room to account for issues with Firefox rounding the content's scroll height
 		this.__maxHeight = `${this.__content.scrollHeight + 1}px`;
 	}
 


### PR DESCRIPTION
This is a bit of an odd one (for some reason GitHub doesn't want to embed the video):
https://github.com/BrightspaceUI/core/assets/19732724/60f7b0b2-6f04-404a-9f98-4bd804d14163

I was able to reproduce the above behaviour on Firefox (no other browser) on my Mac's retina display with standard zoom using the following HTML:
`<p style="margin: 0cm 0cm 8pt; line-height: 107%; font-size: 11pt;">Test</p>`

I could not reproduce the same issue when moving the demo page over to my second 1080p monitor.

Through copious amounts of logging, the issue here seems to be how Firefox measures the `scrollHeight` of the content when a `max-height` is applied to the component. When the content has enough space to fully display (`max-height > scrollHeight`), Firefox measures the content's `scrollHeight` as 26px (using the above sample HTML). However, when `max-height <= scrollHeight`, Firefox measures the content's `scrollHeight` as 27px.

This is what leads to the oscillation. The component measures that the height of the content is 26px, so we set the component's max-height to 26px. This causes Firefox to seemingly recalculate the height of the content, and it measures at 27px. This change kicks off the `ResizeObserver`, which re-measures and sets the component's max-height to 26px. Then the cycle just continues. The actual unrounded content height in both of these cases (measured via `getComputedStyle(content).height`) is ~26.2px, which makes me think this is some funky rounding issue Firefox is running into.

I don't really _like_ the idea of just adding a pixel of give room to `max-height` in this case, but I haven't really found a good answer to the problem beyond that. There doesn't seem to be a way to differentiate between the content legitimately resizing and whatever is happening in Firefox here. I'm not aware of a way to calculate an unrounded `scrollHeight`, so that feels like it limits the available solutions here.