### PR TITLE
Update SelectionMixin to focus radios based on DOM order instead of subscription order.

### DIFF
--- a/components/list/demo/list-item-actions.html
+++ b/components/list/demo/list-item-actions.html
@@ -184,6 +184,12 @@
 						<d2l-list-item selectable key="3" label="Geomorphology and GIS">
 							<d2l-list-item-content>Geomorphology and GIS</d2l-list-item-content>
 						</d2l-list-item>
+						<d2l-list-item selectable key="4" label="Introductory Differential Equations">
+							<d2l-list-item-content>Introductory Differential Equations</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item selectable key="5" label="Fermentation Biology">
+							<d2l-list-item-content>Fermentation Biology</d2l-list-item-content>
+						</d2l-list-item>
 					</d2l-list>
 				</template>
 			</d2l-demo-snippet>

--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -1,4 +1,4 @@
-import { getFirstFocusableDescendant, getLastFocusableDescendant, getNextFocusable, getPreviousFocusable} from '../../helpers/focus.js';
+import { getFirstFocusableDescendant, getLastFocusableDescendant, getNextFocusable, getPreviousFocusable } from '../../helpers/focus.js';
 import { CollectionMixin } from '../../mixins/collection/collection-mixin.js';
 import { isComposedAncestor } from '../../helpers/dom.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';

--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -1,4 +1,4 @@
-import { getNextFocusable, getPreviousFocusable } from '../../helpers/focus.js';
+import { getFirstFocusableDescendant, getLastFocusableDescendant, getNextFocusable, getPreviousFocusable} from '../../helpers/focus.js';
 import { CollectionMixin } from '../../mixins/collection/collection-mixin.js';
 import { isComposedAncestor } from '../../helpers/dom.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
@@ -180,7 +180,7 @@ export const SelectionMixin = superclass => class extends RtlMixin(CollectionMix
 
 		if (!selectionInput) {
 			// no selection-input since next/previous focusable is before/after list... cycle to first/last
-			focusable = forward ? getNextFocusable(this, false, true, false) : getPreviousFocusable(this, false, true, false);
+			focusable = forward ?  getFirstFocusableDescendant(this, false) : getLastFocusableDescendant(this, false);
 			selectionInput = getSelectionInput(focusable, forward);
 		}
 

--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -155,8 +155,10 @@ export const SelectionMixin = superclass => class extends RtlMixin(CollectionMix
 
 	_handleRadioKeyUp(e) {
 
+		const target = e.composedPath()[0];
+
 		// check composed path for radio (e.target could be d2l-list-item or other element due to retargeting)
-		if (!e.composedPath()[0].classList.contains('d2l-selection-input-radio')) return;
+		if (!target.classList.contains('d2l-selection-input-radio')) return;
 		if (e.keyCode < keyCodes.LEFT || e.keyCode > keyCodes.DOWN) return;
 
 		const getSelectionInput = (focusable, forward) => {
@@ -175,7 +177,7 @@ export const SelectionMixin = superclass => class extends RtlMixin(CollectionMix
 		const forward = (this.dir !== 'rtl' && e.keyCode === keyCodes.RIGHT) || (this.dir === 'rtl' && e.keyCode === keyCodes.LEFT) || (e.keyCode === keyCodes.DOWN);
 
 		// first try to find next/previous selection-input relative to the event target within the selection component sub-tree that also belongs to the selection component
-		let focusable = forward ? getNextFocusable(e.composedPath()[0], false, true, true) : getPreviousFocusable(e.composedPath()[0], false, true, true);
+		let focusable = forward ? getNextFocusable(target, false, true, true) : getPreviousFocusable(target, false, true, true);
 		let selectionInput = getSelectionInput(focusable, forward);
 
 		if (!selectionInput) {

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -57,10 +57,12 @@ export function getLastFocusableDescendant(node, includeHidden) {
 	return null;
 }
 
-export function getPreviousFocusable(node, includeHidden) {
+export function getPreviousFocusable(node, includeHidden, ignore, ignoreChildren) {
 	if (!node) return null;
 
 	if (includeHidden === undefined) includeHidden = false;
+	if (ignore === undefined) ignore = true;
+	if (ignoreChildren === undefined) ignoreChildren = true;
 
 	const _getPreviousFocusable = (node, ignore, ignoreChildren) => {
 		if (!ignore && isFocusable(node, includeHidden)) return node;
@@ -86,7 +88,7 @@ export function getPreviousFocusable(node, includeHidden) {
 		return null;
 	};
 
-	const focusable = _getPreviousFocusable(node, true, true);
+	const focusable = _getPreviousFocusable(node, ignore, ignoreChildren);
 	return focusable;
 }
 

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -57,12 +57,10 @@ export function getLastFocusableDescendant(node, includeHidden) {
 	return null;
 }
 
-export function getPreviousFocusable(node, includeHidden, ignore, ignoreChildren) {
+export function getPreviousFocusable(node, includeHidden) {
 	if (!node) return null;
 
 	if (includeHidden === undefined) includeHidden = false;
-	if (ignore === undefined) ignore = true;
-	if (ignoreChildren === undefined) ignoreChildren = true;
 
 	const _getPreviousFocusable = (node, ignore, ignoreChildren) => {
 		if (!ignore && isFocusable(node, includeHidden)) return node;
@@ -88,7 +86,7 @@ export function getPreviousFocusable(node, includeHidden, ignore, ignoreChildren
 		return null;
 	};
 
-	const focusable = _getPreviousFocusable(node, ignore, ignoreChildren);
+	const focusable = _getPreviousFocusable(node, true, true);
 	return focusable;
 }
 


### PR DESCRIPTION
[DE54118](https://rally1.rallydev.com/#/?detail=/defect/709376015737&fdp=true)

This PR fixes an issue where `SelectionMixin` manages the focus order of `d2l-selection-input` (radios) incorrectly. The current logic relies on the `Map` of selectables to determine the next/previous item to focus, and it incorrectly assumes that the order within the map (subscription order) is the DOM order.

This fix changes the logic to find the next/previous `d2l-selection-input` (radio) based tree-walking when the key is pressed. An alternate solution that sorts the subscribed selectables based on DOM order is: https://github.com/BrightspaceUI/core/pull/3813