### PR TITLE
Add instructions to d2l-input-text.

### DIFF
--- a/components/inputs/demo/input-text.html
+++ b/components/inputs/demo/input-text.html
@@ -69,6 +69,13 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Control Instructions</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-input-text label="Name" control-instructions="Use the keyboard to enter some sweet stuff... :)"></d2l-input-text>
+				</template>
+			</d2l-demo-snippet>
+
 			<h3>Invalid</h3>
 			<d2l-demo-snippet>
 				<template>

--- a/components/inputs/demo/input-text.html
+++ b/components/inputs/demo/input-text.html
@@ -69,10 +69,10 @@
 				</template>
 			</d2l-demo-snippet>
 
-			<h2>Control Instructions</h2>
+			<h2>Instructions</h2>
 			<d2l-demo-snippet>
 				<template>
-					<d2l-input-text label="Name" control-instructions="Use the keyboard to enter some sweet stuff... :)"></d2l-input-text>
+					<d2l-input-text label="Name" instructions="Use the keyboard to enter some sweet stuff... :)"></d2l-input-text>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/inputs/docs/input-text.md
+++ b/components/inputs/docs/input-text.md
@@ -77,10 +77,10 @@ The `<d2l-input-text>` element is a simple wrapper around the native `<input typ
 | `aria-invalid` | String | Indicates that the input value is invalid |
 | `autocomplete` | String | Specifies which types of values [can be autofilled](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) by the browser |
 | `autofocus` | Boolean | When set, will automatically place focus on the input |
-| `control-instructions` | String | Additional information relating to how to use the control |
 | `description` | String | A description to be added to the `input` for accessibility |
 | `disabled` | Boolean | Disables the input |
 | `input-width` | String, default: `100%` | Restricts the maximum width of the input box without impacting the width of the label |
+| `instructions` | String | Additional information relating to how to use the component |
 | `label-hidden` | Boolean | Hides the label visually (moves it to the input's `aria-label` attribute) |
 | `labelled-by` | String | HTML id of an element in the same shadow root which acts as the input's label |
 | `max` | String | For number inputs, maximum value |

--- a/components/inputs/docs/input-text.md
+++ b/components/inputs/docs/input-text.md
@@ -77,6 +77,7 @@ The `<d2l-input-text>` element is a simple wrapper around the native `<input typ
 | `aria-invalid` | String | Indicates that the input value is invalid |
 | `autocomplete` | String | Specifies which types of values [can be autofilled](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) by the browser |
 | `autofocus` | Boolean | When set, will automatically place focus on the input |
+| `control-instructions` | String | Additional information relating to how to use the control |
 | `description` | String | A description to be added to the `input` for accessibility |
 | `disabled` | Boolean | Disables the input |
 | `input-width` | String, default: `100%` | Restricts the maximum width of the input box without impacting the width of the label |

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -282,7 +282,7 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 					@blur="${this._handleInputTextBlur}"
 					@change="${this._handleChange}"
 					class="d2l-dropdown-opener"
-					control-instructions="${ifDefined((this._showInfoTooltip && !errorTooltip && !this.invalid && !this.disabled && this.childErrors.size === 0 && !this.skeleton && this._inputTextFocusShowTooltip) ? this.localize(`${this._namespace}.openInstructions`, { format: shortDateFormat }) : undefined)}"
+					control-instructions="${ifDefined((this._showInfoTooltip && !errorTooltip && !this.invalid && this.childErrors.size === 0 && this._inputTextFocusShowTooltip) ? this.localize(`${this._namespace}.openInstructions`, { format: shortDateFormat }) : undefined)}"
 					description="${ifDefined(this.emptyText ? this.emptyText : undefined)}"
 					?disabled="${this.disabled}"
 					@focus="${this._handleInputTextFocus}"

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -282,7 +282,7 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 					@blur="${this._handleInputTextBlur}"
 					@change="${this._handleChange}"
 					class="d2l-dropdown-opener"
-					control-instructions="${ifDefined((this._showInfoTooltip && !errorTooltip && !this.invalid && this.childErrors.size === 0 && this._inputTextFocusShowTooltip) ? this.localize(`${this._namespace}.openInstructions`, { format: shortDateFormat }) : undefined)}"
+					instructions="${ifDefined((this._showInfoTooltip && !errorTooltip && !this.invalid && this.childErrors.size === 0 && this._inputTextFocusShowTooltip) ? this.localize(`${this._namespace}.openInstructions`, { format: shortDateFormat }) : undefined)}"
 					description="${ifDefined(this.emptyText ? this.emptyText : undefined)}"
 					?disabled="${this.disabled}"
 					@focus="${this._handleInputTextFocus}"

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -242,7 +242,6 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 			? html`<d2l-icon icon="tier1:alert" slot="left" style="${styleMap({ color: 'var(--d2l-color-cinnabar)' })}"></d2l-icon>`
 			: html`<d2l-icon icon="tier1:calendar" slot="left"></d2l-icon>`;
 		const errorTooltip = (this.validationError && !this.opened && this.childErrors.size === 0) ? html`<d2l-tooltip align="start" announced for="${this._inputId}" state="error">${this.validationError}</d2l-tooltip>` : null;
-		const infoTooltip = (this._showInfoTooltip && !errorTooltip && !this.invalid && !this.disabled && this.childErrors.size === 0 && !this.skeleton && this._inputTextFocusShowTooltip) ? html`<d2l-tooltip align="start" announced delay="1000" for="${this._inputId}">${this.localize(`${this._namespace}.openInstructions`, { format: shortDateFormat })}</d2l-tooltip>` : null;
 
 		const dropdownContent = this._dropdownFirstOpened ? html`
 			<d2l-dropdown-content
@@ -276,7 +275,6 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 				<div>${this.emptyText}</div>
 			</div>
 			${errorTooltip}
-			${infoTooltip}
 			<d2l-dropdown ?disabled="${this.disabled || this.skeleton}" no-auto-open>
 				<d2l-input-text
 					?novalidate="${this.noValidate}"
@@ -284,6 +282,7 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 					@blur="${this._handleInputTextBlur}"
 					@change="${this._handleChange}"
 					class="d2l-dropdown-opener"
+					control-instructions="${ifDefined((this._showInfoTooltip && !errorTooltip && !this.invalid && !this.disabled && this.childErrors.size === 0 && !this.skeleton && this._inputTextFocusShowTooltip) ? this.localize(`${this._namespace}.openInstructions`, { format: shortDateFormat }) : undefined)}"
 					description="${ifDefined(this.emptyText ? this.emptyText : undefined)}"
 					?disabled="${this.disabled}"
 					@focus="${this._handleInputTextFocus}"

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -49,6 +49,11 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			 */
 			autofocus: { type: Boolean },
 			/**
+			 * ADVANCED: Additional information relating to how to use the control
+			 * @type {string}
+			 */
+			controlInstructions: { type: String, attribute: 'control-instructions' },
+			/**
 			 * Additional information communicated in the aria-describedby on the input
 			 * @type {string}
 			 */
@@ -461,8 +466,13 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 		}
 
 		let tooltip = nothing;
-		if (this.validationError && !this.skeleton && !this.noValidate) {
-			tooltip = html`<d2l-tooltip state="error" announced align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>`;
+		if (!this.skeleton) {
+			if (this.validationError && !this.noValidate) {
+				// this tooltip is using "announced" since we don't want aria-describedby wire-up which would bury the message in VoiceOver's More Content Available menu
+				tooltip = html`<d2l-tooltip state="error" announced align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>`;
+			} else if (this.controlInstructions) {
+				tooltip = html`<d2l-tooltip align="start" for="${this._inputId}" delay="1000">${this.controlInstructions}</d2l-tooltip>`;
+			}
 		}
 
 		return html`${tooltip}${label}${input}`;

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -49,11 +49,6 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			 */
 			autofocus: { type: Boolean },
 			/**
-			 * ADVANCED: Additional information relating to how to use the control
-			 * @type {string}
-			 */
-			controlInstructions: { type: String, attribute: 'control-instructions' },
-			/**
 			 * Additional information communicated in the aria-describedby on the input
 			 * @type {string}
 			 */
@@ -73,6 +68,11 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			 * @type {string}
 			 */
 			inputWidth: { attribute: 'input-width', type: String },
+			/**
+			 * ADVANCED: Additional information relating to how to use the component
+			 * @type {string}
+			 */
+			instructions: { type: String, attribute: 'instructions' },
 			/**
 			 * Hides the label visually (moves it to the input's "aria-label" attribute)
 			 * @type {boolean}
@@ -470,8 +470,8 @@ class InputText extends FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(
 			if (this.validationError && !this.noValidate) {
 				// this tooltip is using "announced" since we don't want aria-describedby wire-up which would bury the message in VoiceOver's More Content Available menu
 				tooltip = html`<d2l-tooltip state="error" announced align="start">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>`;
-			} else if (this.controlInstructions) {
-				tooltip = html`<d2l-tooltip align="start" for="${this._inputId}" delay="1000">${this.controlInstructions}</d2l-tooltip>`;
+			} else if (this.instructions) {
+				tooltip = html`<d2l-tooltip align="start" for="${this._inputId}" delay="1000">${this.instructions}</d2l-tooltip>`;
 			}
 		}
 

--- a/components/inputs/test/input-date-range.visual-diff.html
+++ b/components/inputs/test/input-date-range.visual-diff.html
@@ -4,9 +4,9 @@
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
 		<script type="module">
-			import { querySelectorComposed } from '../../../helpers/dom.js';
 			import '../../typography/typography.js';
 			import '../input-date-range.js';
+			import { querySelectorComposed } from '../../../helpers/dom.js';
 			import sinon from 'sinon';
 
 			window.querySelectorComposed = querySelectorComposed;

--- a/components/inputs/test/input-date-range.visual-diff.html
+++ b/components/inputs/test/input-date-range.visual-diff.html
@@ -4,9 +4,12 @@
 		<link rel="stylesheet" href="../../../test/styles.css" type="text/css">
 		<link rel="stylesheet" href="../../../test/sass.output.css" type="text/css">
 		<script type="module">
+			import { querySelectorComposed } from '../../../helpers/dom.js';
 			import '../../typography/typography.js';
 			import '../input-date-range.js';
 			import sinon from 'sinon';
+
+			window.querySelectorComposed = querySelectorComposed;
 
 			const newToday = new Date('2018-02-12T12:00Z');
 			sinon.useFakeTimers({ now: newToday.getTime(), toFake: ['Date'] });

--- a/components/inputs/test/input-date-range.visual-diff.js
+++ b/components/inputs/test/input-date-range.visual-diff.js
@@ -61,32 +61,6 @@ describe('d2l-input-date-range', () => {
 		}, inputSelector, date);
 	}
 
-	async function getRectInnerTooltip(page, selector, inputDateSelector) {
-		return page.$eval(selector, (elem, inputDateSelector) => {
-			let content = window.querySelectorComposed(elem.shadowRoot, 'd2l-tooltip[showing]');
-			/*
-			let content = elem.shadowRoot.querySelector('d2l-tooltip');
-			if (!content || !content.showing) {
-				const inputDate = elem.shadowRoot.querySelector(inputDateSelector);
-				content = inputDate.shadowRoot.querySelector('d2l-tooltip');
-			}
-			*/
-			const contentWidth = content.shadowRoot.querySelector('.d2l-tooltip-content');
-			const openerRect = elem.getBoundingClientRect();
-			const contentRect = contentWidth.getBoundingClientRect();
-			const x = Math.min(openerRect.x, contentRect.x);
-			const y = Math.min(openerRect.y, contentRect.y);
-			const width = Math.max(openerRect.right, contentRect.right) - x;
-			const height = Math.max(openerRect.bottom, contentRect.bottom) - y;
-			return {
-				x: x - 10,
-				y: y - 10,
-				width: width + 20,
-				height: height + 20
-			};
-		}, inputDateSelector);
-	}
-
 	[
 		'basic',
 		'basic-wrapped',
@@ -114,7 +88,7 @@ describe('d2l-input-date-range', () => {
 				elem.addEventListener('d2l-tooltip-show', resolve, { once: true });
 			});
 		});
-		const rect = await getRectInnerTooltip(page, '#basic', 'd2l-input-date.d2l-input-date-range-start');
+		const rect = await getRectTooltip(page, '#basic');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
@@ -250,7 +224,7 @@ describe('d2l-input-date-range', () => {
 
 					it('focus end', async function() {
 						await focusOnInput(page, '#min-max', endDateSelector);
-						const rect = await getRectTooltip(page, '#min-max', 1);
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});
@@ -282,13 +256,13 @@ describe('d2l-input-date-range', () => {
 
 					it('focus start', async function() {
 						await focusOnInput(page, '#min-max', startDateSelector);
-						const rect = await getRectInnerTooltip(page, '#min-max', startDateSelector);
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
 					it('focus end', async function() {
 						await focusOnInput(page, '#min-max', endDateSelector);
-						const rect = await getRectInnerTooltip(page, '#min-max', endDateSelector);
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});
@@ -331,13 +305,13 @@ describe('d2l-input-date-range', () => {
 
 					it('focus start', async function() {
 						await focusOnInput(page, '#min-max', startDateSelector);
-						const rect = await getRectInnerTooltip(page, '#min-max', startDateSelector);
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
 					it('focus end', async function() {
 						await focusOnInput(page, '#min-max', endDateSelector);
-						const rect = await getRectInnerTooltip(page, '#min-max', endDateSelector);
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});

--- a/components/inputs/test/input-date-range.visual-diff.js
+++ b/components/inputs/test/input-date-range.visual-diff.js
@@ -63,11 +63,14 @@ describe('d2l-input-date-range', () => {
 
 	async function getRectInnerTooltip(page, selector, inputDateSelector) {
 		return page.$eval(selector, (elem, inputDateSelector) => {
+			let content = window.querySelectorComposed(elem.shadowRoot, 'd2l-tooltip[showing]');
+			/*
 			let content = elem.shadowRoot.querySelector('d2l-tooltip');
 			if (!content || !content.showing) {
 				const inputDate = elem.shadowRoot.querySelector(inputDateSelector);
 				content = inputDate.shadowRoot.querySelector('d2l-tooltip');
 			}
+			*/
 			const contentWidth = content.shadowRoot.querySelector('.d2l-tooltip-content');
 			const openerRect = elem.getBoundingClientRect();
 			const contentRect = contentWidth.getBoundingClientRect();

--- a/components/inputs/test/input-date-time-range.visual-diff.html
+++ b/components/inputs/test/input-date-time-range.visual-diff.html
@@ -6,7 +6,10 @@
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-date-time-range.js';
+			import { querySelectorComposed } from '../../../helpers/dom.js';
 			import sinon from 'sinon';
+
+			window.querySelectorComposed = querySelectorComposed;
 
 			const newToday = new Date('2018-02-12T12:00Z');
 			sinon.useFakeTimers({ now: newToday.getTime(), toFake: ['Date'] });

--- a/components/inputs/test/input-date-time-range.visual-diff.js
+++ b/components/inputs/test/input-date-time-range.visual-diff.js
@@ -329,7 +329,7 @@ describe('d2l-input-date-time-range', () => {
 
 					it('focus end', async function() {
 						await focusOnInput(page, '#min-max', endDateSelector);
-						const rect = await getRectTooltip(page, '#min-max', 1);
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});
@@ -361,7 +361,7 @@ describe('d2l-input-date-time-range', () => {
 					it('focus start', async function() {
 						await focusOnInput(page, '#min-max', startDateSelector);
 						const rect = testCase.startDateTooltip
-							? await getRectInnerTooltip(page, '#min-max', startDateSelector)
+							? await getRectTooltip(page, '#min-max')
 							: await visualDiff.getRect(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
@@ -369,7 +369,7 @@ describe('d2l-input-date-time-range', () => {
 					it('focus end', async function() {
 						await focusOnInput(page, '#min-max', endDateSelector);
 						const rect = testCase.endDateTooltip
-							? await getRectInnerTooltip(page, '#min-max', endDateSelector)
+							? await getRectTooltip(page, '#min-max')
 							: await visualDiff.getRect(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
@@ -412,41 +412,18 @@ describe('d2l-input-date-time-range', () => {
 
 					it('focus start', async function() {
 						await focusOnInput(page, '#min-max', startDateSelector);
-						const rect = await getRectInnerTooltip(page, '#min-max', startDateSelector);
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 
 					it('focus end', async function() {
 						await focusOnInput(page, '#min-max', endDateSelector);
-						const rect = await getRectInnerTooltip(page, '#min-max', endDateSelector);
+						const rect = await getRectTooltip(page, '#min-max');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});
 			});
 		});
-
-		async function getRectInnerTooltip(page, selector, inputDateSelector) {
-			return page.$eval(selector, (elem, inputDateSelector) => {
-				let content = elem.shadowRoot.querySelector('d2l-tooltip');
-				if (!content || !content.showing) {
-					const inputDate = elem.shadowRoot.querySelector(inputDateSelector);
-					content = inputDate.shadowRoot.querySelector('d2l-tooltip');
-				}
-				const contentWidth = content.shadowRoot.querySelector('.d2l-tooltip-content');
-				const openerRect = elem.getBoundingClientRect();
-				const contentRect = contentWidth.getBoundingClientRect();
-				const x = Math.min(openerRect.x, contentRect.x);
-				const y = Math.min(openerRect.y, contentRect.y);
-				const width = Math.max(openerRect.right, contentRect.right) - x;
-				const height = Math.max(openerRect.bottom, contentRect.bottom) - y;
-				return {
-					x: x - 10,
-					y: y - 10,
-					width: width + 20,
-					height: height + 20
-				};
-			}, inputDateSelector);
-		}
 
 	});
 

--- a/components/inputs/test/input-date.visual-diff.html
+++ b/components/inputs/test/input-date.visual-diff.html
@@ -5,7 +5,10 @@
 		<script type="module">
 			import '../../../test/typography-preload.js';
 			import '../input-date.js';
+			import { querySelectorComposed } from '../../../helpers/dom.js';
 			import sinon from 'sinon';
+
+			window.querySelectorComposed = querySelectorComposed;
 
 			const newToday = new Date('2018-02-12T12:00Z');
 			sinon.useFakeTimers({ now: newToday.getTime(), toFake: ['Date'] });

--- a/components/inputs/test/input-helper.js
+++ b/components/inputs/test/input-helper.js
@@ -65,9 +65,9 @@ export function getRect(page, selector) {
 	});
 }
 
-export function getRectTooltip(page, selector, tooltipIndex) {
-	return page.$eval(selector, (elem, tooltipIndex) => {
-		const content = elem.shadowRoot.querySelectorAll('d2l-tooltip')[tooltipIndex ? tooltipIndex : 0];
+export function getRectTooltip(page, selector) {
+	return page.$eval(selector, elem => {
+		const content = window.querySelectorComposed(elem.shadowRoot, 'd2l-tooltip[showing]');
 		const contentWidth = content.shadowRoot.querySelector('.d2l-tooltip-content');
 		const openerRect = elem.getBoundingClientRect();
 		const contentRect = contentWidth.getBoundingClientRect();
@@ -81,7 +81,7 @@ export function getRectTooltip(page, selector, tooltipIndex) {
 			width: width + 20,
 			height: height + 20
 		};
-	}, tooltipIndex);
+	});
 }
 
 export async function focusOnInput(page, selector, inputSelector) {

--- a/components/inputs/test/input-text.axe.js
+++ b/components/inputs/test/input-text.axe.js
@@ -53,8 +53,8 @@ describe('d2l-input-text', () => {
 		await expect(elem).to.be.accessible();
 	});
 
-	it('control-instructions', async() => {
-		const elem = await fixture(html`<d2l-input-text label="label" control-instructions="some control instructions"></d2l-input-text>`);
+	it('instructions', async() => {
+		const elem = await fixture(html`<d2l-input-text label="label" instructions="some instructions"></d2l-input-text>`);
 		await expect(elem).to.be.accessible();
 	});
 

--- a/components/inputs/test/input-text.axe.js
+++ b/components/inputs/test/input-text.axe.js
@@ -53,4 +53,9 @@ describe('d2l-input-text', () => {
 		await expect(elem).to.be.accessible();
 	});
 
+	it('control-instructions', async() => {
+		const elem = await fixture(html`<d2l-input-text label="label" control-instructions="some control instructions"></d2l-input-text>`);
+		await expect(elem).to.be.accessible();
+	});
+
 });

--- a/components/inputs/test/input-time-range.visual-diff.html
+++ b/components/inputs/test/input-time-range.visual-diff.html
@@ -6,7 +6,10 @@
 		<script type="module">
 			import '../../typography/typography.js';
 			import '../input-time-range.js';
+			import { querySelectorComposed } from '../../../helpers/dom.js';
 			import sinon from 'sinon';
+
+			window.querySelectorComposed = querySelectorComposed;
 
 			const newToday = new Date('2018-07-12T09:33Z');
 			sinon.useFakeTimers({ now: newToday.getTime(), toFake: ['Date'] });

--- a/components/inputs/test/input-time-range.visual-diff.js
+++ b/components/inputs/test/input-time-range.visual-diff.js
@@ -197,7 +197,7 @@ describe('d2l-input-time-range', () => {
 
 					it('focus end', async function() {
 						await focusOnInput(page, '#basic', endTimeSelector);
-						const rect = await getRectTooltip(page, '#basic', 1);
+						const rect = await getRectTooltip(page, '#basic');
 						await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 					});
 				});


### PR DESCRIPTION
[DE53316](https://rally1.rallydev.com/#/?detail=/defect/700336570793&fdp=true)

This PR adds the `control-instructions` advanced property to the `d2l-input-text` component which wires the tooltip directly up to the input via `aria-describedby`. It also updates `d2l-input-date` to provide the `control-instructions` property instead of rendering a disconnected flakey tooltip for improved accessibility.

This does not remove the `description` property from `d2l-input-text` - that is a separate set of work as mentioned in the Rally ticket.