### PR TITLE
fix: wait for positioning before scrolling in filter load more

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -743,7 +743,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				value: dimension.searchValue,
 				loadMoreCompleteCallback: (options) => {
 					applySearch(options);
-					e.detail.complete();
+					this.shadowRoot.querySelector('d2l-dropdown-menu').addEventListener('d2l-dropdown-position', e.detail.complete, { once: true });
 				}
 			},
 			bubbles: true,


### PR DESCRIPTION
Wait for dropdown menu to finish its positioning after loading the items before focusing on the first newly loaded item.
Rally: [US153373](https://rally1.rallydev.com/#/?detail=/userstory/703321522879&fdp=true)