### PR TITLE
fix: reflect input-color's value to formValue

### DIFF
--- a/components/inputs/input-color.js
+++ b/components/inputs/input-color.js
@@ -285,6 +285,10 @@ class InputColor extends FocusMixin(FormElementMixin(LocalizeCoreElement(LitElem
 
 		if (changedProperties.has('label') || changedProperties.has('type')) this._validateLabel();
 
+		if (changedProperties.has('value') || changedProperties.has('type') || changedProperties.has('disallowNone')) {
+			this.setFormValue(this.value);
+		}
+
 	}
 
 	_getLabel() {

--- a/components/inputs/test/input-color.test.js
+++ b/components/inputs/test/input-color.test.js
@@ -46,6 +46,32 @@ describe('d2l-input-color', () => {
 
 	});
 
+	describe('formValue reflection', () => {
+
+		it('should reflect default "value" to "formValue"', async() => {
+			const elem = await fixture(html`<d2l-input-color></d2l-input-color>`);
+			expect(elem.formValue).to.be.undefined;
+		});
+
+		it('should reflect default "value" to "formValue" when "disallow-none"', async() => {
+			const elem = await fixture(html`<d2l-input-color disallow-none></d2l-input-color>`);
+			expect(elem.formValue).to.equal('#000000');
+		});
+
+		it('should reflect initial "value" to "formValue"', async() => {
+			const elem = await fixture(html`<d2l-input-color value="#ff0000"></d2l-input-color>`);
+			expect(elem.formValue).to.equal('#FF0000');
+		});
+
+		it('should reflect updated "value" to "formValue"', async() => {
+			const elem = await fixture(html`<d2l-input-color value="#ff0000"></d2l-input-color>`);
+			elem.value = '#00ff00';
+			await elem.updateComplete;
+			expect(elem.formValue).to.equal('#00FF00');
+		});
+
+	});
+
 	describe('events', () => {
 
 		it('should fire "change" event when value is changed', async() => {


### PR DESCRIPTION
Jake noticed that when `<d2l-input-color>` is inside a `<d2l-form>`, its value isn't properly reflected in the value that gets submitted with the form. For inputs that don't have an explicit native `<input>`, we need to manually keep that in sync.