### PR TITLE
ci: Move static builds to d2l.dev bucket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,14 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          role-to-assume: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
+          role-to-assume: arn:aws:iam::022062736489:role/r+BrightspaceUI+core+repo
           role-duration-seconds: 3600
           aws-region: ca-central-1
 
       - name: Publish
         uses: BrightspaceUI/actions/publish-to-s3@main
         with:
-          bucket-path: s3://brightspace-ui-core.d2l.dev/branches/pr-${{ github.event.number }}
+          bucket-path: s3://d2l.dev/pr-previews/brightspace-ui-core/pr-${{ github.event.number }}
           publish-directory: ./build/
 
       - name: Notify
@@ -84,7 +84,7 @@ jobs:
 
             We've deployed an automatic preview for this PR - you can see your changes here:
 
-            | URL | https://pr-${{ github.event.number }}-brightspace-ui-core.d2l.dev/ |
+            | URL | https://pr-previews.d2l.dev/brightspace-ui-core/pr-${{ github.event.number }}/ |
             |---|---|
 
             > **Note**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Publish
         uses: BrightspaceUI/actions/publish-to-s3@main
         with:
-          bucket-path: s3://d2l.dev/pr-previews/brightspace-ui-core/pr-${{ github.event.number }}
+          bucket-path: s3://d2l.dev/live/prs/BrightspaceUI/core/pr-${{ github.event.number }}
           publish-directory: ./build/
 
       - name: Notify
@@ -84,7 +84,7 @@ jobs:
 
             We've deployed an automatic preview for this PR - you can see your changes here:
 
-            | URL | https://pr-previews.d2l.dev/brightspace-ui-core/pr-${{ github.event.number }}/ |
+            | URL | https://live.d2l.dev/prs/BrightspaceUI/core/pr-${{ github.event.number }}/ |
             |---|---|
 
             > **Note**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Publish
         uses: BrightspaceUI/actions/publish-to-s3@main
         with:
-          bucket-path: s3://d2l.dev/live/prs/BrightspaceUI/core/pr-${{ github.event.number }}
+          bucket-path: s3://d2l.dev/live/prs/${{ github.repository }}/pr-${{ github.event.number }}
           publish-directory: ./build/
 
       - name: Notify
@@ -84,7 +84,7 @@ jobs:
 
             We've deployed an automatic preview for this PR - you can see your changes here:
 
-            | URL | https://live.d2l.dev/prs/BrightspaceUI/core/pr-${{ github.event.number }}/ |
+            | URL | https://live.d2l.dev/prs/${{ github.repository }}/pr-${{ github.event.number }}/ |
             |---|---|
 
             > **Note**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,5 @@ jobs:
       - name: Publish
         uses: BrightspaceUI/actions/publish-to-s3@main
         with:
-          bucket-path: s3://d2l.dev/live/BrightspaceUI/core
+          bucket-path: s3://d2l.dev/live/${{ github.repository }}
           publish-directory: ./build/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,5 @@ jobs:
       - name: Publish
         uses: BrightspaceUI/actions/publish-to-s3@main
         with:
-          bucket-path: s3://d2l.dev/brightspace-ui-core/main
+          bucket-path: s3://d2l.dev/live/BrightspaceUI/core
           publish-directory: ./build/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,12 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          role-to-assume: arn:aws:iam::037018655140:role/brightspace-ui-core.d2l.dev-githubactions-access
+          role-to-assume: arn:aws:iam::022062736489:role/r+BrightspaceUI+core+repo
           role-duration-seconds: 3600
           aws-region: ca-central-1
 
       - name: Publish
         uses: BrightspaceUI/actions/publish-to-s3@main
         with:
-          bucket-path: s3://brightspace-ui-core.d2l.dev/branches/main
+          bucket-path: s3://d2l.dev/brightspace-ui-core/main
           publish-directory: ./build/

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Start a [@web/dev-server](https://modern-web.dev/docs/dev-server/overview/) that
 npm start
 ```
 
-D2L employees can also view the latest main-branch demos at https://brightspace-ui-core.d2l.dev/.
+D2L employees can also view the latest main-branch demos at https://live.d2l.dev/BrightspaceUI/core/.
 
 ### Linting
 


### PR DESCRIPTION
This moves core's static builds to the `d2l.dev` S3 bucket, as part of standardizing the PR Preview process. This will let us delete the custom `brightspace-ui-core.d2l.dev` bucket.

This is step 2 of a multi-step process for UI core:

1. `repo-settings`: Get d2l.dev S3 access (https://github.com/Brightspace/repo-settings/pull/1250)
2. `BrightspaceUI/core`: Switch core's CI and Release to publish to d2l.dev S3
3. `d2l.dev`: Swap the `d2l.dev` routes to point to the new S3 locations
4. `repo-settings`: Remove the assumable role `brightspace-ui-core.d2l.dev-githubactions-access`
5. AWS console: Delete the `brightspace-ui-core.d2l.dev` bucket and IAM roles
    - I'll need help with this last step, I don't have access to the relevant account anymore

[US156216](https://rally1.rallydev.com/#/?detail=/userstory/719304972319&fdp=true)
