### PR TITLE
feat: Add skeleton grouping to `d2l-collapsible-panel-group`

### DIFF
--- a/components/collapsible-panel/collapsible-panel-group.js
+++ b/components/collapsible-panel/collapsible-panel-group.js
@@ -1,11 +1,12 @@
 import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { SkeletonGroupMixin } from '../skeleton/skeleton-group-mixin.js';
 
 /**
  * A component that renders a container and layout for collapsible panels
  * @slot default - Slot for panels. Only accepts `d2l-collapsible-panel`
  */
-class CollapsiblePanelGroup extends LitElement {
+class CollapsiblePanelGroup extends SkeletonGroupMixin(LitElement) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
## Description

Make `d2l-collapsible-panel-group` a "skeleton group". Any time a collapsible panel is in a `skeleton` state, all panels will also be in a skeleton state.

## Rally
[US156732](https://rally1.rallydev.com/#/15545167705d/dashboard?detail=%2Fuserstory%2F720188082449&parentRef=%2Fportfolioitem%2Ffeature%2F705085592923)