### PR TITLE
Null check before adding event listener

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -743,7 +743,8 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 				value: dimension.searchValue,
 				loadMoreCompleteCallback: (options) => {
 					applySearch(options);
-					this.shadowRoot.querySelector('d2l-dropdown-menu').addEventListener('d2l-dropdown-position', e.detail.complete, { once: true });
+					const menu = this.shadowRoot.querySelector('d2l-dropdown-menu');
+					menu ? menu.addEventListener('d2l-dropdown-position', e.detail.complete, { once: true }) : e.detail.complete();
 				}
 			},
 			bubbles: true,


### PR DESCRIPTION
Implementing [this suggestion](https://github.com/BrightspaceUI/core/pull/3870#discussion_r1300371107).  We are seeing this fail when using load more for our filters [here](https://github.com/Brightspace/nova/blob/main/src/app/shared/components/activities/activity-filter.js#L506)