### PR TITLE
Link - new window fixes

### DIFF
--- a/components/link/link.js
+++ b/components/link/link.js
@@ -125,13 +125,19 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				}
 				d2l-icon.d2l-new-window {
 					color: var(--d2l-color-celestine);
-					margin-inline-start: 0.5ch;
+					height: 0.78em;
+					margin-inline-start: 0.3em;
 					vertical-align: inherit;
+					width: 0.78em;
 				}
 
 				:host([small]) d2l-icon.d2l-new-window {
-					height: 14px;
-					width: 14px;
+					height: 1em;
+					width: 1em;
+				}
+
+				:host(:hover) d2l-icon.d2l-new-window {
+					--d2l-icon-fill-color: var(--d2l-color-celestine-minus-1);
 				}
 
 				@media print {

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -169,7 +169,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 			? '_blank'
 			: this.target;
 		const newWindowIndicator = this.newWindow
-			? html`<span style="white-space: nowrap;"><span style="font-size: 0;">&nbsp;</span><d2l-icon class="d2l-new-window" icon="tier1:new-window"></d2l-icon></span>`
+			? html`<span style="white-space: nowrap; line-height: 0;"><span style="font-size: 0;">&nbsp;</span><d2l-icon class="d2l-new-window" icon="tier1:new-window"></d2l-icon></span>`
 			: nothing;
 		const newWindowMessage = (target === '_blank')
 			? html`<span class="d2l-offscreen">${this.localize('components.link.open-in-new-window')}</span>`

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -125,6 +125,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				}
 				d2l-icon.d2l-new-window {
 					color: var(--d2l-color-celestine);
+					margin-inline-start: 0.5ch;
 					vertical-align: inherit;
 				}
 
@@ -167,7 +168,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 			? '_blank'
 			: this.target;
 		const newWindowIndicator = this.newWindow
-			? html`&nbsp;<d2l-icon class="d2l-new-window" icon="tier1:new-window"></d2l-icon>`
+			? html`<span style="font-size: 0;">&nbsp;</span><d2l-icon class="d2l-new-window" icon="tier1:new-window"></d2l-icon>`
 			: nothing;
 		const newWindowMessage = (target === '_blank')
 			? html`<span class="d2l-offscreen">${this.localize('components.link.open-in-new-window')}</span>`
@@ -180,7 +181,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				?download="${this.download}"
 				href="${ifDefined(this.href)}"
 				target="${ifDefined(target)}"
-			><span style="white-space: nowrap;"><span style="white-space: normal;"><slot></slot></span>${newWindowIndicator}${newWindowMessage}</span></a>`;
+			><span style="white-space: nowrap;"><span style="white-space: ${getComputedStyle(this).whiteSpace || 'normal'};"><slot></slot></span>${newWindowIndicator}${newWindowMessage}</span></a>`;
 	}
 
 }

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -182,9 +182,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				?download="${this.download}"
 				href="${ifDefined(this.href)}"
 				target="${ifDefined(target)}"
-			>
-				<slot></slot>${newWindowIndicator}${newWindowMessage}
-			</a>`;
+			><slot></slot>${newWindowIndicator}${newWindowMessage}</a>`;
 	}
 
 }

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -116,7 +116,6 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				}
 				a {
 					display: inherit;
-					white-space: nowrap;
 				}
 				a.truncate {
 					-webkit-box-orient: vertical;
@@ -170,7 +169,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 			? '_blank'
 			: this.target;
 		const newWindowIndicator = this.newWindow
-			? html`<span style="font-size: 0;">&nbsp;</span><d2l-icon class="d2l-new-window" icon="tier1:new-window"></d2l-icon>`
+			? html`<span style="white-space: nowrap;"><span style="font-size: 0;">&nbsp;</span><d2l-icon class="d2l-new-window" icon="tier1:new-window"></d2l-icon></span>`
 			: nothing;
 		const newWindowMessage = (target === '_blank')
 			? html`<span class="d2l-offscreen">${this.localize('components.link.open-in-new-window')}</span>`
@@ -183,7 +182,9 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				?download="${this.download}"
 				href="${ifDefined(this.href)}"
 				target="${ifDefined(target)}"
-			><span style="white-space: ${getComputedStyle(this).whiteSpace || 'normal'};"><slot></slot></span>${newWindowIndicator}${newWindowMessage}</a>`;
+			>
+				<slot></slot>${newWindowIndicator}${newWindowMessage}
+			</a>`;
 	}
 
 }

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -164,7 +164,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 			'd2l-link-small': this.small,
 			'truncate': this.lines > 0
 		};
-		const styles = (this.lines > 0) ? { '-webkit-line-clamp': this.lines } : {};
+		const styles = { whiteSpace: 'nowrap', webkitLineClamp: this.lines || null };
 		const target = this.newWindow && this.target === undefined
 			? '_blank'
 			: this.target;
@@ -182,7 +182,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				?download="${this.download}"
 				href="${ifDefined(this.href)}"
 				target="${ifDefined(target)}"
-			><span style="white-space: nowrap;"><span style="white-space: ${getComputedStyle(this).whiteSpace || 'normal'};"><slot></slot></span>${newWindowIndicator}${newWindowMessage}</span></a>`;
+			><span style="white-space: ${getComputedStyle(this).whiteSpace || 'normal'};"><slot></slot></span>${newWindowIndicator}${newWindowMessage}</a>`;
 	}
 
 }

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -125,18 +125,13 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				}
 				d2l-icon.d2l-new-window {
 					color: var(--d2l-color-celestine);
-					height: 0.78em;
-					margin-inline-start: 0.3em;
+					height: 0.95em;
+					margin-inline-start: 0.315em;
 					vertical-align: inherit;
-					width: 0.78em;
+					width: 0.95em;
 				}
 
-				:host([small]) d2l-icon.d2l-new-window {
-					height: 1em;
-					width: 1em;
-				}
-
-				:host(:hover) d2l-icon.d2l-new-window {
+				a:hover d2l-icon.d2l-new-window {
 					--d2l-icon-fill-color: var(--d2l-color-celestine-minus-1);
 				}
 

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -116,6 +116,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				}
 				a {
 					display: inherit;
+					white-space: nowrap;
 				}
 				a.truncate {
 					-webkit-box-orient: vertical;
@@ -164,7 +165,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 			'd2l-link-small': this.small,
 			'truncate': this.lines > 0
 		};
-		const styles = { whiteSpace: 'nowrap', webkitLineClamp: this.lines || null };
+		const styles = { webkitLineClamp: this.lines || null };
 		const target = this.newWindow && this.target === undefined
 			? '_blank'
 			: this.target;


### PR DESCRIPTION
- Match the host `white-space` style
- Don't underline the space between the link text and icon

The only downside is that it doesn't update with changes to the host `white-space`, but that should basically not be an issue in practice.

Alternative to the alternatives #4050 and #4045