### PR TITLE
Fix flaky math vdiffs

### DIFF
--- a/components/html-block/test/html-block.vdiff.js
+++ b/components/html-block/test/html-block.vdiff.js
@@ -196,11 +196,7 @@ describe('d2l-html-block', () => {
 			html`<d2l-html-block style="width: 650px;" html="${mathBlock}"></d2l-html-block>`,
 			{ mathjax: { renderLatex: true } }
 		);
-		await waitUntil(() => {
-			// eslint-disable-next-line no-console
-			console.log('math (block) height', elem.clientHeight);
-			return elem.clientHeight === 145;
-		});
+		await waitUntil(() => elem.clientHeight === 144);
 		await expect(elem).to.be.golden();
 	});
 
@@ -284,11 +280,7 @@ describe('d2l-html-block', () => {
 			html`<d2l-html-block style="width: 650px;" html="An equation...${mathInline} embedded inline with text, and showing placement of indicies for summations."></d2l-html-block>`,
 			{ mathjax: { renderLatex: true } }
 		);
-		await waitUntil(() => {
-			// eslint-disable-next-line no-console
-			console.log('math (inline) height', elem.clientHeight);
-			return elem.clientHeight === 61;
-		});
+		await waitUntil(() => elem.clientHeight === 61);
 		await expect(elem).to.be.golden();
 	});
 
@@ -312,11 +304,7 @@ describe('d2l-html-block', () => {
 			${mathBlock}"></d2l-html-block>`,
 			{ mathjax: { renderLatex: true } }
 		);
-		await waitUntil(() => {
-			// eslint-disable-next-line no-console
-			console.log('math (block) and code (block) height', elem.clientHeight);
-			return elem.clientHeight === 263;
-		});
+		await waitUntil(() => elem.clientHeight === 263);
 		await expect(elem).to.be.golden();
 	});
 

--- a/components/html-block/test/html-block.vdiff.js
+++ b/components/html-block/test/html-block.vdiff.js
@@ -1,5 +1,5 @@
 import '../html-block.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
+import { expect, fixture, html, waitUntil } from '@brightspace-ui/testing';
 
 const content = `
 	Just a text node...
@@ -196,6 +196,11 @@ describe('d2l-html-block', () => {
 			html`<d2l-html-block style="width: 650px;" html="${mathBlock}"></d2l-html-block>`,
 			{ mathjax: { renderLatex: true } }
 		);
+		await waitUntil(() => {
+			// eslint-disable-next-line no-console
+			console.log('math (block) height', elem.clientHeight);
+			return elem.clientHeight === 145;
+		});
 		await expect(elem).to.be.golden();
 	});
 
@@ -279,6 +284,11 @@ describe('d2l-html-block', () => {
 			html`<d2l-html-block style="width: 650px;" html="An equation...${mathInline} embedded inline with text, and showing placement of indicies for summations."></d2l-html-block>`,
 			{ mathjax: { renderLatex: true } }
 		);
+		await waitUntil(() => {
+			// eslint-disable-next-line no-console
+			console.log('math (inline) height', elem.clientHeight);
+			return elem.clientHeight === 61;
+		});
 		await expect(elem).to.be.golden();
 	});
 
@@ -302,6 +312,11 @@ describe('d2l-html-block', () => {
 			${mathBlock}"></d2l-html-block>`,
 			{ mathjax: { renderLatex: true } }
 		);
+		await waitUntil(() => {
+			// eslint-disable-next-line no-console
+			console.log('math (block) and code (block) height', elem.clientHeight);
+			return elem.clientHeight === 263;
+		});
 		await expect(elem).to.be.golden();
 	});
 


### PR DESCRIPTION
Just waiting `150ms` for MathJax to render math in `html-block`s is still flaking out sporadically. Unfortunately, this uses the nuclear option of waiting until the elements are the exact size we're expecting them to be when the math has rendered.