### PR TITLE
fix: `d2l-list-item` > add `mouseenter`/`mouseleave` events to content

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -735,7 +735,9 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				</div>` : nothing}
 				<div slot="content"
 					class="d2l-list-item-content"
-					id="${this._contentId}">
+					id="${this._contentId}"
+					@mouseenter="${this._onMouseEnter}"
+					@mouseleave="${this._onMouseLeave}">
 					<slot name="illustration" class="d2l-list-item-illustration">${illustration}</slot>
 					<slot>${content}</slot>
 				</div>


### PR DESCRIPTION
## Description

There's an issue in Rubrics where the drag handle doesn't appear when hovering the rows (it only appears when hovering over the controls container).

I think this is what's required to fix.

After making this change, I played around with hover/focus on vanilla lists. I didn't see any issues, but someone more well-versed in `d2l-list` can put this through its paces more rigorously.

## Rally

[DE55064](https://rally1.rallydev.com/#/15545167705d/custom/21568985922?detail=%2Fdefect%2F723654980255)