### PR TITLE
fix: show tooltips if initialized while target descendants have focus

### DIFF
--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -1,5 +1,6 @@
 import '../tooltip.js';
-import { aTimeout, expect, fixture, focusElem, html, oneEvent, sendKeys } from '@brightspace-ui/testing';
+import { aTimeout, defineCE, expect, fixture, focusElem, html, oneEvent, sendKeys } from '@brightspace-ui/testing';
+import { LitElement } from 'lit';
 import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`
@@ -203,6 +204,26 @@ describe('d2l-tooltip', () => {
 			await oneEvent(tooltipFixture, 'd2l-tooltip-show');
 			expect(dynamicTooltip.showing).to.be.true;
 		});
+
+		it('should show if added to a target with a nested element that already has focus', async() => {
+
+			const targetTag = defineCE(class extends LitElement {
+				render() {return html`<button>nested target</button>`; }
+			});
+			const elem = await fixture(`<div><${targetTag} id="target"></${targetTag}></div>`);
+			const target = elem.querySelector(targetTag);
+
+			await focusElem(target.shadowRoot.querySelector('button'));
+
+			const tooltip = document.createElement('d2l-tooltip');
+			tooltip.announced = true;
+			elem.appendChild(tooltip);
+
+			await oneEvent(elem, 'd2l-tooltip-show');
+			expect(tooltip.showing).to.be.true;
+
+		});
+
 	});
 
 	describe('delay', () => {

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -1,11 +1,11 @@
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { css, html, LitElement } from 'lit';
-import { cssEscape, elemIdListAdd, elemIdListRemove, getBoundingAncestor, getOffsetParent } from '../../helpers/dom.js';
+import { cssEscape, elemIdListAdd, elemIdListRemove, getBoundingAncestor, getOffsetParent, isComposedAncestor } from '../../helpers/dom.js';
+import { getComposedActiveElement, isFocusable } from '../../helpers/focus.js';
 import { announce } from '../../helpers/announce.js';
 import { bodySmallStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
-import { isFocusable } from '../../helpers/focus.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -950,7 +950,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			}
 			if (this.showing) {
 				this.updatePosition();
-			} else if (this.getRootNode().activeElement === this._target) {
+			} else if (isComposedAncestor(this._target, getComposedActiveElement())) {
 				this._onTargetFocus();
 			}
 		}


### PR DESCRIPTION
I ran into this case while migrating visual diffs.

This fixes an edge case where a tooltip is initially rendered and its target already has focus. This may not happen too often in practice, but in tests where things execute quickly it definitely can.

Previously this worked only if the target itself was the active element, but `<d2l-text-input>`'s validation tooltip has the `<d2l-text-input>` itself as the target (for complicated reasons but mostly because we wanted hovering over the whole thing to show the tooltip) but the actual element that gets focused is the underlying `<input type="text">`.