### PR TITLE
Fix Safari drag handle hover

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -93,8 +93,10 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			::slotted([slot="drop-target"]) {
 				grid-row: 1 / 2;
 			}
+
 			::slotted([slot="outside-control"]) {
 				grid-column: outside-control-start / outside-control-end;
+				pointer-events: none;
 			}
 
 			::slotted([slot="expand-collapse"]) {


### PR DESCRIPTION
Safari likes to allow pointer events on slots that are underneath other slots in `d2l-list`, so turn them off for the `outside-control` slot, since the `outside-control-action` slot is where the interaction actually occurs.