### PR TITLE
Update OSLO codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 *       @BrightspaceUI/gaudi-dev
-helpers/getLocalizeResources.js @BrightspaceUI/team-usa-devs @BrightspaceUI/team-usa-senior-devs
 golden/
 .vdiff.json
 package-lock.json


### PR DESCRIPTION
Gaudi is taking over OSLO, so update `helpers/getLocalizeResources.js` codeowners

[US154660](https://rally1.rallydev.com/#/?detail=/userstory/706269970679&fdp=true): OSLO Codeowner Changes