### PR TITLE
Don't throw missing label error if host is no longer connected

### DIFF
--- a/mixins/labelled/labelled-mixin.js
+++ b/mixins/labelled/labelled-mixin.js
@@ -207,7 +207,7 @@ export const LabelledMixin = superclass => class extends superclass {
 		this._validatingLabelTimeout = setTimeout(() => {
 			this._validatingLabelTimeout = null;
 			const hasLabel = (typeof this.label === 'string') && this.label.length > 0;
-			if (!hasLabel) {
+			if (this.isConnected && !hasLabel) {
 				if (this.labelledBy) {
 					if (this._labelElem) {
 						this._throwError(


### PR DESCRIPTION
Because there is a hard [3-second delay](https://github.com/BrightspaceUI/core/blob/ef076269421ed0ceb07c28fed82367c5b9fed612/mixins/labelled/labelled-mixin.js#L204) in `lablledMixin` before throwing a missing label error, the error can be thrown between tests, or in other tests entirely, causing tests to fail in a confusing way. Checking that the host component is still connected before throwing prevents this.