### PR TITLE
fix: list item mixin usage of `content` [Ignore for now, testing some stuff]

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -739,7 +739,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 					@mouseenter="${this._onMouseEnter}"
 					@mouseleave="${this._onMouseLeave}">
 					<slot name="illustration" class="d2l-list-item-illustration">${illustration}</slot>
-					<slot>${content}</slot>
+					${content ?? html`<slot></slot>`}
 				</div>
 				<div slot="actions"
 					@mouseenter="${this._onMouseEnter}"


### PR DESCRIPTION
For some reason with our usage of the `ListItemMixin` [here](https://github.com/Brightspace/d2l-outcomes/blob/main/src/components/management/outcomes-management-list-item.js#L129-L135), this just doesn't work if you try to render a list item outside of a list. Although this isn't really a practical use case this small fix addresses my situation in [vdiffs](https://github.com/Brightspace/d2l-outcomes/blob/main/test/visual-diff/pages/d2l-outcomes-management-list-item.visual-diff.html#L19-L24) with not breaking anything else (from what I can see). It's strange because the old vdiff stuff this never happened. Was working on switching us over and these just render as [empty list items with the new vdiff framework](https://vdiff.d2l.dev/Brightspace/d2l-outcomes/08f9b084941371c840a8938465627b3287455729/2023-09-27_18-23-37/report/?file=test%2Fd2l-outcomes-management-list-item.vdiff.js). I tried wrapping the content HTML in `<d2l-list-item-content>` (as seen in [list-item-custom.js](https://github.com/BrightspaceUI/core/blob/main/components/list/demo/list-item-custom.js#L177-L180)) but this still didn't work.