### PR TITLE
fix: Exclude visual-diff goldens from rollup

### DIFF
--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -18,7 +18,7 @@ const nonJsGlob = [
 	'@(components|controllers|directives|helpers|mixins|templates|test)/**/*.*',
 	'*.*',
 	'!**/*.@(js|md|json)',
-	'!**/screenshots/**/*',
+	'!**/golden/**/*',
 ];
 
 export default {

--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -12,12 +12,13 @@ const buildDate = Intl.DateTimeFormat('en-CA', { timeZone: 'America/Toronto' }).
 const jsGlob = [
 	'@(components|controllers|directives|helpers|mixins|templates|test)/**/*.js',
 	'./index.js',
-	'!**/*.@(test|axe|visual-diff).js',
+	'!**/*.@(test|axe|visual-diff|vdiff).js',
 ];
 const nonJsGlob = [
 	'@(components|controllers|directives|helpers|mixins|templates|test)/**/*.*',
 	'*.*',
 	'!**/*.@(js|md|json)',
+	'!**/screenshots/**/*',
 	'!**/golden/**/*',
 ];
 


### PR DESCRIPTION
We originally set up rollup to ignore visual-diff goldens and test files... but then with the new vdiff, the identifying path changed from `screenshots` to `golden`, and files changed from `visual-diff.js` to `vdiff.js`. As a result, we've been bundling a bunch of (probably unnecessary) vdiffs with every static build, e.g.:
https://live.d2l.dev/BrightspaceUI/core/components/card/test/golden/card/chromium/link.png

This PR goes back to filtering those out.

**Edit:** Confirmed, the equivalent file was not included in this PR's bundle:
https://live.d2l.dev/prs/BrightspaceUI/core/pr-4144/components/card/test/golden/card/chromium/link.png