### PR TITLE
Allow native button in localizeHTML.

### DIFF
--- a/mixins/localize/localize-mixin.js
+++ b/mixins/localize/localize-mixin.js
@@ -231,7 +231,7 @@ export const LocalizeMixin = superclass => class extends _LocalizeMixinBase(supe
 
 };
 
-export const allowedTags = Object.freeze(['d2l-link', 'd2l-tooltip-help', 'p', 'br', 'b', 'strong', 'i', 'em']);
+export const allowedTags = Object.freeze(['d2l-link', 'd2l-tooltip-help', 'p', 'br', 'b', 'strong', 'i', 'em', 'button']);
 
 const markupError = `localizeHTML() rich-text replacements must use localizeMarkup templates with only the following allowed elements: ${allowedTags}. For more information, see: https://github.com/BrightspaceUI/core/blob/main/mixins/localize/`;
 const validTerminators = '([>\\s/]|$)';


### PR DESCRIPTION
The `d2l-file-input` component requires a special button rendered in the upload instruction. In order to facilitate localizing this text, we need to add native `button` to the allowed list.

![image](https://github.com/BrightspaceUI/core/assets/9042472/6e0bc783-c977-4a1e-93cc-f798820bd72d)
