### PR TITLE
fix: Toast Alert: Multiple Toasts: Fix auto-close bug when rapidly opened

### DIFF
--- a/components/alert/test/alert-toast.vdiff.js
+++ b/components/alert/test/alert-toast.vdiff.js
@@ -168,6 +168,15 @@ describe('alert-toast', () => {
 				await expect(document).to.be.golden();
 			});
 
+			it('open quickly then wait', async() => {
+				const elem = await fixture(multipleAlertsAutoClose, { viewport });
+				elem.querySelector('d2l-alert-toast')._setReduceMotion(false);
+				await openAlerts(elem);
+				clock.tick(4100);
+				await expect(document).to.be.golden();
+				elem.querySelector('d2l-alert-toast')._setReduceMotion(true);
+			});
+
 		});
 
 	});


### PR DESCRIPTION
[Rally story](https://rally1.rallydev.com/#/15545167705ud/custom/21568985922?detail=%2Fuserstory%2F726057205269)

Bug:
When a toast that should auto-close has another toast opened quickly after it is opened, its timer never gets started and it never auto-closes (unless hovered/focused on and then removed).