### PR TITLE
Fix firefox demo snippet fullscreen

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -92,8 +92,7 @@ class DemoSnippet extends LitElement {
 			}
 			d2l-dropdown.settings-dropdown.peek,
 			d2l-dropdown.settings-dropdown:hover,
-			d2l-dropdown.settings-dropdown:focus-within,
-			d2l-dropdown.settings-dropdown:has(d2l-button-subtle[active]) {
+			d2l-dropdown.settings-dropdown:focus-within {
 				box-shadow: 0 -1px 0 1px white;
 				translate: 0;
 			}


### PR DESCRIPTION
I'm not even sure why I added this selector originally. Seems quite unnecessary. Firefox doesn't support `:has()` and breaks the whole rule.