### PR TITLE
fix: alias runConstructor to @brightspace-ui/testing version

### DIFF
--- a/components/alert/test/alert-toast.test.js
+++ b/components/alert/test/alert-toast.test.js
@@ -1,6 +1,5 @@
 import '../alert-toast.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-alert-toast', () => {
 

--- a/components/alert/test/alert.test.js
+++ b/components/alert/test/alert.test.js
@@ -1,6 +1,5 @@
 import '../alert.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const alertFixture = html`
 		<d2l-alert id="button-close" type="default" button-text="Do it!" has-close-button

--- a/components/backdrop/test/backdrop.test.js
+++ b/components/backdrop/test/backdrop.test.js
@@ -1,6 +1,5 @@
 import '../backdrop.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 const backdropFixture = html`
 	<div>

--- a/components/breadcrumbs/test/breadcrumb.test.js
+++ b/components/breadcrumbs/test/breadcrumb.test.js
@@ -1,6 +1,6 @@
 import '../breadcrumb.js';
 import '../breadcrumb-current-page.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-breadcrumb', () => {
 

--- a/components/breadcrumbs/test/breadcrumbs.test.js
+++ b/components/breadcrumbs/test/breadcrumbs.test.js
@@ -1,5 +1,5 @@
 import '../breadcrumbs.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-breadcrumbs', () => {
 

--- a/components/button/test/button-icon.test.js
+++ b/components/button/test/button-icon.test.js
@@ -1,6 +1,5 @@
 import '../button-icon.js';
-import { fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-button-icon', () => {
 

--- a/components/button/test/button-move.test.js
+++ b/components/button/test/button-move.test.js
@@ -1,6 +1,5 @@
-import { clickElem, expect, fixture, html, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
 import { moveActions } from '../button-move.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-button-move', () => {
 

--- a/components/button/test/button-subtle.test.js
+++ b/components/button/test/button-subtle.test.js
@@ -1,6 +1,5 @@
 import '../button-subtle.js';
-import { fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-button-subtle', () => {
 

--- a/components/button/test/button.test.js
+++ b/components/button/test/button.test.js
@@ -1,6 +1,5 @@
 import '../button.js';
-import { fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-button', () => {
 

--- a/components/button/test/floating-buttons.test.js
+++ b/components/button/test/floating-buttons.test.js
@@ -1,5 +1,5 @@
 import '../floating-buttons.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-floating-buttons', () => {
 

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -1,4 +1,4 @@
-import { aTimeout, expect, fixture, html, oneEvent, waitUntil } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, html, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
 import { checkIfDatesEqual,
 	getDatesInMonthArray,
 	getNextMonth,
@@ -8,7 +8,6 @@ import { checkIfDatesEqual,
 	getPrevMonth
 } from '../calendar.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';
 
 const normalFixture = html`<d2l-calendar selected-value="2015-09-02"></d2l-calendar>`;

--- a/components/card/test/card-content-meta.test.js
+++ b/components/card/test/card-content-meta.test.js
@@ -1,5 +1,5 @@
 import '../card-content-meta.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-card-content-meta', () => {
 

--- a/components/card/test/card-content-title.test.js
+++ b/components/card/test/card-content-title.test.js
@@ -1,5 +1,5 @@
 import '../card-content-title.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-card-content-title', () => {
 

--- a/components/card/test/card-footer-link.test.js
+++ b/components/card/test/card-footer-link.test.js
@@ -1,5 +1,5 @@
 import '../card-footer-link.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-card-footer-link', () => {
 

--- a/components/card/test/card-loading-shimmer.test.js
+++ b/components/card/test/card-loading-shimmer.test.js
@@ -1,5 +1,5 @@
 import '../card-loading-shimmer.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-card-loading-shimmer', () => {
 

--- a/components/card/test/card.test.js
+++ b/components/card/test/card.test.js
@@ -1,6 +1,5 @@
 import '../card.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-card', () => {
 

--- a/components/collapsible-panel/test/collapsible-panel.test.js
+++ b/components/collapsible-panel/test/collapsible-panel.test.js
@@ -1,8 +1,7 @@
 import '../collapsible-panel.js';
 import '../collapsible-panel-summary-item.js';
 import '../collapsible-panel-group.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-collapsible-panel', () => {
 

--- a/components/count-badge/test/count-badge-icon.test.js
+++ b/components/count-badge/test/count-badge-icon.test.js
@@ -1,5 +1,5 @@
 import '../count-badge-icon.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-count-badge-icon', () => {
 	it('should construct', () => {

--- a/components/count-badge/test/count-badge.test.js
+++ b/components/count-badge/test/count-badge.test.js
@@ -1,5 +1,5 @@
 import '../count-badge.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-count-badge', () => {
 	it('should construct', () => {

--- a/components/demo/test/demo-page.test.js
+++ b/components/demo/test/demo-page.test.js
@@ -1,7 +1,6 @@
 import '../demo-page.js';
 
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-demo-page', () => {
 

--- a/components/description-list/test/description-list.test.js
+++ b/components/description-list/test/description-list.test.js
@@ -1,7 +1,6 @@
 import '../description-list-wrapper.js';
 
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-dl-wrapper', () => {
 

--- a/components/dialog/test/dialog-confirm.test.js
+++ b/components/dialog/test/dialog-confirm.test.js
@@ -1,9 +1,8 @@
 import '../../button/button.js';
 import '../dialog-confirm.js';
-import { expect, fixture, oneEvent } from '@brightspace-ui/testing';
+import { expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { html } from 'lit';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-dialog-confirm', () => {
 

--- a/components/dialog/test/dialog-fullscreen.test.js
+++ b/components/dialog/test/dialog-fullscreen.test.js
@@ -1,5 +1,5 @@
 import '../dialog-fullscreen.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-dialog-fullscreen', () => {
 

--- a/components/dialog/test/dialog.test.js
+++ b/components/dialog/test/dialog.test.js
@@ -1,8 +1,7 @@
 import '../dialog.js';
-import { expect, fixture, oneEvent } from '@brightspace-ui/testing';
+import { expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { html } from 'lit';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-dialog', () => {
 

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -1,7 +1,6 @@
 import '../dropdown.js';
 import '../dropdown-content.js';
-import { aTimeout, expect, fixture, focusElem, html, nextFrame, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { aTimeout, expect, fixture, focusElem, html, nextFrame, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const normalFixture = html`
 	<div>

--- a/components/dropdown/test/dropdown-menu.test.js
+++ b/components/dropdown/test/dropdown-menu.test.js
@@ -4,8 +4,7 @@ import '../../menu/menu.js';
 import '../../menu/menu-item.js';
 import '../../menu/menu-item-link.js';
 import '../../menu/menu-item-radio.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const itemFixture = html`
 	<div>

--- a/components/dropdown/test/dropdown-openers.test.js
+++ b/components/dropdown/test/dropdown-openers.test.js
@@ -2,8 +2,7 @@ import '../dropdown-button-subtle.js';
 import '../dropdown-button.js';
 import '../dropdown-context-menu.js';
 import '../dropdown-more.js';
-import { fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-dropdown-openers', () => {
 

--- a/components/dropdown/test/dropdown-tabs.test.js
+++ b/components/dropdown/test/dropdown-tabs.test.js
@@ -1,5 +1,5 @@
 import '../dropdown-tabs.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-dropdown-tabs', () => {
 

--- a/components/empty-state/test/empty-state-illustrated.test.js
+++ b/components/empty-state/test/empty-state-illustrated.test.js
@@ -1,9 +1,8 @@
 import '../empty-state-illustrated.js';
 import '../empty-state-action-button.js';
 import '../empty-state-action-link.js';
-import { fixture, oneEvent, waitUntil } from '@brightspace-ui/testing';
+import { fixture, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
 import { html } from 'lit';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-empty-state-illustrated',  () => {
 

--- a/components/empty-state/test/empty-state-simple.test.js
+++ b/components/empty-state/test/empty-state-simple.test.js
@@ -1,9 +1,8 @@
 import '../empty-state-action-button.js';
 import '../empty-state-action-link.js';
 import '../empty-state-simple.js';
-import { fixture, oneEvent } from '@brightspace-ui/testing';
+import { fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { html } from 'lit';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-empty-state-simple',  () => {
 

--- a/components/expand-collapse/test/expand-collapse-content.test.js
+++ b/components/expand-collapse/test/expand-collapse-content.test.js
@@ -1,6 +1,5 @@
 import '../expand-collapse-content.js';
-import { fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 const collapsedContentFixture = html`<d2l-expand-collapse-content>A message.</d2l-expand-collapse-content>`;
 const expandedContentFixture = html`<d2l-expand-collapse-content expanded>A message.</d2l-expand-collapse-content>`;

--- a/components/filter/test/filter-dimension-set-empty-state.test.js
+++ b/components/filter/test/filter-dimension-set-empty-state.test.js
@@ -1,5 +1,5 @@
 import '../filter-dimension-set-empty-state.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-filter-dimension-set-empty-state', () => {
 

--- a/components/filter/test/filter-dimension-set-value.test.js
+++ b/components/filter/test/filter-dimension-set-value.test.js
@@ -1,6 +1,5 @@
 import '../filter-dimension-set-value.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { spy } from 'sinon';
 
 const valuefixture = html`

--- a/components/filter/test/filter-dimension-set.test.js
+++ b/components/filter/test/filter-dimension-set.test.js
@@ -1,8 +1,7 @@
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
 import '../filter-dimension-set-empty-state.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { spy } from 'sinon';
 
 const dimensionfixture = html`

--- a/components/filter/test/filter-overflow-group.test.js
+++ b/components/filter/test/filter-overflow-group.test.js
@@ -2,8 +2,7 @@ import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
 import '../filter-overflow-group.js';
-import { aTimeout, expect, fixture, html, oneEvent, waitUntil } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { aTimeout, expect, fixture, html, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
 
 describe('d2l-filter-overflow-group', () => {
 	describe('constructor', () => {

--- a/components/filter/test/filter-tags.test.js
+++ b/components/filter/test/filter-tags.test.js
@@ -2,8 +2,7 @@ import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
 import '../filter-tags.js';
-import { expect, fixture, html, oneEvent, waitUntil } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
 import { spy } from 'sinon';
 
 const basic = html`

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -2,9 +2,8 @@ import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-empty-state.js';
 import '../filter-dimension-set-value.js';
-import { expect, fixture, html, oneEvent, waitUntil } from '@brightspace-ui/testing';
+import { expect, fixture, html, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
 import { spy, stub } from 'sinon';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const singleSetDimensionFixture = html`
 	<d2l-filter>

--- a/components/focus-trap/test/focus-trap.test.js
+++ b/components/focus-trap/test/focus-trap.test.js
@@ -1,6 +1,5 @@
 import '../focus-trap.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import sinon from 'sinon';
 
 const normalFixture = html`

--- a/components/form/test/form-error-summary.test.js
+++ b/components/form/test/form-error-summary.test.js
@@ -1,7 +1,6 @@
 import '../form-errory-summary.js';
-import { expect, fixture } from '@brightspace-ui/testing';
+import { expect, fixture, runConstructor } from '@brightspace-ui/testing';
 import { html } from 'lit';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const errorSummaryFixture = html`<d2l-form-error-summary></d2l-form-error-summary>`;
 

--- a/components/form/test/form-native.test.js
+++ b/components/form/test/form-native.test.js
@@ -1,9 +1,8 @@
 import '../../validation/validation-custom.js';
 import '../form-native.js';
 import './form-element.js';
-import { expect, fixture } from '@brightspace-ui/testing';
+import { expect, fixture, runConstructor } from '@brightspace-ui/testing';
 import { html } from 'lit';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-form-native', () => {
 

--- a/components/hierarchical-view/test/hierarchical-view.test.js
+++ b/components/hierarchical-view/test/hierarchical-view.test.js
@@ -1,6 +1,5 @@
 import '../hierarchical-view.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { aTimeout, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { spy } from 'sinon';
 
 const viewsFixture = html`

--- a/components/html-block/test/html-block.test.js
+++ b/components/html-block/test/html-block.test.js
@@ -1,7 +1,6 @@
 import '../html-block.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { provideInstance } from '../../../mixins/provider/provider-mixin.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { unsafeStatic } from 'lit/static-html.js';
 
 class TestRenderer {

--- a/components/icons/test/icon-custom.test.js
+++ b/components/icons/test/icon-custom.test.js
@@ -1,5 +1,5 @@
 import '../icon-custom.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-icon-custom', () => {
 

--- a/components/icons/test/icon.test.js
+++ b/components/icons/test/icon.test.js
@@ -1,5 +1,5 @@
 import '../icon.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-icon', () => {
 

--- a/components/inputs/test/input-checkbox.test.js
+++ b/components/inputs/test/input-checkbox.test.js
@@ -1,6 +1,5 @@
 import '../input-checkbox.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const uncheckedFixture = html`<d2l-input-checkbox aria-label="basic"></d2l-input-checkbox>`;
 const indeterminateCheckedFixture = html`<d2l-input-checkbox indeterminate checked></d2l-input-checkbox>`;

--- a/components/inputs/test/input-color.test.js
+++ b/components/inputs/test/input-color.test.js
@@ -1,6 +1,5 @@
 import '../input-color.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-input-color', () => {
 

--- a/components/inputs/test/input-date-range.test.js
+++ b/components/inputs/test/input-date-range.test.js
@@ -1,7 +1,6 @@
-import { aTimeout, expect, fixture, oneEvent } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { getShiftedEndDate } from '../input-date-range.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = '<d2l-input-date-range label="label text"></d2l-input-date-range>';
 const minMaxFixture = '<d2l-input-date-range label="label text" min-value="2020-01-01" max-value="2020-06-01"></d2l-input-date-range>';

--- a/components/inputs/test/input-date-time-range.test.js
+++ b/components/inputs/test/input-date-time-range.test.js
@@ -1,7 +1,6 @@
-import { aTimeout, expect, fixture, oneEvent } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { getShiftedEndDateTime } from '../input-date-time-range.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = '<d2l-input-date-time-range label="label text"></d2l-input-date-time-range>';
 const minMaxFixture = '<d2l-input-date-time-range label="Assignment Dates" min-value="2018-08-27T12:30:00Z" max-value="2018-09-30T12:30:00Z"></d2l-input-date-time-range>';

--- a/components/inputs/test/input-date-time.test.js
+++ b/components/inputs/test/input-date-time.test.js
@@ -1,7 +1,6 @@
-import { aTimeout, expect, fixture, oneEvent } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { _formatLocalDateTimeInISO } from '../input-date-time.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';
 
 const basicFixture = '<d2l-input-date-time label="label text"></d2l-input-date-time>';

--- a/components/inputs/test/input-date.test.js
+++ b/components/inputs/test/input-date.test.js
@@ -1,7 +1,6 @@
-import { aTimeout, expect, fixture, oneEvent, waitUntil } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
 import { formatISODateInUserCalDescriptor } from '../input-date.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';
 
 const basicFixture = '<d2l-input-date has-now label="label text"></d2l-input-date>';

--- a/components/inputs/test/input-fieldset.test.js
+++ b/components/inputs/test/input-fieldset.test.js
@@ -1,5 +1,5 @@
 import '../input-fieldset.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-input-fieldset', () => {
 

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -1,7 +1,6 @@
 import '../input-number.js';
-import { aTimeout, defineCE, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { aTimeout, defineCE, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { LitElement } from 'lit';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const normalFixture = html`<d2l-input-number label="label"></d2l-input-number>`;
 const defaultValueFixture = html`<d2l-input-number label="label" value="1.1"></d2l-input-number>`;

--- a/components/inputs/test/input-percent.test.js
+++ b/components/inputs/test/input-percent.test.js
@@ -1,6 +1,5 @@
 import '../input-percent.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { aTimeout, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const normalFixture = html`<d2l-input-percent label="label"></d2l-input-percent>`;
 const defaultValueFixture = html`<d2l-input-percent label="label" value="80"></d2l-input-percent>`;

--- a/components/inputs/test/input-radio-spacer.test.js
+++ b/components/inputs/test/input-radio-spacer.test.js
@@ -1,5 +1,5 @@
 import '../input-radio-spacer.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-input-radio-spacer', () => {
 

--- a/components/inputs/test/input-search.test.js
+++ b/components/inputs/test/input-search.test.js
@@ -1,6 +1,5 @@
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { INPUT_TIMEOUT_MS, SUPPRESS_ENTER_TIMEOUT_MS } from '../input-search.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import { useFakeTimers } from 'sinon';
 
 const normalFixture = html`<d2l-input-search label="search"></d2l-input-search>`;

--- a/components/inputs/test/input-text.test.js
+++ b/components/inputs/test/input-text.test.js
@@ -1,6 +1,5 @@
 import '../input-text.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { aTimeout, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const normalFixture = html`<d2l-input-text label="label"></d2l-input-text>`;
 

--- a/components/inputs/test/input-textarea.test.js
+++ b/components/inputs/test/input-textarea.test.js
@@ -1,6 +1,5 @@
 import '../input-textarea.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const normalFixture = html`<d2l-input-textarea label="label"></d2l-input-textarea>`;
 

--- a/components/inputs/test/input-time-range.test.js
+++ b/components/inputs/test/input-time-range.test.js
@@ -1,9 +1,8 @@
-import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { formatDateInISOTime, getDateFromISOTime } from '../../../helpers/dateTime.js';
 import { getDefaultTime } from '../input-time.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { getShiftedEndTime } from '../input-time-range.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';
 
 const basicFixture = '<d2l-input-time-range label="label text"></d2l-input-time-range>';

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -1,7 +1,6 @@
 import '../input-time.js';
-import { aTimeout, expect, fixture, oneEvent } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';
 
 const basicFixture = '<d2l-input-time label="label text"></d2l-input-time>';

--- a/components/link/test/link.test.js
+++ b/components/link/test/link.test.js
@@ -1,6 +1,5 @@
 import '../link.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const normalFixture = html`<d2l-link href="https://www.d2l.com">Link Test</d2l-link>`;
 

--- a/components/list/test/list-item-drag-handle.test.js
+++ b/components/list/test/list-item-drag-handle.test.js
@@ -1,6 +1,5 @@
-import { clickElem, expect, fixture, focusElem, html, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, focusElem, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
 import { dragActions } from '../list-item-drag-handle.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('ListItemDragHandle', () => {
 

--- a/components/list/test/list-item-generic-layout.test.js
+++ b/components/list/test/list-item-generic-layout.test.js
@@ -2,9 +2,8 @@ import '../list.js';
 import '../list-item.js';
 import '../../button/button-icon.js';
 
-import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { aTimeout, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 import sinon from 'sinon';
 
 const normalFixture = html`

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -3,8 +3,7 @@ import '../list-controls.js';
 import '../list-item.js';
 import '../list-item-button.js';
 import '../list-item-content.js';
-import { clickElem, expect, fixture, html, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { clickElem, expect, fixture, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
 
 const clickItemInput = async item => {
 	const selectionInput = item.shadowRoot.querySelector('d2l-selection-input');

--- a/components/loading-spinner/test/loading-spinner.test.js
+++ b/components/loading-spinner/test/loading-spinner.test.js
@@ -1,5 +1,5 @@
 import '../loading-spinner.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-loading-spinner', () => {
 

--- a/components/menu/test/menu-item-checkbox.test.js
+++ b/components/menu/test/menu-item-checkbox.test.js
@@ -1,6 +1,5 @@
 import '../menu-item-checkbox.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 function dispatchItemSelectEvent(elem) {
 	const e = new CustomEvent(

--- a/components/menu/test/menu-item-link.test.js
+++ b/components/menu/test/menu-item-link.test.js
@@ -1,6 +1,5 @@
 import '../menu-item-link.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-menu-item-link', () => {
 

--- a/components/menu/test/menu-item-radio.test.js
+++ b/components/menu/test/menu-item-radio.test.js
@@ -1,6 +1,5 @@
 import '../menu-item-radio.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 function dispatchItemSelectEvent(elem) {
 	const e = new CustomEvent(

--- a/components/menu/test/menu-item-return.test.js
+++ b/components/menu/test/menu-item-return.test.js
@@ -1,5 +1,5 @@
 import '../menu-item-return.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-menu-item-return', () => {
 

--- a/components/menu/test/menu-item-separator.test.js
+++ b/components/menu/test/menu-item-separator.test.js
@@ -1,6 +1,5 @@
 import '../menu-item-separator.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-menu-item-separator', () => {
 

--- a/components/menu/test/menu.test.js
+++ b/components/menu/test/menu.test.js
@@ -2,10 +2,9 @@ import '../menu.js';
 import '../menu-item.js';
 import '../menu-item-radio.js';
 import './custom-slots.js';
-import { clickElem, defineCE, expect, fixture, focusElem, html, nextFrame, oneEvent, sendKeysElem, waitUntil } from '@brightspace-ui/testing';
+import { clickElem, defineCE, expect, fixture, focusElem, html, nextFrame, oneEvent, runConstructor, sendKeysElem, waitUntil } from '@brightspace-ui/testing';
 import { LitElement } from 'lit';
 import { MenuItemMixin } from '../menu-item-mixin.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 describe('d2l-menu', () => {
 

--- a/components/meter/test/meter-circle.test.js
+++ b/components/meter/test/meter-circle.test.js
@@ -1,5 +1,5 @@
 import '../meter-circle.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-meter-circle', () => {
 

--- a/components/meter/test/meter-linear.test.js
+++ b/components/meter/test/meter-linear.test.js
@@ -1,5 +1,5 @@
 import '../meter-linear.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-meter-linear', () => {
 

--- a/components/meter/test/meter-radial.test.js
+++ b/components/meter/test/meter-radial.test.js
@@ -1,5 +1,5 @@
 import '../meter-radial.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-meter-radial', () => {
 

--- a/components/more-less/test/more-less.test.js
+++ b/components/more-less/test/more-less.test.js
@@ -1,6 +1,5 @@
 import '../more-less.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 export function waitForHeight(elem) {
 	return new Promise((resolve) => {

--- a/components/object-property-list/test/object-property-list.test.js
+++ b/components/object-property-list/test/object-property-list.test.js
@@ -2,8 +2,7 @@ import '../object-property-list.js';
 import '../object-property-list-item.js';
 import '../object-property-list-item-link.js';
 import '../../status-indicator/status-indicator.js';
-import { aTimeout, expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { aTimeout, expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 const validateSeparators = (elem, count) => {
 	const items = elem.querySelectorAll('d2l-object-property-list-item:not([hidden]), d2l-object-property-list-item-link:not([hidden])');

--- a/components/offscreen/test/offscreen.test.js
+++ b/components/offscreen/test/offscreen.test.js
@@ -1,5 +1,5 @@
 import '../offscreen.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-offscreen', () => {
 

--- a/components/overflow-group/test/overflow-group.test.js
+++ b/components/overflow-group/test/overflow-group.test.js
@@ -1,7 +1,6 @@
 import '../overflow-group.js';
 import '../../button/button.js';
-import { fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-overflow-group', () => {
 	describe('constructor', () => {

--- a/components/paging/test/pager-load-more.test.js
+++ b/components/paging/test/pager-load-more.test.js
@@ -1,8 +1,7 @@
 import '../pager-load-more.js';
-import { defineCE, expect, fixture, oneEvent } from '@brightspace-ui/testing';
+import { defineCE, expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { html, LitElement } from 'lit';
 import { PageableMixin } from '../pageable-mixin.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const tagName = defineCE(
 	class extends PageableMixin(LitElement) {

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -8,8 +8,7 @@ import '../selection-input.js';
 import '../selection-select-all.js';
 import '../selection-select-all-pages.js';
 import '../selection-summary.js';
-import { expect, fixture, html, nextFrame, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, nextFrame, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { SelectionInfo } from '../selection-mixin.js';
 import Sinon from 'sinon';
 

--- a/components/status-indicator/test/status-indicator.test.js
+++ b/components/status-indicator/test/status-indicator.test.js
@@ -1,6 +1,5 @@
 import '../status-indicator.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-status-indicator', () => {
 

--- a/components/switch/test/switch-visibility.test.js
+++ b/components/switch/test/switch-visibility.test.js
@@ -1,5 +1,5 @@
 import '../switch-visibility.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-switch-visibility', () => {
 

--- a/components/switch/test/switch.test.js
+++ b/components/switch/test/switch.test.js
@@ -1,7 +1,6 @@
 import '../switch.js';
-import { expect, fixture, html, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
+import { expect, fixture, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const switchFixture = html`<d2l-switch text="some text"></d2l-switch>`;
 

--- a/components/table/test/table.test.js
+++ b/components/table/test/table.test.js
@@ -1,7 +1,6 @@
 import '../table-controls.js';
 import '../table-wrapper.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-table-wrapper', () => {
 

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -1,7 +1,6 @@
 import '../tabs.js';
 import '../tab-panel.js';
-import { fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const normalFixture = html`
 	<div>

--- a/components/tag-list/test/tag-list.test.js
+++ b/components/tag-list/test/tag-list.test.js
@@ -1,9 +1,8 @@
 import './tag-list-item-mixin-consumer.js';
 import '../tag-list.js';
 import '../tag-list-item.js';
-import { clickElem, expect, fixture, html, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`
 	<d2l-tag-list description="Testing Tags">

--- a/components/tooltip/test/tooltip-help.test.js
+++ b/components/tooltip/test/tooltip-help.test.js
@@ -1,5 +1,5 @@
 import '../tooltip-help.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-tooltip-help', () => {
 

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -1,7 +1,6 @@
 import '../tooltip.js';
-import { aTimeout, defineCE, expect, fixture, focusElem, html, oneEvent, sendKeys } from '@brightspace-ui/testing';
+import { aTimeout, defineCE, expect, fixture, focusElem, html, oneEvent, runConstructor, sendKeys } from '@brightspace-ui/testing';
 import { LitElement } from 'lit';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
 
 const basicFixture = html`
 	<div>

--- a/components/validation/test/validation-custom.test.js
+++ b/components/validation/test/validation-custom.test.js
@@ -1,6 +1,5 @@
 import '../validation-custom.js';
-import { aTimeout, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { aTimeout, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const basicFixture = html`
 	<div>

--- a/templates/primary-secondary/test/primary-secondary.test.js
+++ b/templates/primary-secondary/test/primary-secondary.test.js
@@ -1,5 +1,5 @@
 import '../primary-secondary.js';
-import { runConstructor } from '../../../tools/constructor-test-helper.js';
+import { runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-template-primary-secondary', () => {
 

--- a/tools/constructor-test-helper.js
+++ b/tools/constructor-test-helper.js
@@ -1,7 +1,1 @@
-import { expect } from '@open-wc/testing';
-
-export function runConstructor(nodeName) {
-	const ctor = customElements.get(nodeName);
-	expect(ctor).to.not.be.undefined;
-	document.createElement(nodeName);
-}
+export { runConstructor } from '@brightspace-ui/testing';

--- a/tools/constructor-test-helper.js
+++ b/tools/constructor-test-helper.js
@@ -1,1 +1,7 @@
-export { runConstructor } from '@brightspace-ui/testing';
+import { expect } from '@open-wc/testing';
+
+export function runConstructor(nodeName) {
+	const ctor = customElements.get(nodeName);
+	expect(ctor).to.not.be.undefined;
+	document.createElement(nodeName);
+}


### PR DESCRIPTION
Now that `runConstructor` exists in `@brightspace-ui/testing`, it doesn't need to be in core anymore. But lots of places are referencing it, so this creates an alias.

Also switches everything in core over to use the testing version which was quite tedious!