### PR TITLE
fix: wait for hidden items to appear before focusing

### DIFF
--- a/components/filter/test/filter-tags.vdiff.js
+++ b/components/filter/test/filter-tags.vdiff.js
@@ -2,7 +2,7 @@ import '../filter.js';
 import '../filter-dimension-set.js';
 import '../filter-dimension-set-value.js';
 import '../filter-tags.js';
-import { aTimeout, clickElem, expect, fixture, html, sendKeys, sendKeysElem } from '@brightspace-ui/testing';
+import { aTimeout, clickElem, expect, fixture, html, oneEvent, sendKeys, sendKeysElem } from '@brightspace-ui/testing';
 
 const singleFilter = html`
 	<d2l-filter id="filter">
@@ -97,7 +97,10 @@ describe('filter-tags', () => {
 				const tagList = filterTags.shadowRoot.querySelector('d2l-tag-list');
 				const showMoreButton = tagList.shadowRoot.querySelector('.d2l-tag-list-button');
 
-				if (showMoreButton) await clickElem(showMoreButton);
+				if (showMoreButton) {
+					clickElem(showMoreButton);
+					await oneEvent(tagList, 'd2l-tag-list-focus');
+				}
 				await expect(elem).to.be.golden();
 			});
 		});

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -407,11 +407,13 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 
 		if (!this.shadowRoot) return;
 
+		const isMoreButton = e.target.classList.contains('d2l-tag-list-button-show-more');
 		await this.updateComplete;
-		if (e.target.classList.contains('d2l-tag-list-button-show-more')) this._items[this._chompIndex].focus();
-		else {
-			const button = this.shadowRoot.querySelector('.d2l-tag-list-button');
-			if (button) button.focus();
+		await new Promise((r) => setTimeout(r, 100)); // wait for items to appear before focusing
+		if (isMoreButton) {
+			this._items[this._chompIndex].focus();
+		} else {
+			this.shadowRoot.querySelector('.d2l-tag-list-button')?.focus();
 		}
 	}
 }

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -415,6 +415,8 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 		} else {
 			this.shadowRoot.querySelector('.d2l-tag-list-button')?.focus();
 		}
+		/** @ignore */
+		this.dispatchEvent(new CustomEvent('d2l-tag-list-focus', { bubbles: false, composed: false }));
 	}
 }
 

--- a/components/tag-list/test/tag-list.vdiff.js
+++ b/components/tag-list/test/tag-list.vdiff.js
@@ -1,7 +1,7 @@
 import '../tag-list.js';
 import '../tag-list-item.js';
 import './tag-list-item-mixin-consumer.js';
-import { clickElem, expect, fixture, focusElem, hoverElem, html, nextFrame, oneEvent, sendKeys, waitUntil } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, focusElem, hoverAt, hoverElem, html, nextFrame, oneEvent, sendKeys, waitUntil } from '@brightspace-ui/testing';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { nothing } from 'lit';
 
@@ -88,6 +88,7 @@ describe('tag-list', () => {
 					const button = elem.shadowRoot.querySelector('.d2l-tag-list-button');
 					if (button) {
 						clickElem(button);
+						hoverAt(0, 0);
 						await oneEvent(elem, 'd2l-tag-list-focus');
 					}
 					await elem.updateComplete;

--- a/components/tag-list/test/tag-list.vdiff.js
+++ b/components/tag-list/test/tag-list.vdiff.js
@@ -86,10 +86,10 @@ describe('tag-list', () => {
 
 				it(`width ${width} click show more`, async() => {
 					const button = elem.shadowRoot.querySelector('.d2l-tag-list-button');
-					if (button) await clickElem(button);
-					await elem.updateComplete;
-
-					await nextFrame();
+					if (button) {
+						clickElem(button);
+						await oneEvent(elem, 'd2l-tag-list-focus');
+					}
 					await expect(elem).to.be.golden();
 				});
 			});

--- a/components/tag-list/test/tag-list.vdiff.js
+++ b/components/tag-list/test/tag-list.vdiff.js
@@ -90,6 +90,9 @@ describe('tag-list', () => {
 						clickElem(button);
 						await oneEvent(elem, 'd2l-tag-list-focus');
 					}
+					await elem.updateComplete;
+
+					await nextFrame();
 					await expect(elem).to.be.golden();
 				});
 			});


### PR DESCRIPTION
I definitely don't love this solution, so interested in other ideas as well.

With Chrome 118, when filter tags are chomped (or unchomped) and focus is moved from the "show more"/"show less" button to either the last item before showing more or the "show more" button the focus now fails.

I _think_ it's because the chomping is triggering the resize observer which in turn does a bunch of recalculation and in the process actually sets `visibility: hidden` on everything. And browsers don't like to focus on hidden things and if a hidden thing has focus, they remove it. What I can't explain is why this just started failing or why it's not failing in other browsers. I also can't find a good way to test if it's about to happen, and no amount of `requestAnimationFrame`s waited long enough -- I needed the longer timeout.

I also played around with just keeping focus on the "show more" / "show less" button and it experienced the same issue because of the `visibility: hidden` thing as well.