### PR TITLE
Add option to specify a provider delegate.

### DIFF
--- a/mixins/provider/README.md
+++ b/mixins/provider/README.md
@@ -4,10 +4,10 @@ The `ProviderMixin` and `RequesterMixin` can be used to create a DI-like system 
 
 ## Usage
 
-Apply the `ProviderMixin` to the component that will be responsible for providing some data to components that request it:
+Apply the `ProviderMixin` to the component that will be responsible for providing some data to components that request it. Optionally, the `ProviderDelegate` class can be used to specify a function that will provide the value when requested. 
 
 ```js
-import { ProviderMixin } from '@brightspace-ui/core/mixins/provider/provider-mixin.js';
+import { ProviderMixin, ProviderDelegate } from '@brightspace-ui/core/mixins/provider/provider-mixin.js';
 
 class InterestingFactProvider extends ProviderMixin(LitElement) {
 	constructor() {
@@ -15,6 +15,8 @@ class InterestingFactProvider extends ProviderMixin(LitElement) {
 		this.provideInstance('d2l-interesting-fact-string', 'Olives are not the same as fish');
 		this.provideInstance('d2l-interesting-fact-object', { fact: 'Olives are not the same as fish' });
 		this.provideInstance('d2l-interesting-fact-function', x => `${x} are not the same as fish`);
+		this.provideInstance('d2l-interesting-fact-delegate', new ProviderDelegate(() => 'Olives are not the same as fish'));
+		this.provideInstance('d2l-interesting-fact-async-delegate', new ProviderDelegate(() => new Promise(...)));
 	}
 }
 ```

--- a/mixins/provider/provider-mixin.js
+++ b/mixins/provider/provider-mixin.js
@@ -1,9 +1,20 @@
+export class ProviderDelegate {
+	constructor(delegate) {
+		this.delegate = delegate;
+	}
+}
+
 export function provideInstance(node, key, obj) {
 	if (!node._providerInstances) {
 		node._providerInstances = new Map();
 		node.addEventListener('d2l-request-instance', e => {
 			if (node._providerInstances.has(e.detail.key)) {
-				e.detail.instance = node._providerInstances.get(e.detail.key);
+				const instance = node._providerInstances.get(e.detail.key);
+				if (instance instanceof ProviderDelegate) {
+					e.detail.instance = instance.delegate();
+				} else {
+					e.detail.instance = instance;
+				}
 				e.stopPropagation();
 			}
 		});

--- a/mixins/provider/test/.eslintrc.json
+++ b/mixins/provider/test/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "brightspace/open-wc-testing-config"
+}

--- a/mixins/provider/test/provider-mixin.test.js
+++ b/mixins/provider/test/provider-mixin.test.js
@@ -1,0 +1,54 @@
+import { provideInstance, ProviderDelegate, requestInstance } from '../provider-mixin.js';
+import { expect } from '@brightspace-ui/testing';
+
+describe('provider-helpers', () => {
+
+	it('should provide number', () => {
+		provideInstance(document, 'instance-number', 42);
+		expect(requestInstance(document.body, 'instance-number')).to.equal(42);
+	});
+
+	it('should provide string', () => {
+		provideInstance(document, 'instance-number', 'forty-two');
+		expect(requestInstance(document.body, 'instance-number')).to.equal('forty-two');
+	});
+
+	it('should provide boolean', () => {
+		provideInstance(document, 'instance-boolean', true);
+		expect(requestInstance(document.body, 'instance-boolean')).to.equal(true);
+	});
+
+	it('should provide function', () => {
+		const someFunction = () => {};
+		provideInstance(document, 'instance-function', someFunction);
+		expect(requestInstance(document.body, 'instance-function')).to.equal(someFunction);
+	});
+
+	it('should provide object', () => {
+		class Beverage {
+			constructor(type) {
+				this.type = type;
+			}
+		}
+		const instance = new Beverage('beer');
+		provideInstance(document, 'instance-object', instance);
+		expect(requestInstance(document.body, 'instance-object')).to.equal(instance);
+	});
+
+	it('should provide delegate result', () => {
+		provideInstance(document, 'instance-delegate', new ProviderDelegate(() => {
+			return 42;
+		}));
+		expect(requestInstance(document.body, 'instance-delegate')).to.equal(42);
+	});
+
+	it('should provide async delegate result', async() => {
+		provideInstance(document, 'instance-async-delegate', new ProviderDelegate(() => {
+			return new Promise(resolve => {
+				setTimeout(() => resolve(42), 200);
+			});
+		}));
+		expect(await requestInstance(document.body, 'instance-async-delegate')).to.equal(42);
+	});
+
+});


### PR DESCRIPTION
This PR updates the `provideInstance` helper method to optionally accept a `ProviderDelegate` that will be invoked when a value is requested.