### PR TITLE
Simplify d2l-test-runner.config.js

### DIFF
--- a/d2l-test-runner.config.js
+++ b/d2l-test-runner.config.js
@@ -1,10 +1,3 @@
-const pattern = type => `+(components|controllers|directives|helpers|mixins|templates)/**/*.${type}.js`;
-
 export default {
-	pattern,
-	groups: [{
-		name: 'aXe',
-		files: pattern('axe'),
-		browsers: ['chrome']
-	}]
+	pattern: type => `**/test/*.${type}.js`
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@brightspace-ui/testing": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/testing/-/testing-1.7.1.tgz",
-      "integrity": "sha512-3vhoAH/szFeUo9f9UomQ8dyLMkGZnPScn9R9j0+/DAKOEa77tCId8G0Hs6+YH/Elr+XOfyOTsfVymNGSW44YXg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/testing/-/testing-1.8.1.tgz",
+      "integrity": "sha512-dEaQd40lEvt4axlCy6l3HOUWj3m53pJnEGBVjHxp0zUdTF9nmuATskYAhulKXotf+FtQTxVK9dLPR/1bnoGNDA==",
       "dev": true,
       "dependencies": {
         "@brightspace-ui/intl": "^3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:style": "stylelint \"**/*.{js,html}\" --ignore-path .gitignore",
     "start": "web-dev-server --node-resolve --watch --open",
     "test": "npm run lint && npm run test:translations && npm run test:unit && npm run test:axe",
-    "test:axe": "d2l-test-runner aXe",
+    "test:axe": "d2l-test-runner axe --chrome",
     "test:unit": "d2l-test-runner",
     "test:translations": "mfv -e -s en -p ./lang/ -i untranslated",
     "test:vdiff": "d2l-test-runner vdiff"


### PR DESCRIPTION
Now that `d2l-test-runner` supports implicit groups and excludes files in `node_modules`, we can simplify the `pattern` and get rid of the explicit `axe` group.