### PR TITLE
Update ProviderDelegate to return cached value.

### DIFF
--- a/mixins/provider/README.md
+++ b/mixins/provider/README.md
@@ -4,7 +4,7 @@ The `ProviderMixin` and `RequesterMixin` can be used to create a DI-like system 
 
 ## Usage
 
-Apply the `ProviderMixin` to the component that will be responsible for providing some data to components that request it. Optionally, the `ProviderDelegate` class can be used to specify a function that will provide the value when requested. 
+Apply the `ProviderMixin` to the component that will be responsible for providing some data to components that request it. Optionally, the `ProviderDelegate` class can be used to specify a function that will provide a cached value when requested. If `noCache: true` is passed, the value will not be cached.
 
 ```js
 import { ProviderMixin, ProviderDelegate } from '@brightspace-ui/core/mixins/provider/provider-mixin.js';
@@ -16,6 +16,7 @@ class InterestingFactProvider extends ProviderMixin(LitElement) {
 		this.provideInstance('d2l-interesting-fact-object', { fact: 'Olives are not the same as fish' });
 		this.provideInstance('d2l-interesting-fact-function', x => `${x} are not the same as fish`);
 		this.provideInstance('d2l-interesting-fact-delegate', new ProviderDelegate(() => 'Olives are not the same as fish'));
+		this.provideInstance('d2l-interesting-fact-delegate', new ProviderDelegate(() => 'Olives are not the same as fish', noCache));
 		this.provideInstance('d2l-interesting-fact-async-delegate', new ProviderDelegate(() => new Promise(...)));
 	}
 }

--- a/mixins/provider/provider-mixin.js
+++ b/mixins/provider/provider-mixin.js
@@ -1,6 +1,13 @@
 export class ProviderDelegate {
-	constructor(delegate) {
-		this.delegate = delegate;
+	constructor(delegate, noCache) {
+		this._noCache = noCache;
+		this._delegate = delegate;
+	}
+	getValue() {
+		if (this._noCache || this._value === undefined) {
+			this._value = this._delegate();
+		}
+		return this._value;
 	}
 }
 
@@ -11,7 +18,7 @@ export function provideInstance(node, key, obj) {
 			if (node._providerInstances.has(e.detail.key)) {
 				const instance = node._providerInstances.get(e.detail.key);
 				if (instance instanceof ProviderDelegate) {
-					e.detail.instance = instance.delegate();
+					e.detail.instance = instance.getValue();
 				} else {
 					e.detail.instance = instance;
 				}

--- a/mixins/provider/test/provider-mixin.test.js
+++ b/mixins/provider/test/provider-mixin.test.js
@@ -42,6 +42,26 @@ describe('provider-helpers', () => {
 		expect(requestInstance(document.body, 'instance-delegate')).to.equal(42);
 	});
 
+	it('should provide cached delegate result', () => {
+		let value = 41;
+		provideInstance(document, 'instance-delegate', new ProviderDelegate(() => {
+			value += 1;
+			return value;
+		}));
+		expect(requestInstance(document.body, 'instance-delegate')).to.equal(42);
+		expect(requestInstance(document.body, 'instance-delegate')).to.equal(42);
+	});
+
+	it('should provide new delegate result', () => {
+		let value = 41;
+		provideInstance(document, 'instance-delegate', new ProviderDelegate(() => {
+			value += 1;
+			return value;
+		}, true));
+		expect(requestInstance(document.body, 'instance-delegate')).to.equal(42);
+		expect(requestInstance(document.body, 'instance-delegate')).to.equal(43);
+	});
+
 	it('should provide async delegate result', async() => {
 		provideInstance(document, 'instance-async-delegate', new ProviderDelegate(() => {
 			return new Promise(resolve => resolve(42));


### PR DESCRIPTION
This PR updates the `ProviderDelegate` to returned a cached value. This avoids consumers having to do their own short-circuiting. Optionally, the consumer can opt out of caching by passing true for the `noCache` parameter. 