### PR TITLE
fix: Try to fix generation of custom-elements.json file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Create custom-elements.json
-        run: npx wca analyze \"{components,templates}/**/*.js\" --format json --outFile custom-elements.json
+        run: npx wca analyze "{components,templates}/**/*.js" --format json --outFile custom-elements.json
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:


### PR DESCRIPTION
It looks like this broke with the release of `web-component-analyzer` [version `2.0.0` last week](https://www.npmjs.com/package/web-component-analyzer/v/2.0.0). Which makes sense as to why it was hard to track down a commit that broke it - we install this as part of the `release` workflow, so not tied to any code change on our part.

I don't know why removing the escape fixes it, but it works locally after I do this.