### PR TITLE
fix: Form: Hide d2l-form-connect from Daylight

### DIFF
--- a/components/form/form.js
+++ b/components/form/form.js
@@ -6,6 +6,7 @@ import { FormMixin } from './form-mixin.js';
  * A component that can be used to build sections containing interactive controls that are validated and submitted as a group.
  * Values of these interactive controls are aggregated but the user is responsible for handling submission via the @d2l-form-submit event.
  * @slot - The native and custom form elements that participate in validation and submission
+ * @fires d2l-form-connect - Internal event
  */
 class Form extends FormMixin(LitElement) {
 


### PR DESCRIPTION
This event is now showing up on Daylight. According to the [Daylight docs](https://daylight.d2l.dev/about/adding-component/#component-code) this should hide the event from the site.