### PR TITLE
Only trap focus if last activated trap

### DIFF
--- a/components/focus-trap/test/focus-trap.test.js
+++ b/components/focus-trap/test/focus-trap.test.js
@@ -16,13 +16,19 @@ const normalFixture = html`
 	</div>
 `;
 
-describe('d2l-focus-trap', () => {
+const siblingsFixture = html`
+	<div>
+		<a id="before" href="http://www.d2l.com">Before</a>
+		<d2l-focus-trap id="focusTrap1">
+			<a href="http://www.d2l.com">First</a>
+		</d2l-focus-trap>
+		<d2l-focus-trap id="focusTrap2">
+			<a href="http://www.d2l.com">Second</a>
+		</d2l-focus-trap>
+	</div>
+`;
 
-	let elem, focusTrap;
-	beforeEach(async() => {
-		elem = await fixture(normalFixture);
-		focusTrap = elem.querySelector('d2l-focus-trap');
-	});
+describe('d2l-focus-trap', () => {
 
 	describe('constructor', () => {
 
@@ -32,158 +38,188 @@ describe('d2l-focus-trap', () => {
 
 	});
 
-	describe('not trapping', () => {
+	describe('single', () => {
 
-		it('does not redirects body focus', () => {
-			elem.querySelector('#before').focus();
-			expect(document.activeElement).to.equal(elem.querySelector('#before'));
-		});
-
-		it('does not render traps', () => {
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').hasAttribute('tabindex')).to.be.false;
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').hasAttribute('tabindex')).to.be.false;
-		});
-
-	});
-
-	describe('trapping', () => {
-
+		let elem, focusTrap;
 		beforeEach(async() => {
-			focusTrap.trap = true;
-			await focusTrap.updateComplete;
+			elem = await fixture(normalFixture);
+			focusTrap = elem.querySelector('d2l-focus-trap');
 		});
 
-		it('render traps', () => {
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').getAttribute('tabindex')).to.equal('0');
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').getAttribute('tabindex')).to.equal('0');
-		});
+		describe('not trapping', () => {
 
-		it('redirects body focus', () => {
-			elem.querySelector('#before').focus();
-			expect(document.activeElement).to.equal(elem.querySelector('#first'));
-		});
-
-		it('does not redirect from children', () => {
-			elem.querySelector('#middle').focus();
-			expect(document.activeElement).to.equal(elem.querySelector('#middle'));
-		});
-
-		it('dispatches d2l-focus-trap-enter', async() => {
-			setTimeout(() => elem.querySelector('#before').focus());
-			await oneEvent(focusTrap, 'd2l-focus-trap-enter');
-		});
-
-		describe('wrapping', () => {
-			let clock;
-
-			beforeEach(() => {
-				clock = sinon.useFakeTimers();
-			});
-			afterEach(() => {
-				clock.restore();
+			it('does not redirects body focus', () => {
+				elem.querySelector('#before').focus();
+				expect(document.activeElement).to.equal(elem.querySelector('#before'));
 			});
 
-			it('wraps to first', async() => {
-				focusTrap.querySelector('#last').focus();
-				focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').focus();
-				clock.tick(50);
+			it('does not render traps', () => {
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').hasAttribute('tabindex')).to.be.false;
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').hasAttribute('tabindex')).to.be.false;
+			});
+
+		});
+
+		describe('trapping', () => {
+
+			beforeEach(async() => {
+				focusTrap.trap = true;
+				await focusTrap.updateComplete;
+			});
+
+			it('render traps', () => {
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').getAttribute('tabindex')).to.equal('0');
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').getAttribute('tabindex')).to.equal('0');
+			});
+
+			it('redirects body focus', () => {
+				elem.querySelector('#before').focus();
 				expect(document.activeElement).to.equal(elem.querySelector('#first'));
 			});
 
-			it('wraps to last', () => {
-				focusTrap.querySelector('#first').focus();
-				focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').focus();
-				clock.tick(50);
-				expect(document.activeElement).to.equal(elem.querySelector('#last'));
+			it('does not redirect from children', () => {
+				elem.querySelector('#middle').focus();
+				expect(document.activeElement).to.equal(elem.querySelector('#middle'));
+			});
+
+			it('dispatches d2l-focus-trap-enter', async() => {
+				setTimeout(() => elem.querySelector('#before').focus());
+				await oneEvent(focusTrap, 'd2l-focus-trap-enter');
+			});
+
+			describe('wrapping', () => {
+				let clock;
+
+				beforeEach(() => {
+					clock = sinon.useFakeTimers();
+				});
+				afterEach(() => {
+					clock.restore();
+				});
+
+				it('wraps to first', async() => {
+					focusTrap.querySelector('#last').focus();
+					focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').focus();
+					clock.tick(50);
+					expect(document.activeElement).to.equal(elem.querySelector('#first'));
+				});
+
+				it('wraps to last', () => {
+					focusTrap.querySelector('#first').focus();
+					focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').focus();
+					clock.tick(50);
+					expect(document.activeElement).to.equal(elem.querySelector('#last'));
+				});
+
+			});
+
+		});
+
+		describe('legacy prompt', () => {
+
+			beforeEach(async() => {
+				focusTrap.trap = true;
+				await focusTrap.updateComplete;
+			});
+
+			it('does not trap after prompt opened', async() => {
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt1' } })
+				);
+
+				await focusTrap.updateComplete;
+
+				elem.querySelector('#before').focus();
+				expect(document.activeElement).to.equal(elem.querySelector('#before'));
+
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').hasAttribute('tabindex')).to.be.false;
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').hasAttribute('tabindex')).to.be.false;
+			});
+
+			it('traps after prompt closed', async() => {
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt1' } })
+				);
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt1' } })
+				);
+
+				await focusTrap.updateComplete;
+
+				elem.querySelector('#before').focus();
+				expect(document.activeElement).to.equal(elem.querySelector('#first'));
+
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').getAttribute('tabindex')).to.equal('0');
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').getAttribute('tabindex')).to.equal('0');
+			});
+
+			it('does not trap after closing one of multiple open prompts', async() => {
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt1' } })
+				);
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt2' } })
+				);
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt2' } })
+				);
+				// intentional duplicate event to ensure focus-trap is tracking prompts properly
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt2' } })
+				);
+
+				await focusTrap.updateComplete;
+
+				elem.querySelector('#before').focus();
+				expect(document.activeElement).to.equal(elem.querySelector('#before'));
+
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').hasAttribute('tabindex')).to.be.false;
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').hasAttribute('tabindex')).to.be.false;
+			});
+
+			it('traps after closing all prompts', async() => {
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt1' } })
+				);
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt2' } })
+				);
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt1' } })
+				);
+				document.body.dispatchEvent(
+					new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt2' } })
+				);
+
+				await focusTrap.updateComplete;
+
+				elem.querySelector('#before').focus();
+				expect(document.activeElement).to.equal(elem.querySelector('#first'));
+
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').getAttribute('tabindex')).to.equal('0');
+				expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').getAttribute('tabindex')).to.equal('0');
 			});
 
 		});
 
 	});
 
-	describe('legacy prompt', () => {
+	describe('siblings', () => {
 
+		let elem, focusTrap1, focusTrap2;
 		beforeEach(async() => {
-			focusTrap.trap = true;
-			await focusTrap.updateComplete;
+			elem = await fixture(siblingsFixture);
+			focusTrap1 = elem.querySelector('#focusTrap1');
+			focusTrap2 = elem.querySelector('#focusTrap2');
 		});
 
-		it('does not trap after prompt opened', async() => {
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt1' } })
-			);
-
-			await focusTrap.updateComplete;
-
+		it('does not redirects body focus', async() => {
+			focusTrap1.trap = true;
+			await focusTrap1.updateComplete;
+			focusTrap2.trap = true;
+			await focusTrap2.updateComplete;
 			elem.querySelector('#before').focus();
-			expect(document.activeElement).to.equal(elem.querySelector('#before'));
-
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').hasAttribute('tabindex')).to.be.false;
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').hasAttribute('tabindex')).to.be.false;
-		});
-
-		it('traps after prompt closed', async() => {
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt1' } })
-			);
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt1' } })
-			);
-
-			await focusTrap.updateComplete;
-
-			elem.querySelector('#before').focus();
-			expect(document.activeElement).to.equal(elem.querySelector('#first'));
-
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').getAttribute('tabindex')).to.equal('0');
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').getAttribute('tabindex')).to.equal('0');
-		});
-
-		it('does not trap after closing one of multiple open prompts', async() => {
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt1' } })
-			);
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt2' } })
-			);
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt2' } })
-			);
-			// intentional duplicate event to ensure focus-trap is tracking prompts properly
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt2' } })
-			);
-
-			await focusTrap.updateComplete;
-
-			elem.querySelector('#before').focus();
-			expect(document.activeElement).to.equal(elem.querySelector('#before'));
-
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').hasAttribute('tabindex')).to.be.false;
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').hasAttribute('tabindex')).to.be.false;
-		});
-
-		it('traps after closing all prompts', async() => {
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt1' } })
-			);
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-open', { bubbles: false, detail: { id: 'prompt2' } })
-			);
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt1' } })
-			);
-			document.body.dispatchEvent(
-				new CustomEvent('d2l-legacy-prompt-close', { bubbles: false, detail: { id: 'prompt2' } })
-			);
-
-			await focusTrap.updateComplete;
-
-			elem.querySelector('#before').focus();
-			expect(document.activeElement).to.equal(elem.querySelector('#first'));
-
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').getAttribute('tabindex')).to.equal('0');
-			expect(focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').getAttribute('tabindex')).to.equal('0');
+			expect(document.activeElement).to.equal(focusTrap2.querySelector('a'));
 		});
 
 	});


### PR DESCRIPTION
This PR updates `d2l-focus-trap` to only trap focus if it's the last activated focus trap. This prevents focus traps that are not nested from stealing focus and causing an infinite loop. 

While nested focus traps are already supported and handled (for nested `d2l-dialog-*` components), it is possible for consumers to use a `d2l-dialog` in their app component, which subsequently uses an LMS/legacy helper to render a `d2l-dialog-fullscreen` at the root. In such a case, the dialog components are not nested, and therefore they compete for focus in an endless loop.