### PR TITLE
feat: US158339 - Move to new release token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:
-          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
           MINOR_RELEASE_WITH_LMS: true
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Already removed `brightspace-bot` as a collaborator and removed access to `D2L_GITHUB_TOKEN`. Because of this, we'll need to backport this change to any maintenance branches for the release to work. I'm thinking I'll proactively do it for `2.154.x`, but none of the others.