### PR TITLE
Increase the timeout of the license checker workflow.

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   lint:
     name: License Checker
-    timeout-minutes: 2
+    timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout


### PR DESCRIPTION
Bump the timeout of this workflow to work-around this issue: https://github.com/actions/setup-node/issues/878