### PR TITLE
Fix d2l-list-item-drag-handle mouse interaction.

### DIFF
--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -335,6 +335,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 					opacity: 0;
 				}
 				:host([selected]) d2l-list-item-drag-handle,
+				d2l-list-item-drag-handle:hover,
 				d2l-list-item-drag-handle.d2l-hovering,
 				d2l-list-item-drag-handle.d2l-focusing {
 					opacity: 1;

--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -72,7 +72,7 @@ class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(RtlMixin(LitElem
 			:host {
 				display: flex;
 				margin: 0.25rem;
-				pointer-events: all; /* required since its parent may set point-events: none; (see generic layout) */
+				pointer-events: auto; /* required since its parent may set point-events: none; (see generic layout) */
 			}
 			:host([hidden]) {
 				display: none;

--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -72,6 +72,7 @@ class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(RtlMixin(LitElem
 			:host {
 				display: flex;
 				margin: 0.25rem;
+				pointer-events: all; /* required since its parent may set point-events: none; (see generic layout) */
 			}
 			:host([hidden]) {
 				display: none;
@@ -181,25 +182,6 @@ class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(RtlMixin(LitElem
 		this.activateKeyboardMode();
 	}
 
-	_onKeyboardButtonFocusIn() {
-		if (hasDisplayedKeyboardTooltip) return;
-		this._displayKeyboardTooltip = true;
-		hasDisplayedKeyboardTooltip = true;
-	}
-
-	_onKeyboardButtonFocusOut(e) {
-		this._displayKeyboardTooltip = false;
-		if (this._movingElement) {
-			this._movingElement = false;
-			e.stopPropagation();
-			e.preventDefault();
-			return;
-		}
-		this._keyboardActive = false;
-		this._dispatchAction(dragActions.save);
-		e.stopPropagation();
-	}
-
 	async _onMoveButtonAction(e) {
 
 		let action = null;
@@ -245,6 +227,25 @@ class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(RtlMixin(LitElem
 
 	}
 
+	_onMoveButtonFocusIn() {
+		if (hasDisplayedKeyboardTooltip) return;
+		this._displayKeyboardTooltip = true;
+		hasDisplayedKeyboardTooltip = true;
+	}
+
+	_onMoveButtonFocusOut(e) {
+		this._displayKeyboardTooltip = false;
+		if (this._movingElement) {
+			this._movingElement = false;
+			e.stopPropagation();
+			e.preventDefault();
+			return;
+		}
+		this._keyboardActive = false;
+		this._dispatchAction(dragActions.save);
+		e.stopPropagation();
+	}
+
 	async _onMoveButtonKeydown(e) {
 		if (!this._keyboardActive) {
 			return;
@@ -274,6 +275,10 @@ class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(RtlMixin(LitElem
 
 	}
 
+	_onMoveButtonMouseDown(e) {
+		e.preventDefault();
+	}
+
 	_renderDragger() {
 		return html`
 			<button
@@ -292,10 +297,11 @@ class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(RtlMixin(LitElem
 			<d2l-button-move
 				class="d2l-list-item-drag-handle-button"
 				@d2l-button-move-action="${this._onMoveButtonAction}"
-				@focusin="${this._onKeyboardButtonFocusIn}"
-				@focusout="${this._onKeyboardButtonFocusOut}"
+				@focusin="${this._onMoveButtonFocusIn}"
+				@focusout="${this._onMoveButtonFocusOut}"
 				id="${this._buttonId}"
 				@keydown="${this._onMoveButtonKeydown}"
+				@mousedown="${this._onMoveButtonMouseDown}"
 				text="${this._defaultLabel}">
 			</d2l-button-move>
 			${this._displayKeyboardTooltip ? html`<d2l-tooltip class="vdiff-target" align="start" announced for="${this._buttonId}" for-type="descriptor">${this._renderTooltipContent()}</d2l-tooltip>` : ''}


### PR DESCRIPTION
[DE55479](https://rally1.rallydev.com/#/?detail=/defect/729253956433&fdp=true)

This PR fixes an issue where the `d2l-list-item-drag-handle`'s up/down arrows are not clickable.

These arrows should be clickable with the mouse... but they are no longer. Clicking them causes the drag handle to revert its rendering back to drag mode (the dots icon).
![image](https://github.com/BrightspaceUI/core/assets/9042472/b3c85d6c-a7cf-4545-bb02-7efd0a0d4b8e)

For Chrome and Firefox, this appears to be a regression from this recent change: https://github.com/BrightspaceUI/core/pull/4100.

For Safari, there's more - it also suffers from [this long-standing terrible issue that Apple refuses to fix](https://bugs.webkit.org/show_bug.cgi?id=22261), where clicking a button that has focus will actually cause it to lose focus, which in this case, causes the drag-handle to toggle out of the `d2l-button-move` interaction. 

