### PR TITLE
US159947 - Fix vdiff tests on new GitHub runners with test concurrency

### DIFF
--- a/.github/workflows/vdiff.yml
+++ b/.github/workflows/vdiff.yml
@@ -21,3 +21,4 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          test-timeout: 10000

--- a/package-lock.json
+++ b/package-lock.json
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@brightspace-ui/testing": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/testing/-/testing-1.8.2.tgz",
-      "integrity": "sha512-irIRJ0ldpO8TpixAGMVwx8awhWBbJCMOeab5hDc6O5vsst1MFcop+Hh9ZvDObnSvYs2otI6yIL5GO1/DKs59hg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/testing/-/testing-1.9.0.tgz",
+      "integrity": "sha512-YbR1tf31mxrPkYhoFUb+s+vJpLVkXh2PvQkVC8a2OhfZKB+cc3rHTN8MDdYZWliKZCYuZxrfBvCxO566OgX+Pw==",
       "dev": true,
       "dependencies": {
         "@brightspace-ui/intl": "^3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:axe": "d2l-test-runner axe --chrome",
     "test:unit": "d2l-test-runner",
     "test:translations": "mfv -e -s en -p ./lang/ -i untranslated",
-    "test:vdiff": "d2l-test-runner vdiff"
+    "test:vdiff": "d2l-test-runner vdiff --timeout 10000"
   },
   "files": [
     "custom-elements.json",


### PR DESCRIPTION
We seem to be getting GitHub runners with more cores, causing tests to run concurrently. This can cause a much slower `screenshot` command, so we need to raise the test timeout. Overall, the concurrency is a good thing, bringing our tests from about 10 minutes to 6 minutes.

This issue also appears locally, and probably has for a while. We likely didn't catch it because it's not common to run _all_ the tests locally, unless you're recreating goldens which simply screenshot and exit, so they're faster and always pass.