### PR TITLE
use a central test eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,5 +27,9 @@
       "no-undef": 0,
       "indent": 0
     }
+  },
+  {
+    "files": "**/test/*",
+    "extends": "brightspace/open-wc-testing-config"
   }]
 }

--- a/components/alert/test/.eslintrc.json
+++ b/components/alert/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/backdrop/test/.eslintrc.json
+++ b/components/backdrop/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/breadcrumbs/test/.eslintrc.json
+++ b/components/breadcrumbs/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/button/test/.eslintrc.json
+++ b/components/button/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/calendar/test/.eslintrc.json
+++ b/components/calendar/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/card/test/.eslintrc.json
+++ b/components/card/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/collapsible-panel/test/.eslintrc.json
+++ b/components/collapsible-panel/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/colors/test/.eslintrc.json
+++ b/components/colors/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/count-badge/test/.eslintrc.json
+++ b/components/count-badge/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/demo/test/.eslintrc.json
+++ b/components/demo/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/description-list/test/.eslintrc.json
+++ b/components/description-list/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/dialog/test/.eslintrc.json
+++ b/components/dialog/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/dropdown/test/.eslintrc.json
+++ b/components/dropdown/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/empty-state/test/.eslintrc.json
+++ b/components/empty-state/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/expand-collapse/test/.eslintrc.json
+++ b/components/expand-collapse/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/filter/test/.eslintrc.json
+++ b/components/filter/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/focus-trap/test/.eslintrc.json
+++ b/components/focus-trap/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/form/test/.eslintrc.json
+++ b/components/form/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/hierarchical-view/test/.eslintrc.json
+++ b/components/hierarchical-view/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/html-block/test/.eslintrc.json
+++ b/components/html-block/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/icons/test/.eslintrc.json
+++ b/components/icons/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/inputs/test/.eslintrc.json
+++ b/components/inputs/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/link/test/.eslintrc.json
+++ b/components/link/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/list/test/.eslintrc.json
+++ b/components/list/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/loading-spinner/test/.eslintrc.json
+++ b/components/loading-spinner/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/menu/test/.eslintrc.json
+++ b/components/menu/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/meter/test/.eslintrc.json
+++ b/components/meter/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/more-less/test/.eslintrc.json
+++ b/components/more-less/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/object-property-list/test/.eslintrc.json
+++ b/components/object-property-list/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/offscreen/test/.eslintrc.json
+++ b/components/offscreen/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/overflow-group/test/.eslintrc.json
+++ b/components/overflow-group/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/paging/test/.eslintrc.json
+++ b/components/paging/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/scroll-wrapper/test/.eslintrc.json
+++ b/components/scroll-wrapper/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/selection/test/.eslintrc.json
+++ b/components/selection/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/skeleton/test/.eslintrc.json
+++ b/components/skeleton/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/status-indicator/test/.eslintrc.json
+++ b/components/status-indicator/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/switch/test/.eslintrc.json
+++ b/components/switch/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/table/test/.eslintrc.json
+++ b/components/table/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/tabs/test/.eslintrc.json
+++ b/components/tabs/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/tag-list/test/.eslintrc.json
+++ b/components/tag-list/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/tooltip/test/.eslintrc.json
+++ b/components/tooltip/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/components/typography/test/.eslintrc.json
+++ b/components/typography/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/wct-lit-config"
-}

--- a/components/validation/test/.eslintrc.json
+++ b/components/validation/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/controllers/attributeObserver/test/.eslintrc.json
+++ b/controllers/attributeObserver/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/controllers/subscriber/test/.eslintrc.json
+++ b/controllers/subscriber/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/directives/animate/test/.eslintrc.json
+++ b/directives/animate/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/directives/run-async/test/.eslintrc.json
+++ b/directives/run-async/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/helpers/test/.eslintrc.json
+++ b/helpers/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/mixins/arrow-keys/test/.eslintrc.json
+++ b/mixins/arrow-keys/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/mixins/async-container/test/.eslintrc.json
+++ b/mixins/async-container/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/wct-lit-config"
-}

--- a/mixins/async-container/test/async-container-mixin.vdiff.js
+++ b/mixins/async-container/test/async-container-mixin.vdiff.js
@@ -45,7 +45,7 @@ describe('async-container-mixin', () => {
 		await expect(elem).to.be.golden();
 	});
 
-	it('mixed', async function() {
+	it('mixed', async() => {
 		const elem = await fixture(createTemplate({ numItems: 2 }));
 		const items = elem.querySelectorAll('d2l-async-demo-item');
 		items[0].key = 'Key 1';
@@ -55,7 +55,7 @@ describe('async-container-mixin', () => {
 		await expect(elem).to.be.golden();
 	});
 
-	it('failure', async function() {
+	it('failure', async() => {
 		const elem = await fixture(createTemplate());
 		const item = elem.querySelector('d2l-async-demo-item');
 		item.key = 'key';
@@ -64,7 +64,7 @@ describe('async-container-mixin', () => {
 		await expect(elem).to.be.golden();
 	});
 
-	it('complete', async function() {
+	it('complete', async() => {
 		const elem = await fixture(createTemplate());
 		const item = elem.querySelector('d2l-async-demo-item');
 		item.key = 'key';

--- a/mixins/focus/test/.eslintrc.json
+++ b/mixins/focus/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/mixins/interactive/test/.eslintrc.json
+++ b/mixins/interactive/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/mixins/labelled/test/.eslintrc.json
+++ b/mixins/labelled/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/mixins/localize/test/.eslintrc.json
+++ b/mixins/localize/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/mixins/provider/test/.eslintrc.json
+++ b/mixins/provider/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/mixins/rtl/test/.eslintrc.json
+++ b/mixins/rtl/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/mixins/visible-on-ancestor/test/.eslintrc.json
+++ b/mixins/visible-on-ancestor/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}

--- a/templates/primary-secondary/test/.eslintrc.json
+++ b/templates/primary-secondary/test/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-	"extends": "brightspace/open-wc-testing-config"
-}


### PR DESCRIPTION
Been meaning to do this for a while. This switches to defining the eslint config for tests at the root of the project, instead of needing to copy it into every `test` directory.

This change actually found a misconfiguration as the `async-container` test config was incorrect.