### PR TITLE
Update note message about site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
             | URL | https://live.d2l.dev/prs/${{ github.repository }}/pr-${{ github.event.number }}/ |
             |---|---|
 
-            > **Note**
+            > [!NOTE]
             > The build needs to finish before your changes are deployed.
             > Changes to the PR will automatically update the instance.
           only-post-once: true


### PR DESCRIPTION
GitHub removed the legacy way of doing this. [New method](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).

Example before when note lost all it's fancy styling
![image](https://github.com/BrightspaceUI/core/assets/9043211/d1b1c966-b61e-4265-a949-2d39f662e07c)
