### PR TITLE
PropertyRequiredMixin Option 2

### DIFF
--- a/components/inputs/input-color.js
+++ b/components/inputs/input-color.js
@@ -104,7 +104,13 @@ class InputColor extends PropertyRequiredMixin(FocusMixin(FormElementMixin(Local
 			 * REQUIRED: Label for the input, comes with a default value for background & foreground types.
 			 * @type {string}
 			 */
-			label: { type: String },
+			label: {
+				type: String,
+				required: {
+					dependentProps: ['type'],
+					validator: (_value, elem, hasValue) => elem.type !== 'custom' || hasValue
+				}
+			},
 			/**
 			 * Hides the label visually
 			 * @type {boolean}
@@ -233,10 +239,6 @@ class InputColor extends PropertyRequiredMixin(FocusMixin(FormElementMixin(Local
 		this._missingLabelErrorHasBeenThrown = false;
 		this._opened = false;
 		this._value = undefined;
-		this.addRequiredProperty('label', {
-			dependentProps: ['type'],
-			validator: hasValue => this.type !== 'custom' || hasValue
-		});
 	}
 
 	get associatedValue() { return this._associatedValue; }

--- a/mixins/labelled/labelled-mixin.js
+++ b/mixins/labelled/labelled-mixin.js
@@ -88,7 +88,20 @@ export const LabelledMixin = superclass => class extends PropertyRequiredMixin(s
 			 * REQUIRED: Explicitly defined label for the element
 			 * @type {string}
 			 */
-			label: { type: String }
+			label: {
+				type: String,
+				required: {
+					message: (_value, elem, defaultMessage) => {
+						if (!elem.labelledBy) return defaultMessage;
+						return `LabelledMixin: "${elem.tagName.toLowerCase()}" is labelled-by="${elem.labelledBy}", but its label is empty`;
+					},
+					validator: (_value, elem, hasValue) => {
+						if (!elem.labelRequired || hasValue) return true;
+						if (!elem.labelledBy) return false;
+						return elem._labelElem !== null;
+					}
+				}
+			}
 		};
 	}
 
@@ -97,17 +110,6 @@ export const LabelledMixin = superclass => class extends PropertyRequiredMixin(s
 		this.labelRequired = true;
 		this._labelElem = null;
 		this._missingLabelErrorHasBeenThrown = false;
-		this.addRequiredProperty('label', {
-			message: defaultMessage => {
-				if (!this.labelledBy) return defaultMessage;
-				return `LabelledMixin: "${this.tagName.toLowerCase()}" is labelled-by="${this.labelledBy}", but its label is empty`;
-			},
-			validator: hasValue => {
-				if (!this.labelRequired || hasValue) return true;
-				if (!this.labelledBy) return false;
-				return this._labelElem !== null;
-			}
-		});
 	}
 
 	async updated(changedProperties) {


### PR DESCRIPTION
This is another flavour of #4272.

Instead of consumers calling `addRequiredProperty('name, opts)` in their constructor, this lets them define that a property is required right in the `static properties` Lit definition.

```javascript
static properties = {
  someProp: { type: String, required: true }
};
```

If options are needed, then `required` can be an object:

```javascript
static properties = {
  someProp: {
    type: String,
    required: {
      validator: () => ...
    }
  }
};
```