### PR TITLE
Plugins helpers

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -210,7 +210,7 @@ registerPlugin('foo-plugins', { prop1: 'other value' }, { key: 'key-2', sort: 2 
 
 // Defer loading dependencies until needed
 registerPlugin('foo-plugins', { getRenderer: async () => {
-    return (await import('./some-module.js').catch(() => {}))?.renderer
+    return (await import('./some-module.js')).renderer
 }});
 ```
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -214,16 +214,16 @@ registerPlugin('foo-plugins', { getRenderer: async () => {
 }});
 ```
 
-The plugin consumer uses the `getPlugins` helper method to get references to the registered plugins by providing a key for the set of plugins. If the consumer knows the key of the plugin it needs, it can request the plugin by using `getPlugin` and specifying the plugin set key and plugin key.
+The plugin consumer uses the `getPlugins` helper method to get references to the registered plugins by providing a key for the set of plugins. If the consumer knows the key of the plugin it needs, it can request the plugin by using `tryGetPluginByKey` and specifying the plugin set key and plugin key.
 
 ```js
-import { getPlugin, getPlugins } from '@brightspace-ui/core/helpers/plugins.js';
+import { getPlugins, tryGetPluginByKey } from '@brightspace-ui/core/helpers/plugins.js';
 
 // Call getPlugins to get plugins
 const plugins = getPlugins('foo-plugins');
 
-// Call getPlugin to get a specific plugin by key
-const plugin = getPlugin('foo-plugins', 'key-1');
+// Call tryGetPluginByKey to get a specific plugin by key
+const plugin = tryGetPluginByKey('foo-plugins', 'key-1');
 ```
 
 ## queueMicrotask

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -191,31 +191,35 @@ const offsetParent = getLegacyOffsetParent(element);
 
 Plugin helpers provide a way for modules to implement and register objects that can be plugged into other project's modules without requiring the plugin consumer to import those modules or objects directly. A higher order module (ex. in BSI) is responsible for importing the plugin registrations.
 
-The plugin implementor uses the `registerPlugin` helper method to make its implementation available to interested consumers. The implementor provides a key for the set of plugins in which to register.
+The plugin implementor uses the `registerPlugin` helper method to make its implementation available to interested consumers. The implementor provides a key for the set of plugins in which to register, and the plugin.
 
-Optionally, an object to specify a `key` for the plugin and/or the `sort` value may be provided. They `key` is useful if consumers intend to request a specific plugin, while the `sort` is useful in cases where order of plugins is important to consumers.
+Optionally, an object to specify a `key` for the plugin and/or the `sort` value may be provided. The `key` is useful if consumers intend to request a specific plugin, while the `sort` is useful in cases where the order of plugins is important to consumers. If `sort` is not specified for at least one plugin, they will be provided to consumers in registration order.
 
 **Important!** plugin registrations should defer loading their dependencies using dynamic imports. They should **not** be synchronously imported in the registration module.
 
 ```js
 import { registerPlugin } from '@brightspace-ui/core/helpers/plugins.js';
 
-// Provide plugin set key, plugin, and optionally a key and/or sort value
+// Provide plugin set key, plugin
+registerPlugin('foo-plugins', { prop1: 'some value' });
+registerPlugin('foo-plugins', { prop1: 'other value' });
+
+// Optionally provide key and/or value
 registerPlugin('foo-plugins', { prop1: 'some value' }, { key: 'key-1', sort: 1 });
 registerPlugin('foo-plugins', { prop1: 'other value' }, { key: 'key-2', sort: 2 });
 
 // Defer loading dependencies until needed
-registerPlugin('foo-plugins', { getRenderer: () => {
+registerPlugin('foo-plugins', { getRenderer: async () => {
     return (await import('./some-module.js').catch(() => {}))?.renderer
 }});
 ```
 
-The plugin consumer uses the `getPlugins` helper method to get references to the registered plugins by providing a key for the set of plugins. If the consumer knows the key of the plugin it needs, it can request it by using `getPlugin` and specifying the plugin set key and plugin key.
+The plugin consumer uses the `getPlugins` helper method to get references to the registered plugins by providing a key for the set of plugins. If the consumer knows the key of the plugin it needs, it can request the plugin by using `getPlugin` and specifying the plugin set key and plugin key.
 
 ```js
 import { getPlugin, getPlugins } from '@brightspace-ui/core/helpers/plugins.js';
 
-// Call getPlugins to get a sorted array of plugins
+// Call getPlugins to get plugins
 const plugins = getPlugins('foo-plugins');
 
 // Call getPlugin to get a specific plugin by key

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -204,7 +204,7 @@ import { registerPlugin } from '@brightspace-ui/core/helpers/plugins.js';
 registerPlugin('foo-plugins', { prop1: 'some value' });
 registerPlugin('foo-plugins', { prop1: 'other value' });
 
-// Optionally provide key and/or value
+// Optionally provide key and/or sort value
 registerPlugin('foo-plugins', { prop1: 'some value' }, { key: 'key-1', sort: 1 });
 registerPlugin('foo-plugins', { prop1: 'other value' }, { key: 'key-2', sort: 2 });
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -187,6 +187,41 @@ import { getLegacyOffsetParent } from '@brightspace-ui/core/helpers/offsetParent
 const offsetParent = getLegacyOffsetParent(element);
 ```
 
+## Plugins
+
+Plugin helpers provide a way for modules to implement and register objects that can be plugged into other project's modules without requiring the plugin consumer to import those modules or objects directly. A higher order module (ex. in BSI) is responsible for importing the plugin registrations.
+
+The plugin implementor uses the `registerPlugin` helper method to make its implementation available to interested consumers. The implementor provides a key for the set of plugins in which to register.
+
+Optionally, an object to specify a `key` for the plugin and/or the `sort` value may be provided. They `key` is useful if consumers intend to request a specific plugin, while the `sort` is useful in cases where order of plugins is important to consumers.
+
+**Important!** plugin registrations should defer loading their dependencies using dynamic imports. They should **not** be synchronously imported in the registration module.
+
+```js
+import { registerPlugin } from '@brightspace-ui/core/helpers/plugins.js';
+
+// Provide plugin set key, plugin, and optionally a key and/or sort value
+registerPlugin('foo-plugins', { prop1: 'some value' }, { key: 'key-1', sort: 1 });
+registerPlugin('foo-plugins', { prop1: 'other value' }, { key: 'key-2', sort: 2 });
+
+// Defer loading dependencies until needed
+registerPlugin('foo-plugins', { getRenderer: () => {
+    return (await import('./some-module.js').catch(() => {}))?.renderer
+}});
+```
+
+The plugin consumer uses the `getPlugins` helper method to get references to the registered plugins by providing a key for the set of plugins. If the consumer knows the key of the plugin it needs, it can request it by using `getPlugin` and specifying the plugin set key and plugin key.
+
+```js
+import { getPlugin, getPlugins } from '@brightspace-ui/core/helpers/plugins.js';
+
+// Call getPlugins to get a sorted array of plugins
+const plugins = getPlugins('foo-plugins');
+
+// Call getPlugin to get a specific plugin by key
+const plugin = getPlugin('foo-plugins', 'key-1');
+```
+
 ## queueMicrotask
 
 A polyfill for [queueMicrotask](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask). For more information on microtasks, read [this article from Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide).

--- a/helpers/plugins.js
+++ b/helpers/plugins.js
@@ -1,10 +1,17 @@
 const pluginSets = new Map();
-const pluginsRequested = new Set();
+
+function getPluginSet(setKey) {
+	let pluginSet = pluginSets.get(setKey);
+	if (pluginSet) return pluginSet;
+
+	pluginSet = { plugins: [], requested: false, requiresSorting: false };
+	pluginSets.set(setKey, pluginSet);
+	return pluginSet;
+}
 
 export function getPlugins(setKey) {
-	if (!pluginsRequested.has(setKey)) pluginsRequested.add(setKey);
-	const pluginSet = pluginSets.get(setKey);
-	if (!pluginSet) return [];
+	const pluginSet = getPluginSet(setKey);
+	pluginSet.requested = true;
 	if (pluginSet.requiresSorting) {
 		pluginSet.plugins.sort((item1, item2) => item1.options.sort - item2.options.sort);
 		pluginSet.requiresSorting = false;
@@ -13,14 +20,10 @@ export function getPlugins(setKey) {
 }
 
 export function registerPlugin(setKey, plugin, options) {
-	if (pluginsRequested.has(setKey)) {
-		throw new Error(`Plugin Set "${setKey}" has already been requested. Additional plugin registrations would result in stale consumer plugins.`);
-	}
+	const pluginSet = getPluginSet(setKey);
 
-	let pluginSet = pluginSets.get(setKey);
-	if (!pluginSet) {
-		pluginSet = { plugins: [], requiresSorting: false };
-		pluginSets.set(setKey, pluginSet);
+	if (pluginSet.requested) {
+		throw new Error(`Plugin Set "${setKey}" has already been requested. Additional plugin registrations would result in stale consumer plugins.`);
 	} else if (options?.key !== undefined) {
 		if (pluginSet.plugins.find(registeredPlugin => registeredPlugin.options.key === options?.key)) {
 			throw new Error(`Plugin Set "${setKey}" already has a plugin with the key "${options.key}".`);
@@ -34,7 +37,6 @@ export function registerPlugin(setKey, plugin, options) {
 // Do not import! Testing only!!
 export function resetPlugins() {
 	pluginSets.clear();
-	pluginsRequested.clear();
 }
 
 export function tryGetPluginByKey(setKey, pluginKey) {

--- a/helpers/plugins.js
+++ b/helpers/plugins.js
@@ -1,10 +1,5 @@
 const pluginSets = new Map();
 
-export function getPlugin(setKey, pluginKey) {
-	const pluginSet = pluginSets.get(setKey);
-	return pluginSet?.plugins.find(plugin => plugin.options.key === pluginKey)?.plugin;
-}
-
 export function getPlugins(setKey) {
 	const pluginSet = pluginSets.get(setKey);
 	if (!pluginSet) return [];
@@ -33,4 +28,10 @@ export function registerPlugin(setKey, plugin, options) {
 // Do not import! Testing only!!
 export function resetPlugins() {
 	pluginSets.clear();
+}
+
+export function tryGetPluginByKey(setKey, pluginKey) {
+	const pluginSet = pluginSets.get(setKey);
+	const plugin = pluginSet?.plugins.find(plugin => plugin.options.key === pluginKey)?.plugin;
+	return plugin || null;
 }

--- a/helpers/plugins.js
+++ b/helpers/plugins.js
@@ -20,10 +20,10 @@ export function registerPlugin(setKey, plugin, options) {
 	if (!pluginSet) {
 		pluginSet = { plugins: [], requiresSorting: false };
 		pluginSets.set(setKey, pluginSet);
-	}
-
-	if (options?.key !== undefined && pluginSet.plugins.find(registeredPlugin => registeredPlugin.options.key === options?.key)) {
-		throw new Error(`Plugin Set "${setKey}" already has plugin with defined key "${options.key}".`);
+	} else if (options?.key !== undefined) {
+		if (pluginSet.plugins.find(registeredPlugin => registeredPlugin.options.key === options?.key)) {
+			throw new Error(`Plugin Set "${setKey}" already has plugin with defined key "${options.key}".`);
+		}
 	}
 
 	pluginSet.plugins.push({ plugin, options: Object.assign({ key: undefined, sort: 0 }, options) });

--- a/helpers/plugins.js
+++ b/helpers/plugins.js
@@ -21,6 +21,16 @@ export function registerPlugin(setKey, plugin, options) {
 		pluginSet = { plugins: [], requiresSorting: false };
 		pluginSets.set(setKey, pluginSet);
 	}
+
+	if (options?.key !== undefined && pluginSet.plugins.find(registeredPlugin => registeredPlugin.options.key === options?.key)) {
+		throw new Error(`Plugin Set "${setKey}" already has plugin with defined key "${options.key}".`);
+	}
+
 	pluginSet.plugins.push({ plugin, options: Object.assign({ key: undefined, sort: 0 }, options) });
 	pluginSet.requiresSorting = pluginSet.requiresSorting || (options?.sort !== undefined);
+}
+
+// Do not import! Testing only!!
+export function resetPlugins() {
+	pluginSets.clear();
 }

--- a/helpers/plugins.js
+++ b/helpers/plugins.js
@@ -1,0 +1,26 @@
+const pluginSets = new Map();
+
+export function getPlugin(setKey, pluginKey) {
+	const pluginSet = pluginSets.get(setKey);
+	return pluginSet?.plugins.find(plugin => plugin.options.key === pluginKey)?.plugin;
+}
+
+export function getPlugins(setKey) {
+	const pluginSet = pluginSets.get(setKey);
+	if (!pluginSet) return [];
+	if (pluginSet.requiresSorting) {
+		pluginSet.plugins.sort((item1, item2) => item1.options.sort - item2.options.sort);
+		pluginSet.requiresSorting = false;
+	}
+	return pluginSet.plugins.map(item => item.plugin);
+}
+
+export function registerPlugin(setKey, plugin, options) {
+	let pluginSet = pluginSets.get(setKey);
+	if (!pluginSet) {
+		pluginSet = { plugins: [], requiresSorting: false };
+		pluginSets.set(setKey, pluginSet);
+	}
+	pluginSet.plugins.push({ plugin, options: Object.assign({ key: undefined, sort: 0 }, options) });
+	pluginSet.requiresSorting = pluginSet.requiresSorting || (options?.sort !== undefined);
+}

--- a/helpers/test/plugins.test.js
+++ b/helpers/test/plugins.test.js
@@ -1,73 +1,104 @@
-import { getPlugin, getPlugins, registerPlugin } from '../plugins.js';
+import { getPlugin, getPlugins, registerPlugin, resetPlugins } from '../plugins.js';
 import { expect } from '@brightspace-ui/testing';
 
 describe('plugins', () => {
 
-	before(() => {
-		registerPlugin('test-plugins', { prop1: 'beer' });
-		registerPlugin('test-plugins', { prop1: 'donuts' });
-		registerPlugin('test-plugins-sorted', { prop1: 'beer' }, { sort: 2 });
-		registerPlugin('test-plugins-sorted', { prop1: 'donuts' }, { sort: 1 });
-		registerPlugin('test-plugins-keyed', { prop1: 'beer' }, { key: 'plugin1' });
-		registerPlugin('test-plugins-keyed', { prop1: 'donuts' }, { key: 'plugin2' });
+	afterEach(() => {
+		resetPlugins();
 	});
 
-	it('getPlugins should return empty array for invalid plugin set key', () => {
-		const plugins = getPlugins('invalid-plugin-set-key');
-		expect(plugins.length).to.equal(0);
+	describe('default', () => {
+
+		beforeEach(() => {
+			registerPlugin('test-plugins', { prop1: 'beer' });
+			registerPlugin('test-plugins', { prop1: 'donuts' });
+		});
+
+		it('getPlugins should return empty array for invalid plugin set key', () => {
+			const plugins = getPlugins('invalid-plugin-set-key');
+			expect(plugins.length).to.equal(0);
+		});
+
+		it('getPlugins should return array of plugins in registration order', () => {
+			const plugins = getPlugins('test-plugins');
+			expect(plugins.length).to.equal(2);
+			expect(plugins[0].prop1).to.equal('beer');
+			expect(plugins[1].prop1).to.equal('donuts');
+		});
+
+		it('getPlugins should return copy of the array for each consumer', () => {
+			const plugins1 = getPlugins('test-plugins');
+			const plugins2 = getPlugins('test-plugins');
+			expect(plugins1).not.to.equal(plugins2);
+		});
+
 	});
 
-	it('getPlugins should return array of plugins in registration order', () => {
-		const plugins = getPlugins('test-plugins');
-		expect(plugins.length).to.equal(2);
-		expect(plugins[0].prop1).to.equal('beer');
-		expect(plugins[1].prop1).to.equal('donuts');
+	describe('sorted', () => {
+
+		beforeEach(() => {
+			registerPlugin('test-plugins', { prop1: 'beer' }, { sort: 3 });
+			registerPlugin('test-plugins', { prop1: 'donuts' }, { sort: 1 });
+		});
+
+		it('getPlugins should return array of plugins in sort order', () => {
+			const plugins = getPlugins('test-plugins');
+			expect(plugins.length).to.equal(2);
+			expect(plugins[0].prop1).to.equal('donuts');
+			expect(plugins[1].prop1).to.equal('beer');
+		});
+
+		it('getPlugins should return array of plugins in new sort order if additional plugins are registered', () => {
+			let plugins = getPlugins('test-plugins');
+			expect(plugins.length).to.equal(2);
+			expect(plugins[0].prop1).to.equal('donuts');
+			expect(plugins[1].prop1).to.equal('beer');
+
+			registerPlugin('test-plugins', { prop1: 'candy apple' }, { sort: 2 });
+
+			plugins = getPlugins('test-plugins');
+			expect(plugins.length).to.equal(3);
+			expect(plugins[0].prop1).to.equal('donuts');
+			expect(plugins[1].prop1).to.equal('candy apple');
+			expect(plugins[2].prop1).to.equal('beer');
+		});
+
 	});
 
-	it('getPlugins should return array of plugins in sort order', () => {
-		const plugins = getPlugins('test-plugins-sorted');
-		expect(plugins.length).to.equal(2);
-		expect(plugins[0].prop1).to.equal('donuts');
-		expect(plugins[1].prop1).to.equal('beer');
-	});
+	describe('keyed', () => {
 
-	it('getPlugins should return copy of the array for each consumer', () => {
-		const plugins1 = getPlugins('test-plugins');
-		const plugins2 = getPlugins('test-plugins');
-		expect(plugins1).not.to.equal(plugins2);
-	});
+		beforeEach(() => {
+			registerPlugin('test-plugins', { prop1: 'beer' }, { key: 'plugin1' });
+			registerPlugin('test-plugins', { prop1: 'donuts' }, { key: 'plugin2' });
+		});
 
-	it('getPlugins should return array of plugins in new sort order if additional plugins are registered', () => {
-		registerPlugin('test-plugins-sorted-add', { prop1: 'beer' }, { sort: 3 });
-		registerPlugin('test-plugins-sorted-add', { prop1: 'donuts' }, { sort: 1 });
+		it('getPlugin should return undefined for invalid plugin set key', () => {
+			const plugin = getPlugin('invalid-plugin-set-key', 'plugin1');
+			expect(plugin).to.equal(undefined);
+		});
 
-		let plugins = getPlugins('test-plugins-sorted-add');
-		expect(plugins.length).to.equal(2);
-		expect(plugins[0].prop1).to.equal('donuts');
-		expect(plugins[1].prop1).to.equal('beer');
+		it('getPlugin should return undefined for invalid plugin key', () => {
+			const plugin = getPlugin('test-plugins', 'pluginx');
+			expect(plugin).to.equal(undefined);
+		});
 
-		registerPlugin('test-plugins-sorted-add', { prop1: 'candy apple' }, { sort: 2 });
+		it('getPlugin should return plugin for specified keys', () => {
+			const plugin = getPlugin('test-plugins', 'plugin1');
+			expect(plugin.prop1).to.equal('beer');
+		});
 
-		plugins = getPlugins('test-plugins-sorted-add');
-		expect(plugins.length).to.equal(3);
-		expect(plugins[0].prop1).to.equal('donuts');
-		expect(plugins[1].prop1).to.equal('candy apple');
-		expect(plugins[2].prop1).to.equal('beer');
-	});
+		it('registerPlugin should not throw when adding a plugin with key not used within the set', () => {
+			expect(() => {
+				registerPlugin('test-plugins-other', { prop1: 'candy apple' }, { key: 'plugin1' });
+			}).to.not.throw();
+		});
 
-	it('getPlugin should return undefined for invalid plugin set key', () => {
-		const plugin = getPlugin('invalid-plugin-set-key', 'plugin1');
-		expect(plugin).to.equal(undefined);
-	});
+		it('registerPlugin should throw when adding a plugin with key already used within the set', () => {
+			expect(() => {
+				registerPlugin('test-plugins', { prop1: 'candy apple' }, { key: 'plugin1' });
+			}).to.throw();
+		});
 
-	it('getPlugin should return undefined for invalid plugin key', () => {
-		const plugin = getPlugin('test-plugins-keyed', 'pluginx');
-		expect(plugin).to.equal(undefined);
-	});
-
-	it('getPlugin should return plugin for specified keys', () => {
-		const plugin = getPlugin('test-plugins-keyed', 'plugin1');
-		expect(plugin.prop1).to.equal('beer');
 	});
 
 });

--- a/helpers/test/plugins.test.js
+++ b/helpers/test/plugins.test.js
@@ -1,0 +1,67 @@
+import { getPlugin, getPlugins, registerPlugin } from '../plugins.js';
+import { expect } from '@brightspace-ui/testing';
+
+describe('plugins', () => {
+
+	before(() => {
+		registerPlugin('test-plugins', { prop1: 'beer' });
+		registerPlugin('test-plugins', { prop1: 'donuts' });
+		registerPlugin('test-plugins-sorted', { prop1: 'beer' }, { sort: 2 });
+		registerPlugin('test-plugins-sorted', { prop1: 'donuts' }, { sort: 1 });
+		registerPlugin('test-plugins-keyed', { prop1: 'beer' }, { key: 'plugin1' });
+		registerPlugin('test-plugins-keyed', { prop1: 'donuts' }, { key: 'plugin2' });
+	});
+
+	it('getPlugins should return empty array for invalid plugin set key', () => {
+		const plugins = getPlugins('invalid-plugin-set-key');
+		expect(plugins.length).to.equal(0);
+	});
+
+	it('getPlugins should return array of plugins in registration order', () => {
+		const plugins = getPlugins('test-plugins');
+		expect(plugins.length).to.equal(2);
+		expect(plugins[0].prop1).to.equal('beer');
+		expect(plugins[1].prop1).to.equal('donuts');
+	});
+
+	it('getPlugins should return array of plugins in sort order', () => {
+		const plugins = getPlugins('test-plugins-sorted');
+		expect(plugins.length).to.equal(2);
+		expect(plugins[0].prop1).to.equal('donuts');
+		expect(plugins[1].prop1).to.equal('beer');
+	});
+
+	it('getPlugins should return array of plugins in new sort order if additional plugins are registered', () => {
+		registerPlugin('test-plugins-sorted-add', { prop1: 'beer' }, { sort: 3 });
+		registerPlugin('test-plugins-sorted-add', { prop1: 'donuts' }, { sort: 1 });
+
+		let plugins = getPlugins('test-plugins-sorted-add');
+		expect(plugins.length).to.equal(2);
+		expect(plugins[0].prop1).to.equal('donuts');
+		expect(plugins[1].prop1).to.equal('beer');
+
+		registerPlugin('test-plugins-sorted-add', { prop1: 'candy apple' }, { sort: 2 });
+
+		plugins = getPlugins('test-plugins-sorted-add');
+		expect(plugins.length).to.equal(3);
+		expect(plugins[0].prop1).to.equal('donuts');
+		expect(plugins[1].prop1).to.equal('candy apple');
+		expect(plugins[2].prop1).to.equal('beer');
+	});
+
+	it('getPlugin should return undefined for invalid plugin set key', () => {
+		const plugin = getPlugin('invalid-plugin-set-key', 'plugin1');
+		expect(plugin).to.equal(undefined);
+	});
+
+	it('getPlugin should return undefined for invalid plugin key', () => {
+		const plugin = getPlugin('test-plugins-keyed', 'pluginx');
+		expect(plugin).to.equal(undefined);
+	});
+
+	it('getPlugin should return plugin for specified keys', () => {
+		const plugin = getPlugin('test-plugins-keyed', 'plugin1');
+		expect(plugin.prop1).to.equal('beer');
+	});
+
+});

--- a/helpers/test/plugins.test.js
+++ b/helpers/test/plugins.test.js
@@ -31,6 +31,12 @@ describe('plugins', () => {
 		expect(plugins[1].prop1).to.equal('beer');
 	});
 
+	it('getPlugins should return copy of the array for each consumer', () => {
+		const plugins1 = getPlugins('test-plugins');
+		const plugins2 = getPlugins('test-plugins');
+		expect(plugins1).not.to.equal(plugins2);
+	});
+
 	it('getPlugins should return array of plugins in new sort order if additional plugins are registered', () => {
 		registerPlugin('test-plugins-sorted-add', { prop1: 'beer' }, { sort: 3 });
 		registerPlugin('test-plugins-sorted-add', { prop1: 'donuts' }, { sort: 1 });

--- a/helpers/test/plugins.test.js
+++ b/helpers/test/plugins.test.js
@@ -1,4 +1,4 @@
-import { getPlugin, getPlugins, registerPlugin, resetPlugins } from '../plugins.js';
+import { getPlugins, registerPlugin, resetPlugins, tryGetPluginByKey } from '../plugins.js';
 import { expect } from '@brightspace-ui/testing';
 
 describe('plugins', () => {
@@ -73,17 +73,17 @@ describe('plugins', () => {
 		});
 
 		it('getPlugin should return undefined for invalid plugin set key', () => {
-			const plugin = getPlugin('invalid-plugin-set-key', 'plugin1');
-			expect(plugin).to.not.be.defined;
+			const plugin = tryGetPluginByKey('invalid-plugin-set-key', 'plugin1');
+			expect(plugin).to.be.null;
 		});
 
 		it('getPlugin should return undefined for invalid plugin key', () => {
-			const plugin = getPlugin('test-plugins', 'pluginx');
-			expect(plugin).to.equal(undefined);
+			const plugin = tryGetPluginByKey('test-plugins', 'pluginx');
+			expect(plugin).to.be.null;
 		});
 
 		it('getPlugin should return plugin for specified keys', () => {
-			const plugin = getPlugin('test-plugins', 'plugin1');
+			const plugin = tryGetPluginByKey('test-plugins', 'plugin1');
 			expect(plugin.prop1).to.equal('beer');
 		});
 

--- a/helpers/test/plugins.test.js
+++ b/helpers/test/plugins.test.js
@@ -32,6 +32,20 @@ describe('plugins', () => {
 			expect(plugins1).not.to.equal(plugins2);
 		});
 
+		it('registerPlugin should throw when called after a consumer has called getPlugins for the same Set key', () => {
+			getPlugins('test-plugins');
+			expect(() => {
+				registerPlugin('test-plugins', { prop1: 'candy apple' });
+			}).to.throw();
+		});
+
+		it('registerPlugin should not throw when called after a consumer has called getPlugins for a different Set key', () => {
+			getPlugins('test-plugins');
+			expect(() => {
+				registerPlugin('test-plugins-other', { prop1: 'candy apple' });
+			}).to.not.throw();
+		});
+
 	});
 
 	describe('sorted', () => {
@@ -46,21 +60,6 @@ describe('plugins', () => {
 			expect(plugins.length).to.equal(2);
 			expect(plugins[0].prop1).to.equal('donuts');
 			expect(plugins[1].prop1).to.equal('beer');
-		});
-
-		it('getPlugins should return array of plugins in new sort order if additional plugins are registered', () => {
-			let plugins = getPlugins('test-plugins');
-			expect(plugins.length).to.equal(2);
-			expect(plugins[0].prop1).to.equal('donuts');
-			expect(plugins[1].prop1).to.equal('beer');
-
-			registerPlugin('test-plugins', { prop1: 'candy apple' }, { sort: 2 });
-
-			plugins = getPlugins('test-plugins');
-			expect(plugins.length).to.equal(3);
-			expect(plugins[0].prop1).to.equal('donuts');
-			expect(plugins[1].prop1).to.equal('candy apple');
-			expect(plugins[2].prop1).to.equal('beer');
 		});
 
 	});

--- a/helpers/test/plugins.test.js
+++ b/helpers/test/plugins.test.js
@@ -74,7 +74,7 @@ describe('plugins', () => {
 
 		it('getPlugin should return undefined for invalid plugin set key', () => {
 			const plugin = getPlugin('invalid-plugin-set-key', 'plugin1');
-			expect(plugin).to.equal(undefined);
+			expect(plugin).to.not.be.defined;
 		});
 
 		it('getPlugin should return undefined for invalid plugin key', () => {


### PR DESCRIPTION
[US160427](https://rally1.rallydev.com/#/?detail=/userstory/731548187981&fdp=true)

This PR adds plugins helpers - `registerPlugin`, `getPlugins`, and `getPlugin` to enable implementors to define plugins without consumers of those plugins being required to import them directly. BSI or a higher level module is responsible for importing the registrations.

Other options were considered, including deferring the registrations or by accepting an async provider method for the plugin, however we do not want plugin implementors assuming that if the registration is deferred, that it would be safe to synchronously import dependencies within the registration module. Typically, we expect projects registrations to be aggregated into a single public export, which means that unrelated plugins could be registered (and synchronous imports loaded) as soon as the registration module is requested. The implementor mindset should be geared towards deferring its dependencies until needed, as shown in the readme.

Required for: https://github.com/BrightspaceUI/lms-core/pull/61