### PR TITLE
[ignore for now] Filter: Overflow group: Fix change event not firing

### DIFF
--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -701,7 +701,7 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 					dimension.appliedCount--;
 					this._totalAppliedCount--;
 				}
-				this._activeFiltersSubscribers.updateSubscribers();
+				this._dispatchChangeEvent(dimension, { valueKey: e.detail.valueKey, selected: newValue });
 			} else if (prop === 'values') {
 				if (dimension.searchValue || dimension.searchType === 'manual') shouldSearch = true;
 				shouldRecount = true;


### PR DESCRIPTION
[Rally Story](https://rally1.rallydev.com/#/15545167705ud/custom/21568985922?detail=%2Fdefect%2F732021201387)

The issue is that when chomped the filters are [kept up to date through the dimension sets](https://github.com/BrightspaceUI/core/blob/main/components/filter/filter-overflow-group.js#L98), which does not trigger a `d2l-filter-change` event on the original filter. I've added dispatching the change event to the `_handleDimensionDataChange` function which is the handler for `d2l-filter-dimension-data-change` events. This is likely the simplest way to fix this, but I don't know if there are side affects that I'm ignoring with this or if there is a reason this was not done initially (other than perhaps it just wasn't necessary).

This does not handle having `cleared` or `allCleared` be accurate in the results, but the event is triggered and the other data within it seems accurate.

`this._activeFiltersSubscribers.updateSubscribers();` happens in `_dispatchChangeEvent` so I removed it.