### PR TITLE
list: attempt to fix flaky unit test

### DIFF
--- a/components/list/list.js
+++ b/components/list/list.js
@@ -172,7 +172,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 						detail: this._listItemChanges
 					}));
 					this._listItemChanges = [];
-				}, 30);
+				}, 60);
 			}
 			this._listItemChanges.push(e.detail);
 


### PR DESCRIPTION
The list tests that involve batching are flaking, mostly (maybe only) on Safari and Firefox.

For the test that I'm seeing flake most often, it's expecting the batch of events to contain 3 events but more often it's 2 and sometimes 1. The biggest source of causing 2 events instead of 3 is that [this event](https://github.com/BrightspaceUI/core/blob/main/components/list/list-item-checkbox-mixin.js#L108) is firing too late and though it happens, the `d2l-list-selection-changes` event will have already fired without it.

To me, this isn't necessarily wrong behaviour just not ideal. I've increase the `setTimeout` time that we wait before triggering the batch event. Let me know if the `30` was an important value. I've also got changes to the test working where we wait for selection to have been included in a `d2l-list-selection-changes` event depending on how many events are in, but that code is super verbose.

I'll run this a bunch of times to see if this change helps here.