### PR TITLE
fix: US160944: Date and Time Ranges: Fix bug where wrapping does not work correctly when component is direct child of custom element

### DIFF
--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -163,8 +163,7 @@ class InputDateRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 		if (!this.label) {
 			console.warn('d2l-input-date-range component requires label text');
 		}
-
-		this.shadowRoot.querySelector('d2l-input-date-time-range-to').setParentNode(this.parentNode);
+		this.shadowRoot.querySelector('d2l-input-date-time-range-to').setParentNode(this);
 	}
 
 	render() {

--- a/components/inputs/input-date-time-range-to.js
+++ b/components/inputs/input-date-time-range-to.js
@@ -2,6 +2,7 @@ import './input-text.js';
 import { css, html, LitElement } from 'lit';
 import { bodySmallStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { getOffsetParent } from '../../helpers/dom.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
@@ -157,7 +158,7 @@ class InputDateTimeRangeTo extends SkeletonMixin(LocalizeCoreElement(LitElement)
 	}
 
 	setParentNode(node) {
-		this._parentNode = node;
+		this._parentNode = node.parentNode instanceof ShadowRoot ? getOffsetParent(node) : node.parentNode;
 	}
 
 	_disconnectObservers() {

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -210,7 +210,7 @@ class InputDateTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMi
 			console.warn('d2l-input-date-time-range component requires label text');
 		}
 
-		this.shadowRoot.querySelector('d2l-input-date-time-range-to').setParentNode(this.parentNode);
+		this.shadowRoot.querySelector('d2l-input-date-time-range-to').setParentNode(this);
 	}
 
 	render() {

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -208,7 +208,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 		}
 		this._initialValues = false;
 
-		this.shadowRoot.querySelector('d2l-input-date-time-range-to').setParentNode(this.parentNode);
+		this.shadowRoot.querySelector('d2l-input-date-time-range-to').setParentNode(this);
 	}
 
 	render() {

--- a/components/inputs/test/input-date-range.vdiff.js
+++ b/components/inputs/test/input-date-range.vdiff.js
@@ -1,7 +1,8 @@
 import '../input-date-range.js';
-import { expect, fixture, focusElem, html, nextFrame, oneEvent, sendKeys, sendKeysElem } from '@brightspace-ui/testing';
+import { defineCE, expect, fixture, focusElem, html, nextFrame, oneEvent, sendKeys, sendKeysElem } from '@brightspace-ui/testing';
 import { reset, useFakeTimers } from 'sinon';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { LitElement } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
 const create = (opts = {}) => {
@@ -69,6 +70,14 @@ const minMaxFixture = create({ maxValue: '2022-01-01', minValue: '2019-01-01' })
 const requiredFixture = create({ labelHidden: false, required: true });
 
 const newToday = new Date('2018-02-12T12:00Z');
+
+const tag = defineCE(
+	class extends LitElement {
+		render() {
+			return html`<d2l-input-date-range class="vdiff-target" child-labels-hidden label="Custom Range"></d2l-input-date-range>`;
+		}
+	}
+);
 
 describe('d2l-input-date-range', () => {
 
@@ -317,6 +326,17 @@ describe('d2l-input-date-range', () => {
 			const elem = await fixture(hiddenLabelsFixture);
 			elem.style.maxWidth = '250px';
 			await nextFrame();
+			await expect(elem).to.be.golden();
+		});
+	});
+
+	describe('within custom elem', () => {
+		it('is correct at default width', async() => {
+			const elem = await fixture(`<${tag}></${tag}>`);
+			await expect(elem).to.be.golden();
+		});
+		it('is correct at small width', async() => {
+			const elem = await fixture(`<${tag}></${tag}>`, { viewport: { width: 350 } });
 			await expect(elem).to.be.golden();
 		});
 	});

--- a/components/inputs/test/input-date-time-range.vdiff.js
+++ b/components/inputs/test/input-date-time-range.vdiff.js
@@ -1,8 +1,8 @@
 import '../input-date-time-range.js';
-import { expect, fixture, focusElem, html, nextFrame, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
+import { defineCE, expect, fixture, focusElem, html, nextFrame, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
+import { LitElement, nothing } from 'lit';
 import { reset, useFakeTimers } from 'sinon';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { nothing } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
 const create = (opts = {}) => {
@@ -78,6 +78,14 @@ const minMaxFixture = create({ labelHidden: false, maxValue: '2018-09-30T12:30:0
 const wideHiddenLabelsValuesFixture = create({ childLabelsHidden: true, endLabel: 'Finish', endValue: '2021-12-04T10:30:00.000Z', labelHidden: false, startLabel: 'Start', startValue: '2020-12-02T06:00:00.000Z', width: 800 });
 
 const newToday = new Date('2018-02-12T12:00Z');
+
+const tag = defineCE(
+	class extends LitElement {
+		render() {
+			return html`<d2l-input-date-time-range class="vdiff-target" child-labels-hidden label="Custom Range"></d2l-input-date-time-range>`;
+		}
+	}
+);
 
 describe('d2l-input-date-time-range', () => {
 
@@ -369,6 +377,17 @@ describe('d2l-input-date-time-range', () => {
 			const elem = wrapper.querySelector('d2l-input-date-time-range');
 			wrapper.style.width = '250px';
 			await nextFrame();
+			await expect(elem).to.be.golden();
+		});
+	});
+
+	describe('within custom elem', () => {
+		it('is correct at default width', async() => {
+			const elem = await fixture(`<${tag}></${tag}>`);
+			await expect(elem).to.be.golden();
+		});
+		it('is correct at small width', async() => {
+			const elem = await fixture(`<${tag}></${tag}>`, { viewport: { width: 350 } });
 			await expect(elem).to.be.golden();
 		});
 	});

--- a/components/inputs/test/input-time-range.vdiff.js
+++ b/components/inputs/test/input-time-range.vdiff.js
@@ -1,7 +1,8 @@
 import '../input-time-range.js';
-import { expect, fixture, focusElem, html, nextFrame, oneEvent, sendKeys, sendKeysElem } from '@brightspace-ui/testing';
+import { defineCE, expect, fixture, focusElem, html, nextFrame, oneEvent, sendKeys, sendKeysElem } from '@brightspace-ui/testing';
 import { reset, useFakeTimers } from 'sinon';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { LitElement } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
 const create = (opts = {}) => {
@@ -72,6 +73,14 @@ const createHiddenLabels = (opts = {}) => {
 
 const newToday = new Date('2018-07-12T09:33Z');
 const viewport = { width: 476, height: 2300 };
+
+const tag = defineCE(
+	class extends LitElement {
+		render() {
+			return html`<d2l-input-time-range class="vdiff-target" child-labels-hidden label="Custom Range"></d2l-input-time-range>`;
+		}
+	}
+);
 
 describe('d2l-input-time-range', () => {
 
@@ -207,6 +216,17 @@ describe('d2l-input-time-range', () => {
 			const elem = await fixture(createHiddenLabels(), { viewport });
 			elem.style.maxWidth = '240px';
 			await nextFrame();
+			await expect(elem).to.be.golden();
+		});
+	});
+
+	describe('within custom elem', () => {
+		it('is correct at default width', async() => {
+			const elem = await fixture(`<${tag}></${tag}>`);
+			await expect(elem).to.be.golden();
+		});
+		it('is correct at small width', async() => {
+			const elem = await fixture(`<${tag}></${tag}>`, { viewport: { width: 250 } });
 			await expect(elem).to.be.golden();
 		});
 	});


### PR DESCRIPTION
[Rally](https://rally1.rallydev.com/#/15545167705ud/custom/21568985922?detail=%2Fuserstory%2F732652754923)

This was triggering a console error due to the fact that if the date/time range component was the first child in a custom element, `this.parentNode` would return `ShadowRoot` which would then throw in the resize observer.

This only happens when the date/time range component is the first child and would likely only be an issue in the UI if `child-labels-hidden` is true.

I'm seeing if I can get unit tests working to just confirm that the error throwing is no longer happening. The visual diff tests do capture this though, as the tests fail if the error happens.