### PR TITLE
Fix lint errors for upcoming changes

### DIFF
--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -19,6 +19,7 @@ export const ButtonMixin = superclass => class extends FocusMixin(superclass) {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			autofocus: { type: Boolean, reflect: true },
 			/**
 			 * Disables the button

--- a/components/button/button-move.js
+++ b/components/button/button-move.js
@@ -40,6 +40,7 @@ class ButtonMove extends ThemeMixin(FocusMixin(RtlMixin(LitElement))) {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			autofocus: { type: Boolean, reflect: true },
 			/**
 			 * A description to be added to the button for accessibility when text on button does not provide enough context

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -1,7 +1,7 @@
 import '../button/button-icon.js';
 import '../colors/colors.js';
 import { bodySmallStyles, heading4Styles } from '../typography/styles.js';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { formatDate, getDateTimeDescriptor } from '@brightspace-ui/intl/lib/dateTime.js';
 import { formatDateInISO, getClosestValidDate, getDateFromDateObj, getDateFromISODate, getToday, isDateInRange } from '../../helpers/dateTime.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -436,7 +436,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 
 	render() {
 		if (this._shownMonth === undefined || !this._shownYear) {
-			return html``;
+			return nothing;
 		}
 
 		const weekdayHeaders = calendarData.daysOfWeekIndex.map((index) => html`

--- a/components/form/form-errory-summary.js
+++ b/components/form/form-errory-summary.js
@@ -1,6 +1,6 @@
 import '../alert/alert.js';
 import '../expand-collapse/expand-collapse-content.js';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { linkStyles } from '../link/link.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
@@ -88,7 +88,7 @@ class FormErrorSummary extends LocalizeCoreElement(RtlMixin(LitElement)) {
 				</d2l-expand-collapse-content>
 			</d2l-alert>
 		`;
-		return this.errors.length > 0 ? errorSummary : html``;
+		return this.errors.length > 0 ? errorSummary : nothing;
 	}
 
 	async focus() {

--- a/components/inputs/demo/input-number.html
+++ b/components/inputs/demo/input-number.html
@@ -22,7 +22,7 @@
 			<h2>Hidden Label</h2>
 			<d2l-demo-snippet>
 				<template>
-					<d2l-input-number label="Age" label-hidden title="title"></d2l-input-number>
+					<d2l-input-number label="Age" label-hidden></d2l-input-number>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/inputs/demo/input-percent.html
+++ b/components/inputs/demo/input-percent.html
@@ -22,7 +22,7 @@
 			<h2>Hidden Label</h2>
 			<d2l-demo-snippet>
 				<template>
-					<d2l-input-percent label="Grade" label-hidden title="title"></d2l-input-percent>
+					<d2l-input-percent label="Grade" label-hidden></d2l-input-percent>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/inputs/docs/input-numeric.md
+++ b/components/inputs/docs/input-numeric.md
@@ -56,7 +56,6 @@ The `<d2l-input-number>` element is similar to `<d2l-input-text>`, except it's i
 | `min-fraction-digits` | Number, default: `0` | Minimum number of digits allowed after the decimal place. Must be between 0 and 20 and less than or equal to `maxFractionDigits` |
 | `placeholder` | String | Placeholder text. |
 | `required` | Boolean, default: `false` | Indicates that a value is required. |
-| `title` | String | Text for additional screen reader and mouseover context. |
 | `unit` | String | Unit associated with the input value, displayed next to input and announced as part of the label |
 | `value` | Number | Value of the input. |
 
@@ -82,7 +81,6 @@ To make your usage of `d2l-input-number` accessible, use the following propertie
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users. |
 | `labelled-by` | Use when another visible element should act as the label |
 | `unit` | Use to render the unit (offscreen) as part of the label. |
-| `title` | Use for additional screen reader and mouseover context. |
 
 ### Usage
 
@@ -128,7 +126,6 @@ The `<d2l-input-percent>` element is similar to `<d2l-input-number>`, except it 
 | `min-fraction-digits` | Number | Minimum number of digits allowed after the decimal place. |
 | `placeholder` | String | Placeholder text. |
 | `required` | Boolean, default: `false` | Indicates that a value is required. |
-| `title` | String | Text for additional screen reader and mouseover context. |
 | `value` | Number | Value of the input. |
 
 ### Events
@@ -151,4 +148,3 @@ To make your usage of `d2l-input-percent` accessible, use the following properti
 |---|---|
 | `label` | **REQUIRED.** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users. |
-| `title` | Use for additional screen reader and mouseover context. |

--- a/components/inputs/docs/input-text.md
+++ b/components/inputs/docs/input-text.md
@@ -96,7 +96,6 @@ The `<d2l-input-text>` element is a simple wrapper around the native `<input typ
 | `required` | Boolean | Indicates that a value is required |
 | `size` | Number | Size of the input |
 | `step` | String | For number inputs, sets the step size |
-| `title` | String | Text for additional screenreader and mouseover context |
 | `type` | String, default: `text` | Can be one of `text`, `email`, `password`, `tel`, `url`. Type `number` is deprecated, use [d2l-input-number](./input-number.md) instead. |
 | `unit` | String | Unit associated with the input value, displayed next to input and announced as part of the label |
 | `value` | String, default: `''` | Value of the input |
@@ -137,7 +136,6 @@ To make your usage of `d2l-input-text` accessible, use the following properties 
 | `label-hidden` | Use if label should be visually hidden but available for screen reader users |
 | `labelled-by` | Use when another visible element should act as the label |
 | `unit` | Use to render the unit (offscreen) as part of the label. |
-| `title` | Text for additional screen reader and mouseover context |
 
 ## Applying styles to native text input
 

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -85,9 +85,9 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 			 */
 			autocomplete: { type: String },
 			/**
-			 * ADVANCED: When set, will automatically place focus on the input
-			 * @type {boolean}
+			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			autofocus: { type: Boolean },
 			/**
 			 * Disables the input
@@ -149,11 +149,6 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 			 * @type {boolean}
 			 */
 			required: { type: Boolean },
-			/**
-			 * Text for additional screen reader and mouseover context
-			 * @type {string}
-			 */
-			title: { type: String },
 			/**
 			 * @ignore
 			 */
@@ -361,7 +356,6 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 				placeholder="${ifDefined(this.placeholder)}"
 				?required="${this.required}"
 				?skeleton="${this.skeleton}"
-				title="${ifDefined(this.title)}"
 				unit="${ifDefined(this.unit)}"
 				unit-label="${ifDefined(this.unitLabel)}"
 				.value="${this._formattedValue}"

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -18,9 +18,9 @@ class InputPercent extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMix
 	static get properties() {
 		return {
 			/**
-			 * When set, will automatically place focus on the input
-			 * @type {boolean}
+			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			autofocus: { type: Boolean },
 			/**
 			 * Disables the input
@@ -57,11 +57,6 @@ class InputPercent extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMix
 			 * @type {boolean}
 			 */
 			required: { type: Boolean },
-			/**
-			 * Text for additional screenreader and mouseover context
-			 * @type {string}
-			 */
-			title: { type: String },
 			/**
 			 * Value of the input
 			 * @type {number}
@@ -128,7 +123,6 @@ class InputPercent extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMix
 				placeholder="${ifDefined(this.placeholder)}"
 				?required="${this.required}"
 				?skeleton="${this.skeleton}"
-				title="${ifDefined(this.title)}"
 				unit="%"
 				value="${ifDefined(this.value)}"
 				value-align="end">

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -45,9 +45,9 @@ class InputText extends PropertyRequiredMixin(FocusMixin(LabelledMixin(FormEleme
 			 */
 			autocomplete: { type: String },
 			/**
-			 * When set, will automatically place focus on the input
-			 * @type {boolean}
+			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			autofocus: { type: Boolean },
 			/**
 			 * Additional information communicated in the aria-describedby on the input
@@ -135,9 +135,9 @@ class InputText extends PropertyRequiredMixin(FocusMixin(LabelledMixin(FormEleme
 			 */
 			step: { type: String },
 			/**
-			 * Text for additional screenreader and mouseover context
-			 * @type {string}
+			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			title: { type: String },
 			/**
 			 * The type of the text input

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -95,7 +95,7 @@ describe('d2l-input-number', () => {
 			});
 		});
 
-		['autocomplete', 'max', 'min', 'placeholder', 'title', 'value'].forEach((name) => {
+		['autocomplete', 'max', 'min', 'placeholder', 'value'].forEach((name) => {
 			it(`should default "${name}" property to 'undefined' when unset`, async() => {
 				expect(elem[name]).to.equal(undefined);
 			});

--- a/components/list/demo/demo-list-nested-iterations-helper.js
+++ b/components/list/demo/demo-list-nested-iterations-helper.js
@@ -8,7 +8,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 class ListNestedIterationsHelper extends LitElement {
 	static get properties() {
 		return {
-			draggable: { type: Boolean }
+			isDraggable: { attribute: 'is-draggable', type: Boolean }
 		};
 	}
 
@@ -55,7 +55,7 @@ class ListNestedIterationsHelper extends LitElement {
 
 	constructor() {
 		super();
-		this.draggable = false;
+		this.isDraggable = false;
 	}
 
 	render() {
@@ -130,11 +130,11 @@ class ListNestedIterationsHelper extends LitElement {
 		for (let i = 0; i < 3; i++) {
 			const childKey = `child-${i}-${childOptions[0]}-${childOptions[1]}`;
 			items.push(html`
-				<d2l-list-item key="${childKey}" label="${childL2Text}" ?selectable="${!!childOptions[0]}" ?draggable="${this.draggable}" ?expandable="${childOptions[1] && i !== 1}" color="${ifDefined((childOptions[2] && i === 0) || childOptions[3] ? '#ff0000' : undefined)}">
+				<d2l-list-item key="${childKey}" label="${childL2Text}" ?selectable="${!!childOptions[0]}" ?draggable="${this.isDraggable}" ?expandable="${childOptions[1] && i !== 1}" color="${ifDefined((childOptions[2] && i === 0) || childOptions[3] ? '#ff0000' : undefined)}">
 					<d2l-list-item-content>${childL2Text}</d2l-list-item-content>
 					${i === 1 || !childOptions[1] ? nothing : html`
 						<d2l-list slot="nested">
-							<d2l-list-item key="${`${childKey}-child`}" label="${childL3Text}" ?selectable="${!!childOptions[0]}" ?draggable="${this.draggable}" color="${ifDefined(childOptions[3] ? '#00ff00' : undefined)}">
+							<d2l-list-item key="${`${childKey}-child`}" label="${childL3Text}" ?selectable="${!!childOptions[0]}" ?draggable="${this.isDraggable}" color="${ifDefined(childOptions[3] ? '#00ff00' : undefined)}">
 								<d2l-list-item-content>${childL3Text}</d2l-list-item-content>
 							</d2l-list-item>
 						</d2l-list>
@@ -152,7 +152,7 @@ class ListNestedIterationsHelper extends LitElement {
 		for (let i = 0; i < 3; i++) {
 			const parentKey = `parent-${i}-${parentOptions[0]}-${parentOptions[1]}`;
 			items.push(html`
-				<d2l-list-item key="${parentKey}" label="${parentText}" ?selectable="${!!parentOptions[0]}" ?draggable="${this.draggable}" ?expandable="${parentOptions[1] && i !== 1}" ?expanded="${parentOptions[1] && i === 0}" color="${ifDefined((parentOptions[2] && i === 0) || parentOptions[3] ? '#ff0000' : undefined)}">
+				<d2l-list-item key="${parentKey}" label="${parentText}" ?selectable="${!!parentOptions[0]}" ?draggable="${this.isDraggable}" ?expandable="${parentOptions[1] && i !== 1}" ?expanded="${parentOptions[1] && i === 0}" color="${ifDefined((parentOptions[2] && i === 0) || parentOptions[3] ? '#ff0000' : undefined)}">
 					<d2l-list-item-content>${parentText}</d2l-list-item-content>
 					${i === 1 || (i === 2 && !parentOptions[1]) ? nothing : html`
 						<d2l-list slot="nested">${nested}</d2l-list>

--- a/components/list/demo/demo-list-nested.js
+++ b/components/list/demo/demo-list-nested.js
@@ -20,7 +20,7 @@ class ListDemoNested extends LitElement {
 	static get properties() {
 		return {
 			demoItemKey: { type: String, attribute: 'demo-item-key' },
-			draggable: { type: Boolean },
+			isDraggable: { attribute: 'is-draggable', type: Boolean },
 			selectable: { type: Boolean },
 			disableExpandFeature: { type: Boolean, attribute: 'disable-expand-feature' },
 			expanded: { type: Boolean },
@@ -197,7 +197,7 @@ class ListDemoNested extends LitElement {
 		return html`
 			<d2l-list-item
 				action-href="${this.includeActionHref ? 'http://www.d2l.com' : ''}"
-				?draggable="${this.draggable}"
+				?draggable="${this.isDraggable}"
 				drag-handle-text="${item.primaryText}"
 				?drop-nested="${item.dropNested}"
 				key="${item.key}"
@@ -221,7 +221,7 @@ class ListDemoNested extends LitElement {
 		const hasChildren = item?.items?.length > 0;
 		return html`
 			<d2l-list-item-button
-				?draggable="${this.draggable}"
+				?draggable="${this.isDraggable}"
 				drag-handle-text="${item.primaryText}"
 				?drop-nested="${item.dropNested}"
 				key="${item.key}"

--- a/components/list/demo/list-drag-and-drop.html
+++ b/components/list/demo/list-drag-and-drop.html
@@ -26,7 +26,7 @@
 
 		<d2l-demo-snippet>
 			<template>
-				<d2l-demo-list-nested demo-item-key="imgPrimaryAndSupporting" draggable selectable disable-expand-feature></d2l-demo-list-nested>
+				<d2l-demo-list-nested demo-item-key="imgPrimaryAndSupporting" is-draggable selectable disable-expand-feature></d2l-demo-list-nested>
 			</template>
 		</d2l-demo-snippet>
 

--- a/components/list/demo/list-expand-collapse.html
+++ b/components/list/demo/list-expand-collapse.html
@@ -18,7 +18,7 @@
 			<template>
 				<d2l-demo-list-nested
 					demo-item-key="imgPrimaryAndSupporting"
-					draggable
+					is-draggable
 					selectable
 					expandable
 					expanded
@@ -30,13 +30,13 @@
 
 		<d2l-demo-snippet>
 			<template>
-				<d2l-demo-list-nested demo-item-key="primaryAndSupportingText" draggable selectable expandable></d2l-demo-list-nested>
+				<d2l-demo-list-nested demo-item-key="primaryAndSupportingText" is-draggable selectable expandable></d2l-demo-list-nested>
 			</template>
 		</d2l-demo-snippet>
 
 		<d2l-demo-snippet>
 			<template>
-				<d2l-demo-list-nested demo-item-key="primaryTextOnly" draggable selectable expandable></d2l-demo-list-nested>
+				<d2l-demo-list-nested demo-item-key="primaryTextOnly" is-draggable selectable expandable></d2l-demo-list-nested>
 			</template>
 		</d2l-demo-snippet>
 
@@ -45,7 +45,7 @@
 			<template>
 				<d2l-demo-list-nested
 					demo-item-key="imgPrimaryAndSupporting"
-					draggable
+					is-draggable
 					selectable
 					expandable
 					expanded
@@ -65,7 +65,7 @@
 		<h2>Draggable</h2>
 		<d2l-demo-snippet>
 			<template>
-				<d2l-demo-list-nested demo-item-key="primaryAndSupportingText" draggable expandable></d2l-demo-list-nested>
+				<d2l-demo-list-nested demo-item-key="primaryAndSupportingText" is-draggable expandable></d2l-demo-list-nested>
 			</template>
 		</d2l-demo-snippet>
 
@@ -81,7 +81,7 @@
 			<template>
 				<d2l-demo-list-nested
 					demo-item-key="imgPrimaryAndSupporting"
-					draggable
+					is-draggable
 					selectable
 					expandable
 					include-secondary-actions
@@ -109,7 +109,7 @@
 			<template>
 				<d2l-demo-list-nested
 					demo-item-key="imgPrimaryAndSupporting"
-					draggable
+					is-draggable
 					selectable
 					expandable
 					no-primary-action></d2l-demo-list-nested>

--- a/components/list/demo/list-nested.html
+++ b/components/list/demo/list-nested.html
@@ -258,7 +258,7 @@
 					} else {
 						draggableSwitch.addEventListener('change', (e) => {
 							const listIterations = document.querySelector('d2l-demo-list-nested-iterations-helper');
-							listIterations.draggable = e.target.on;
+							listIterations.isDraggable = e.target.on;
 						});
 					}
 				};

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -254,6 +254,7 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 			 * **Drag & drop:** Whether the item is draggable
 			 * @type {boolean}
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			draggable: { type: Boolean, reflect: true },
 			/**
 			 * @ignore

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -47,6 +47,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			role: { type: String, reflect: true },
 			/**
 			 * Specifies whether the grid is active or not

--- a/components/list/list-item-role-mixin.js
+++ b/components/list/list-item-role-mixin.js
@@ -7,6 +7,7 @@ export const ListItemRoleMixin = superclass => class extends superclass {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			role: { type: String, reflect: true },
 			_nested: { type: Boolean, reflect: true },
 			_separators: { type: String, reflect: true }

--- a/components/list/test/list.vdiff.js
+++ b/components/list/test/list.vdiff.js
@@ -728,7 +728,7 @@ describe('list-nested', () => {
 			{ name: 'all-iterations-draggable-force-show', draggable: true, media: 'print' }
 		].forEach(({ name, draggable, media }) => {
 			it(`${name}${rtl ? '-rtl' : ''}`, async() => {
-				const elem = await fixture(html`<d2l-demo-list-nested-iterations-helper ?draggable="${draggable}"></d2l-demo-list-nested-iterations-helper>`,
+				const elem = await fixture(html`<d2l-demo-list-nested-iterations-helper ?is-draggable="${draggable}"></d2l-demo-list-nested-iterations-helper>`,
 					{ media, rtl, viewport: { width: 1300, height: 7000 } }
 				);
 				await nextFrame();

--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -18,6 +18,7 @@ export const MenuItemMixin = superclass => class extends superclass {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			hidden: { type: Boolean, reflect: true },
 			/**
 			 * @ignore
@@ -26,10 +27,12 @@ export const MenuItemMixin = superclass => class extends superclass {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			role: { type: String, reflect: true },
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			tabindex: { type: String, reflect: true },
 			/**
 			 * REQUIRED: Text displayed by the menu item

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -36,6 +36,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			role: { type: String, attribute: 'role' }
 		};
 	}

--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { bodySmallStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { MeterMixin } from './meter-mixin.js';
@@ -121,7 +121,7 @@ class MeterLinear extends MeterMixin(RtlMixin(LitElement)) {
 			'd2l-meter-linear-primary-ltr': !this.percent,
 			'd2l-meter-linear-primary': true
 		};
-		const secondaryTextElement = secondary ? html`<div class="d2l-meter-linear-secondary">${secondary}</div>` : html``;
+		const secondaryTextElement = secondary ? html`<div class="d2l-meter-linear-secondary">${secondary}</div>` : nothing;
 
 		return html `
 			<div

--- a/components/meter/meter-radial.js
+++ b/components/meter/meter-radial.js
@@ -1,6 +1,6 @@
 import '../colors/colors.js';
 import { bodySmallStyles, heading4Styles } from '../typography/styles.js';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { MeterMixin } from './meter-mixin.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
@@ -61,7 +61,7 @@ class MeterRadial extends MeterMixin(RtlMixin(LitElement)) {
 		const progressFill = percent * lengthOfLine;
 		const primary = this._primary(this.value, this.max);
 		const secondary = this._secondary(this.value, this.max, this.text);
-		const secondaryTextElement = this.text ? html`<div class="d2l-body-small d2l-meter-radial-text">${secondary}</div>` : html``;
+		const secondaryTextElement = this.text ? html`<div class="d2l-body-small d2l-meter-radial-text">${secondary}</div>` : nothing;
 		const textClasses = {
 			'd2l-meter-radial-text-ltr': !this.percent,
 			'd2l-heading-4': true,

--- a/components/object-property-list/object-property-list-item.js
+++ b/components/object-property-list/object-property-list-item.js
@@ -14,6 +14,7 @@ export class ObjectPropertyListItem extends SkeletonMixin(LitElement) {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			hidden: { type: Boolean },
 			/**
 			 * Name of an optional icon to display

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -16,6 +16,7 @@ class Tab extends SkeletonMixin(RtlMixin(LitElement)) {
 		return {
 			ariaSelected: { type: String, reflect: true, attribute: 'aria-selected' },
 			controlsPanel: { type: String, reflect: true, attribute: 'controls-panel' },
+			// eslint-disable-next-line lit/no-native-attributes
 			role: { type: String, reflect: true },
 			text: { type: String }
 		};

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -13,6 +13,7 @@ export const TabPanelMixin = superclass => class extends superclass {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			role: { type: String, reflect: true },
 			/**
 			 * Use to select the tab

--- a/mixins/rtl/rtl-mixin.js
+++ b/mixins/rtl/rtl-mixin.js
@@ -8,6 +8,7 @@ export const RtlMixin = dedupeMixin(superclass => class extends superclass {
 			/**
 			 * @ignore
 			 */
+			// eslint-disable-next-line lit/no-native-attributes
 			dir: { type: String, reflect: true }
 		};
 	}


### PR DESCRIPTION
This updates core to adhere to the changes in an upcoming `1.0.0` release of `eslint-config-brightspace`. There were two new rules that this specifically addresses:

[prefer-nothing](https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/prefer-nothing.md): pretty straightforward -- use `nothing` whenever possible.

[no-native-attributes](https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-native-attributes.md): ideally, we'd never be duplicating native attribute names on custom elements. In practice, we've done this in a few "legitimate" cases (like `role`), a few mistakes (like `draggable`) and a few places we thought were OK but in reality we shouldn't have (`autofocus`, `title`).

For the most part, I've added ignore comments. For number/percent inputs though, I was able to remove the `title` attribute and clean up the [few places](https://github.com/Brightspace/nova/pull/6218) that [were using it](https://github.com/BrightspaceHypermediaComponents/activities/pull/4373).