### PR TITLE
Don't try to set up resize observer if there's no content to observe

### DIFF
--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -554,6 +554,8 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 	__startResizeObserver() {
 		const content = this.shadowRoot.querySelector('.d2l-hierarchical-view-content');
+		if (!content) return;
+
 		this.__bound_dispatchViewResize = this.__bound_dispatchViewResize || this.__dispatchViewResize.bind(this);
 		this.__resizeObserver = this.__resizeObserver || new ResizeObserver(this.__bound_dispatchViewResize);
 		this.__resizeObserver.disconnect();


### PR DESCRIPTION
Curious about thoughts on this one, because I'm not super sure if there are ramifications here that I'm not thinking of. To keep a long story short, it looks like there can be some interesting timing shenanigans that go on when something extends both `HierarchicalViewMixin` and `LocalizeDynamicMixin`, in which we end up trying to hook up the resize observer before the element has actually rendered (all that exists is the shadowroot).

This cropped up in the HTML editor ages ago and we worked around it at the time (https://github.com/BrightspaceUI/htmleditor/blob/main/components/toolbar/table-create.js#L88), but in some testing I did today, I noticed a couple things:
- When this fails (`content` is null), it seems to always be caused by the Lit update triggered by the lang terms being fetched.
- The failures happen in the middle of rendering, but always seem to be followed by successful hookups, so I think in reality the observer is still being connected properly; it's just failing on _some_ updates.

Independent of the above, I'm also just not sure what else we could or should try to do if we find that the element is connected but hasn't rendered yet. There's nothing to observe at that point and it feels like a bit of a violation of Lit's lifecycle rules to wait until an update has finished during `connectedCallback`. Maybe I'm off base there though.

EDIT: This was really just making a long story longer... So many words for one early exit. 😅 