### PR TITLE
If d2l-dialog-confirm text value is not a string, just render it.

### DIFF
--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -77,7 +77,7 @@ class DialogConfirm extends DialogMixin(LitElement) {
 						<div><h2 id="${this._titleId}" class="d2l-heading-3">${this.titleText}</h2></div>
 					</div>` : null}
 				<div id="${this._textId}" class="d2l-dialog-content">
-					<div>${this.text ? this.text.split('\n').map(line => html`<p>${line}</p>`) : null}</div>
+					<div>${this?.text?.split ? this.text.split('\n').map(line => html`<p>${line}</p>`) : this.text}</div>
 				</div>
 				<div class="d2l-dialog-footer">
 					<slot name="footer" class="d2l-dialog-footer-slot"></slot>


### PR DESCRIPTION
This PR updates `d2l-dialog-confirm` to render the `text` property value "as-is" if the `split()` function is not present. 

The MVC Inline Dialog's secondary text can contain SML, [rendered as HTML here](https://github.com/Brightspace/lms/blob/7e119c1870e327cf9d3be2ac8a77720c8c14ecd5/lp/framework/web/D2L.LP.Web.UI/Desktop/MasterPages/Dialog/Inline/InlineDialogFactory.cs#L66). That HTML would get encoded as block of text, which isn't what we'd want.

A potential solution to this is to quietly allow the LMS MVC Inline Dialog JavaScript to set `d2l-dialog-confirm`'s `text` property to a DOM node. To allow that, we simply need to not assume the `text` property value is a string.

Background: the purpose of the `split` method is to convert a string containing line-breaks into paragraph elements. Whether intentional or not, the code would currently explode if a consumer tried to set the property to a DOM node.

As a separate option, we can comb through all the lang-terms to find the ones that contain SML, but I figured I would test the water with this first.