### PR TITLE
Add Button: List: Fix drag and drop border bug

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -642,7 +642,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 		const nestedList = this._getNestedList();
 		if (this._hasNestedList !== !!nestedList) {
 			this._hasNestedList = !!nestedList;
-			this._hasNestedListAddButton = nestedList.hasAttribute('add-button');
+			this._hasNestedListAddButton = this._hasNestedList && nestedList.hasAttribute('add-button');
 			/** @ignore */
 			this.dispatchEvent(new CustomEvent('d2l-list-item-nested-change', { bubbles: true, composed: true }));
 		}


### PR DESCRIPTION
**Problem**:
Can be seen in the [drag and drop demo](https://live.d2l.dev/BrightspaceUI/core/components/list/demo/list-drag-and-drop.html) "Add Button" demo at the bottom of the page. Drag the two nested items out of the bottom nested list and note that the border isn't full length and there is a console error.
The issue was that it actually no longer had a nested list and was failing when checking for `add-button` attribute.