### PR TITLE
fix: show animation on tooltip hover

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -355,22 +355,22 @@ class Tooltip extends RtlMixin(LitElement) {
 				width: 100%;
 			}
 
-			:host([_open-dir="bottom"]) .d2l-tooltip-container {
+			:host([_open-dir="bottom"][showing]) .d2l-tooltip-container {
 				-webkit-animation: d2l-tooltip-bottom-animation 200ms ease;
 				animation: d2l-tooltip-bottom-animation 200ms ease;
 			}
 
-			:host([_open-dir="top"]) .d2l-tooltip-container {
+			:host([_open-dir="top"][showing]) .d2l-tooltip-container {
 				-webkit-animation: d2l-tooltip-top-animation 200ms ease;
 				animation: d2l-tooltip-top-animation 200ms ease;
 			}
 
-			:host([_open-dir="left"]) .d2l-tooltip-container {
+			:host([_open-dir="left"][showing]) .d2l-tooltip-container {
 				-webkit-animation: d2l-tooltip-left-animation 200ms ease;
 				animation: d2l-tooltip-left-animation 200ms ease;
 			}
 
-			:host([_open-dir="right"]) .d2l-tooltip-container {
+			:host([_open-dir="right"][showing]) .d2l-tooltip-container {
 				-webkit-animation: d2l-tooltip-right-animation 200ms ease;
 				animation: d2l-tooltip-right-animation 200ms ease;
 			}

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -387,10 +387,10 @@ class Tooltip extends RtlMixin(LitElement) {
 			}
 
 			@media (prefers-reduced-motion: reduce) {
-				:host([_open-dir="bottom"]) .d2l-tooltip-container,
-				:host([_open-dir="top"]) .d2l-tooltip-container,
-				:host([_open-dir="left"]) .d2l-tooltip-container,
-				:host([_open-dir="right"]) .d2l-tooltip-container {
+				:host([_open-dir="bottom"][showing]) .d2l-tooltip-container,
+				:host([_open-dir="top"][showing]) .d2l-tooltip-container,
+				:host([_open-dir="left"][showing]) .d2l-tooltip-container,
+				:host([_open-dir="right"][showing]) .d2l-tooltip-container {
 					-webkit-animation: none;
 					animation: none;
 				}


### PR DESCRIPTION
Before, the animation would only play once, now whenever the user hovers over the tooltip the animation will play


https://github.com/BrightspaceUI/core/assets/24593380/ec447607-b46d-4457-b831-e6b3a859ce98

