### PR TITLE
Fix bad tooltip positioning when used in other components

### DIFF
--- a/components/button/button.js
+++ b/components/button/button.js
@@ -42,6 +42,7 @@ class Button extends ButtonMixin(LitElement) {
 				button {
 					font-family: inherit;
 					padding: 0.55rem 1.5rem;
+					position: relative;
 					width: 100%;
 				}
 

--- a/components/count-badge/count-badge-icon.js
+++ b/components/count-badge/count-badge-icon.js
@@ -68,6 +68,7 @@ class CountBadgeIcon extends FocusMixin(CountBadgeMixin(LitElement)) {
 		d2l-icon {
 			border: 2px solid transparent;
 			border-radius: 6px;
+			position: relative;
 		}
 		`];
 	}

--- a/components/count-badge/count-badge-mixin.js
+++ b/components/count-badge/count-badge-mixin.js
@@ -198,7 +198,8 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 		if (!numberStyles || numberStyles.visibility !== 'hidden') {
 			numberStyles = {
 				...numberStyles,
-				visibility: hideNumber ? 'hidden' : 'visible'
+				visibility: hideNumber ? 'hidden' : 'visible',
+				zIndex: 1
 			};
 		}
 		return html`
@@ -213,7 +214,8 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 		<div id="${this._labelId}"
 			aria-label="${this.text}"
 			aria-atomic="true"
-			aria-live="${this.announceChanges ? 'polite' : 'off'}">
+			aria-live="${this.announceChanges ? 'polite' : 'off'}"
+			style="isolation: isolate">
 			${innerHtml}
 		</div>
 		${this.hasTooltip && !this.skeleton ? html`<d2l-tooltip class="vdiff-target" for="${badgeId}" for-type="label">${this.text}</d2l-tooltip>` : null}

--- a/components/count-badge/count-badge.js
+++ b/components/count-badge/count-badge.js
@@ -18,6 +18,7 @@ class CountBadge extends FocusMixin(CountBadgeMixin(LitElement)) {
 
 		.d2l-count-badge-wrapper {
 			border: 2px solid transparent;
+			position: relative;
 		}
 
 		:host([size="small"]) .d2l-count-badge-wrapper {

--- a/components/form/test/form-helper.test.js
+++ b/components/form/test/form-helper.test.js
@@ -142,7 +142,7 @@ describe('form-helper', () => {
 
 		const implicitLabelWithTooltipFixture = html`
 			<label>Do you like peas?
-				<input id='target' type="checkbox" name="peas">
+				<input id='target' type="checkbox" name="peas" style="position: relative;">
 				<d2l-tooltip for="target">Tooltip that shouldn't be included in label text</d2l-tooltip>
 			</label>
 		`;

--- a/components/form/test/form-native.test.js
+++ b/components/form/test/form-native.test.js
@@ -14,9 +14,9 @@ describe('d2l-form-native', () => {
 		<d2l-form-native>
 			<d2l-validation-custom for="mycheck" @d2l-validation-custom-validate=${_validateCheckbox} failure-text="The checkbox failed validation" >
 			</d2l-validation-custom>
-			<input type="checkbox" id="mycheck" name="checkers" value="red-black">
+			<input type="checkbox" id="mycheck" name="checkers" value="red-black" style="position: relative;">
 			<input type="file" name="optional-file">
-			<select aria-label="Pets" name="pets" id="pets" required>
+			<select aria-label="Pets" name="pets" id="pets" required style="position: relative;">
 				<option value="">--Please choose an option--</option>
 				<option value="dog">Dog</option>
 				<option value="cat">Cat</option>

--- a/components/form/test/form.test.js
+++ b/components/form/test/form.test.js
@@ -17,9 +17,9 @@ describe('d2l-form', () => {
 			<d2l-form>
 				<d2l-validation-custom for="mycheck" @d2l-validation-custom-validate=${_validateCheckbox} failure-text="The checkbox failed validation" >
 				</d2l-validation-custom>
-				<input type="checkbox" id="mycheck" name="checkers" value="red-black">
+				<input type="checkbox" id="mycheck" name="checkers" value="red-black" style="position: relative;">
 				<input type="file" name="optional-file">
-				<select aria-label="Pets" name="pets" id="pets" required>
+				<select aria-label="Pets" name="pets" id="pets" required style="position: relative;">
 					<option value="">--Please choose an option--</option>
 					<option value="dog">Dog</option>
 					<option value="cat">Cat</option>
@@ -116,23 +116,23 @@ describe('d2l-form', () => {
 
 		const rootFormFixture = html`
 			<d2l-form>
-				<d2l-validation-custom for="mycheck" @d2l-validation-custom-validate=${_validateCheckbox} failure-text="The checkbox failed validation" >
+				<d2l-validation-custom for="mycheck" @d2l-validation-custom-validate="${_validateCheckbox}" failure-text="The checkbox failed validation" >
 				</d2l-validation-custom>
-				<input type="checkbox" id="mycheck" name="checkers" value="red-black">
+				<input type="checkbox" id="mycheck" name="checkers" value="red-black" style="position: relative;">
 				<div>
 					<d2l-form id="nested-form">
-						<select aria-label="Home planet" name="home-planet" id="nested-home-planet" required>
+						<select aria-label="Home planet" name="home-planet" id="nested-home-planet" required style="position: relative;">
 							<option value="">--Please choose an option--</option>
 							<option value="earth">Earth</option>
 							<option value="other">Other</option>
 						</select>
-						<label>Story<input type="text" id="nested-story" name="story"></label>
-						<d2l-validation-custom for="nested-story" @d2l-validation-custom-validate=${_validateStory} failure-text="Wrong story" >
+						<label>Story<input type="text" id="nested-story" name="story" style="position: relative;"></label>
+						<d2l-validation-custom for="nested-story" @d2l-validation-custom-validate="${_validateStory}" failure-text="Wrong story" style="position: relative;">
 						</d2l-validation-custom>
 						<d2l-test-form-element id="nested-custom-ele"></d2l-test-form-element>
 					</d2l-form>
 				</div>
-				<select aria-label="Pets" name="pets" id="pets" required>
+				<select aria-label="Pets" name="pets" id="pets" required style="position: relative;">
 					<option value="">--Please choose an option--</option>
 					<option value="dog">Dog</option>
 					<option value="cat">Cat</option>

--- a/components/form/test/nested-form.js
+++ b/components/form/test/nested-form.js
@@ -21,11 +21,11 @@ class NestedForm extends LitElement {
 			<d2l-form ?no-nesting=${this.noNesting}>
 				<label>
 					First Name
-					<input type="text" id="composed-nested-first-name" name="first-name" required minlength="4" maxlength="15">
+					<input type="text" id="composed-nested-first-name" name="first-name" required minlength="4" maxlength="15" style="position: relative;">
 				</label>
-				<d2l-validation-custom for="composed-nested-pets" @d2l-validation-custom-validate=${this._validateSelect} failure-text="Expected Hamster" >
+				<d2l-validation-custom for="composed-nested-pets" @d2l-validation-custom-validate=${this._validateSelect} failure-text="Expected Hamster">
 				</d2l-validation-custom>
-				<select aria-label="Pets" name="pets" id="composed-nested-pets">
+				<select aria-label="Pets" name="pets" id="composed-nested-pets" style="position: relative;">
 					<option value="">--Please choose an option--</option>
 					<option value="dog">Dog</option>
 					<option value="cat">Cat</option>
@@ -34,7 +34,7 @@ class NestedForm extends LitElement {
 					<option value="spider">Spider</option>
 					<option value="goldfish">Goldfish</option>
 				</select>
-				<input type="radio" id="composed-nested-my-radio" name="composed-nested-optional-radio">
+				<input type="radio" id="composed-nested-my-radio" name="composed-nested-optional-radio" style="position: relative;">
 				<d2l-test-form-element id="composed-nested-custom-ele"></d2l-test-form-element>
 			</d2l-form>
 		`;

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -126,6 +126,7 @@ class InputDateRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			}
 			d2l-input-date {
 				display: block;
+				position: relative;
 			}
 		`];
 	}

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -165,6 +165,7 @@ class InputDateTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMi
 			}
 			d2l-input-date-time {
 				display: block;
+				position: relative;
 			}
 			::slotted(*) {
 				margin-top: 0.6rem;

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -107,6 +107,9 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 			.d2l-input-date-time-container {
 				margin-top: -0.3rem;
 			}
+			d2l-input-date {
+				position: relative;
+			}
 			d2l-input-date,
 			d2l-input-time {
 				margin-top: 0.3rem;

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -137,6 +137,9 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 				margin-top: 0.3rem;
 				padding-top: 0.3rem;
 			}
+			d2l-input-text {
+				position: relative;
+			}
 		`];
 	}
 

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -194,6 +194,9 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 				:host([hidden]) {
 					display: none;
 				}
+				d2l-input-text {
+					position: relative;
+				}
 			`
 		];
 	}

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -211,9 +211,9 @@ class InputText extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(La
 				.d2l-input {
 					-webkit-appearance: textfield;
 					overflow: hidden;
+					position: relative;
 					text-overflow: ellipsis;
 					white-space: nowrap;
-					position: relative;
 				}
 				#after-slot {
 					display: inline-block;

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -197,6 +197,10 @@ class InputText extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(La
 				:host([value-align="end"]) {
 					--d2l-input-text-align: end;
 				}
+				#d2l-input-text-container {
+					display: inline;
+					position: relative;
+				}
 				.d2l-input-label {
 					display: inline-block;
 					vertical-align: bottom;
@@ -484,13 +488,13 @@ class InputText extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(La
 		if (!this.skeleton) {
 			if (this.validationError && !this.noValidate) {
 				// this tooltip is using "announced" since we don't want aria-describedby wire-up which would bury the message in VoiceOver's More Content Available menu
-				tooltip = html`<d2l-tooltip state="error" announced align="start" class="vdiff-target">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>`;
+				tooltip = html`<d2l-tooltip state="error" for="d2l-input-text-container" announced align="start" class="vdiff-target">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>`;
 			} else if (this.instructions) {
 				tooltip = html`<d2l-tooltip align="start" for="${this._inputId}" delay="1000" class="vdiff-target">${this.instructions}</d2l-tooltip>`;
 			}
 		}
 
-		return html`${tooltip}${label}${input}`;
+		return html`<div id="d2l-input-text-container">${tooltip}${label}${input}</div>`;
 	}
 
 	updated(changedProperties) {

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -213,6 +213,7 @@ class InputText extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(La
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
+					position: relative;
 				}
 				#after-slot {
 					display: inline-block;

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -134,6 +134,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			}
 			d2l-input-time {
 				display: block;
+				position: relative;
 			}
 		`];
 	}

--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -85,6 +85,9 @@ class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(RtlMixin(LitElem
 				padding: 0;
 				width: 0.9rem;
 			}
+			d2l-button-move {
+				position: relative;
+			}
 			/* Firefox includes a hidden border which messes up button dimensions */
 			button::-moz-focus-inner {
 				border: 0;

--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -89,6 +89,7 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 				outline: none;
 				overflow: hidden;
 				padding: 0.25rem 0.6rem;
+				position: relative;
 				text-overflow: ellipsis;
 			}
 			:host(:focus-within) .tag-list-item-container,

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -5,7 +5,7 @@ import { LitElement } from 'lit';
 const basicFixture = html`
 	<div>
 		<div id="implicit-target" tabindex="-1" role="button">
-			<button id="explicit-target">Hover me for tips</button>
+			<button style="position: relative;" id="explicit-target">Hover me for tips</button>
 			<d2l-tooltip for="explicit-target" for-type="descriptor">If I got a problem then a problem's got a problem.</d2l-tooltip>
 		</div>
 	</div>
@@ -13,7 +13,7 @@ const basicFixture = html`
 
 const labelFixture = html`
 	<div>
-		<button id="label-target">Hover me for tips</button>
+		<button id="label-target" style="position: relative;">Hover me for tips</button>
 		<d2l-tooltip for="label-target" for-type="label">If I got a problem then a problem's got a problem.</d2l-tooltip>
 	</div>
 `;

--- a/components/tooltip/test/tooltip.test.js
+++ b/components/tooltip/test/tooltip.test.js
@@ -209,13 +209,14 @@ describe('d2l-tooltip', () => {
 			const targetTag = defineCE(class extends LitElement {
 				render() {return html`<button>nested target</button>`; }
 			});
-			const elem = await fixture(`<div><${targetTag} id="target"></${targetTag}></div>`);
+			const elem = await fixture(`<div id="wrap" style="position: relative;"><${targetTag} id="target"></${targetTag}></div>`);
 			const target = elem.querySelector(targetTag);
 
 			await focusElem(target.shadowRoot.querySelector('button'));
 
 			const tooltip = document.createElement('d2l-tooltip');
 			tooltip.announced = true;
+			tooltip.for = 'wrap';
 			elem.appendChild(tooltip);
 
 			await oneEvent(elem, 'd2l-tooltip-show');

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -472,11 +472,6 @@ class Tooltip extends RtlMixin(LitElement) {
 		requestAnimationFrame(() => {
 			if (this.isConnected) {
 				this._updateTarget();
-				if ((this.for && !this._target) || window.getComputedStyle(this._target).position === 'static') {
-					const host = this.getRootNode().host?.tagName.toLowerCase() ?? 'body';
-					const targetSelector = this.for ? `(#${this.for}) ` : '';
-					console.warn(`In <${host}>, <d2l-tooltip> target element ${targetSelector}does not have a CSS position. The tooltip may not position itself correctly on the page.`);
-				}
 			}
 		});
 	}
@@ -730,14 +725,21 @@ class Tooltip extends RtlMixin(LitElement) {
 	_findTarget() {
 		const ownerRoot = this.getRootNode();
 
-		let target;
+		let target, targetSelector;
 		if (this.for) {
-			const targetSelector = `#${cssEscape(this.for)}`;
+			targetSelector = `#${cssEscape(this.for)}`;
 			target = ownerRoot.querySelector(targetSelector);
-			target = target || (ownerRoot && ownerRoot.host && ownerRoot.host.querySelector(targetSelector));
+			target = target || ownerRoot?.host?.querySelector(targetSelector);
 		} else {
+			console.warn('<d2l-tooltip>: missing required attribute "for"');
 			const parentNode = this.parentNode;
 			target = parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE ? ownerRoot.host : parentNode;
+		}
+
+		if (window.getComputedStyle(target).position === 'static') {
+			const host = this.getRootNode().host?.tagName.toLowerCase() ?? 'body';
+			const selectorText = targetSelector ? `(${targetSelector}) ` : '';
+			console.warn(`In <${host}>, <d2l-tooltip> target element ${selectorText}does not have a CSS position. The tooltip may not position itself correctly on the page.`);
 		}
 
 		return target;

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -472,6 +472,11 @@ class Tooltip extends RtlMixin(LitElement) {
 		requestAnimationFrame(() => {
 			if (this.isConnected) {
 				this._updateTarget();
+				if ((this.for && !this._target) || window.getComputedStyle(this._target).position === 'static') {
+					const host = this.getRootNode().host?.tagName.toLowerCase() ?? 'body';
+					const targetSelector = this.for ? `(#${this.for}) ` : '';
+					console.warn(`In <${host}>, <d2l-tooltip> target element ${targetSelector}does not have a CSS position. The tooltip may not position itself correctly on the page.`);
+				}
 			}
 		});
 	}
@@ -734,6 +739,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			const parentNode = this.parentNode;
 			target = parentNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE ? ownerRoot.host : parentNode;
 		}
+
 		return target;
 	}
 


### PR DESCRIPTION
When we use `d2l-tooltip` inside other components, the tooltip can be positioned incorrectly if we don't give the target element a non-`static` `position`.

Reported [here](https://grow.d2l.com/d2l/le/enhancedSequenceViewer/6942?url=https%3A%2F%2Fe16bd763-9b2f-4f8d-b9da-2c008c2b19ff.sequences.api.brightspace.com%2F6942%2Factivity%2F11371%3FfilterOnDatesAndDepth%3D1).