### PR TITLE
fix: Add Button in List: Grid mode tooltip

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -434,6 +434,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 		this.first = false;
 		this.noPrimaryAction = false;
 		this.paddingType = 'normal';
+		this._addButtonTopId = getUniqueId();
 		this._contentId = getUniqueId();
 		this._displayKeyboardTooltip = false;
 		this._hasColorSlot = false;
@@ -667,7 +668,14 @@ export const ListItemMixin = superclass => class extends composeMixins(
 
 		const alignNested = ((this.draggable && this.selectable) || (this.expandable && this.selectable && this.color)) ? 'control' : undefined;
 		const primaryAction = ((!this.noPrimaryAction && this._renderPrimaryAction) ? this._renderPrimaryAction(this._contentId) : null);
-		const tooltipForId = (primaryAction ? this._primaryActionId : (this.selectable ? this._checkboxId : null));
+		let tooltipForId = null;
+		if (this._showAddButton) {
+			tooltipForId = this._addButtonTopId;
+		} else if (primaryAction) {
+			tooltipForId = this._primaryActionId;
+		} else if (this.selectable) {
+			tooltipForId = this._checkboxId;
+		}
 		const addButtonText = this._addButtonText || this.localize('components.list-item.addItem');
 		const innerView = html`
 			<d2l-list-item-generic-layout
@@ -680,7 +688,13 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				?no-primary-action="${this.noPrimaryAction}">
 				${this._showAddButton && this.first ? html`
 				<div slot="add-top">
-					<d2l-button-add text="${addButtonText}" mode="icon-when-interacted" @click="${this._handleButtonAddClick}" data-is-first></d2l-button-add>
+					<d2l-button-add
+						text="${addButtonText}"
+						mode="icon-when-interacted"
+						@click="${this._handleButtonAddClick}"
+						data-is-first
+						id="${this._addButtonTopId}">
+					</d2l-button-add>
 				</div>
 				` : nothing}
 				<div slot="outside-control-container" class="${classMap(bottomBorderClasses)}"></div>


### PR DESCRIPTION
When in grid mode, there should be an instructional tooltip displayed when the user first tabs in. This did not work as expected with button-add.

Worth noting is that button-add does normally have its own tooltip that says "Add Item" by default. This one does seem like it should take priority for this first focus. I also think the position start is okay here because otherwise it seems too much related specifically to the add button itself if it's centred but adding in @geurts to see if there's any thoughts on that.

<img width="840" alt="Screenshot 2024-02-29 at 3 44 19 PM" src="https://github.com/BrightspaceUI/core/assets/6804600/ba4dc7c0-5065-41a7-a9a9-be83e891cf16">
