### PR TITLE
fix: add docs for "supporting" slot

### DIFF
--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -138,6 +138,10 @@ This `d2l-menu-item-link` is used for navigating. It gives users the ability to 
 | `href` | String, required | The URL the menu item link navigates to |
 | `text` | String, required | Text displayed by the menu item |
 | `disabled` | Boolean | Disables the menu item |
+
+### Slots
+
+* `supporting`: Allows supporting information to be displayed on the right-most side of the menu item
 <!-- docs: end hidden content -->
 
 ### Accessibility Properties
@@ -180,6 +184,10 @@ The `d2l-menu-item-checkbox` component is used for selection. It can be wired-up
 | `value` | String, required | |
 | `disabled` | Boolean | Disables the menu item |
 | `selected` | Boolean | Thie will set the item to be selected by default |
+
+### Slots
+
+* `supporting`: Allows supporting information to be displayed on the right-most side of the menu item
 
 ### Events
 
@@ -226,6 +234,10 @@ The `d2l-menu-item-radio` component is used for selection. It can be wired-up to
 | `value` | String, required | |
 | `disabled` | Boolean | Disables the menu item |
 | `selected` | Boolean | This will set the item to be seelcted by default |
+
+### Slots
+
+* `supporting`: Allows supporting information to be displayed on the right-most side of the menu item
 
 ### Events
 

--- a/components/menu/menu-item-checkbox.js
+++ b/components/menu/menu-item-checkbox.js
@@ -6,6 +6,7 @@ import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * A menu item component used for selection. Multiple checkboxes can be selected at once.
+ * @slot supporting - Allows supporting information to be displayed on the right-most side of the menu item
  */
 class MenuItemCheckbox extends RtlMixin(MenuItemSelectableMixin(LitElement)) {
 
@@ -27,7 +28,7 @@ class MenuItemCheckbox extends RtlMixin(MenuItemSelectableMixin(LitElement)) {
 	render() {
 		return html`
 			<d2l-icon icon="tier1:check"></d2l-icon>
-	<div class="d2l-menu-item-text">${this.text}</div>
+			<div class="d2l-menu-item-text">${this.text}</div>
 			<div class="d2l-menu-item-supporting"><slot name="supporting"></slot></div>
 		`;
 	}

--- a/components/menu/menu-item-link.js
+++ b/components/menu/menu-item-link.js
@@ -6,6 +6,7 @@ import { menuItemStyles } from './menu-item-styles.js';
 /**
  * A menu item component used for navigating.
  * @fires click - Dispatched when the link is clicked
+ * @slot supporting - Allows supporting information to be displayed on the right-most side of the menu item
  */
 class MenuItemLink extends MenuItemMixin(LitElement) {
 

--- a/components/menu/menu-item-radio.js
+++ b/components/menu/menu-item-radio.js
@@ -6,6 +6,7 @@ import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * A menu item component used for radio selection. Only one radio item in a given d2l-menu may be selected at once (i.e., selecting one option will deselect the other selected "d2l-menu-item-radio" item).
+ * @slot supporting - Allows supporting information to be displayed on the right-most side of the menu item
  */
 class MenuItemRadio extends RtlMixin(MenuItemRadioMixin(LitElement)) {
 


### PR DESCRIPTION
The "supporting" slot is supported by link, checkbox and radio menu items but it's not included in the Daylight Site documentation.