### PR TITLE
Switch to new `post-mode` for live site comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,4 +88,4 @@ jobs:
             > [!NOTE]
             > The build needs to finish before your changes are deployed.
             > Changes to the PR will automatically update the instance.
-          only-post-once: true
+          post-mode: once


### PR DESCRIPTION
See [comment-on-pr#post-mode](https://github.com/BrightspaceUI/actions/tree/main/comment-on-pr#post-mode) and https://github.com/BrightspaceUI/actions/pull/148 for details. Made sure to re-run the workflow posting the comment to test behaviour was correct.