### PR TITLE
Rework loading complete mixin

### DIFF
--- a/mixins/loading-complete/README.md
+++ b/mixins/loading-complete/README.md
@@ -17,7 +17,7 @@ class MyComponent extends LoadingCompleteMixin(LitElement) {
 }
 ```
 
-To make use of the `loadingComplete` promise, simply `await` it where needed
+To make use of the `loadingComplete` promise, simply `await` it where needed:
 
 ```js
 async removeSkeleton() {
@@ -26,13 +26,13 @@ async removeSkeleton() {
 }
 ```
 
-If for any reason `resolveLoadingComplete` is never called, `loadingComplete` won't resolve and any consumers will hang
+If for any reason `resolveLoadingComplete` is never called, `loadingComplete` won't resolve and any consumers will hang.
 
 ### `getLoadingComplete`
 
-In some cases, instead of finding one spot to call `resolveLoadingComplete`, you may find it easier to `await` a set of promises in a custom `getLoadingComplete` method
+In some cases, instead of finding one spot to call `resolveLoadingComplete`, you may find it easier to `await` a set of promises in a custom `getLoadingComplete` method.
 
-You'll also need to use this method if you're working in a general-use mixin rather than directly in a component
+You'll also need to use this method if you're working in a general-use mixin rather than directly in a component.
 
 ```js
 class MyComponent extends LoadingCompleteMixin(LitElement) {
@@ -44,4 +44,4 @@ class MyComponent extends LoadingCompleteMixin(LitElement) {
 	}
 }
 ```
-Make sure all your promises are set before `firstUpdated`
+Note that the work to generate these promises should have already started, before `firstUpdated`, and we simply `await` them here.

--- a/mixins/loading-complete/README.md
+++ b/mixins/loading-complete/README.md
@@ -1,9 +1,9 @@
 # LoadingCompleteMixin
 
-The `LoadingCompleteMixin` contains boilerplate code for [`getLoadingComplete`](https://github.com/BrightspaceUI/testing#waiting-for-asynchronous-components). It simplifies fixture setup for custom components in automated tests.
+The `LoadingCompleteMixin` contains boilerplate code for [`getLoadingComplete`](https://github.com/BrightspaceUI/testing#waiting-for-asynchronous-components). It simplifies fixture setup for custom components in automated tests, and provides a `loadingComplete` promise that can be used internally.
 
 ## Usage
-Apply the mixin and call `resolveLoadingComplete()` once your component has finished loading to indicate it is ready for validation.
+Apply the mixin and call `resolveLoadingComplete()` once your component has finished loading
 
 ```js
 import { LoadingCompleteMixin } from '@brightspace-ui/core/mixins/loading-complete/loading-complete-mixin.js';
@@ -11,12 +11,37 @@ import { LoadingCompleteMixin } from '@brightspace-ui/core/mixins/loading-comple
 class MyComponent extends LoadingCompleteMixin(LitElement) {
 
 	connectedCallback() {
-		this._fetchMyData().then(() => {
-			this.resolveLoadingComplete();
-		});
+		this._fetchMyData().then(this.resolveLoadingComplete);
 	}
 
 }
 ```
 
-If for whatever reason `resolveLoadingComplete` is never called, the `getLoadingComplete` promise will never resolve. In such cases any consumers (e.g. fixtures) will hang. If this behavior is not desired, ensure all code paths eventually call `resolveLoadingComplete`, or specify `{ awaitLoadingComplete: false }` in the `fixture` call.
+To make use of the `loadingComplete` promise, simply `await` it where needed
+
+```js
+async removeSkeleton() {
+	await this.loadingComplete;
+	this.skeleton = false;
+}
+```
+
+If for any reason `resolveLoadingComplete` is never called, `loadingComplete` won't resolve and any consumers will hang
+
+### `getLoadingComplete`
+
+In some cases, instead of finding one spot to call `resolveLoadingComplete`, you may find it easier to `await` a set of promises in a custom `getLoadingComplete` method
+
+You'll also need to use this method if you're working in a general-use mixin rather than directly in a component
+
+```js
+class MyComponent extends LoadingCompleteMixin(LitElement) {
+
+	async getLoadingComplete() {
+		await super.getLoadingComplete();
+		await this._myCustomIconImport;
+		await Promise.all(this._allMyDataPromises);
+	}
+}
+```
+Make sure all your promises are set before `firstUpdated`

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -5,7 +5,7 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	#loadingCompleteResolve;
 
 	// eslint-disable-next-line sort-class-members/sort-class-members
-	#loadingCompletePromise = Object.hasOwn(this.constructor.prototype, 'getLoadingComplete')
+	#loadingCompletePromise = !Object.hasOwn(this.constructor.prototype, 'getLoadingComplete')
 		? new Promise(resolve => this.#loadingCompleteResolve = resolve)
 		: Promise.resolve();
 
@@ -14,14 +14,12 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	}
 
 	get resolveLoadingComplete() {
-		return () => this.#resolveLoadingComplete();
-	}
-
-	#resolveLoadingComplete() {
-		if (this.#loadingCompleteResolve) {
-			this.#loadingCompleteResolve();
-			this.#loadingCompleteResolve = null;
-		}
+		return () => {
+			if (this.#loadingCompleteResolve) {
+				this.#loadingCompleteResolve();
+				this.#loadingCompleteResolve = null;
+			}
+		};
 	}
 
 	async getLoadingComplete() {

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -5,25 +5,16 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	#loadingCompleteResolve;
 
 	// eslint-disable-next-line sort-class-members/sort-class-members
-	#loadingCompletePromise = this.getLoadingComplete === this.#getLoadingComplete
+	#loadingCompletePromise = Object.hasOwn(this.constructor.prototype, 'getLoadingComplete')
 		? new Promise(resolve => this.#loadingCompleteResolve = resolve)
 		: Promise.resolve();
-
-	get getLoadingComplete() {
-		return this.#getLoadingComplete;
-	}
 
 	get loadingComplete() {
 		return this.getLoadingComplete();
 	}
 
 	get resolveLoadingComplete() {
-		return this.#resolveLoadingComplete.bind(this);
-	}
-
-	async #getLoadingComplete() {
-		await super.getLoadingComplete?.();
-		return this.#loadingCompletePromise;
+		return () => this.#resolveLoadingComplete();
 	}
 
 	#resolveLoadingComplete() {
@@ -31,6 +22,11 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 			this.#loadingCompleteResolve();
 			this.#loadingCompleteResolve = null;
 		}
+	}
+
+	async getLoadingComplete() {
+		await super.getLoadingComplete?.();
+		return this.#loadingCompletePromise;
 	}
 
 });

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -14,7 +14,7 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	}
 
 	get loadingComplete() {
-		return this.#getLoadingComplete();
+		return this.getLoadingComplete();
 	}
 
 	get resolveLoadingComplete() {

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -5,7 +5,7 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	#loadingCompleteResolve;
 
 	// eslint-disable-next-line sort-class-members/sort-class-members
-	#loadingCompletePromise = !Object.hasOwn(this.constructor.prototype, 'getLoadingComplete')
+	#loadingCompletePromise = !Object.prototype.hasOwnProperty.call(this.constructor.prototype, 'getLoadingComplete')
 		? new Promise(resolve => this.#loadingCompleteResolve = resolve)
 		: Promise.resolve();
 


### PR DESCRIPTION
This expands the mixin for more general use. We already have [a number of uses](https://github.com/search?q=saved%3AD2L+%2F%5Cw*%5C.getloadingcomplete%2F&type=code&saved_searches=%5B%7B%22name%22%3A%22D2L%22%2C%22query%22%3A%22org%3ABrightspace+OR+org%3ABrightspaceUI+OR+org%3ABrightspaceUILabs+OR+org%3ABrightspaceHypermediaComponents%22%7D%5D&expanded_query=org%3ABrightspace+org%3ABrightspaceUI+org%3ABrightspaceUILabs+org%3ABrightspaceHypermediaComponents+%2F%5Cw*%5C.getloadingcomplete%2F) of `getLoadingComplete` outside of tests, so we can't rely on it only being used there.