### PR TITLE
Show example usage of loadingComplete mixin with lazy loading langterms

### DIFF
--- a/components/tabs/demo/tabs-loading.html
+++ b/components/tabs/demo/tabs-loading.html
@@ -36,14 +36,5 @@
 
 		</d2l-demo-page>
 
-		<script>
-			document.addEventListener('d2l-tab-panel-selected', (e) => {
-				console.log('tab panel selected', e);
-			});
-			document.addEventListener('d2l-tab-panel-text-changed', (e) => {
-				console.log('tab panel text changed', e);
-			});
-		</script>
-
 	</body>
 </html>

--- a/components/tabs/demo/tabs-loading.html
+++ b/components/tabs/demo/tabs-loading.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+		<script type="module">
+			import '../../demo/demo-page.js';
+			import '../../button/button-subtle.js';
+			import '../../dropdown/dropdown-button-subtle.js';
+			import '../../dropdown/dropdown-menu.js';
+			import '../../menu/menu.js';
+			import '../../menu/menu-item.js';
+			import '../tabs.js';
+			import '../tab-panel.js';
+		</script>
+	</head>
+	<body unresolved>
+
+		<d2l-demo-page page-title="d2l-tabs">
+
+			<h2>Tabs</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-tabs>
+						<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+						<d2l-tab-panel text="Earth &amp; Planetary Sciences">Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
+						<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
+						<d2l-tab-panel text="Math">Tab content for Math</d2l-tab-panel>
+					</d2l-tabs>
+				</template>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+
+		<script>
+			document.addEventListener('d2l-tab-panel-selected', (e) => {
+				console.log('tab panel selected', e);
+			});
+			document.addEventListener('d2l-tab-panel-text-changed', (e) => {
+				console.log('tab panel text changed', e);
+			});
+		</script>
+
+	</body>
+</html>

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -54,7 +54,7 @@ if (!Array.prototype.findIndex) {
  * @slot ext - Additional content (e.g., a button) positioned at right
  * @fires d2l-tabs-initialized - Dispatched when the component is initialized
  */
-class Tabs extends LoadingCompleteMixin(LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(RtlMixin(LitElement))))) {
+class Tabs extends LocalizeCoreElement(LoadingCompleteMixin(ArrowKeysMixin(SkeletonMixin(RtlMixin(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -271,6 +271,7 @@ class Tabs extends LoadingCompleteMixin(LocalizeCoreElement(ArrowKeysMixin(Skele
 
 	async firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
+		console.log('First render');
 
 		this.arrowKeysFocusablesProvider = async() => {
 			return [...this.shadowRoot.querySelectorAll('d2l-tab-internal')];
@@ -309,7 +310,7 @@ class Tabs extends LoadingCompleteMixin(LocalizeCoreElement(ArrowKeysMixin(Skele
 		this._resizeObserver.observe(this.shadowRoot.querySelector('.d2l-tabs-container-list'));
 
 		await this.loadingComplete;
-		alert(`I got these langterms:\n${Object.entries(this.__resources).filter(([k]) => k.includes('.tabs.')).map(([k, v]) => `${k}: ${v.value}`).join('\n')}`);
+		console.log('Loading complete');
 	}
 
 	render() {
@@ -383,11 +384,6 @@ class Tabs extends LoadingCompleteMixin(LocalizeCoreElement(ArrowKeysMixin(Skele
 
 	focus() {
 		return this._focusSelected();
-	}
-
-	async getLoadingComplete() {
-		await super.getLoadingComplete();
-		await new Promise(r => setTimeout(r, 2000));
 	}
 
 	getTabListRect() {
@@ -905,8 +901,8 @@ class Tabs extends LoadingCompleteMixin(LocalizeCoreElement(ArrowKeysMixin(Skele
 		const scrollVisibilityPromise = this._updateScrollVisibility(measures);
 		return Promise.all([
 			scrollVisibilityPromise,
-			scrollToPromise
-		]).then(this.resolveLoadingComplete);
+			scrollToPromise,
+		]).then(() => new Promise(r => setTimeout(r, 5000))).then(this.resolveLoadingComplete);
 	}
 
 	_updateScrollVisibility(measures) {

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -54,7 +54,7 @@ if (!Array.prototype.findIndex) {
  * @slot ext - Additional content (e.g., a button) positioned at right
  * @fires d2l-tabs-initialized - Dispatched when the component is initialized
  */
-class Tabs extends LocalizeCoreElement(LoadingCompleteMixin(ArrowKeysMixin(SkeletonMixin(RtlMixin(LitElement))))) {
+class Tabs extends LoadingCompleteMixin(LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(RtlMixin(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -271,7 +271,7 @@ class Tabs extends LocalizeCoreElement(LoadingCompleteMixin(ArrowKeysMixin(Skele
 
 	async firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-		console.log('First render');
+		console.log('First render'); // eslint-disable-line
 
 		this.arrowKeysFocusablesProvider = async() => {
 			return [...this.shadowRoot.querySelectorAll('d2l-tab-internal')];
@@ -310,7 +310,7 @@ class Tabs extends LocalizeCoreElement(LoadingCompleteMixin(ArrowKeysMixin(Skele
 		this._resizeObserver.observe(this.shadowRoot.querySelector('.d2l-tabs-container-list'));
 
 		await this.loadingComplete;
-		console.log('Loading complete');
+		console.log('Loading complete'); // eslint-disable-line
 	}
 
 	render() {

--- a/helpers/localize-core-element.js
+++ b/helpers/localize-core-element.js
@@ -1,12 +1,15 @@
+import { LoadingCompleteMixin } from '../../mixins/loading-complete/loading-complete-mixin.js';
 import { LocalizeMixin } from '../mixins/localize/localize-mixin.js';
 
-export const LocalizeCoreElement = superclass => class extends LocalizeMixin(superclass) {
+export const LocalizeCoreElement = superclass => class extends LoadingCompleteMixin(LocalizeMixin(superclass)) {
 
 	static get localizeConfig() {
 		return {
 			importFunc: async lang => {
 				await new Promise(r => setTimeout(r, 2000));
-				return (await import(`../lang/${lang}.js`)).default;
+				const langterms = (await import(`../lang/${lang}.js`)).default;
+				console.log('Loaded langterms');
+				return langterms;
 			},
 			lazyLoad: true
 		};

--- a/helpers/localize-core-element.js
+++ b/helpers/localize-core-element.js
@@ -1,4 +1,4 @@
-import { LoadingCompleteMixin } from '../../mixins/loading-complete/loading-complete-mixin.js';
+import { LoadingCompleteMixin } from '../mixins/loading-complete/loading-complete-mixin.js';
 import { LocalizeMixin } from '../mixins/localize/localize-mixin.js';
 
 export const LocalizeCoreElement = superclass => class extends LoadingCompleteMixin(LocalizeMixin(superclass)) {
@@ -8,7 +8,7 @@ export const LocalizeCoreElement = superclass => class extends LoadingCompleteMi
 			importFunc: async lang => {
 				await new Promise(r => setTimeout(r, 2000));
 				const langterms = (await import(`../lang/${lang}.js`)).default;
-				console.log('Loaded langterms');
+				console.log('Loaded langterms'); // eslint-disable-line
 				return langterms;
 			},
 			lazyLoad: true

--- a/helpers/localize-core-element.js
+++ b/helpers/localize-core-element.js
@@ -4,7 +4,11 @@ export const LocalizeCoreElement = superclass => class extends LocalizeMixin(sup
 
 	static get localizeConfig() {
 		return {
-			importFunc: async lang => (await import(`../lang/${lang}.js`)).default
+			importFunc: async lang => {
+				await new Promise(r => setTimeout(r, 2000));
+				return (await import(`../lang/${lang}.js`)).default;
+			},
+			lazyLoad: true
 		};
 	}
 

--- a/mixins/loading-complete/README.md
+++ b/mixins/loading-complete/README.md
@@ -1,0 +1,22 @@
+# LoadingCompleteMixin
+
+The `LoadingCompleteMixin` contains boilerplate code for [`getLoadingComplete`](https://github.com/BrightspaceUI/testing#waiting-for-asynchronous-components). It simplifies fixture setup for custom components in automated tests.
+
+## Usage
+Apply the mixin and call `loadingComplete()` once your component has finished loading to indicate it is ready for validation.
+
+```js
+import { LoadingCompleteMixin } from '@brightspace-ui/core/mixins/loading-complete/loading-complete-mixin.js';
+
+class MyComponent extends LoadingCompleteMixin(LitElement) {
+
+	connectedCallback() {
+		this._fetchMyData().then(() => {
+			this.loadingComplete();
+		});
+	}
+
+}
+```
+
+If for whatever reason `loadingComplete` is never called, the `getLoadingComplete` promise will never resolve. In such cases any consumers (e.g. fixtures) will hang. If this behavior is not desired, ensure all code paths eventually call `loadingComplete`, or specify `{ awaitLoadingComplete: false }` in the `fixture` call.

--- a/mixins/loading-complete/README.md
+++ b/mixins/loading-complete/README.md
@@ -3,7 +3,7 @@
 The `LoadingCompleteMixin` contains boilerplate code for [`getLoadingComplete`](https://github.com/BrightspaceUI/testing#waiting-for-asynchronous-components). It simplifies fixture setup for custom components in automated tests.
 
 ## Usage
-Apply the mixin and call `loadingComplete()` once your component has finished loading to indicate it is ready for validation.
+Apply the mixin and call `resolveLoadingComplete()` once your component has finished loading to indicate it is ready for validation.
 
 ```js
 import { LoadingCompleteMixin } from '@brightspace-ui/core/mixins/loading-complete/loading-complete-mixin.js';
@@ -12,11 +12,11 @@ class MyComponent extends LoadingCompleteMixin(LitElement) {
 
 	connectedCallback() {
 		this._fetchMyData().then(() => {
-			this.loadingComplete();
+			this.resolveLoadingComplete();
 		});
 	}
 
 }
 ```
 
-If for whatever reason `loadingComplete` is never called, the `getLoadingComplete` promise will never resolve. In such cases any consumers (e.g. fixtures) will hang. If this behavior is not desired, ensure all code paths eventually call `loadingComplete`, or specify `{ awaitLoadingComplete: false }` in the `fixture` call.
+If for whatever reason `resolveLoadingComplete` is never called, the `getLoadingComplete` promise will never resolve. In such cases any consumers (e.g. fixtures) will hang. If this behavior is not desired, ensure all code paths eventually call `resolveLoadingComplete`, or specify `{ awaitLoadingComplete: false }` in the `fixture` call.

--- a/mixins/loading-complete/README.md
+++ b/mixins/loading-complete/README.md
@@ -1,9 +1,9 @@
 # LoadingCompleteMixin
 
-The `LoadingCompleteMixin` contains boilerplate code for [`getLoadingComplete`](https://github.com/BrightspaceUI/testing#waiting-for-asynchronous-components). It simplifies fixture setup for custom components in automated tests.
+The `LoadingCompleteMixin` contains boilerplate code for [`getLoadingComplete`](https://github.com/BrightspaceUI/testing#waiting-for-asynchronous-components). It simplifies fixture setup for custom components in automated tests, and provides a `loadingComplete` promise that can be used internally.
 
 ## Usage
-Apply the mixin and call `resolveLoadingComplete()` once your component has finished loading to indicate it is ready for validation.
+Apply the mixin and call `resolveLoadingComplete()` once your component has finished loading
 
 ```js
 import { LoadingCompleteMixin } from '@brightspace-ui/core/mixins/loading-complete/loading-complete-mixin.js';
@@ -11,12 +11,37 @@ import { LoadingCompleteMixin } from '@brightspace-ui/core/mixins/loading-comple
 class MyComponent extends LoadingCompleteMixin(LitElement) {
 
 	connectedCallback() {
-		this._fetchMyData().then(() => {
-			this.resolveLoadingComplete();
-		});
+		this._fetchMyData().then(this.resolveLoadingComplete);
 	}
 
 }
 ```
 
-If for whatever reason `resolveLoadingComplete` is never called, the `getLoadingComplete` promise will never resolve. In such cases any consumers (e.g. fixtures) will hang. If this behavior is not desired, ensure all code paths eventually call `resolveLoadingComplete`, or specify `{ awaitLoadingComplete: false }` in the `fixture` call.
+To make use of the `loadingComplete` promise, simply `await` it where needed
+
+```js
+async removeSkeleton() {
+	await this.loadingComplete;
+	this.skeleton = false;
+}
+```
+
+If for any reason `resolveLoadingComplete` is never called, `loadingComplete` won't resolve and any consumers will hang
+
+### `getLoadingComplete`
+
+In some cases, instead of finding one spot to call `resolveLoadingComplete`, you may find it easier to `await` a set of promises in a custom `getLoadingComplete` method
+
+You'll also need to use this method if you're working in a general-use mixin rather than directly in a component
+
+```js
+class MyComponent extends LoadingCompleteMixin(LitElement) {
+
+	async getLoadingComplete() {
+		await super.getLoadingComplete();
+		await this._myCustomIconImport;
+		await Promise.all(this._allMyDataPromises);
+	}
+}
+```
+Make sure all your promises are set before `firstUpdated`

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -5,7 +5,7 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	#loadingCompleteResolve;
 
 	// eslint-disable-next-line sort-class-members/sort-class-members
-	#loadingCompletePromise = Object.hasOwn(this.constructor.prototype, 'getLoadingComplete')
+	#loadingCompletePromise = !Object.hasOwn(this.constructor.prototype, 'getLoadingComplete')
 		? new Promise(resolve => this.#loadingCompleteResolve = resolve)
 		: Promise.resolve();
 
@@ -14,14 +14,12 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	}
 
 	get resolveLoadingComplete() {
-		return () => this.#resolveLoadingComplete();
-	}
-
-	#resolveLoadingComplete() {
-		if (this.#loadingCompleteResolve) {
-			this.#loadingCompleteResolve();
-			this.#loadingCompleteResolve = null;
-		}
+		return () => {
+			if (this.#loadingCompleteResolve) {
+				this.#loadingCompleteResolve();
+				this.#loadingCompleteResolve = null;
+			}
+		};
 	}
 
 	async getLoadingComplete() {

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -5,25 +5,16 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	#loadingCompleteResolve;
 
 	// eslint-disable-next-line sort-class-members/sort-class-members
-	#loadingCompletePromise = this.getLoadingComplete === this.#getLoadingComplete
+	#loadingCompletePromise = Object.hasOwn(this.constructor.prototype, 'getLoadingComplete')
 		? new Promise(resolve => this.#loadingCompleteResolve = resolve)
 		: Promise.resolve();
-
-	get getLoadingComplete() {
-		return this.#getLoadingComplete;
-	}
 
 	get loadingComplete() {
 		return this.getLoadingComplete();
 	}
 
 	get resolveLoadingComplete() {
-		return this.#resolveLoadingComplete.bind(this);
-	}
-
-	async #getLoadingComplete() {
-		await super.getLoadingComplete?.();
-		return this.#loadingCompletePromise;
+		return () => this.#resolveLoadingComplete();
 	}
 
 	#resolveLoadingComplete() {
@@ -31,6 +22,11 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 			this.#loadingCompleteResolve();
 			this.#loadingCompleteResolve = null;
 		}
+	}
+
+	async getLoadingComplete() {
+		await super.getLoadingComplete?.();
+		return this.#loadingCompletePromise;
 	}
 
 });

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -14,7 +14,7 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	}
 
 	get loadingComplete() {
-		return this.#getLoadingComplete();
+		return this.getLoadingComplete();
 	}
 
 	get resolveLoadingComplete() {

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -11,7 +11,7 @@ export const LoadingCompleteMixin = (superclass) => class extends superclass {
 		return this._loadingCompletePromise;
 	}
 
-	loadingComplete() {
+	resolveLoadingComplete() {
 		if (this._loadingCompleteResolve) {
 			this._loadingCompleteResolve();
 			this._loadingCompleteResolve = null;

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -1,0 +1,21 @@
+export const LoadingCompleteMixin = (superclass) => class extends superclass {
+
+	constructor() {
+		super();
+		this._loadingCompletePromise = new Promise(resolve => {
+			this._loadingCompleteResolve = resolve;
+		});
+	}
+
+	getLoadingComplete() {
+		return this._loadingCompletePromise;
+	}
+
+	loadingComplete() {
+		if (this._loadingCompleteResolve) {
+			this._loadingCompleteResolve();
+			this._loadingCompleteResolve = null;
+		}
+	}
+
+};

--- a/mixins/localize/localize-mixin.js
+++ b/mixins/localize/localize-mixin.js
@@ -26,6 +26,7 @@ export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinC
 				const resourcesLoadedPromise = Promise.all(localizeResources);
 				resourcesLoadedPromise
 					.then((results) => {
+
 						if (results.length === 0) {
 							return;
 						}
@@ -62,6 +63,10 @@ export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinC
 	}
 
 	async getUpdateComplete() {
+		if (this.constructor.localizeConfig?.lazyLoad) {
+			return super.getUpdateComplete();
+		}
+
 		await super.getUpdateComplete();
 		const hasResources = this._hasResources();
 		const resourcesLoaded = this.__resources !== undefined;
@@ -78,7 +83,7 @@ export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinC
 			return super.shouldUpdate(changedProperties);
 		}
 
-		const ready = this.__resources !== undefined;
+		const ready = this.constructor.localizeConfig?.lazyLoad || this.__resources !== undefined;
 		if (!ready) {
 			changedProperties.forEach((oldValue, propName) => {
 				this.__updatedProperties.set(propName, oldValue);
@@ -95,6 +100,13 @@ export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinC
 
 		return super.shouldUpdate(changedProperties);
 
+	}
+
+	async getLoadingComplete() {
+		if (this.constructor.localizeConfig?.lazyLoad) {
+			await super.getLoadingComplete?.();
+			return this.__resourcesLoadedPromise;
+		}
 	}
 
 	localize(key) {


### PR DESCRIPTION
Just an example of how the mixin in #4507 can be used across multiple layers.

~Once the build publishes~ the `tabs-loading` [demo page](https://live.d2l.dev/prs/BrightspaceUI/core/pr-4508/components/tabs/demo/tabs-loading.html) will show it working.