### PR TITLE
fix: Tooltip: Safari: show-truncated-only not working [GAUD-6196]

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -998,7 +998,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			await clone.updateComplete;
 		}
 
-		this._truncating = clone.scrollWidth > target.offsetWidth;
+		this._truncating = (clone.scrollWidth - target.offsetWidth) > 2;
 		this._resizeRunSinceTruncationCheck = false;
 		target.removeChild(cloneContainer);
 	}

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -998,7 +998,7 @@ class Tooltip extends RtlMixin(LitElement) {
 			await clone.updateComplete;
 		}
 
-		this._truncating = (clone.scrollWidth - target.offsetWidth) > 2;
+		this._truncating = (clone.scrollWidth - target.offsetWidth) > 2; // Safari adds 1px to scrollWidth necessitating a subtraction comparison.
 		this._resizeRunSinceTruncationCheck = false;
 		target.removeChild(cloneContainer);
 	}


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/jira/software/c/projects/GAUD/boards/330?selectedIssue=GAUD-6196)

**Problem**:
In the tag-list the truncation tooltip is always showing (other than on first focus). For example:
<img width="149" alt="Screenshot 2024-03-26 at 1 11 31 PM" src="https://github.com/BrightspaceUI/core/assets/6804600/dd9e8ee5-06f0-469e-b6ef-ed87d489a2b1">

This was also causing the keyboard instructional tooltip to not show.

Our expectation seems to be that generally `scrollWidth` of the clone is equal to `offsetWidth` of the target. However, Safari seems to be adding 1px to the `scrollWidth`. I couldn't find a why for this, but let me know if there's something I missed there.