### PR TITLE
fix: Alert-toast: Reset role when closed [GAUD-6138]

### DIFF
--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -387,14 +387,19 @@ class AlertToast extends LitElement {
 		}
 	}
 
+	_onStateClosed() {
+		this._state = states.CLOSED;
+		this._totalSiblingHeightBelow = 0;
+		this._numAlertsBelow = 0;
+		this._closeClicked = false;
+		this.removeAttribute('role');
+	}
+
 	_onTransitionEnd() {
 		if (this._state === states.OPENING || this._state === states.SLIDING) {
 			this._state = states.OPEN;
 		} else if (this._state === states.CLOSING) {
-			this._state = states.CLOSED;
-			this._totalSiblingHeightBelow = 0;
-			this._closeClicked = false;
-			this._numAlertsBelow = 0;
+			this._onStateClosed();
 		}
 	}
 
@@ -433,10 +438,7 @@ class AlertToast extends LitElement {
 				const bottom = this._innerContainer.getBoundingClientRect().bottom;
 
 				if (activeReduceMotion || this._state === states.PREOPENING) {
-					this._state = states.CLOSED;
-					this._totalSiblingHeightBelow = 0;
-					this._numAlertsBelow = 0;
-					this._closeClicked = false;
+					this._onStateClosed();
 				}
 
 				this.dispatchEvent(new CustomEvent(


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/jira/software/c/projects/GAUD/boards/330?selectedIssue=GAUD-6138)

**Problem:**
When a toast alert closes, generally the role does not reset and this can cause unexpected screen reader behaviour. 

It was noted as an issue on Chrome + NVDA (inconsistent experience; didn't say "Alert" on second opening and read the close button text twice). This seems to no longer be an issue (Chrome + Windows seems to be reseting `role` for some reason?), but I noticed on VoiceOver + Chrome it was only reading the alert the first time it was shown. 

I also am having trouble with VoiceOver + Safari reading the text at all (seems like it can be super delayed) but that seems like a separate issue.

**Solution notes:**
This removes the `role` attribute when the toast alert closes. Let me know if there's anything I'm missing as to why we wouldn't want to do that. I notice we already remove it when opened has changed to closed and prefers reduced motion is enabled or state is preopening.