### PR TITLE
fix: add max height to sort button cell

### DIFF
--- a/components/table/demo/table-test.js
+++ b/components/table/demo/table-test.js
@@ -99,7 +99,7 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 					<tbody>
 						<tr class="d2l-table-header">
 							<th scope="col" sticky></th>
-							${this._renderSortButton('Avocado')}
+							${this._renderDoubleSortButton('Avocado')}
 							${fruits.map(fruit => this._renderSortButton(fruit))}
 						</tr>
 						<tr header>
@@ -151,6 +151,22 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 		const noSort = this._sortField !== fruit.toLowerCase();
 		return html`
 			<th scope="col">
+				<d2l-table-col-sort-button
+					@click="${this._handleSort}"
+					?desc="${this._sortDesc}"
+					?nosort="${noSort}">${fruit}</d2l-table-col-sort-button>
+			</th>
+		`;
+	}
+
+	_renderDoubleSortButton(fruit) {
+		const noSort = this._sortField !== fruit.toLowerCase();
+		return html`
+			<th scope="col">
+				<d2l-table-col-sort-button
+					@click="${this._handleSort}"
+					?desc="${this._sortDesc}"
+					?nosort="${noSort}">${fruit}</d2l-table-col-sort-button>
 				<d2l-table-col-sort-button
 					@click="${this._handleSort}"
 					?desc="${this._sortDesc}"

--- a/components/table/demo/table-test.js
+++ b/components/table/demo/table-test.js
@@ -99,7 +99,7 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 					<tbody>
 						<tr class="d2l-table-header">
 							<th scope="col" sticky></th>
-							${this._renderDoubleSortButton('Avocado')}
+							${this._renderSortButton('Avocado')}
 							${fruits.map(fruit => this._renderSortButton(fruit))}
 						</tr>
 						<tr header>
@@ -151,22 +151,6 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 		const noSort = this._sortField !== fruit.toLowerCase();
 		return html`
 			<th scope="col">
-				<d2l-table-col-sort-button
-					@click="${this._handleSort}"
-					?desc="${this._sortDesc}"
-					?nosort="${noSort}">${fruit}</d2l-table-col-sort-button>
-			</th>
-		`;
-	}
-
-	_renderDoubleSortButton(fruit) {
-		const noSort = this._sortField !== fruit.toLowerCase();
-		return html`
-			<th scope="col">
-				<d2l-table-col-sort-button
-					@click="${this._handleSort}"
-					?desc="${this._sortDesc}"
-					?nosort="${noSort}">${fruit}</d2l-table-col-sort-button>
 				<d2l-table-col-sort-button
 					@click="${this._handleSort}"
 					?desc="${this._sortDesc}"

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -47,6 +47,7 @@ export class TableColSortButton extends FocusMixin(LitElement) {
 				letter-spacing: inherit;
 				line-height: 0.9rem;
 				margin: 0;
+				max-height: 48px;
 				padding: var(--d2l-table-cell-padding);
 				text-decoration: none;
 				width: var(--d2l-sortable-button-width);

--- a/components/table/test/table.vdiff.js
+++ b/components/table/test/table.vdiff.js
@@ -27,6 +27,19 @@ function createSortableHeaderRow() {
 		</tr>
 	`;
 }
+
+function createSortableHeaderRowWithDoubleButton() {
+	return html`
+		<tr>
+			<th>
+				<d2l-table-col-sort-button>Double 1</d2l-table-col-sort-button>
+				<d2l-table-col-sort-button>Double 2</d2l-table-col-sort-button>
+			</th>
+			<th><d2l-table-col-sort-button desc>Cell A</d2l-table-col-sort-button></th>
+			<th><d2l-table-col-sort-button nosort>Cell B</d2l-table-col-sort-button></th>
+		</tr>
+	`;
+}
 function createFruitHeaderRows(opts) {
 	const { selectable, headerAttribute, stickyAttribute, stickyClass, trClass } = { selectable: false, headerAttribute: false, stickyAttribute: false, ...opts };
 	return html`
@@ -410,6 +423,14 @@ describe('table', () => {
 				it('col-sort-button', async() => {
 					const elem = await createTableFixture(html`
 						<thead>${createSortableHeaderRow()}</thead>
+						<tbody>${createRows([1])}</tbody>
+					`);
+					await expect(elem).to.be.golden();
+				});
+
+				it('col-sort-button-double', async() => {
+					const elem = await createTableFixture(html`
+						<thead>${createSortableHeaderRowWithDoubleButton()}</thead>
 						<tbody>${createRows([1])}</tbody>
 					`);
 					await expect(elem).to.be.golden();


### PR DESCRIPTION
This is a draft of the solution I've thought of:

The current strategy is to use the height of the parent `th` component. When multiple buttons or items are put inside it all the button will use the height of all of them put together (or height - `8px` for light). So if the cell is 50px with 2 buttons inside, each of the buttons will be 42px tall.

My proposed solution is to set a max height for the button of 48px (which follows the height we want for header cells), or some other number.

The problem currently is that the first row has a height of 54px, there's a little bit of space that's not covered on hover.

![Screenshot (127)](https://github.com/BrightspaceUI/core/assets/24593380/796fdf2b-e879-4faa-87d5-d62a24e9bc67)

![Screenshot (128)](https://github.com/BrightspaceUI/core/assets/24593380/b082cd4e-8520-4984-89ff-39af79b5f166)

![Screenshot (129)](https://github.com/BrightspaceUI/core/assets/24593380/05170dcc-9c1f-446e-bc97-d801972a3e28)

![Screenshot (130)](https://github.com/BrightspaceUI/core/assets/24593380/27114ad5-74f4-43f2-ab29-c4d37f3caebc)

![Screenshot (131)](https://github.com/BrightspaceUI/core/assets/24593380/c85c1a74-ee04-488d-83a2-26d6916c33cb)


