### PR TITLE
GAUD-6207 - Turn on update-package-lock slack notifications

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -23,3 +23,6 @@ jobs:
           AUTO_MERGE_TOKEN: ${{ secrets.CORE_GITHUB_TOKEN }}        
           APPROVAL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.CORE_GITHUB_TOKEN }}
+          SLACK_CHANNEL_FAILURE: '#gaudi-dev-alerts'
+          SLACK_CHANNEL_STALE_PR: '#gaudi-dev-alerts'
+          SLACK_TOKEN: ${{ secrets.D2L_SLACK_TOKEN }}


### PR DESCRIPTION
This will let us know if the `update-package-lock` workflow failed, or the PR it opens has been open for more than 3 days.