### PR TITLE
[d2l-meter] property for hiding text 

### DIFF
--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -90,17 +90,15 @@
 						<d2l-meter-circle value="0" max="10"></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" text="Completed" text-hidden></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" percent></d2l-meter-circle>
-						<d2l-meter-circle value="10" max="10" text="Completed"></d2l-meter-circle>
-						<d2l-meter-circle value="10" max="10" diameter=185 text="Completed"></d2l-meter-circle>
-						<d2l-meter-circle value="19" max="26" style="width: 185px;"></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10" text="Completed" diameter="5rem"></d2l-meter-circle>
+						<d2l-meter-circle value="19" max="26" text="Completed" diameter="185px"></d2l-meter-circle>
 					</div>
 					<div class="dark-background">
 						<d2l-meter-circle value="0" max="10" foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" text="Completed" text-hidden foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" percent foreground-light></d2l-meter-circle>
-						<d2l-meter-circle value="10" max="10" text="Completed" foreground-light></d2l-meter-circle>
-						<d2l-meter-circle value="19" max="26" style="width: 25%;" text="Completed" foreground-light></d2l-meter-circle>
-						<d2l-meter-circle value="19" max="26" diameter=25 diameter-units="%" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10" text="Completed" diameter="5rem" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="19" max="26" text="Completed" diameter="185px" foreground-light></d2l-meter-circle>
 					</div>
 				</template>
 			</d2l-demo-snippet>

--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -91,16 +91,16 @@
 						<d2l-meter-circle value="5" max="13" text="Completed" text-hidden></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" percent></d2l-meter-circle>
 						<d2l-meter-circle value="10" max="10" text="Completed"></d2l-meter-circle>
-						<d2l-meter-circle value="19" max="26" style="width: 25%;"></d2l-meter-circle>
-						<d2l-meter-circle value="19" max="26" style="width: 25%;" text="Completed"></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10" diameter=185 text="Completed"></d2l-meter-circle>
+						<d2l-meter-circle value="19" max="26" style="width: 185px;"></d2l-meter-circle>
 					</div>
 					<div class="dark-background">
 						<d2l-meter-circle value="0" max="10" foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" text="Completed" text-hidden foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" percent foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="10" max="10" text="Completed" foreground-light></d2l-meter-circle>
-						<d2l-meter-circle value="19" max="26" style="width: 25%;" foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="19" max="26" style="width: 25%;" text="Completed" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="19" max="26" diameter=25 diameter-units="%" foreground-light></d2l-meter-circle>
 					</div>
 				</template>
 			</d2l-demo-snippet>

--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -88,19 +88,19 @@
 				<template>
 					<div>
 						<d2l-meter-circle value="0" max="10"></d2l-meter-circle>
-						<d2l-meter-circle value="5" max="13"></d2l-meter-circle>
+						<d2l-meter-circle value="5" max="13" text="Completed" text-hidden></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" percent></d2l-meter-circle>
-						<d2l-meter-circle value="10" max="10" text="Completed" text-hidden></d2l-meter-circle>
 						<d2l-meter-circle value="10" max="10" text="Completed"></d2l-meter-circle>
 						<d2l-meter-circle value="19" max="26" style="width: 25%;"></d2l-meter-circle>
+						<d2l-meter-circle value="19" max="26" style="width: 25%;" text="Completed"></d2l-meter-circle>
 					</div>
 					<div class="dark-background">
 						<d2l-meter-circle value="0" max="10" foreground-light></d2l-meter-circle>
-						<d2l-meter-circle value="5" max="13" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="5" max="13" text="Completed" text-hidden foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" percent foreground-light></d2l-meter-circle>
-						<d2l-meter-circle value="10" max="10" text="Completed" text-hidden foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="10" max="10" text="Completed" foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="19" max="26" style="width: 25%;" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="19" max="26" style="width: 25%;" text="Completed" foreground-light></d2l-meter-circle>
 					</div>
 				</template>
 			</d2l-demo-snippet>

--- a/components/meter/demo/meter.html
+++ b/components/meter/demo/meter.html
@@ -67,16 +67,16 @@
 						<d2l-meter-radial value="0" max="10"></d2l-meter-radial>
 						<d2l-meter-radial value="5" max="13"></d2l-meter-radial>
 						<d2l-meter-radial value="5" max="13" percent></d2l-meter-radial>
-						<d2l-meter-radial value="10" max="10"></d2l-meter-radial>
-						<d2l-meter-radial value="5" max="10" text="Completed"></d2l-meter-radial>
+						<d2l-meter-radial value="10" max="10" text="Completed" text-hidden></d2l-meter-radial>
+						<d2l-meter-radial value="10" max="10" text="Completed"></d2l-meter-radial>
 						<d2l-meter-radial value="19" max="26" style="width: 25%;"></d2l-meter-radial>
 					</div>
 					<div class="dark-background">
 						<d2l-meter-radial value="0" max="10" foreground-light></d2l-meter-radial>
 						<d2l-meter-radial value="5" max="13" foreground-light></d2l-meter-radial>
 						<d2l-meter-radial value="5" max="13" percent foreground-light></d2l-meter-radial>
-						<d2l-meter-radial value="10" max="10" foreground-light></d2l-meter-radial>
-						<d2l-meter-radial value="5" max="10" text="Completed" foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="10" max="10" text="Completed" text-hidden foreground-light></d2l-meter-radial>
+						<d2l-meter-radial value="10" max="10" text="Completed" foreground-light></d2l-meter-radial>
 						<d2l-meter-radial value="19" max="26" style="width: 25%;" foreground-light></d2l-meter-radial>
 					</div>
 				</template>
@@ -90,14 +90,16 @@
 						<d2l-meter-circle value="0" max="10"></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13"></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" percent></d2l-meter-circle>
-						<d2l-meter-circle value="10" max="10"></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10" text="Completed" text-hidden></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10" text="Completed"></d2l-meter-circle>
 						<d2l-meter-circle value="19" max="26" style="width: 25%;"></d2l-meter-circle>
 					</div>
 					<div class="dark-background">
 						<d2l-meter-circle value="0" max="10" foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="5" max="13" percent foreground-light></d2l-meter-circle>
-						<d2l-meter-circle value="10" max="10" foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10" text="Completed" text-hidden foreground-light></d2l-meter-circle>
+						<d2l-meter-circle value="10" max="10" text="Completed" foreground-light></d2l-meter-circle>
 						<d2l-meter-circle value="19" max="26" style="width: 25%;" foreground-light></d2l-meter-circle>
 					</div>
 				</template>

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -13,15 +13,12 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 		return [ bodySmallStyles, bodyStandardStyles, css`
 		:host {
 			display: inline-block;
-			width: auto;
+			width: 2.4rem;
 		}
 		.d2l-meter-circle {
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
-		}
-		:host(:not([style*=width])) .base-width {
-			width: 2.4rem;
 		}
 		.d2l-meter-circle-full-bar,
 		.d2l-meter-circle-progress-bar {
@@ -63,6 +60,9 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 	}
 
 	render() {
+		if (this.diameter) {
+			this.style.setProperty('width', `${this.diameter}${this.diameterUnits}`);
+		}
 		const lengthOfLine = 21 * Math.PI * 2; // approximation perimeter of circle
 		const percent = this.max > 0 ? (this.value / this.max) : 0;
 		const visibility = (percent < 0.005) ? 'hidden' : 'visible';
@@ -79,18 +79,12 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 			'd2l-meter-circle-text': true
 		};
 
-		// For circle meters that will not have text displayed we need to add a basic width to the svg meter (2.4rem)
-		// In the css, if the host level has has the width declared for the meter then we will stop the 2.4rem width from being applied to the svg
-		const svgClasses = {
-			'base-width': (!this.text || !!this.textHidden)
-		};
-
 		return html`
 			<div
 				class="d2l-meter-circle"
 				aria-label="${this._ariaLabel(primary, secondary)}"
 				role="img">
-				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision" class="${classMap(svgClasses)}">
+				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision">
 					<circle class="d2l-meter-circle-full-bar" cx="24" cy="24" r="21"></circle>
 					<circle
 						class="d2l-meter-circle-progress-bar"

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -83,7 +83,7 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 		// In the css, if the host level has has the width declared for the meter then we will stop the 2.4rem width from being applied to the svg
 		const svgClasses = {
 			'base-width': (!this.text || !!this.textHidden)
-		}
+		};
 
 		return html`
 			<div

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -13,12 +13,15 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 		return [ bodySmallStyles, bodyStandardStyles, css`
 		:host {
 			display: inline-block;
-			width: 2.4rem;
+			width: auto;
 		}
 		.d2l-meter-circle {
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
+		}
+		:host(:not([style*=width])) .base-width {
+			width: 2.4rem;
 		}
 		.d2l-meter-circle-full-bar,
 		.d2l-meter-circle-progress-bar {
@@ -76,12 +79,18 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 			'd2l-meter-circle-text': true
 		};
 
+		// For circle meters that will not have text displayed we need to add a basic width to the svg meter (2.4rem)
+		// In the css, if the host level has has the width declared for the meter then we will stop the 2.4rem width from being applied to the svg
+		const svgClasses = {
+			'base-width': (!this.text || !!this.textHidden)
+		}
+
 		return html`
 			<div
 				class="d2l-meter-circle"
 				aria-label="${this._ariaLabel(primary, secondary)}"
 				role="img">
-				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision">
+				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision" class="${classMap(svgClasses)}">
 					<circle class="d2l-meter-circle-full-bar" cx="24" cy="24" r="21"></circle>
 					<circle
 						class="d2l-meter-circle-progress-bar"

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -1,7 +1,6 @@
 import '../colors/colors.js';
-import { bodySmallStyles } from '../typography/styles.js';
+import { bodySmallStyles, bodyStandardStyles } from '../typography/styles.js';
 import { css, html, LitElement, nothing } from 'lit';
-import { bodyStandardStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { MeterMixin } from './meter-mixin.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -81,8 +81,7 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 
 		return html`
 			<div
-				class="${(this.text && !this.textHidden) ? 'fit-content ' : ''}d2l-meter-circle"
-				role="img"
+				class="d2l-meter-circle"
 				aria-label="${this._ariaLabel(primary, secondary)}">
 				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision" role="img">
 					<circle class="d2l-meter-circle-full-bar" cx="24" cy="24" r="21"></circle>

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -51,7 +51,6 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 		}
 		.d2l-meter-circle-text-secondary {
 			color: var(--d2l-color-ferrite);
-			font-size: 0.6rem;
 			text-align: center;
 		}
 		:host([foreground-light]) .d2l-meter-circle-text-secondary {

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -1,5 +1,6 @@
 import '../colors/colors.js';
-import { css, html, LitElement } from 'lit';
+import { bodySmallStyles } from '../typography/styles.js';
+import { css, html, LitElement, nothing } from 'lit';
 import { bodyStandardStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { MeterMixin } from './meter-mixin.js';
@@ -10,10 +11,18 @@ import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
  */
 class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 	static get styles() {
-		return [ bodyStandardStyles, css`
+		return [ bodySmallStyles, bodyStandardStyles, css`
 		:host {
 			display: inline-block;
 			width: 2.4rem;
+		}
+		:host([text]:not([text-hidden])) {
+			width: fit-content;
+		}
+		.d2l-meter-circle {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
 		}
 		.d2l-meter-circle-full-bar,
 		.d2l-meter-circle-progress-bar {
@@ -41,6 +50,14 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 		:host([foreground-light]) .d2l-meter-circle-text {
 			fill: white;
 		}
+		.d2l-meter-circle-text-secondary {
+			color: var(--d2l-color-ferrite);
+			font-size: 0.6rem;
+			text-align: center;
+		}
+		:host([foreground-light]) .d2l-meter-circle-text-secondary {
+			color: white;
+		}
 		:host([dir="rtl"]) .d2l-meter-circle-text-ltr {
 			direction: ltr;
 		}
@@ -57,6 +74,7 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 
 		const primary = this._primary(this.value, this.max) || '';
 		const secondary = this._secondary(this.value, this.max, this.text);
+		const secondaryTextElement = (this.text && !this.textHidden) ? html`<div class="d2l-body-small d2l-meter-circle-text-secondary">${secondary}</div>` : nothing;
 		const textClasses = {
 			'd2l-meter-circle-text-ltr': !this.percent,
 			'd2l-body-standard': true,
@@ -64,19 +82,25 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 		};
 
 		return html`
-			<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision" role="img" aria-label="${this._ariaLabel(primary, secondary)}">
-				<circle class="d2l-meter-circle-full-bar" cx="24" cy="24" r="21"></circle>
-				<circle
-					class="d2l-meter-circle-progress-bar"
-					cx="24" cy="24" r="21"
-					stroke-dasharray="${progressFill} ${space}"
-					stroke-dashoffset="${dashOffset}"
-					visibility="${visibility}"></circle>
+			<div
+				class="${(this.text && !this.textHidden) ? 'fit-content ' : ''}d2l-meter-circle"
+				role="img"
+				aria-label="${this._ariaLabel(primary, secondary)}">
+				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision" role="img">
+					<circle class="d2l-meter-circle-full-bar" cx="24" cy="24" r="21"></circle>
+					<circle
+						class="d2l-meter-circle-progress-bar"
+						cx="24" cy="24" r="21"
+						stroke-dasharray="${progressFill} ${space}"
+						stroke-dashoffset="${dashOffset}"
+						visibility="${visibility}"></circle>
 
-				<text class=${classMap(textClasses)} x="24" y="28" text-anchor="middle">
-					${primary}
-				</text>
-			</svg>
+					<text class=${classMap(textClasses)} x="24" y="28" text-anchor="middle">
+						${primary}
+					</text>
+				</svg>
+				${secondaryTextElement}
+			</div>
 		`;
 	}
 }

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -13,7 +13,10 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 		return [ bodySmallStyles, bodyStandardStyles, css`
 		:host {
 			display: inline-block;
-			width: 2.4rem;
+			width: auto;
+		}
+		svg {
+			margin: 0 auto;
 		}
 		.d2l-meter-circle {
 			display: flex;
@@ -59,10 +62,19 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 	` ];
 	}
 
+	static get properties() {
+		return {
+			/**
+			 * Width styling of the meter
+			 * Valid values: A string repersenting the numerical and unit value
+			 * ex. "25%", "185px", "20rem"
+			 * @type {string}
+			 */
+			diameter: { type: String },
+		};
+	}
+
 	render() {
-		if (this.diameter) {
-			this.style.setProperty('width', `${this.diameter}${this.diameterUnits}`);
-		}
 		const lengthOfLine = 21 * Math.PI * 2; // approximation perimeter of circle
 		const percent = this.max > 0 ? (this.value / this.max) : 0;
 		const visibility = (percent < 0.005) ? 'hidden' : 'visible';
@@ -84,7 +96,7 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 				class="d2l-meter-circle"
 				aria-label="${this._ariaLabel(primary, secondary)}"
 				role="img">
-				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision">
+				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision" style="width: ${this.diameter || '2.4rem'};">
 					<circle class="d2l-meter-circle-full-bar" cx="24" cy="24" r="21"></circle>
 					<circle
 						class="d2l-meter-circle-progress-bar"

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -15,9 +15,6 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 			display: inline-block;
 			width: 2.4rem;
 		}
-		:host([text]:not([text-hidden])) {
-			width: fit-content;
-		}
 		.d2l-meter-circle {
 			display: flex;
 			flex-direction: column;
@@ -82,8 +79,9 @@ class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
 		return html`
 			<div
 				class="d2l-meter-circle"
-				aria-label="${this._ariaLabel(primary, secondary)}">
-				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision" role="img">
+				aria-label="${this._ariaLabel(primary, secondary)}"
+				role="img">
+				<svg viewBox="0 0 48 48" shape-rendering="geometricPrecision">
 					<circle class="d2l-meter-circle-full-bar" cx="24" cy="24" r="21"></circle>
 					<circle
 						class="d2l-meter-circle-progress-bar"

--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -121,7 +121,7 @@ class MeterLinear extends MeterMixin(RtlMixin(LitElement)) {
 			'd2l-meter-linear-primary-ltr': !this.percent,
 			'd2l-meter-linear-primary': true
 		};
-		const secondaryTextElement = secondary ? html`<div class="d2l-meter-linear-secondary">${secondary}</div>` : nothing;
+		const secondaryTextElement = (secondary && !this.textHidden) ? html`<div class="d2l-meter-linear-secondary">${secondary}</div>` : nothing;
 
 		return html `
 			<div

--- a/components/meter/meter-mixin.js
+++ b/components/meter/meter-mixin.js
@@ -22,6 +22,11 @@ export const MeterMixin = superclass => class extends LocalizeCoreElement(superc
 			 */
 			text: { type: String },
 			/**
+			 * Displays the text as a label beneath the meter
+			 * @type {boolean}
+			 */
+			textHidden: { type: Boolean, attribute: 'text-hidden' },
+			/**
 			 * REQUIRED: Current number of completed units.
 			 * Valid values: A number between 0 and max
 			 * @type {number}
@@ -34,6 +39,7 @@ export const MeterMixin = superclass => class extends LocalizeCoreElement(superc
 		super();
 		this.max = 100;
 		this.percent = false;
+		this.textHidden = false;
 		this.value = 0;
 
 		this._namespace = 'components.meter-mixin';

--- a/components/meter/meter-mixin.js
+++ b/components/meter/meter-mixin.js
@@ -22,10 +22,10 @@ export const MeterMixin = superclass => class extends LocalizeCoreElement(superc
 			 */
 			text: { type: String },
 			/**
-			 * Displays the text as a label beneath the meter
+			 * Hides the text from being displayed beneath the meter
 			 * @type {boolean}
 			 */
-			textHidden: { type: Boolean, attribute: 'text-hidden' },
+			textHidden: { type: Boolean, attribute: 'text-hidden', reflect: true },
 			/**
 			 * REQUIRED: Current number of completed units.
 			 * Valid values: A number between 0 and max

--- a/components/meter/meter-mixin.js
+++ b/components/meter/meter-mixin.js
@@ -6,6 +6,19 @@ export const MeterMixin = superclass => class extends LocalizeCoreElement(superc
 	static get properties() {
 		return {
 			/**
+			 * To be used by the circle-meter only.
+			 * Width styling of the meter
+			 * Valid values: A number > 0
+			 * @type {number}
+			 */
+			diameter: { type: Number },
+			/**
+			 * To be used by the circle-meter only.
+			 * Units for the width styling, default `px`
+			 * @type { string }
+			 */
+			diameterUnits: { type: String, attribute: 'diameter-units' },
+			/**
 			 * Max number of units that are being measured by this meter.
 			 * Valid values: A number > 0
 			 * @type {number}
@@ -41,6 +54,7 @@ export const MeterMixin = superclass => class extends LocalizeCoreElement(superc
 		this.percent = false;
 		this.textHidden = false;
 		this.value = 0;
+		this.diameterUnits = 'px';
 
 		this._namespace = 'components.meter-mixin';
 	}

--- a/components/meter/meter-radial.js
+++ b/components/meter/meter-radial.js
@@ -61,7 +61,7 @@ class MeterRadial extends MeterMixin(RtlMixin(LitElement)) {
 		const progressFill = percent * lengthOfLine;
 		const primary = this._primary(this.value, this.max);
 		const secondary = this._secondary(this.value, this.max, this.text);
-		const secondaryTextElement = this.text ? html`<div class="d2l-body-small d2l-meter-radial-text">${secondary}</div>` : nothing;
+		const secondaryTextElement = (this.text && !this.textHidden) ? html`<div class="d2l-body-small d2l-meter-radial-text">${secondary}</div>` : nothing;
 		const textClasses = {
 			'd2l-meter-radial-text-ltr': !this.percent,
 			'd2l-heading-4': true,

--- a/components/meter/test/meter-circle.vdiff.js
+++ b/components/meter/test/meter-circle.vdiff.js
@@ -20,6 +20,8 @@ describe('meter-circle', () => {
 		{ name: 'complete', template: html`<d2l-meter-circle value="5" max="5"></d2l-meter-circle>` },
 		{ name: 'round-to-zero', template: html`<d2l-meter-circle value="0.004" max="100"></d2l-meter-circle>` },
 		{ name: 'max-zero-with-value', template: html`<d2l-meter-circle value="10" max="0"></d2l-meter-circle>` },
+		{ name: 'text', template: html`<d2l-meter-circle value="10" max="10" text="Completed"></d2l-meter-circle>` },
+		{ name: 'text-hidden', template: html`<d2l-meter-circle value="10" max="10" text="Completed" text-hidden></d2l-meter-circle>` },
 		{ name: 'foreground-light', wrapped: true, template: html`
 			<div style="background-color: var(--d2l-color-celestine); padding: 1rem;">
 				<d2l-meter-circle value="16" max="47" foreground-light></d2l-meter-circle>

--- a/components/meter/test/meter-circle.vdiff.js
+++ b/components/meter/test/meter-circle.vdiff.js
@@ -36,6 +36,16 @@ describe('meter-circle', () => {
 			<div style="width: 90px;">
 				<d2l-meter-circle value="16" max="47" style="width: 30%;"></d2l-meter-circle>
 			</div>
+		` },
+		{ name: 'scaled-larger-diameter', wrapped: true, template: html`
+			<div style="width: 90px;">
+				<d2l-meter-circle value="16" max="47" diameter=300 diameter-units="%"></d2l-meter-circle>
+			</div>
+		` },
+		{ name: 'scaled-smaller-diameter', wrapped: true, template: html`
+			<div style="width: 90px;">
+				<d2l-meter-circle value="16" max="47" diameter=30 diameter-units="%"></d2l-meter-circle>
+			</div>
 		` }
 	].forEach(({ name, template, wrapped }) => {
 		it(name, async() => {

--- a/components/meter/test/meter-circle.vdiff.js
+++ b/components/meter/test/meter-circle.vdiff.js
@@ -27,24 +27,14 @@ describe('meter-circle', () => {
 				<d2l-meter-circle value="16" max="47" foreground-light></d2l-meter-circle>
 			</div>
 		` },
-		{ name: 'scaled-larger', wrapped: true, template: html`
-			<div style="width: 90px;">
-				<d2l-meter-circle value="16" max="47" style="width: 300%;"></d2l-meter-circle>
-			</div>
-		` },
-		{ name: 'scaled-smaller', wrapped: true, template: html`
-			<div style="width: 90px;">
-				<d2l-meter-circle value="16" max="47" style="width: 30%;"></d2l-meter-circle>
-			</div>
-		` },
 		{ name: 'scaled-larger-diameter', wrapped: true, template: html`
 			<div style="width: 90px;">
-				<d2l-meter-circle value="16" max="47" diameter=300 diameter-units="%"></d2l-meter-circle>
+				<d2l-meter-circle value="16" max="47" diameter="300%"></d2l-meter-circle>
 			</div>
 		` },
 		{ name: 'scaled-smaller-diameter', wrapped: true, template: html`
 			<div style="width: 90px;">
-				<d2l-meter-circle value="16" max="47" diameter=30 diameter-units="%"></d2l-meter-circle>
+				<d2l-meter-circle value="16" max="47" diameter="30%"></d2l-meter-circle>
 			</div>
 		` }
 	].forEach(({ name, template, wrapped }) => {

--- a/components/meter/test/meter-linear.vdiff.js
+++ b/components/meter/test/meter-linear.vdiff.js
@@ -47,6 +47,7 @@ describe('meter-linear', () => {
 
 	[
 		{ name: 'normal-text', template: html`<d2l-meter-linear id="normal-text" value="4" max="10" text="You're doing great!"></d2l-meter-linear>` },
+		{ name: 'text-hidden', template: html`<d2l-meter-linear id="text-hidden" value="4" max="10" text="You're doing great!" text-hidden></d2l-meter-linear>` },
 		{ name: 'normal-max-zero-value-zero', template: html`<d2l-meter-linear value="0" max="0" text="Visited: {x/y}" percent></d2l-meter-linear>` },
 		{ name: 'normal-round-to-zero', template: html`<d2l-meter-linear value="0.004" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>` },
 		{ name: 'normal-over-100', template: html`<d2l-meter-linear value="15" max="10" text="Visited: {x/y}" percent></d2l-meter-linear>` },

--- a/components/meter/test/meter-radial.vdiff.js
+++ b/components/meter/test/meter-radial.vdiff.js
@@ -19,6 +19,8 @@ describe('meter-radial', () => {
 	[
 		{ name: 'no-progress', template: html`<d2l-meter-radial value="0" max="10"></d2l-meter-radial>` },
 		{ name: 'complete', template: html`<d2l-meter-radial value="256" max="256"></d2l-meter-radial>` },
+		{ name: 'text', template: html`<d2l-meter-radial value="256" max="256" text="Completed"></d2l-meter-radial>` },
+		{ name: 'text', template: html`<d2l-meter-radial value="256" max="256" text="Completed" text-hidden></d2l-meter-radial>` },
 		{ name: 'round-to-zero', template: html`<d2l-meter-radial value="0.004" max="100" percent></d2l-meter-radial>` },
 		{ name: 'max-zero-with-value', template: html`<d2l-meter-radial value="10" max="0"></d2l-meter-radial>` },
 		{ name: 'foreground-light', wrapped: true, template: html`


### PR DESCRIPTION
## Context

- circle meter took in a `text` property like the radial meter, however it only assigned it to the aria text. We'd like the circle meter to be able to behave similarly to the radial meter
- https://d2l.slack.com/archives/C0PHG3QB0/p1712758381367159

## Implementation Details

- add `text-hidden` prop to meter-mixin
- begin using the new prop to dynamically inject text beneath the circle meter

