### PR TITLE
GAUD 5465: use "slider" ARIA role and only render divider when resizable

### DIFF
--- a/lang/ar.js
+++ b/lang/ar.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "مسافة للخلف/حذف",
 	"components.tag-list-item.tooltip-delete-key-desc": "حذف العلامة المركّز عليها",
 	"components.tag-list-item.tooltip-title": "عناصر التحكم في لوحة المفاتيح",
-	"templates.primary-secondary.keyboardHorizontal": "السهم المتّجه إلى اليسار أو إلى اليمين لضبط حجم لوحات العرض",
-	"templates.primary-secondary.keyboardVertical": "السهم المتّجه إلى الأعلى أو إلى الأسفل لضبط حجم لوحات العرض"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "مسافة للخلف/حذف",
 	"components.tag-list-item.tooltip-delete-key-desc": "حذف العلامة المركّز عليها",
 	"components.tag-list-item.tooltip-title": "عناصر التحكم في لوحة المفاتيح",
-	"templates.primary-secondary.adjustableSplitView": "تقسيم العرض القابل للضبط",
 	"templates.primary-secondary.keyboardHorizontal": "السهم المتّجه إلى اليسار أو إلى اليمين لضبط حجم لوحات العرض",
 	"templates.primary-secondary.keyboardVertical": "السهم المتّجه إلى الأعلى أو إلى الأسفل لضبط حجم لوحات العرض"
 };

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Yn ôl/Dileu",
 	"components.tag-list-item.tooltip-delete-key-desc": "Dileu’r tag â ffocws",
 	"components.tag-list-item.tooltip-title": "Rheolyddion Bysellfwrdd",
-	"templates.primary-secondary.keyboardHorizontal": "Saeth i'r chwith neu'r dde i addasu maint y paneli gweld",
-	"templates.primary-secondary.keyboardVertical": "Saeth i fyny neu i lawr i addasu maint y paneli gweld"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Yn ôl/Dileu",
 	"components.tag-list-item.tooltip-delete-key-desc": "Dileu’r tag â ffocws",
 	"components.tag-list-item.tooltip-title": "Rheolyddion Bysellfwrdd",
-	"templates.primary-secondary.adjustableSplitView": "Gwedd Hollt Addasadwy",
 	"templates.primary-secondary.keyboardHorizontal": "Saeth i'r chwith neu'r dde i addasu maint y paneli gweld",
 	"templates.primary-secondary.keyboardVertical": "Saeth i fyny neu i lawr i addasu maint y paneli gweld"
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Tilbage/Slet",
 	"components.tag-list-item.tooltip-delete-key-desc": "Slet det fokuserede tag",
 	"components.tag-list-item.tooltip-title": "Kontrolelementer på tastaturet",
-	"templates.primary-secondary.keyboardHorizontal": "Pil til venstre eller højre for at justere størrelsen på visningspaneler",
-	"templates.primary-secondary.keyboardVertical": "Pil op eller ned for at justere størrelsen på visningspaneler"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Tilbage/Slet",
 	"components.tag-list-item.tooltip-delete-key-desc": "Slet det fokuserede tag",
 	"components.tag-list-item.tooltip-title": "Kontrolelementer på tastaturet",
-	"templates.primary-secondary.adjustableSplitView": "Justerbar delt visning",
 	"templates.primary-secondary.keyboardHorizontal": "Pil til venstre eller højre for at justere størrelsen på visningspaneler",
 	"templates.primary-secondary.keyboardVertical": "Pil op eller ned for at justere størrelsen på visningspaneler"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Rücktaste/Entfernen",
 	"components.tag-list-item.tooltip-delete-key-desc": "Ausgewählten Tag löschen",
 	"components.tag-list-item.tooltip-title": "Tastatursteuerung",
-	"templates.primary-secondary.keyboardHorizontal": "Pfeil nach links oder rechts, um die Größe der Ansichtsbereiche anzupassen",
-	"templates.primary-secondary.keyboardVertical": "Pfeil nach oben oder unten, um die Größe der Ansichtsbereiche anzupassen"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Rücktaste/Entfernen",
 	"components.tag-list-item.tooltip-delete-key-desc": "Ausgewählten Tag löschen",
 	"components.tag-list-item.tooltip-title": "Tastatursteuerung",
-	"templates.primary-secondary.adjustableSplitView": "Anpassbare geteilte Ansicht",
 	"templates.primary-secondary.keyboardHorizontal": "Pfeil nach links oder rechts, um die Größe der Ansichtsbereiche anzupassen",
 	"templates.primary-secondary.keyboardVertical": "Pfeil nach oben oder unten, um die Größe der Ansichtsbereiche anzupassen"
 };

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backspace/Delete",
 	"components.tag-list-item.tooltip-delete-key-desc": "Delete the focused tag",
 	"components.tag-list-item.tooltip-title": "Keyboard Controls",
-	"templates.primary-secondary.adjustableSplitView": "Adjustable Split View",
 	"templates.primary-secondary.keyboardHorizontal": "Arrow left or right to adjust the size of the view panels",
 	"templates.primary-secondary.keyboardVertical": "Arrow up or down to adjust the size of the view panels"
 };

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backspace/Delete",
 	"components.tag-list-item.tooltip-delete-key-desc": "Delete the focused tag",
 	"components.tag-list-item.tooltip-title": "Keyboard Controls",
-	"templates.primary-secondary.keyboardHorizontal": "Arrow left or right to adjust the size of the view panels",
-	"templates.primary-secondary.keyboardVertical": "Arrow up or down to adjust the size of the view panels"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backspace/Delete",
 	"components.tag-list-item.tooltip-delete-key-desc": "Delete the focused tag",
 	"components.tag-list-item.tooltip-title": "Keyboard Controls",
-	"templates.primary-secondary.adjustableSplitView": "Adjustable Split View",
 	"templates.primary-secondary.keyboardHorizontal": "Arrow left or right to adjust the size of the view panels",
 	"templates.primary-secondary.keyboardVertical": "Arrow up or down to adjust the size of the view panels"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backspace/Delete",
 	"components.tag-list-item.tooltip-delete-key-desc": "Delete the focused tag",
 	"components.tag-list-item.tooltip-title": "Keyboard Controls",
-	"templates.primary-secondary.keyboardHorizontal": "Arrow left or right to adjust the size of the view panels",
-	"templates.primary-secondary.keyboardVertical": "Arrow up or down to adjust the size of the view panels"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retroceso/Eliminar",
 	"components.tag-list-item.tooltip-delete-key-desc": "Eliminar la etiqueta seleccionada",
 	"components.tag-list-item.tooltip-title": "Controles del teclado",
-	"templates.primary-secondary.adjustableSplitView": "Vista dividida ajustable",
 	"templates.primary-secondary.keyboardHorizontal": "Flecha hacia la izquierda o la derecha para ajustar el tamaño de los paneles de visualización",
 	"templates.primary-secondary.keyboardVertical": "Flecha hacia arriba o abajo para ajustar el tamaño de los paneles de visualización"
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retroceso/Eliminar",
 	"components.tag-list-item.tooltip-delete-key-desc": "Eliminar la etiqueta seleccionada",
 	"components.tag-list-item.tooltip-title": "Controles del teclado",
-	"templates.primary-secondary.keyboardHorizontal": "Flecha hacia la izquierda o la derecha para ajustar el tamaño de los paneles de visualización",
-	"templates.primary-secondary.keyboardVertical": "Flecha hacia arriba o abajo para ajustar el tamaño de los paneles de visualización"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retroceso/Suprimir",
 	"components.tag-list-item.tooltip-delete-key-desc": "Eliminar la etiqueta enfocada",
 	"components.tag-list-item.tooltip-title": "Controles del teclado",
-	"templates.primary-secondary.adjustableSplitView": "Pantalla dividida ajustable",
 	"templates.primary-secondary.keyboardHorizontal": "Utilice la flecha izquierda o derecha para ajustar el tamaño de los paneles de visualización",
 	"templates.primary-secondary.keyboardVertical": "Utilice la flecha hacia arriba o hacia abajo para ajustar el tamaño de los paneles de visualización"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retroceso/Suprimir",
 	"components.tag-list-item.tooltip-delete-key-desc": "Eliminar la etiqueta enfocada",
 	"components.tag-list-item.tooltip-title": "Controles del teclado",
-	"templates.primary-secondary.keyboardHorizontal": "Utilice la flecha izquierda o derecha para ajustar el tamaño de los paneles de visualización",
-	"templates.primary-secondary.keyboardVertical": "Utilice la flecha hacia arriba o hacia abajo para ajustar el tamaño de los paneles de visualización"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retour arrière/Supprimer",
 	"components.tag-list-item.tooltip-delete-key-desc": "Supprimez l’étiquette ciblée",
 	"components.tag-list-item.tooltip-title": "Commandes du clavier",
-	"templates.primary-secondary.keyboardHorizontal": "Flèche vers la gauche ou vers la droite pour régler la taille des panneaux d’affichage",
-	"templates.primary-secondary.keyboardVertical": "Flèche vers le haut ou vers le bas pour régler la taille des panneaux d’affichage"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retour arrière/Supprimer",
 	"components.tag-list-item.tooltip-delete-key-desc": "Supprimez l’étiquette ciblée",
 	"components.tag-list-item.tooltip-title": "Commandes du clavier",
-	"templates.primary-secondary.adjustableSplitView": "Vue fractionnée réglable",
 	"templates.primary-secondary.keyboardHorizontal": "Flèche vers la gauche ou vers la droite pour régler la taille des panneaux d’affichage",
 	"templates.primary-secondary.keyboardVertical": "Flèche vers le haut ou vers le bas pour régler la taille des panneaux d’affichage"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retour arrière/suppression",
 	"components.tag-list-item.tooltip-delete-key-desc": "Supprimer la balise ciblée",
 	"components.tag-list-item.tooltip-title": "Commandes du clavier",
-	"templates.primary-secondary.keyboardHorizontal": "Utiliser la flèche vers la gauche ou vers la droite pour régler la taille des volets d'affichage",
-	"templates.primary-secondary.keyboardVertical": "Flèche vers le haut ou vers le bas pour régler la taille des volets d'affichage"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retour arrière/suppression",
 	"components.tag-list-item.tooltip-delete-key-desc": "Supprimer la balise ciblée",
 	"components.tag-list-item.tooltip-title": "Commandes du clavier",
-	"templates.primary-secondary.adjustableSplitView": "Vue partagée réglable",
 	"templates.primary-secondary.keyboardHorizontal": "Utiliser la flèche vers la gauche ou vers la droite pour régler la taille des volets d'affichage",
 	"templates.primary-secondary.keyboardVertical": "Flèche vers le haut ou vers le bas pour régler la taille des volets d'affichage"
 };

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "बैकस्पेस/हटाएँ",
 	"components.tag-list-item.tooltip-delete-key-desc": "फ़ोकिस किए हुए टैग को हटाएँ",
 	"components.tag-list-item.tooltip-title": "कीबोर्ड कंट्रोल",
-	"templates.primary-secondary.adjustableSplitView": "समायोजन योग्य विभाजन दृश्य",
 	"templates.primary-secondary.keyboardHorizontal": "दृश्य पैनल्स का आकार समायोजित करने के लिए तीर बाएँ या दाएँ करें",
 	"templates.primary-secondary.keyboardVertical": "दृश्य पैनल्स का आकार समायोजित करने के लिए तीर ऊपर या नीचे करें"
 };

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "बैकस्पेस/हटाएँ",
 	"components.tag-list-item.tooltip-delete-key-desc": "फ़ोकिस किए हुए टैग को हटाएँ",
 	"components.tag-list-item.tooltip-title": "कीबोर्ड कंट्रोल",
-	"templates.primary-secondary.keyboardHorizontal": "दृश्य पैनल्स का आकार समायोजित करने के लिए तीर बाएँ या दाएँ करें",
-	"templates.primary-secondary.keyboardVertical": "दृश्य पैनल्स का आकार समायोजित करने के लिए तीर ऊपर या नीचे करें"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backspace キー／Delete キー",
 	"components.tag-list-item.tooltip-delete-key-desc": "フォーカスされたタグを削除します",
 	"components.tag-list-item.tooltip-title": "キーボードコントロール",
-	"templates.primary-secondary.adjustableSplitView": "調整可能な分割ビュー",
 	"templates.primary-secondary.keyboardHorizontal": "左矢印または右矢印を使用して、ビューパネルのサイズを調整します",
 	"templates.primary-secondary.keyboardVertical": "上矢印または下矢印を使用して、ビューパネルのサイズを調整します"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backspace キー／Delete キー",
 	"components.tag-list-item.tooltip-delete-key-desc": "フォーカスされたタグを削除します",
 	"components.tag-list-item.tooltip-title": "キーボードコントロール",
-	"templates.primary-secondary.keyboardHorizontal": "左矢印または右矢印を使用して、ビューパネルのサイズを調整します",
-	"templates.primary-secondary.keyboardVertical": "上矢印または下矢印を使用して、ビューパネルのサイズを調整します"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "백스페이스/삭제",
 	"components.tag-list-item.tooltip-delete-key-desc": "포커스된 태그를 삭제합니다",
 	"components.tag-list-item.tooltip-title": "키보드 컨트롤",
-	"templates.primary-secondary.adjustableSplitView": "조정 가능한 분할 보기",
 	"templates.primary-secondary.keyboardHorizontal": "왼쪽 또는 오른쪽 화살표로 보기 패널의 크기 조정",
 	"templates.primary-secondary.keyboardVertical": "위 또는 아래 화살표로 보기 패널의 크기 조정"
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "백스페이스/삭제",
 	"components.tag-list-item.tooltip-delete-key-desc": "포커스된 태그를 삭제합니다",
 	"components.tag-list-item.tooltip-title": "키보드 컨트롤",
-	"templates.primary-secondary.keyboardHorizontal": "왼쪽 또는 오른쪽 화살표로 보기 패널의 크기 조정",
-	"templates.primary-secondary.keyboardVertical": "위 또는 아래 화살표로 보기 패널의 크기 조정"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backspace/Verwijderen",
 	"components.tag-list-item.tooltip-delete-key-desc": "Verwijder de gerichte tag",
 	"components.tag-list-item.tooltip-title": "Bedieningselementen op het toetsenbord",
-	"templates.primary-secondary.adjustableSplitView": "Instelbare gesplitste weergave",
 	"templates.primary-secondary.keyboardHorizontal": "Pijl naar links of rechts om de grootte van de weergavevensters aan te passen",
 	"templates.primary-secondary.keyboardVertical": "Pijl omhoog of omlaag om de grootte van de weergavevensters aan te passen"
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backspace/Verwijderen",
 	"components.tag-list-item.tooltip-delete-key-desc": "Verwijder de gerichte tag",
 	"components.tag-list-item.tooltip-title": "Bedieningselementen op het toetsenbord",
-	"templates.primary-secondary.keyboardHorizontal": "Pijl naar links of rechts om de grootte van de weergavevensters aan te passen",
-	"templates.primary-secondary.keyboardVertical": "Pijl omhoog of omlaag om de grootte van de weergavevensters aan te passen"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retroceder/Excluir",
 	"components.tag-list-item.tooltip-delete-key-desc": "Excluir a marca de foco",
 	"components.tag-list-item.tooltip-title": "Controles do teclado",
-	"templates.primary-secondary.keyboardHorizontal": "Use a seta para a esquerda ou para a direita para ajustar o tamanho dos painéis de exibição",
-	"templates.primary-secondary.keyboardVertical": "Use a seta para cima ou para baixo para ajustar o tamanho dos painéis de exibição"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Retroceder/Excluir",
 	"components.tag-list-item.tooltip-delete-key-desc": "Excluir a marca de foco",
 	"components.tag-list-item.tooltip-title": "Controles do teclado",
-	"templates.primary-secondary.adjustableSplitView": "Exibição dividida ajustável",
 	"templates.primary-secondary.keyboardHorizontal": "Use a seta para a esquerda ou para a direita para ajustar o tamanho dos painéis de exibição",
 	"templates.primary-secondary.keyboardVertical": "Use a seta para cima ou para baixo para ajustar o tamanho dos painéis de exibição"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backstegstangenten/Delete-tangenten",
 	"components.tag-list-item.tooltip-delete-key-desc": "Ta bort den fokuserade taggen",
 	"components.tag-list-item.tooltip-title": "Tangentbordskontroller",
-	"templates.primary-secondary.keyboardHorizontal": "Pil vänster eller höger för att justera storleken på vypaneler",
-	"templates.primary-secondary.keyboardVertical": "Pil upp eller ned för att justera storleken på vypaneler"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Backstegstangenten/Delete-tangenten",
 	"components.tag-list-item.tooltip-delete-key-desc": "Ta bort den fokuserade taggen",
 	"components.tag-list-item.tooltip-title": "Tangentbordskontroller",
-	"templates.primary-secondary.adjustableSplitView": "Justerbar delad vy",
 	"templates.primary-secondary.keyboardHorizontal": "Pil vänster eller höger för att justera storleken på vypaneler",
 	"templates.primary-secondary.keyboardVertical": "Pil upp eller ned för att justera storleken på vypaneler"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Geri Al/Sil",
 	"components.tag-list-item.tooltip-delete-key-desc": "Odaklanılan etiketi sil",
 	"components.tag-list-item.tooltip-title": "Klavye Kontrolleri",
-	"templates.primary-secondary.adjustableSplitView": "Ayarlanabilir Bölünmüş Görüntü",
 	"templates.primary-secondary.keyboardHorizontal": "Görüntü panellerinin boyutunu ayarlamak için sol veya sağ okları kullanın",
 	"templates.primary-secondary.keyboardVertical": "Görüntü panellerinin boyutunu ayarlamak için yukarı veya aşağı okları kullanın"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "Geri Al/Sil",
 	"components.tag-list-item.tooltip-delete-key-desc": "Odaklanılan etiketi sil",
 	"components.tag-list-item.tooltip-title": "Klavye Kontrolleri",
-	"templates.primary-secondary.keyboardHorizontal": "Görüntü panellerinin boyutunu ayarlamak için sol veya sağ okları kullanın",
-	"templates.primary-secondary.keyboardVertical": "Görüntü panellerinin boyutunu ayarlamak için yukarı veya aşağı okları kullanın"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "退格键/Delete 键",
 	"components.tag-list-item.tooltip-delete-key-desc": "删除具有焦点的标签",
 	"components.tag-list-item.tooltip-title": "键盘控制",
-	"templates.primary-secondary.adjustableSplitView": "可调分屏视图",
 	"templates.primary-secondary.keyboardHorizontal": "向左或向右箭头可调整视图面板的大小",
 	"templates.primary-secondary.keyboardVertical": "向上或向下箭头可调整视图面板的大小"
 };

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "退格键/Delete 键",
 	"components.tag-list-item.tooltip-delete-key-desc": "删除具有焦点的标签",
 	"components.tag-list-item.tooltip-title": "键盘控制",
-	"templates.primary-secondary.keyboardHorizontal": "向左或向右箭头可调整视图面板的大小",
-	"templates.primary-secondary.keyboardVertical": "向上或向下箭头可调整视图面板的大小"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -123,6 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "退格/刪除",
 	"components.tag-list-item.tooltip-delete-key-desc": "刪除對焦標記",
 	"components.tag-list-item.tooltip-title": "鍵盤控制項",
-	"templates.primary-secondary.keyboardHorizontal": "向左或向右箭頭可調整檢視面板的大小",
-	"templates.primary-secondary.keyboardVertical": "向上或向下箭頭可調整檢視面板的大小"
+	"templates.primary-secondary.divider": "Secondary panel divider",
+	"templates.primary-secondary.secondary-panel": "Secondary panel"
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -123,7 +123,6 @@ export default {
 	"components.tag-list-item.tooltip-delete-key": "退格/刪除",
 	"components.tag-list-item.tooltip-delete-key-desc": "刪除對焦標記",
 	"components.tag-list-item.tooltip-title": "鍵盤控制項",
-	"templates.primary-secondary.adjustableSplitView": "可調整的分割檢視",
 	"templates.primary-secondary.keyboardHorizontal": "向左或向右箭頭可調整檢視面板的大小",
 	"templates.primary-secondary.keyboardVertical": "向上或向下箭頭可調整檢視面板的大小"
 };


### PR DESCRIPTION
This addresses two problems with the primary/secondary template:

The first is that when the panels aren't resizable, the divider was still there and discoverable to assistive technology. In this scenario, I've updated it to render a "readonly" version of the divider, also known as "a grey line".

While fixing the first thing, I discovered that the "separator" ARIA role we were using for the divider simply wasn't working as expected. It seems like support for it was never really ironed out or implemented widely. To address this, we've converted it to a "slider" role. We've also:

- Added a "secondary panel" label to the `<aside>` element
- Removed the keyboard instructions for using the divider since it's a standard ARIA thing and simplified its label to "Secondary panel divider" which matches the label on the `<aside>`
- Changed the scale of the divider max/min/value to be percents instead of arbitrary pixel values
- Set `aria-valuetext` to `<value> %` so it reads out as a percent instead of a number