### PR TITLE
fix: don't validate disconnected nested forms (GAUD-6271)

### DIFF
--- a/components/form/form.js
+++ b/components/form/form.js
@@ -139,10 +139,14 @@ class Form extends FormMixin(LitElement) {
 		this._nestedForms.set(e.target, form);
 
 		const onFormDisconnect = () => {
-			form.removeEventListener('d2l-form-disconnect', onFormDisconnect);
-			this._nestedForms.delete(e.target);
+			this._nestedForms.forEach((value, key) => {
+				if (value === form) {
+					form.removeEventListener('d2l-form-disconnected', onFormDisconnect);
+					this._nestedForms.delete(key);
+				}
+			});
 		};
-		form.addEventListener('d2l-form-disconnect', onFormDisconnect);
+		form.addEventListener('d2l-form-disconnected', onFormDisconnect);
 	}
 
 	async _submitData(submitter) {

--- a/components/form/test/form.test.js
+++ b/components/form/test/form.test.js
@@ -2,8 +2,8 @@ import '../../validation/validation-custom.js';
 import '../form.js';
 import './form-element.js';
 import './nested-form.js';
-import { expect, fixture } from '@brightspace-ui/testing';
-import { html } from 'lit';
+import { defineCE, expect, fixture } from '@brightspace-ui/testing';
+import { html, LitElement } from 'lit';
 
 describe('d2l-form', () => {
 
@@ -331,6 +331,47 @@ describe('d2l-form', () => {
 			});
 
 		});
+
+		describe('connect/disconnect', () => {
+
+			it('should not validate nested forms which have been disconnected', async() => {
+
+				const nestedElem = defineCE(class extends LitElement {
+					render() {
+						return html`
+							<d2l-form>
+								<input type="text" aria-label="Input 1" name="input1" required>
+							</d2l-form>
+						`;
+					}
+				});
+
+				const elem = await fixture(`
+					<d2l-form>
+						<${nestedElem}></${nestedElem}>
+						<input type="text" aria-label="Input 2" name="input2" required>
+					</d2l-form>
+				`);
+
+				let errors = await elem.validate();
+
+				expect([...errors.entries()]).to.deep.equal([
+					[elem.querySelector(nestedElem).shadowRoot.querySelector('[name="input1"]'), ['Input 1 is required.']],
+					[elem.querySelector('[name="input2"]'), ['Input 2 is required.']],
+				]);
+
+				elem.querySelector(nestedElem).shadowRoot.querySelector('d2l-form').remove();
+
+				errors = await elem.validate();
+
+				expect([...errors.entries()]).to.deep.equal([
+					[elem.querySelector('[name="input2"]'), ['Input 2 is required.']],
+				]);
+
+			});
+
+		});
+
 	});
 
 });

--- a/components/form/test/form.test.js
+++ b/components/form/test/form.test.js
@@ -339,17 +339,20 @@ describe('d2l-form', () => {
 				const nestedElem = defineCE(class extends LitElement {
 					render() {
 						return html`
-							<d2l-form>
+							<d2l-form id="nested1">
 								<input type="text" aria-label="Input 1" name="input1" required>
+							</d2l-form>
+							<d2l-form id="nested2">
+								<input type="text" aria-label="Input 2" name="input2" required>
 							</d2l-form>
 						`;
 					}
 				});
 
 				const elem = await fixture(`
-					<d2l-form>
+					<d2l-form id="root">
 						<${nestedElem}></${nestedElem}>
-						<input type="text" aria-label="Input 2" name="input2" required>
+						<input type="text" aria-label="Input 3" name="input3" required>
 					</d2l-form>
 				`);
 
@@ -357,15 +360,17 @@ describe('d2l-form', () => {
 
 				expect([...errors.entries()]).to.deep.equal([
 					[elem.querySelector(nestedElem).shadowRoot.querySelector('[name="input1"]'), ['Input 1 is required.']],
-					[elem.querySelector('[name="input2"]'), ['Input 2 is required.']],
+					[elem.querySelector(nestedElem).shadowRoot.querySelector('[name="input2"]'), ['Input 2 is required.']],
+					[elem.querySelector('[name="input3"]'), ['Input 3 is required.']],
 				]);
 
-				elem.querySelector(nestedElem).shadowRoot.querySelector('d2l-form').remove();
+				elem.querySelector(nestedElem).shadowRoot.querySelector('#nested1').remove();
 
 				errors = await elem.validate();
 
 				expect([...errors.entries()]).to.deep.equal([
-					[elem.querySelector('[name="input2"]'), ['Input 2 is required.']],
+					[elem.querySelector(nestedElem).shadowRoot.querySelector('[name="input2"]'), ['Input 2 is required.']],
+					[elem.querySelector('[name="input3"]'), ['Input 3 is required.']],
 				]);
 
 			});


### PR DESCRIPTION
@rileyodonnelld2l noticed this issue. The scenario: they had a form which contained a HTML Editor, which could launch the "insert link" dialog which contained a nested form that "joined" the outer form (aside: it probably should have had `no-nesting` on it since joining the parent form is weird, but regardless). Even after the insert link dialog was closed and it was totally removed from the DOM, the outer form would still include it in its validation.

The reason for this is that the logic that handles disconnected nested forms never worked, and this fell into a special edge case that required it to work.

The main reason for that was a mismatch between the event being dispatched (`d2l-form-disconnected`) and the event being listened for (`d2l-form-disconnect`). Beyond that though, the logic to remove the nested form was still flawed, because it was assuming the target of the event would match the nested form itself, but if the nested form was inside a custom element, the event would be re-targeted to the custom element.

And then on top of all that, if a custom element contained multiple nested forms it couldn't handle that and would always just remember the last one that connected.