### PR TITLE
Add experimental support for MML3 features within MathJax (including mlongdiv)

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -47,6 +47,7 @@ class HtmlBlockMathRenderer {
 
 		const mathJaxConfig = {
 			deferTypeset: true,
+			enableMML3Support: context.enableMML3Support,
 			renderLatex: context.renderLatex,
 			outputScale: context.outputScale || 1,
 			window: window
@@ -102,7 +103,15 @@ export function loadMathJax(mathJaxConfig) {
 				settings: { zoom: 'None' }
 			}
 		},
-		loader: { load: ['ui/menu'] },
+		loader: {
+			load: mathJaxConfig && mathJaxConfig.enableMML3Support
+				? [
+					'[mml]/mml3',
+					'ui/menu'
+				] : [
+					'ui/menu'
+				]
+		},
 		startup: {
 			ready: () => {
 

--- a/tools/mathjax-test-context.js
+++ b/tools/mathjax-test-context.js
@@ -2,5 +2,6 @@ console.warn('Using mathjax test context, this is intended for demo pages and te
 
 document.getElementsByTagName('html')[0].dataset.mathjaxContext = JSON.stringify({
 	outputScale: 1.1,
-	renderLatex: !(window.location.search.indexOf('latex=false') !== -1)
+	renderLatex: !(window.location.search.indexOf('latex=false') !== -1),
+	enableMML3Support: true
 });


### PR DESCRIPTION
MathJax offers experimental support for some MathML elements via an mml3 extension. This gives us at least some support for symbols like long division that we wouldn't get otherwise (stock MathJax yields a math input error if you try to use, say, `<mlongdiv>`. It's likely ideal for us to support this rather than not.