### PR TITLE
Fix tooltips used on targets with delegated focus

### DIFF
--- a/components/inputs/test/input-date-range.vdiff.js
+++ b/components/inputs/test/input-date-range.vdiff.js
@@ -328,12 +328,14 @@ describe('d2l-input-date-range', () => {
 					it('focus start', async() => {
 						focusElem(elem.shadowRoot.querySelector(startDateSelector));
 						await oneEvent(elem, 'd2l-tooltip-show');
+						await nextFrame();
 						await expect(elem).to.be.golden();
 					});
 
 					it('focus end', async() => {
 						focusElem(elem.shadowRoot.querySelector(endDateSelector));
 						await oneEvent(elem, 'd2l-tooltip-show');
+						await nextFrame();
 						await expect(elem).to.be.golden();
 					});
 				});

--- a/components/inputs/test/input-date-range.vdiff.js
+++ b/components/inputs/test/input-date-range.vdiff.js
@@ -328,14 +328,12 @@ describe('d2l-input-date-range', () => {
 					it('focus start', async() => {
 						focusElem(elem.shadowRoot.querySelector(startDateSelector));
 						await oneEvent(elem, 'd2l-tooltip-show');
-						await nextFrame();
 						await expect(elem).to.be.golden();
 					});
 
 					it('focus end', async() => {
 						focusElem(elem.shadowRoot.querySelector(endDateSelector));
 						await oneEvent(elem, 'd2l-tooltip-show');
-						await nextFrame();
 						await expect(elem).to.be.golden();
 					});
 				});

--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -264,7 +264,7 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 		} else if (options.hasTruncationTooltip || hasDescription) {
 			const tooltipHeader = hasDescription ? html`<div class="d2l-heading-4">${tagContent}</div>` : tagContent;
 			tooltip = html`
-				<d2l-tooltip class="vdiff-target" for="${this._id}" ?show-truncated-only="${!hasDescription}">
+				<d2l-tooltip class="vdiff-target" for="${this._id}" ?show-truncated-only="${!hasDescription}" for-type="${hasDescription ? 'descriptor' : 'label'}">
 					${tooltipHeader}
 					${hasDescription ? options.description : nothing}
 				</d2l-tooltip>`;

--- a/components/tooltip/README.md
+++ b/components/tooltip/README.md
@@ -40,7 +40,7 @@ If the tooltip's target is an interactive element then it will automatically be 
 
 **Static / Custom Target Elements:**
 
-If the tooltip's target is a static or custom element then the target must be both focusable and given an interactive ARIA role. Note, a role should only be added to an element if the role semantically aligns with what the element represents. [A list of interactive roles can be found here.](https://github.com/BrightspaceUI/core/blob/main/components/tooltip/tooltip.js#L52)
+If the tooltip's target is a static or custom element then the target must either use the [FocusMixin](https://github.com/BrightspaceUI/core/blob/main/mixins/focus/README.md), or be both focusable and given an interactive ARIA role. Note, a role should only be added to an element if the role semantically aligns with what the element represents. [A list of interactive roles can be found here.](https://github.com/BrightspaceUI/core/blob/main/components/tooltip/tooltip.js#L52)
 
 Adding roles to custom elements that contain internal interactive elements should be avoided to prevent the element type being announced twice. In situations like these, the tooltip should be moved inside the custom element so that it can be attached directly as shown below:
 ```html

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -737,6 +737,8 @@ class Tooltip extends RtlMixin(LitElement) {
 				await customElements.whenDefined(target.localName);
 				await target.updateComplete;
 				target = target?.shadowRoot?.querySelector(target?.constructor.focusElementSelector) ?? target;
+			} else {
+				this.#targetDelegated = false;
 			}
 		} else {
 			console.warn('<d2l-tooltip>: missing required attribute "for"');
@@ -920,9 +922,11 @@ class Tooltip extends RtlMixin(LitElement) {
 			await this.updateComplete;
 			await this.updatePosition();
 			if (dispatch) {
-				this.dispatchEvent(new CustomEvent(
-					'd2l-tooltip-show', { bubbles: true, composed: true }
-				));
+				requestAnimationFrame(() => {
+					this.dispatchEvent(new CustomEvent(
+						'd2l-tooltip-show', { bubbles: true, composed: true }
+					));
+				});
 			}
 
 			if (this.announced && !this._isInteractive(this._target)) announce(this.innerText);
@@ -966,10 +970,10 @@ class Tooltip extends RtlMixin(LitElement) {
 
 			if (this.#targetDelegated) {
 				if (this.forType === 'label') {
-					this.removeAttribute('aria-labelledby');
+					this._target.removeAttribute('aria-labelledby');
 					this._target.ariaLabel = this.shadowRoot.querySelector('slot').assignedNodes().map(n => n.textContent).join('\n');
 				} else if (!this.announced || isInteractive) {
-					this.removeAttribute('aria-describedby');
+					this._target.removeAttribute('aria-describedby');
 					this._target.ariaDescription = this.shadowRoot.querySelector('slot').assignedNodes().map(n => n.textContent).join('\n');
 				}
 			}

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -909,24 +909,25 @@ class Tooltip extends RtlMixin(LitElement) {
 	}
 
 	async _showingChanged(newValue, dispatch) {
+		if (!this.isConnected) return;
+
 		clearTimeout(this._hoverTimeout);
 		clearTimeout(this._longPressTimeout);
+
 		if (newValue) {
 			if (!this.forceShow) {
-				if (activeTooltip) activeTooltip.hide();
+				activeTooltip?.hide();
 				activeTooltip = this;
 			}
-
 			this._dismissibleId = setDismissible(() => this.hide());
 			this.setAttribute('aria-hidden', 'false');
 			await this.updateComplete;
-			await this.updatePosition();
-			if (dispatch) {
-				//requestAnimationFrame(() => {
+
+			if (this._showing && dispatch) {
+				await this.updatePosition();
 				this.dispatchEvent(new CustomEvent(
 					'd2l-tooltip-show', { bubbles: true, composed: true }
 				));
-				//});
 			}
 
 			if (this.announced && !this._isInteractive(this._target)) announce(this.innerText);

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -922,11 +922,11 @@ class Tooltip extends RtlMixin(LitElement) {
 			await this.updateComplete;
 			await this.updatePosition();
 			if (dispatch) {
-				requestAnimationFrame(() => {
-					this.dispatchEvent(new CustomEvent(
-						'd2l-tooltip-show', { bubbles: true, composed: true }
-					));
-				});
+				//requestAnimationFrame(() => {
+				this.dispatchEvent(new CustomEvent(
+					'd2l-tooltip-show', { bubbles: true, composed: true }
+				));
+				//});
 			}
 
 			if (this.announced && !this._isInteractive(this._target)) announce(this.innerText);

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -1009,7 +1009,7 @@ class Tooltip extends RtlMixin(LitElement) {
 		// if no resize has happened since truncation was previously calculated the result will not have changed
 		if (!this._resizeRunSinceTruncationCheck || !this.showTruncatedOnly) return;
 
-		const target = this._target;
+		const target = this.#targetDelegated ? this._target.getRootNode().host : this._target;
 		const cloneContainer = document.createElement('div');
 		cloneContainer.style.position = 'absolute';
 		cloneContainer.style.overflow = 'hidden';


### PR DESCRIPTION
Currently, if a tooltip targets an element with delegated focus (i.e. basically everything: `d2l-button`, `d2l-link`, `d2l-input-text`, etc.), that target will never be properly described by the tooltip because once it delegates focus internally, the newly focused element is not described by the tooltip.

Non-interactable target warnings are currently disabled on the constructor after a single warning, so most tooltips are never communicating this issue.

Once that restriction is removed, all focus-delegated targets begin to warn because they are not in `interactiveElements` and do not have a `role` as the delegate should handle both of these.

- Detect elements using `FocusMixin`, use their delegate as the tooltip target (which also prevents the warning)
- Since delegates are always across shadow DOM boundaries, set an `aria-label/description` directly on the target
- Manage `label`, `description`, `labelledby`, and `describedby` appropriately
- Move the old "I don't know, maybe?" warning to a definitely-worded error
- Disable logging the error only once
- Prevent disconnected tooltips from hiding the `activeTooltip`
- Prevents firing `d2l-tooltip-show` on tooltips that were never shown before being hidden by another tooltip
- Read `tag-list-item` truncated text as a label, instead of duplicating it as a description

[GAUD-6266](https://desire2learn.atlassian.net/browse/GAUD-6266): Investigate "d2l-tooltip" non-accessible warnings

[GAUD-6266]: https://desire2learn.atlassian.net/browse/GAUD-6266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ