### PR TITLE
Allow exemptions to focus trapping

### DIFF
--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -40,7 +40,7 @@ class FocusTrap extends FocusMixin(LitElement) {
 	].join(', ');
 
 	static #isExempt(target) {
-		return !!target.closest(this.#exemptSelectors);
+		return !!target?.closest(this.#exemptSelectors);
 	}
 
 	constructor() {

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -34,6 +34,15 @@ class FocusTrap extends FocusMixin(LitElement) {
 		`;
 	}
 
+	static #exemptSelectors = [
+		'.equatio-toolbar-wrapper',
+		'.equatio-toolbar-shadow-root-container'
+	].join(', ');
+
+	static #isExempt(target) {
+		return !!target.closest(this.#exemptSelectors);
+	}
+
 	constructor() {
 		super();
 		this.trap = false;
@@ -97,13 +106,13 @@ class FocusTrap extends FocusMixin(LitElement) {
 		if (!this.trap || this._legacyPromptIds.size > 0 || lastTrap !== this) return;
 		const container = this._getContainer();
 		const target = e.composedPath()[0];
-		if (isComposedAncestor(container, target)) return;
+		if (isComposedAncestor(container, target) || FocusTrap.#isExempt(target)) return;
 		this._focusFirst();
 	}
 
 	_handleEndFocusIn(e) {
 		const container = this._getContainer();
-		if (this.shadowRoot && isComposedAncestor(container, e.relatedTarget)) {
+		if (this.shadowRoot && (isComposedAncestor(container, e.relatedTarget) || FocusTrap.#isExempt(e.relatedTarget))) {
 			// user is exiting trap via forward tabbing...
 			const firstFocusable = getNextFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-start'));
 			if (firstFocusable) {
@@ -127,7 +136,7 @@ class FocusTrap extends FocusMixin(LitElement) {
 
 	_handleStartFocusIn(e) {
 		const container = this._getContainer();
-		if (this.shadowRoot && isComposedAncestor(container, e.relatedTarget)) {
+		if (this.shadowRoot && (isComposedAncestor(container, e.relatedTarget) || FocusTrap.#isExempt(e.relatedTarget))) {
 			// user is exiting trap via back tabbing...
 			const lastFocusable = getPreviousFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-end'));
 			if (lastFocusable) {

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -35,6 +35,7 @@ class FocusTrap extends FocusMixin(LitElement) {
 	}
 
 	static #exemptSelectors = [
+		'.d2l-focus-trap-exempt',
 		'.equatio-toolbar-wrapper',
 		'.equatio-toolbar-shadow-root-container'
 	].join(', ');

--- a/components/focus-trap/test/focus-trap.test.js
+++ b/components/focus-trap/test/focus-trap.test.js
@@ -13,6 +13,7 @@ const normalFixture = html`
 			<a id="last" href="http://www.d2l.com">Last</a>
 		</d2l-focus-trap>
 		<a id="after" href="http://www.d2l.com">After</a>
+		<a class="d2l-focus-trap-exempt" href="http://www.d2l.com">Exempt</a>
 	</div>
 `;
 
@@ -75,6 +76,11 @@ describe('d2l-focus-trap', () => {
 			it('redirects body focus', () => {
 				elem.querySelector('#before').focus();
 				expect(document.activeElement).to.equal(elem.querySelector('#first'));
+			});
+
+			it('does not redirect from exempt elements', () => {
+				elem.querySelector('.d2l-focus-trap-exempt').focus();
+				expect(document.activeElement).to.equal(elem.querySelector('.d2l-focus-trap-exempt'));
 			});
 
 			it('does not redirect from children', () => {


### PR DESCRIPTION
[GAUD-6323](https://desire2learn.atlassian.net/browse/GAUD-6323): equatio chrome extension not functioning in quizzing tool

To allow specific elements outside a focus trap container to be focused, we can add an exemption list. This allows for mouse clicks and roundabout screenreader navigation to focus the exempted elements, but not normal keyboard navigation (tabbing).

[GAUD-6323]: https://desire2learn.atlassian.net/browse/GAUD-6323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ