### PR TITLE
fix: switch to Rally-free version of semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,13 @@ jobs:
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
           MINOR_RELEASE_WITH_LMS: true
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          RALLY_API_KEY: ${{ secrets.RALLY_API_KEY }}
       - name: Get new git HEAD
         id: git
         run: echo "head=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Rally is gone and can no longer be relied upon to provide us with the current active development release of the LMS. I've [updated the action](https://github.com/Brightspace/lms-version-actions/pull/33) to query a new S3 bucket which will be the source of truth for the release calendar.

This PR switches to that new updated version by passing the proper AWS credentials in place of the `RALLY_API_KEY`.