### PR TITLE
feat: Remove unused override

### DIFF
--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -46,12 +46,7 @@ export const SelectionMixin = superclass => class extends RtlMixin(CollectionMix
 			 * Whether to render with single selection behaviour. If `selection-single` is specified, the nested `d2l-selection-input` elements will render radios instead of checkboxes, and the selection component will maintain a single selected item.
 			 * @type {boolean}
 			 */
-			selectionSingle: { type: Boolean, attribute: 'selection-single' },
-			/**
-			 * ADVANCED: Temporary optional parameter used to override existing count. Will be removed soon, use with caution.
-			 * @type {number}
-			 */
-			selectionCountOverride: { type: Number, attribute: 'selection-count-override' }
+			selectionSingle: { type: Boolean, attribute: 'selection-single' }
 		};
 	}
 

--- a/components/selection/selection-summary.js
+++ b/components/selection/selection-summary.js
@@ -55,38 +55,31 @@ class Summary extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) {
 			return;
 		}
 
-		let count;
-		if (this._provider && this._provider.selectionCountOverride !== undefined) {
-			count = this._provider.selectionCountOverride;
-			this._summary = this._provider.selectionCountOverride === 0 && this.noSelectionText ?
-				this.noSelectionText : this.localize('components.selection.selected', 'count', count);
-		} else {
-			/* If lazy loading items is supported (ex. d2l-list) then check the keys to determine if the plus sign should be included.
-			 * If lazy loading is not supported (ex. d2l-table-wrapper), then skip this.
-			 */
-			let includePlus = false;
-			if (this._provider && this._provider._getLazyLoadItems) {
-				const lazyLoadListItems = this._provider._getLazyLoadItems();
-				if (lazyLoadListItems.size > 0) {
-					for (const selectedItemKey of this.selectionInfo.keys) {
-						if (lazyLoadListItems.has(selectedItemKey)) {
-							includePlus = true;
-							break;
-						}
+		/* If lazy loading items is supported (ex. d2l-list) then check the keys to determine if the plus sign should be included.
+		 * If lazy loading is not supported (ex. d2l-table-wrapper), then skip this.
+		 */
+		let includePlus = false;
+		if (this._provider && this._provider._getLazyLoadItems) {
+			const lazyLoadListItems = this._provider._getLazyLoadItems();
+			if (lazyLoadListItems.size > 0) {
+				for (const selectedItemKey of this.selectionInfo.keys) {
+					if (lazyLoadListItems.has(selectedItemKey)) {
+						includePlus = true;
+						break;
 					}
 				}
 			}
+		}
 
-			count = (this._provider && this.selectionInfo.state === SelectionInfo.states.allPages) ?
-				this._provider.itemCount : this.selectionInfo.keys.length;
+		const count = (this._provider && this.selectionInfo.state === SelectionInfo.states.allPages) ?
+			this._provider.itemCount : this.selectionInfo.keys.length;
 
-			if (this.selectionInfo.state === SelectionInfo.states.none && this.noSelectionText) {
-				this._summary = this.noSelectionText;
-			} else if (includePlus) {
-				this._summary = this.localize('components.selection.selected-plus', 'count', count);
-			} else {
-				this._summary = this.localize('components.selection.selected', 'count', count);
-			}
+		if (this.selectionInfo.state === SelectionInfo.states.none && this.noSelectionText) {
+			this._summary = this.noSelectionText;
+		} else if (includePlus) {
+			this._summary = this.localize('components.selection.selected-plus', 'count', count);
+		} else {
+			this._summary = this.localize('components.selection.selected', 'count', count);
 		}
 	}
 


### PR DESCRIPTION
Overall goal: 
Remove an override that is no longer in use (sorry this took so long)

Backstory:
A few years ago we had added an override for the selection count for this component meant to be temporary. We then temporarily disabled the select-all button on our `d2l-list` (which removed our usage of this override) with the intention of undoing that. However, we never got to undoing that which meant we never got to fixing/removing this override.

PR where this was added:
https://github.com/BrightspaceUI/core/pull/2846

[Usages](https://search.d2l.dev/search?full=%22selection-count-override%22&defs=&refs=&path=&hist=&type=&xrd=&nn=8&searchall=true) of this property. Seems like it's not actually in use and the same definition is somehow in two other places that I don't think we really need to worry about.