### PR TITLE
Fix backdrop body scrolling methods

### DIFF
--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -206,6 +206,29 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Dialog (native)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-button id="openNative">Show Dialog</d2l-button>
+					<d2l-dialog id="dialogNative" title-text="Dialog Title">
+						<div>
+							<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
+							<p>Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
+							<p>Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
+						</div>
+						<d2l-button slot="footer" primary data-dialog-action="ok">Click Me!</d2l-button>
+						<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+					</d2l-dialog>
+					<script>
+						document.querySelector('#dialogNative')._useNative = true;
+						document.querySelector('#openNative').addEventListener('click', () => {
+							document.querySelector('#dialogNative').opened = true;
+						});
+					</script>
+				</template>
+			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 	</body>
 </html>

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -1,3 +1,4 @@
+import '../backdrop/backdrop.js';
 import '../focus-trap/focus-trap.js';
 import '../../helpers/viewport-size.js';
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -1,6 +1,5 @@
 import '../focus-trap/focus-trap.js';
 import '../../helpers/viewport-size.js';
-import { allowBodyScroll, preventBodyScroll } from '../backdrop/backdrop.js';
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
 import { getComposedActiveElement, getFirstFocusableDescendant, getNextFocusable, isFocusable } from '../../helpers/focus.js';
@@ -313,8 +312,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._focusOpener();
 		this._state = null;
 		this.opened = false;
-		allowBodyScroll(this._bodyScrollKey);
-		this._bodyScrollKey = null;
 		if (this._action === undefined) this._action = abortAction;
 		/** Dispatched with the action value when the dialog is closed for any reason */
 		this.dispatchEvent(new CustomEvent(
@@ -415,9 +412,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._parentDialog = findComposedAncestor(this, (node) => {
 			return node.classList && node.classList.contains('d2l-dialog-outer');
 		});
-
-		// native dialog backdrop does not prevent body scrolling
-		this._bodyScrollKey = preventBodyScroll();
 
 		// focus first focusable child prior to auto resize (fixes screen reader hiccups)
 		this._focusInitial();

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -1,6 +1,6 @@
-import '../backdrop/backdrop.js';
 import '../focus-trap/focus-trap.js';
 import '../../helpers/viewport-size.js';
+import { allowBodyScroll, preventBodyScroll } from '../backdrop/backdrop.js';
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
 import { getComposedActiveElement, getFirstFocusableDescendant, getNextFocusable, isFocusable } from '../../helpers/focus.js';
@@ -313,6 +313,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._focusOpener();
 		this._state = null;
 		this.opened = false;
+		if (this._useNative) allowBodyScroll(this);
 		if (this._action === undefined) this._action = abortAction;
 		/** Dispatched with the action value when the dialog is closed for any reason */
 		this.dispatchEvent(new CustomEvent(
@@ -413,6 +414,8 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._parentDialog = findComposedAncestor(this, (node) => {
 			return node.classList && node.classList.contains('d2l-dialog-outer');
 		});
+
+		if (this._useNative) preventBodyScroll(this);
 
 		// focus first focusable child prior to auto resize (fixes screen reader hiccups)
 		this._focusInitial();


### PR DESCRIPTION
Currently, backdrop methods to control body scrolling can register and track the same host multiple times, which can be disconnected from the DOM before all `scrollKeys` for that host can be removed, leaving an orphaned `scrollKey` that prevents the body scrolling from returning to its original value.

This change instead uses a `Set` to store references to host instances themselves rather than generating unique string ids for each `preventBodyScroll` call.

There are two uses of these methods outside core. Namely, `htmleditor` and `nova`, which I have updated and will open PRs for once this is approved.

[GAUD-6349](https://desire2learn.atlassian.net/browse/GAUD-6349): Fix d2l-backdrop `scrollKey` registration

[GAUD-6349]: https://desire2learn.atlassian.net/browse/GAUD-6349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ