### PR TITLE
fix: protect against missing addEventListener on MediaQueryList

### DIFF
--- a/components/scroll-wrapper/scroll-wrapper.js
+++ b/components/scroll-wrapper/scroll-wrapper.js
@@ -174,13 +174,13 @@ class ScrollWrapper extends RtlMixin(LitElement) {
 
 	connectedCallback() {
 		super.connectedCallback();
-		PRINT_MEDIA_QUERY_LIST?.addEventListener('change', this._handlePrintChange);
+		PRINT_MEDIA_QUERY_LIST.addEventListener?.('change', this._handlePrintChange);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this._disconnectAll();
-		PRINT_MEDIA_QUERY_LIST?.removeEventListener('change', this._handlePrintChange);
+		PRINT_MEDIA_QUERY_LIST.removeEventListener?.('change', this._handlePrintChange);
 	}
 
 	firstUpdated(changedProperties) {


### PR DESCRIPTION
The [MediaQueryListEvent API isn't supported until Safari 14](https://caniuse.com/mdn-api_mediaquerylistevent), which is why were were trying to protect against it not existing here. Except the optional chain is on `PRINT_MEDIA_QUERY_LIST`, not the method that will be missing. This switches the chain to the method.