### PR TITLE
PoC - HTML elem context provider

### DIFF
--- a/helpers/html-elem-context-provider.js
+++ b/helpers/html-elem-context-provider.js
@@ -1,0 +1,32 @@
+const attributeCallbacks = new Map();
+
+const contextObserver = new MutationObserver(mutations => {
+	mutations.forEach(mutation => {
+		const callbacks = attributeCallbacks.get(mutation.attributeName);
+		if (callbacks !== undefined && callbacks.length > 0) {
+			callbacks.forEach(callback => callback());
+		}
+	});
+});
+
+let observerInitialized = false;
+
+export function getContext(attributeName) {
+	const contextString = document.documentElement.hasAttribute(attributeName)
+		? document.documentElement.getAttribute(attributeName)
+		: undefined;
+
+	return JSON.parse(contextString);
+}
+
+export function registerOnChangeHandler(attributeName, onChange, sendImmediate) {
+	if (!observerInitialized) {
+		contextObserver.observe(document.documentElement, { attributes: true });
+		observerInitialized = true;
+	}
+
+	if (sendImmediate) onChange(getContext(attributeName));
+
+	if (!attributeCallbacks.has(attributeName)) attributeCallbacks.set(attributeName, []);
+	attributeCallbacks.get(attributeName).push(() => onChange(getContext(attributeName)));
+}


### PR DESCRIPTION
Quick proof of concept around what a centralized HTML elem context provider might look like. Note that there's no reliance on the actual `lms-context-provider` here, as `core` can't reference it. Consumers (i.e. BSI) would need to hook that stuff up themselves.