### PR TITLE
Update docs and demo for d2l-input-radio-spacer

### DIFF
--- a/components/inputs/demo/input-radio-spacer-test.js
+++ b/components/inputs/demo/input-radio-spacer-test.js
@@ -1,20 +1,43 @@
 import '../input-radio-spacer.js';
 import { html, LitElement } from 'lit';
+import { bodySmallStyles } from '../../typography/styles.js';
 import { radioStyles } from '../input-radio-styles.js';
 
 class TestInputRadioSpacer extends LitElement {
 
 	static get styles() {
-		return radioStyles;
+		return [ radioStyles, bodySmallStyles ];
 	}
 
 	render() {
 		return html`
-			<input type="radio" class="d2l-input-radio" aria-label="Option 1"> Option 1
-			<d2l-input-radio-spacer>
-				Additional content can go here and will
-				line up nicely with the edge of the radio.
-			</d2l-input-radio-spacer>
+			<div>
+				<label class="d2l-input-radio-label">
+					<input type="radio" name="myGroup" value="normal" checked>
+					Option 1
+				</label>
+				<d2l-input-radio-spacer>
+					Additional content can go here and will line up nicely with the edge of the radio.
+				</d2l-input-radio-spacer>
+			</div>
+			<div>
+				<label class="d2l-input-radio-label">
+					<input type="radio" name="myGroup" value="normal">
+					Option 1 (A really really long label that will wrap to the next line where the indentation will be applied. All the text should align.)
+				</label>
+				<d2l-input-radio-spacer>
+					Additional content can go here and will line up nicely with the edge of the radio.
+				</d2l-input-radio-spacer>
+			</div>
+			<div>
+				<label class="d2l-input-radio-label">
+					<input type="radio" name="myGroup" value="normal">
+					Option 1
+				</label>
+				<d2l-input-radio-spacer>
+					<div class="d2l-body-small">Additional content can go here and will line up nicely with the edge of the radio.</div>
+				</d2l-input-radio-spacer>
+			</div>
 		`;
 	}
 

--- a/components/inputs/docs/input-radio.md
+++ b/components/inputs/docs/input-radio.md
@@ -116,7 +116,7 @@ If you'd like to manually link the radio input with a label, or use an ARIA labe
 
 ## Radio Spacer [d2l-input-radio-spacer]
 
-To align related content below radio buttons, the `d2l-input-radio-spacer` element can be used:
+To align related content below radio buttons, the `d2l-input-radio-spacer` element can be used in conjunction with the `d2l-input-radio-label` class:
 
 <!-- docs: demo code display:block -->
 ```html
@@ -133,11 +133,13 @@ To align related content below radio buttons, the `d2l-input-radio-spacer` eleme
 
     render() {
       return html`
-      <input type="radio" class="d2l-input-radio" aria-label="Option 1"> Option 1
-      <d2l-input-radio-spacer>
-      Additional content can go here and will
-      line up nicely with the edge of the radio.
-      </d2l-input-radio-spacer>
+        <label class="d2l-input-radio-label">
+          <input type="radio" value="normal" checked>
+          Option 1
+        </label>
+        <d2l-input-radio-spacer>
+          Additional content can go here and will line up nicely with the edge of the radio.
+        </d2l-input-radio-spacer>
       `;
     }
 


### PR DESCRIPTION
[GAUD-6341](https://desire2learn.atlassian.net/browse/GAUD-6341)

This PR updates the docs and demo to show the correct usage of `d2l-input-radio-spacer`. To summarize, the `d2l-input-radio-spacer` is meant to be used in conjunction with the `.d2l-input-radio-label` CSS class - they will both apply the same whitespace to achieve the alignment. If they are not used together, the consumer will not get the desired alignment.

Updated demo showing correct usage:
![image](https://github.com/BrightspaceUI/core/assets/9042472/429f999c-b5fe-4163-a93f-5a12373c5db0)


[GAUD-6341]: https://desire2learn.atlassian.net/browse/GAUD-6341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ