### PR TITLE
Table updates: Support radio menu items in a slot for additional sorting [GAUD-6122]

### DIFF
--- a/components/table/demo/table-test.js
+++ b/components/table/demo/table-test.js
@@ -7,6 +7,7 @@ import '../../inputs/input-checkbox.js';
 import '../../inputs/input-text.js';
 import '../../menu/menu.js';
 import '../../menu/menu-item.js';
+import '../../menu/menu-item-radio.js';
 import '../../paging/pager-load-more.js';
 import '../../selection/selection-action.js';
 import '../../selection/selection-action-dropdown.js';
@@ -91,7 +92,7 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 					<thead>
 						<tr>
 							<th scope="col" sticky><d2l-selection-select-all></d2l-selection-select-all></th>
-							${this._renderDoubleSortButton('City', 'Country')}
+							${this._renderDoubleSortButton('City, Country')}
 							${columns.map(columnHeading => this._renderSortButton(columnHeading))}
 						</tr>
 					</thead>
@@ -158,38 +159,48 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 		const desc = e.target.hasAttribute('desc');
 		this._sortDesc = field === this._sortField ? !desc : false; // if sorting on same field then reverse, otherwise sort ascending
 		this._sortField = field;
+		this._complexField = undefined;
 
 		this._data = this._data.sort((a, b) => {
-			if (this._sortField === 'city' || this._sortField === 'country') {
-				if (this._sortDesc) {
-					if (a[this._sortField] > b[this._sortField]) return -1;
-					if (a[this._sortField] < b[this._sortField]) return 1;
-				} else {
-					if (a[this._sortField] < b[this._sortField]) return -1;
-					if (a[this._sortField] > b[this._sortField]) return 1;
-				}
-			} else {
-				if (this._sortDesc) {
-					return b.data[this._sortField] - a.data[this._sortField];
-				}
-				return a.data[this._sortField] - b.data[this._sortField];
+			if (this._sortDesc) {
+				return b.data[this._sortField] - a.data[this._sortField];
 			}
+			return a.data[this._sortField] - b.data[this._sortField];
 		});
 	}
 
-	_renderDoubleSortButton(item1, item2) {
+	_handleSortComplex(e) {
+		const target = e.target;
+		if (!target) return;
+
+		this._sortField = target.parentNode?.innerText;
+		this._complexField = target.getAttribute('data-field');
+		this._sortDesc = target.hasAttribute('data-desc');
+
+		this._data = this._data.sort((a, b) => {
+			if (this._sortDesc) {
+				if (a[this._complexField] > b[this._complexField]) return -1;
+				if (a[this._complexField] < b[this._complexField]) return 1;
+			} else {
+				if (a[this._complexField] < b[this._complexField]) return -1;
+				if (a[this._complexField] > b[this._complexField]) return 1;
+			}
+			return 0;
+		});
+	}
+
+	_renderDoubleSortButton(name) {
+		const noSort = this._sortField?.toLowerCase() !== name.toLowerCase();
 		return html`
 			<th scope="col">
 				<d2l-table-col-sort-button
-					@click="${this._handleSort}"
-					data-type="words"
 					?desc="${this._sortDesc}"
-					?nosort="${this._sortField !== item1.toLowerCase()}">${item1}</d2l-table-col-sort-button>
-				<d2l-table-col-sort-button
-					@click="${this._handleSort}"
-					data-type="words"
-					?desc="${this._sortDesc}"
-					?nosort="${this._sortField !== item2.toLowerCase()}">${item2}</d2l-table-col-sort-button>
+					?nosort="${noSort}">${name}
+					<d2l-menu-item-radio slot="items" text="City, A to Z" data-field="city" @d2l-menu-item-select="${this._handleSortComplex}" value="1"></d2l-menu-item-radio>
+					<d2l-menu-item-radio slot="items" text="City, Z to A" data-field="city" data-desc @d2l-menu-item-select="${this._handleSortComplex}" value="2"></d2l-menu-item-radio>
+					<d2l-menu-item-radio slot="items" text="Country, A to Z" data-field="country" @d2l-menu-item-select="${this._handleSortComplex}" value="3"></d2l-menu-item-radio>
+					<d2l-menu-item-radio slot="items" text="Country, Z to A" data-field="country" data-desc @d2l-menu-item-select="${this._handleSortComplex}" value="4"></d2l-menu-item-radio>
+				</d2l-table-col-sort-button>
 			</th>
 		`;
 	}

--- a/components/table/demo/table-test.js
+++ b/components/table/demo/table-test.js
@@ -24,13 +24,13 @@ const columns = ['Population', 'Size', 'Elevation'];
 const thText = ['Additional', 'Placeholder', 'Header', 'Row'];
 
 const data = () => [
-	{ name: 'Ottawa, Canada', city: 'Ottawa', country: 'Canada', data: { 'population': 994837, 'size': 2790, 'elevation': 70 }, selected: true },
-	{ name: 'Toronto, Canada', city: 'Toronto', country: 'Canada', data: { 'population': 2930000, 'size': 630, 'elevation': 76 }, selected: true },
-	{ name: 'Sydney, Australia', city: 'Sydney', country: 'Australia', data: { 'population': 5312000, 'size': 12368, 'elevation': 3 }, selected: false },
-	{ name: 'Cairo, Egypt', city: 'Cairo', country: 'Egypt', data: { 'population': 9540000, 'size': 3085, 'elevation': 23 }, selected: false },
-	{ name: 'Moscow, Russia', city: 'Moscow', country: 'Russia', data: { 'population': 12712305, 'size': 2511, 'elevation': 124 }, selected: false },
-	{ name: 'London, England', city: 'London', country: 'England', data: { 'population': 8982000, 'size': 1572, 'elevation': 11 }, selected: false },
-	{ name: 'Tokyo, Japan', city: 'Tokyo', country: 'Japan', data: { 'population': 13960000, 'size': 2194, 'elevation': 40 }, selected: false }
+	{ name: 'Ottawa, Canada', data: { 'city': 'Ottawa', 'country': 'Canada', 'population': 994837, 'size': 2790, 'elevation': 70 }, selected: true },
+	{ name: 'Toronto, Canada', data: { 'city': 'Toronto', 'country': 'Canada', 'population': 2930000, 'size': 630, 'elevation': 76 }, selected: true },
+	{ name: 'Sydney, Australia', data: { 'city': 'Sydney', 'country': 'Australia', 'population': 5312000, 'size': 12368, 'elevation': 3 }, selected: false },
+	{ name: 'Cairo, Egypt', data: { 'city': 'Cairo', 'country': 'Egypt', 'population': 9540000, 'size': 3085, 'elevation': 23 }, selected: false },
+	{ name: 'Moscow, Russia', data: { 'city': 'Moscow', 'country': 'Russia', 'population': 12712305, 'size': 2511, 'elevation': 124 }, selected: false },
+	{ name: 'London, England', data: { 'city': 'London', 'country': 'England', 'population': 8982000, 'size': 1572, 'elevation': 11 }, selected: false },
+	{ name: 'Tokyo, Japan', data: { 'city': 'Tokyo', 'country': 'Japan', 'population': 13960000, 'size': 2194, 'elevation': 40 }, selected: false }
 ];
 
 const formatter = new Intl.NumberFormat('en-US');
@@ -148,7 +148,7 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 	_handlePagerLoadMore(e) {
 		const startIndex = this._data.length + 1;
 		for (let i = 0; i < e.target.pageSize; i++) {
-			this._data.push({ name: `Country ${startIndex + i}`, data: { 'population': 26320000, 'size': 6340, 'elevation': 4 }, selected: false });
+			this._data.push({ name: `City ${startIndex + i}, Country ${startIndex + i}`, data: { 'city': `City ${startIndex + i}`, 'country': `Country ${startIndex + i}`, 'population': 26320000, 'size': 6340, 'elevation': 4 }, selected: false });
 		}
 		this.requestUpdate();
 		e.detail.complete();
@@ -159,38 +159,30 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 		const desc = e.target.hasAttribute('desc');
 		this._sortDesc = field === this._sortField ? !desc : false; // if sorting on same field then reverse, otherwise sort ascending
 		this._sortField = field;
-		this._complexField = undefined;
-
-		this._data = this._data.sort((a, b) => {
-			if (this._sortDesc) {
-				return b.data[this._sortField] - a.data[this._sortField];
-			}
-			return a.data[this._sortField] - b.data[this._sortField];
-		});
+		this._handleSortData();
 	}
 
 	_handleSortComplex(e) {
-		const target = e.target;
-		if (!target) return;
+		this._sortField = e.target?.getAttribute('data-field');
+		this._sortDesc = e.target?.hasAttribute('data-desc');
+		this._handleSortData();
+	}
 
-		this._sortField = target.parentNode?.innerText;
-		this._complexField = target.getAttribute('data-field');
-		this._sortDesc = target.hasAttribute('data-desc');
-
+	_handleSortData() {
 		this._data = this._data.sort((a, b) => {
 			if (this._sortDesc) {
-				if (a[this._complexField] > b[this._complexField]) return -1;
-				if (a[this._complexField] < b[this._complexField]) return 1;
+				if (a.data[this._sortField] > b.data[this._sortField]) return -1;
+				if (a.data[this._sortField] < b.data[this._sortField]) return 1;
 			} else {
-				if (a[this._complexField] < b[this._complexField]) return -1;
-				if (a[this._complexField] > b[this._complexField]) return 1;
+				if (a.data[this._sortField] < b.data[this._sortField]) return -1;
+				if (a.data[this._sortField] > b.data[this._sortField]) return 1;
 			}
 			return 0;
 		});
 	}
 
 	_renderDoubleSortButton(name) {
-		const noSort = this._sortField?.toLowerCase() !== name.toLowerCase();
+		const noSort = this._sortField?.toLowerCase() !== 'city' && this._sortField?.toLowerCase() !== 'country';
 		return html`
 			<th scope="col">
 				<d2l-table-col-sort-button

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -1,16 +1,21 @@
 import '../colors/colors.js';
+import '../dropdown/dropdown.js';
+import '../dropdown/dropdown-menu.js';
 import '../icons/icon.js';
+import '../menu/menu.js';
 import { css, html, LitElement, unsafeCSS } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { getFocusPseudoClass } from '../../helpers/focus.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
+import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * Button for sorting a table column in ascending/descending order.
  * @slot - Text of the sort button
  */
-export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElement)) {
+export class TableColSortButton extends RtlMixin(LocalizeCoreElement(FocusMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -37,7 +42,9 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 			nosort: {
 				reflect: true,
 				type: Boolean
-			}
+			},
+			_hasDropdownItems: { state: true },
+			_selectedMenuItemText: { state: true }
 		};
 	}
 
@@ -58,6 +65,10 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 				--d2l-table-col-sort-button-top-left-radius: var(--d2l-table-col-sort-button-border-radius);
 				--d2l-table-col-sort-button-top-right-radius: var(--d2l-table-col-sort-button-border-radius);
 			}
+			:host > :first-child {
+				height: var(--d2l-table-col-sort-button-height);
+				width: var(--d2l-table-col-sort-button-width);
+			}
 			button {
 				align-items: center;
 				background-color: transparent;
@@ -72,12 +83,16 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 				display: inline-flex;
 				font-family: inherit;
 				font-size: inherit;
-				height: var(--d2l-table-col-sort-button-height);
+				height: 100%;
 				letter-spacing: inherit;
 				margin-inline-start: var(--d2l-table-col-sort-button-size-offset);
 				padding: var(--d2l-table-col-sort-button-padding);
+				text-align: left;
 				text-decoration: none;
-				width: var(--d2l-table-col-sort-button-width);
+				width: 100%;
+			}
+			:host([dir="rtl"]) button {
+				text-align: right;
 			}
 			button::-moz-focus-inner {
 				border: 0;
@@ -104,6 +119,8 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 		super();
 		this.desc = false;
 		this.nosort = false;
+
+		this._hasDropdownItems = false;
 	}
 
 	static get focusElementSelector() {
@@ -115,25 +132,62 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 		const buttonTitle = this.nosort
 			? undefined
 			: this.localize('components.table-col-sort-button.title', {
-				dataType: this.dataType,
-				direction: this.desc ? 'desc' : undefined
+				dataType: this._hasDropdownItems && this._selectedMenuItemText ? 'value' : this.dataType,
+				direction: this.desc ? 'desc' : undefined,
+				selectedMenuItemText: this._selectedMenuItemText
 			});
-
 		const iconView = !this.nosort ?
 			html`<d2l-icon icon="${this.desc ? 'tier1:arrow-toggle-down' : 'tier1:arrow-toggle-up'}"></d2l-icon>` :
 			null;
 
-		return html`<button type="button" title="${ifDefined(buttonTitle)}" aria-description="${buttonDescription}"><slot></slot>${iconView}</button>`;
+		const button = html`<button class="${classMap({ 'd2l-dropdown-opener': this._hasDropdownItems })}" type="button" title="${ifDefined(buttonTitle)}" aria-description="${buttonDescription}">
+			<slot></slot>${iconView}
+		</button>`;
+		const buttonOnlyRender = !this._hasDropdownItems
+			? html`${button}<slot name="items" @slotchange="${this._handleSlotChange}"></slot>`
+			: null;
+		const dropdownButtonRender = this._hasDropdownItems ? html`
+			<d2l-dropdown>
+				${button}
+				<d2l-dropdown-menu id="dropdown" no-pointer align="start" vertical-offset="5">
+					<d2l-menu @d2l-menu-item-change="${this._handleMenuItemChange}">
+						<slot name="items" @slotchange="${this._handleSlotChange}"></slot>
+					</d2l-menu>
+				</d2l-dropdown-menu>
+			</d2l-dropdown>
+		` : null;
+
+		return dropdownButtonRender || buttonOnlyRender;
 	}
 
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
-		if (!changedProperties.has('dataType')) return;
-
-		if (this.dataType !== 'words' && this.dataType !== 'numbers' && this.dataType !== 'dates' && this.dataType !== undefined) {
-			console.warn('d2l-table-col-sort-button: data-type attribute has been set to an invalid value.');
+		if (changedProperties.has('dataType')) {
+			if (this.dataType !== 'words' && this.dataType !== 'numbers' && this.dataType !== 'dates' && this.dataType !== undefined) {
+				console.warn('d2l-table-col-sort-button: data-type attribute has been set to an invalid value.');
+			}
 		}
+
+		// de-select any selected dropdown menu item
+		if (changedProperties.has('nosort') && this.nosort && this._hasDropdownItems) {
+			const selectedItem = this.querySelector('[selected]');
+			if (selectedItem) selectedItem.selected = false;
+		}
+	}
+
+	_handleMenuItemChange(e) {
+		const buttonText = e.target?.text;
+		if (buttonText) this._selectedMenuItemText = buttonText;
+	}
+
+	_handleSlotChange(e) {
+		const items = e.target?.assignedNodes({ flatten: true }).filter((node) => node.nodeType === Node.ELEMENT_NODE);
+		const filteredItems = items.filter((item) => {
+			const role = item.getAttribute('role');
+			return (role === 'menuitem' || role === 'menuitemcheckbox' || role === 'menuitemradio');
+		});
+		this._hasDropdownItems = filteredItems.length > 0;
 	}
 }
 

--- a/components/table/test/table.vdiff.js
+++ b/components/table/test/table.vdiff.js
@@ -1,9 +1,10 @@
 import '../../inputs/input-number.js';
 import '../../inputs/input-text.js';
 import '../../button/button-icon.js';
+import '../../menu/menu-item-radio.js';
 import '../demo/table-test.js';
 import '../table-col-sort-button.js';
-import { defineCE, expect, fixture, focusElem, hoverElem, html, nextFrame } from '@brightspace-ui/testing';
+import { clickElem, defineCE, expect, fixture, focusElem, hoverElem, html, nextFrame } from '@brightspace-ui/testing';
 import { LitElement, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -41,6 +42,20 @@ function createSortableButtonIconHeaderRow() {
 	return html`
 		<tr>
 			<th><d2l-table-col-sort-button>Ascending</d2l-table-col-sort-button><d2l-button-icon text="Help" icon="tier1:help"></d2l-button-icon></th>
+			<th><d2l-table-col-sort-button desc>Descending</d2l-table-col-sort-button></th>
+			<th><d2l-table-col-sort-button nosort>No Sort</d2l-table-col-sort-button></th>
+		</tr>
+	`;
+}
+function createSortableButtonDropdownHeaderRow() {
+	return html`
+		<tr>
+			<th>
+				<d2l-table-col-sort-button>Options
+					<d2l-menu-item-radio slot="items" text="Item 1" value="1"></d2l-menu-item-radio>
+					<d2l-menu-item-radio slot="items" text="Item 2" value="2"></d2l-menu-item-radio>
+				</d2l-table-col-sort-button>
+			</th>
 			<th><d2l-table-col-sort-button desc>Descending</d2l-table-col-sort-button></th>
 			<th><d2l-table-col-sort-button nosort>No Sort</d2l-table-col-sort-button></th>
 		</tr>
@@ -555,6 +570,23 @@ describe('table', () => {
 						<tbody>${createRows([1])}</tbody>
 					`);
 					await focusElem(elem.shadowRoot.querySelector('d2l-button-icon'));
+					await expect(elem).to.be.golden();
+				});
+
+				it('col-sort-button-dropdown', async() => {
+					const elem = await createTableFixture(html`
+						<thead>${createSortableButtonDropdownHeaderRow()}</thead>
+						<tbody>${createRows([1])}</tbody>
+					`);
+					await expect(elem).to.be.golden();
+				});
+
+				it('col-sort-button-dropdown-open', async() => {
+					const elem = await createTableFixture(html`
+						<thead>${createSortableButtonDropdownHeaderRow()}</thead>
+						<tbody>${createRows([1, 2, 3])}</tbody>
+					`);
+					await clickElem(elem.shadowRoot.querySelector('d2l-table-col-sort-button'));
 					await expect(elem).to.be.golden();
 				});
 

--- a/lang/en.js
+++ b/lang/en.js
@@ -107,7 +107,7 @@ export default {
 	"components.switch.conditions": "Conditions must be met",
 	"components.table-col-sort-button.addSortOrder": "Click to add sort order",
 	"components.table-col-sort-button.changeSortOrder": "Click to change sort order",
-	'components.table-col-sort-button.title': "{dataType, select, dates {{direction, select, desc {Sorted new to old} other {Sorted old to new}}} numbers {{direction, select, desc {Sorted high to low} other {Sorted low to high}}} words {{direction, select, desc {Sorted Z to A} other {Sorted A to Z}}} other {Sorted}}",
+	'components.table-col-sort-button.title': "{dataType, select, dates {{direction, select, desc {Sorted new to old} other {Sorted old to new}}} numbers {{direction, select, desc {Sorted high to low} other {Sorted low to high}}} words {{direction, select, desc {Sorted A to Z} other {Sorted Z to A}}} value {Sorted {selectedMenuItemText}} other {Sorted}}",
 	"components.table-controls.label": "Actions for table",
 	"components.tabs.next": "Scroll Forward",
 	"components.tabs.previous": "Scroll Backward",


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/jira/software/c/projects/GAUD/boards/330?selectedIssue=GAUD-6122)

This allows consumers to put `d2l-menu-item-radio` items in the `items` slot in order to have cases with more than asc and desc (e.g., first name/last name combinations).
Note that this does not work with sticky headers.
I'll be adding documentation with further examples in a followup story.