### PR TITLE
use a static event name

### DIFF
--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -390,7 +390,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 
 	_handleExpandCollapse(e) {
 		const eventPromise = this.expanded ? e.detail.expandComplete : e.detail.collapseComplete;
-		const event = `d2l-collapsible-panel-${this.expanded ? 'expand' : 'collapse' }`;
+		const event = this.expanded ? 'd2l-collapsible-panel-expand' : 'd2l-collapsible-panel-collapse';
 
 		this.dispatchEvent(new CustomEvent(
 			event, { bubbles: false, composed: false, detail: { complete: eventPromise } }


### PR DESCRIPTION
From the docs I knew these events existed, but they weren't showing up in code search because their names were dynamically built up. Switching to a static definition to help with code searching.