### PR TITLE
chore: Add lifecycle info to localize mixin

### DIFF
--- a/mixins/localize/README.md
+++ b/mixins/localize/README.md
@@ -61,9 +61,15 @@ static get localizeConfig() {
 }
 ```
 
+### Lifecycle
+
+The `LocalizeMixin` blocks Lit component updates until the translations are loaded by returning `false` from `shouldUpdate()`. This means that the component is guaranteed to load valid terms [anywhere in the Lit lifecycle from `willUpdate()` onwards](https://lit.dev/docs/components/lifecycle/#reactive-update-cycle).
+
+Two common patterns for using `localize()` are within `render()` to modify the component's rendering, and within `firstUpdated()` to modify a page's `document.title`.
+
 ### `localize()`
 
-The `localize()` method is used to localize a piece of text in the component's `render()` method.
+The `localize()` method is used to localize a piece of text.
 
 If the localized string contains arguments, pass them as a key-value object as the 2nd parameter:
 


### PR DESCRIPTION
I want to clarify the Lit lifecycle implications for `LocalizeMixin`, to make it clear when we are guaranteed to have valid terms.

This came up when we were trying to troubleshoot where to update `document.title`, which some of our components were doing too soon in `connectedCallback` - some Slack conversation here:
https://d2l.slack.com/archives/C0PHG3QB0/p1715891946771899
