### PR TITLE
Strip out mo/mi elements when rendering MathML if they only contain non-breaking space characters or other whitespace

### DIFF
--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -78,7 +78,7 @@
 							&lt;li&gt;ordered item 1&lt;/li&gt;
 							&lt;li&gt;ordered item 2&lt;/li&gt;
 						&lt;/ol&gt;
-						&lt;div&gt;&lt;a href=&quot;https://d2l.com&quot;&gt;anchor&lt;/a&gt;&lt;/div&gt;">					
+						&lt;div&gt;&lt;a href=&quot;https://d2l.com&quot;&gt;anchor&lt;/a&gt;&lt;/div&gt;">
 					</d2l-html-block>
 				</template>
 			</d2l-demo-snippet>
@@ -494,7 +494,7 @@
 								&lt;/mrow&gt;
 								&lt;mo&gt;)&lt;/mo&gt;
 							&lt;/mrow&gt;
-						&lt;/math&gt; and other symbols.">					
+						&lt;/math&gt; and other symbols.">
 					</d2l-html-block>
 				</template>
 			</d2l-demo-snippet>
@@ -504,7 +504,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-html-block html="&lt;div&gt;$$ f(x) = \int \mathrm{e}^{-x}\,\mathrm{d}x $$ $$ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} $$&lt;/div&gt;
-						&lt;div&gt;$$ {\color{red}x} + {\color{blue}y} = {\color{green}z} $$&lt;/div&gt;">					
+						&lt;div&gt;$$ {\color{red}x} + {\color{blue}y} = {\color{green}z} $$&lt;/div&gt;">
 					</d2l-html-block>
 				</template>
 			</d2l-demo-snippet>

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -66,11 +66,19 @@ class HtmlBlockMathRenderer {
 
 		if (context.enableMML3Support) {
 			// There's a bug in the experimental MML3 plugin that causes mi and mo elements containing non-breaking
-			// spaces to break MathJax's math processing. Unfortunately, WIRIS tends to add a lot of these in chemistry
-			// equations. Since they're not really intended in the MathML spec anyways, we'll just remove them.
-			// See https://github.com/mathjax/MathJax/issues/3030 for more details.
+			// spaces to break MathJax's math processing (e.g. <mo>&nbsp;</mo>, <mi>Some&nbsp;Identifier</mi>).
+			// Unfortunately, WIRIS tends to add a lot of these in chemistry equations, so they break math processing.
+			//
+			// In order to address this, we can just remove any non-breaking spaces entirely, replacing them with
+			// empty strings. MathJax will ignore any empty elements as a result, and while this may mean intended
+			// whitespace is occasionally removed, it's necessary for MathJax to render anything at all.
+			//
+			// NOTE: MathJax evidently has a fix for this in MathJax 4, so we should consider trying to remove this when
+			// the update comes out of beta and we decide to take it on.
+			//
+			// See https://github.com/mathjax/MathJax/issues/3030 for some related discussion.
 			elem.querySelectorAll('mo, mi').forEach(elm => {
-				if (elm.innerHTML.replace(/&nbsp;/g, '').trim().length === 0) elm.remove();
+				elm.innerHTML = elm.innerHTML.replace(/&nbsp;/g, '');
 			});
 		}
 

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -64,6 +64,16 @@ class HtmlBlockMathRenderer {
 			elm.style.height = '0.5rem';
 		});
 
+		if (context.enableMML3Support) {
+			// There's a bug in the experimental MML3 plugin that causes mi and mo elements containing non-breaking
+			// spaces to break MathJax's math processing. Unfortunately, WIRIS tends to add a lot of these in chemistry
+			// equations. Since they're not really intended in the MathML spec anyways, we'll just remove them.
+			// See https://github.com/mathjax/MathJax/issues/3030 for more details.
+			elem.querySelectorAll('mo, mi').forEach(elm => {
+				if (elm.innerHTML.replace(/&nbsp;/g, '').trim().length === 0) elm.remove();
+			});
+		}
+
 		// If we're using deferred rendering, we need to create a document structure
 		// within the element so MathJax can appropriately process math.
 		if (!options.noDeferredRendering) elem.innerHTML = `<mjx-doc><mjx-head></mjx-head><mjx-body>${elem.innerHTML}</mjx-body></mjx-doc>`;


### PR DESCRIPTION
There's a bug in MathJax's experimental `[mml]/mml3` package that can cause equations to fail to render if extra spaces are added to equations via `<mo>` and `<mi>` elements containing non-breaking spaces. We don't really want this behaviour anyways, since adding extra spaces just messes up MathJax's rendering, so the simplest option here is to just remove these elements if we find them.

It does look like there's a fix for this, but only in MathJax 4, which is still in beta, so not something we'll be updating quite yet.