### PR TITLE
Prevent Lit from creating markers in the html-block render container when using the old rendering mode

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -231,12 +231,19 @@ class HtmlBlock extends LitElement {
 			'd2l-html-block-compact': this.compact
 		};
 
-		return html`
-			<div class="${classMap(renderContainerClasses)}">
-				${(this._embedsFeatureEnabled() && !this.noDeferredRendering) ? until(this._processEmbeds(), nothing) : nothing}
-			</div>
-			${this.noDeferredRendering ? html`<slot @slotchange="${this._handleSlotChange}"></slot>` : ''}
-		`;
+		if (this._embedsFeatureEnabled()) {
+			return html`
+				<div class="${classMap(renderContainerClasses)}">
+					${!this.noDeferredRendering ? until(this._processEmbeds(), nothing) : nothing}
+				</div>
+				${this.noDeferredRendering ? html`<slot @slotchange="${this._handleSlotChange}"></slot>` : ''}
+			`;
+		} else {
+			return html`
+				<div class="${classMap(renderContainerClasses)}"></div>
+				${this.noDeferredRendering ? html`<slot @slotchange="${this._handleSlotChange}"></slot>` : ''}
+			`;
+		}
 	}
 
 	async updated(changedProperties) {


### PR DESCRIPTION
Rendering `nothing` in the html-block's render container causes Lit to place element markers inside of it. This is normally perfectly fine, except under the old editing mode (i.e. when `_embedsFeatureEnabled()` returns false), we then proceed to directly set the container's `innerHTML`, causing Lit to get mad and throw an error. This error isn't functional, because with that feature disabled we're never using Lit to render anything other than `nothing` in the container. However, I want to keep log noise to a minimum by restructuring the render method to avoid that scenario.