### PR TITLE
feat: dropdown: add ability to override inner button-icon height, use in table-wrapper

### DIFF
--- a/components/dropdown/dropdown-context-menu.js
+++ b/components/dropdown/dropdown-context-menu.js
@@ -33,7 +33,13 @@ class DropdownContextMenu extends DropdownOpenerMixin(VisibleOnAncestorMixin(Lit
 	static get styles() {
 		return [dropdownOpenerStyles, visibleOnAncestorStyles, css`
 			:host {
+				--d2l-dropdown-context-menu-min-height: calc(2rem + 2px);
+				--d2l-dropdown-context-menu-min-width: calc(2rem + 2px);
 				display: inline-block;
+			}
+			d2l-button-icon {
+				--d2l-button-icon-min-height: var(--d2l-dropdown-context-menu-min-height);
+				--d2l-button-icon-min-width: var(--d2l-dropdown-context-menu-min-height);
 			}
 		`];
 	}

--- a/components/table/demo/table-test.js
+++ b/components/table/demo/table-test.js
@@ -2,6 +2,7 @@ import '../table-col-sort-button.js';
 import '../table-controls.js';
 import '../../button/button-icon.js';
 import '../../dropdown/dropdown-button-subtle.js';
+import '../../dropdown/dropdown-context-menu.js';
 import '../../dropdown/dropdown-menu.js';
 import '../../inputs/input-checkbox.js';
 import '../../inputs/input-text.js';
@@ -56,10 +57,12 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 			:host([visible-background]) {
 				--d2l-table-controls-background-color: #dddddd;
 			}
-			.d2l-table > * > tr > :has(d2l-button-icon) {
+			.d2l-table > * > tr > :has(d2l-button-icon),
+			.d2l-table > * > tr > :has(d2l-dropdown-context-menu) {
 				padding-block: 0;
 			}
-			.d2l-table > * > tr > :has(d2l-table-col-sort-button) d2l-button-icon {
+			.d2l-table > * > tr > :has(d2l-table-col-sort-button) d2l-button-icon,
+			.d2l-table > * > tr > :has(d2l-table-col-sort-button) d2l-dropdown-context-menu {
 				vertical-align: top;
 			}
 		`];
@@ -198,7 +201,7 @@ class TestTable extends RtlMixin(DemoPassthroughMixin(TableWrapper, 'd2l-table-w
 					source-type="numbers"
 					?desc="${this._sortDesc}"
 					?nosort="${noSort}">${item}</d2l-table-col-sort-button>
-				${item === 'Size' && this.showButtons ? html`<d2l-button-icon text="Help" icon="tier1:help"></d2l-button-icon>` : nothing}
+				${item === 'Size' && this.showButtons ? html`<d2l-dropdown-context-menu text="Help"></d2l-dropdown-context-menu>` : nothing}
 			</th>
 		`;
 	}

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -37,6 +37,10 @@ export const tableStyles = css`
 		--d2l-button-icon-min-height: calc(var(--d2l-table-cell-overall-height) - 2 * var(--d2l-table-cell-col-sort-button-size-offset));
 		--d2l-button-icon-min-width: calc(var(--d2l-table-cell-overall-height) - 2 * var(--d2l-table-cell-col-sort-button-size-offset));
 	}
+	d2l-table-wrapper d2l-dropdown-context-menu {
+		--d2l-dropdown-context-menu-min-height: calc(var(--d2l-table-cell-overall-height) - 2 * var(--d2l-table-cell-col-sort-button-size-offset));
+		--d2l-dropdown-context-menu-min-width: calc(var(--d2l-table-cell-overall-height) - 2 * var(--d2l-table-cell-col-sort-button-size-offset));
+	}
 
 	/* once we only support browsers that support :has the section below can be removed up until @supports */
 	.d2l-table .d2l-checkbox,


### PR DESCRIPTION
Related to [backport](https://desire2learn.atlassian.net/jira/software/c/projects/GAUD/boards/330?selectedIssue=GAUD-6126)
Similar to `d2l-button-icon` components in table cells, we want to also be able to make `d2l-dropdown-context-menu` usages a certain size. This adds css vars in order to do so. Let me know if there's a better way to do this that I've missed - I don't love having to set the default for `--d2l-button-icon-min-height` and width, I just want to be able to set an override.