### PR TITLE
MAN-2993: Promote z-index for scroll-wrapper-actions

### DIFF
--- a/components/scroll-wrapper/scroll-wrapper.js
+++ b/components/scroll-wrapper/scroll-wrapper.js
@@ -124,7 +124,7 @@ class ScrollWrapper extends RtlMixin(LitElement) {
 				position: -webkit-sticky;
 				position: sticky;
 				top: var(--d2l-table-sticky-top, 0);
-				z-index: 4;
+				z-index: 5;
 			}
 
 			.d2l-scroll-wrapper-button {

--- a/components/table/table-controls.js
+++ b/components/table/table-controls.js
@@ -20,7 +20,7 @@ class TableControls extends SelectionControls {
 			:host {
 				--d2l-selection-controls-background-color: var(--d2l-table-controls-background-color);
 				--d2l-selection-controls-shadow-display: var(--d2l-table-controls-shadow-display);
-				z-index: 5; /* Must be greater than d2l-table-wrapper and d2l-scroll-wrapper */
+				z-index: 6; /* Must be greater than d2l-table-wrapper and d2l-scroll-wrapper */
 			}
 			:host([no-sticky]) {
 				z-index: auto;


### PR DESCRIPTION
[MAN-2993](https://desire2learn.atlassian.net/browse/MAN-2993)
Related to https://d2l.slack.com/archives/C04511G83KR/p1717183794167289

The `sticky-headers-scroll-wrapper` attribute is causing issues with tooltip display in mastery view.
One possible workaround is to instead [manually wrap the d2l-table in a scroll-wrapper](https://github.com/Brightspace/d2l-outcomes/pull/1287). This appears to work for our particular use case.

However since both the table sticky headers and the scroll-wrapper actions both have [z-index: 4](https://github.com/BrightspaceUI/core/pull/3635), the sticky headers take precedence in the render order, blocking out the left-side chevron:

![image](https://github.com/BrightspaceUI/core/assets/11915922/41eaa519-d965-4412-bfd9-17bca81729a3)

Promoting the z-index for the scroll-wrapper-actions is the most straightforward (naive?) way to solve the issue.

DISCLAIMER: This is not an ideal solution. If we think it's risky/unnecessary for these changes to apply globally we can just apply some of these z-index overrides at the consumer-level (though this does end up being a little less pretty)

[MAN-2993]: https://desire2learn.atlassian.net/browse/MAN-2993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ