### PR TITLE
fix: reset dialog width when autosize is off

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -561,6 +561,8 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			await this.updateComplete;
 			this._height = this._getHeight();
 			await this.updateComplete;
+		} else {
+			this._width = 0;
 		}
 		await new Promise(resolve => {
 			requestAnimationFrame(async() => {


### PR DESCRIPTION
When the viewport is larger, dialogs will be in "autosize" mode, meaning their widths will be calculated based on the viewport width minus a buffer. This is done by setting a via inline `style` on the dialog's `div.d2l-dialog-outer`. When dialogs are smaller, "autosize" mode is disabled and dialogs take up the full viewport width, and the inline style is removed from that div.

Where the problem occurs is if the page initially loads wider, and then is dynamically shrunk by the user. In this case, the `div` will have a set width, but then `autosize` gets disabled as the viewport shrinks but the width doesn't get reset to `0` so that div's width remains. This causes the defect where the minimum width of the dialog is around `540px`.

To fix this, we simply set the width back to `0` when `autosize` goes off.

I tried for a good two hours to get a vdiff test to demonstrate this, but came up short. It seems like the vdiff's `setViewport` is triggering the dialog to re-render differently that just resizing the window in a normal browser.