### PR TITLE
fix: shorter error messages when they contain composed path to elements

### DIFF
--- a/helpers/error.js
+++ b/helpers/error.js
@@ -1,11 +1,13 @@
 import { getComposedParent } from './dom.js';
 
+const numParentLevels = 10;
+
 function getComposedPath(elem, opts) {
 
 	if (!opts?.composedPath) return '';
 
 	const composedParents = [];
-	let parent = elem;
+	let parent = getComposedParent(elem);
 	while (parent !== null && parent?.tagName?.toLowerCase() !== 'body') {
 		if (parent?.tagName) {
 			composedParents.push(parent.tagName.toLowerCase());
@@ -15,8 +17,8 @@ function getComposedPath(elem, opts) {
 
 	if (composedParents.length === 0) return '';
 
-	composedParents.reverse();
-	const path = ` Path: "${composedParents.join(' > ')}".`;
+	const slicedParents = composedParents.slice(0, numParentLevels);
+	const path = ` ${slicedParents.length} parent nodes: "${slicedParents.join(', ')}".`;
 	return path;
 
 }

--- a/helpers/test/error.test.js
+++ b/helpers/test/error.test.js
@@ -1,0 +1,30 @@
+import { expect, fixture, html } from '@brightspace-ui/testing';
+import { createElementErrorMessage } from '../error.js';
+
+describe('error', () => {
+
+	describe('createElementErrorMessage', () => {
+
+		it('should default with no composed path', async() => {
+			const elem = await fixture(html`<input type="text">`);
+			const message = createElementErrorMessage('TestThing', elem, 'Test message');
+			expect(message).to.equal('<input>: Test message. (@brightspace-ui/core:TestThing)');
+		});
+
+		it('should include composed path', async() => {
+			const parent = await fixture(html`<main><section><div><span class="elem"></span></div></section></main>`);
+			const elem = parent.querySelector('.elem');
+			const message = createElementErrorMessage('TestThing', elem, 'Test message', { composedPath: true });
+			expect(message).to.equal('<span>: Test message. 4 parent nodes: "div, section, main, div". (@brightspace-ui/core:TestThing)');
+		});
+
+		it('should truncate composed path at 10 elements', async() => {
+			const parent = await fixture(html`<p-11><p-10><p-9><p-8><p-7><p-6><p-5><p-4><p-3><p-2><p-1><span class="elem"></span></p-1></p-2></p-3></p-4></p-5></p-6></p-7></p-8></p-9></p-10></p-11>`);
+			const elem = parent.querySelector('.elem');
+			const message = createElementErrorMessage('TestThing', elem, 'Test message', { composedPath: true });
+			expect(message).to.equal('<span>: Test message. 10 parent nodes: "p-1, p-2, p-3, p-4, p-5, p-6, p-7, p-8, p-9, p-10". (@brightspace-ui/core:TestThing)');
+		});
+
+	});
+
+});


### PR DESCRIPTION
Whenever we include the composed path to an element in the error message -- for example a missing attribute like a label -- we included the FULL path of all ancestors. That was resulting in error messages like this:

> Uncaught TypeError: <d2l-input-text>: "label" attribute is required. Path: "div > div > div > div > div > div > div > div > div > d2l-expand-collapse-content > div > div > slot > div > d2l-my-courses > d2l-my-courses-container > d2l-all-courses > d2l-dialog-fullscreen > div > d2l-focus-trap > slot > div > div > div > slot > div > div > div > d2l-my-courses-search > d2l-dropdown > slot > div > d2l-input-search > d2l-input-text". (@brightspace-ui/core:PropertyRequiredMixin)

Very useful, but also very long. The index where we store these errors in OpenSearch had a character limit of 256 (that error is 476 characters long), and when things exceed that limit, it simply ignores them.

Separately, I've [increased that limit to 512 characters](https://github.com/Brightspace/brightspace-aws-logging/pull/2323) for next month, but theoretically there's nothing that would prevent us from exceeding that as well.

This change stops reversing the chain (so we start with the nearest parent) and limits the ancestor path that we include in the message to 10 elements, which seems like a reasonable number to narrow down the source of the problem. Added some tests while I was in here.