### PR TITLE
Reposition fixed position dropdown when DOM mutations occur in the ancestor path

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -285,6 +285,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 		this._verticalOffset = defaultVerticalOffset;
 
 		this.__reposition = this.__reposition.bind(this);
+		this.__onAncestorMutation = this.__onAncestorMutation.bind(this);
 		this.__onResize = this.__onResize.bind(this);
 		this.__onAutoCloseFocus = this.__onAutoCloseFocus.bind(this);
 		this.__onAutoCloseClick = this.__onAutoCloseClick.bind(this);
@@ -460,7 +461,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 
 		this.__removeRepositionHandlers();
 
-		this._ancestorMutationObserver ??= new MutationObserver(this.__reposition);
+		this._ancestorMutationObserver ??= new MutationObserver(this.__onAncestorMutation);
 		const mutationConfig = { attributes: true, childList: true, subtree: true };
 
 		let node = this;
@@ -538,6 +539,13 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 
 	__handleHeaderSlotChange(e) {
 		this._hasHeader = e.target.assignedNodes().length !== 0;
+	}
+
+	__onAncestorMutation(mutations) {
+		const opener = this.__getOpener();
+		// ignore mutations that are within this dropdown
+		const reposition = !!mutations.find(mutation => !isComposedAncestor(opener, mutation.target));
+		if (reposition) this.__reposition();
 	}
 
 	__onAutoCloseClick(e) {

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -137,7 +137,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 	}
 
 	willUpdate(changedProperties) {
-		if (changedProperties.has('preferFixedPositioning')) {
+		if (this._fixedPositioning === undefined || changedProperties.has('preferFixedPositioning')) {
 			this._fixedPositioning = (window.D2L?.LP?.Web?.UI?.Flags.Flag('GAUD-131-dropdown-fixed-positioning', false) && this.preferFixedPositioning);
 		}
 	}


### PR DESCRIPTION
[GAUD-6454](https://desire2learn.atlassian.net/browse/GAUD-6454)

This PR updates the fixed position dropdown to reposition itself when it observes DOM mutations in its ancestor path. It wires up the observer in each DOM scope, however it _does not_ wire-up to sibling scopes.

[GAUD-6454]: https://desire2learn.atlassian.net/browse/GAUD-6454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ