### PR TITLE
feat: InteractiveMixin: Change how escape and tab are handled [GAUD-6474]

### DIFF
--- a/mixins/interactive/interactive-mixin.js
+++ b/mixins/interactive/interactive-mixin.js
@@ -9,7 +9,8 @@ import { RtlMixin } from '../rtl/rtl-mixin.js';
 
 const keyCodes = {
 	ENTER: 13,
-	ESCAPE: 27
+	ESCAPE: 27,
+	TAB: 9
 };
 
 export function isInteractiveDescendant(node) {
@@ -106,10 +107,15 @@ export const InteractiveMixin = superclass => class extends LocalizeCoreElement(
 	}
 
 	async _handleInteractiveKeyDown(e) {
-		if (this._interactive && e.keyCode === keyCodes.ESCAPE) {
+		if (!this._interactive) return;
+
+		if (e.keyCode === keyCodes.ESCAPE && !e.target?.opened) {
+			e.stopPropagation();
 			this._interactive = false;
 			await this.updateComplete;
 			this.shadowRoot.querySelector('.interactive-toggle').focus();
+		} else if (e.keyCode === keyCodes.TAB) {
+			e.stopPropagation();
 		}
 	}
 


### PR DESCRIPTION
Part of [Jira ticket](https://desire2learn.atlassian.net/jira/software/c/projects/GAUD/boards/330?selectedIssue=GAUD-6474)

Open to suggestions on this.
We want `d2l-input-date-time-range` and `d2l-input-date-range` to be within `InteractiveMixin` for usage in a filter list item. In order for the keyboard behaviour to work as expected, changes are needed to how escape and tab are handled.

Problems:
- Escape: When the date/time input dropdown is opened, close would exit the dropdown but also leave interactive mode, which we wouldn't want. To mitigate this I added a check for `e.target?.opened` but let me know if that's getting too specific with knowledge of our dropdown being involved.
- Tab: in date-time the tab key would normally take the user between inputs. The current behaviour is that it goes to the next tab stop. Note that previously if the user was within an interactive area and then pressed tab, they would go to the next tab stop, but with this change they exit the interactive area and focus goes back to the interactive area (i.e., focus ring is around the interactive area)

If you wish to test this out with the date-time range, it can be seen [https://live.d2l.dev/prs/BrightspaceUI/core/pr-4742/components/filter/demo/filter.html] in the last demo on the page ("Date Filter")