### PR TITLE
feat: Date and time inputs: Add prefer-fixed-positioning attribute

### DIFF
--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -93,6 +93,11 @@ class InputDateRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
+			 * Temporary.
+			 * @ignore
+			 */
+			preferFixedPositioning: { type: Boolean, attribute: 'prefer-fixed-positioning' },
+			/**
 			 * Indicates that values are required
 			 * @type {boolean}
 			 */
@@ -197,6 +202,7 @@ class InputDateRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 						max-value="${ifDefined(this.maxValue)}"
 						min-value="${ifDefined(this.minValue)}"
 						?opened="${this.startOpened}"
+						?prefer-fixed-positioning="${this.preferFixedPositioning}"
 						?required="${this.required}"
 						?skeleton="${this.skeleton}"
 						slot="left"
@@ -215,6 +221,7 @@ class InputDateRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 						max-value="${ifDefined(this.maxValue)}"
 						min-value="${ifDefined(this.minValue)}"
 						?opened="${this.endOpened}"
+						?prefer-fixed-positioning="${this.preferFixedPositioning}"
 						?required="${this.required}"
 						?skeleton="${this.skeleton}"
 						slot="right"

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -131,6 +131,11 @@ class InputDateTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMi
 			 */
 			minValue: { attribute: 'min-value', reflect: true, type: String },
 			/**
+			 * Temporary.
+			 * @ignore
+			 */
+			preferFixedPositioning: { type: Boolean, attribute: 'prefer-fixed-positioning' },
+			/**
 			 * Indicates that values are required
 			 * @type {boolean}
 			 */
@@ -248,6 +253,7 @@ class InputDateTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMi
 							max-value="${ifDefined(this.maxValue)}"
 							min-value="${ifDefined(this.minValue)}"
 							?opened="${this.startOpened}"
+							?prefer-fixed-positioning="${this.preferFixedPositioning}"
 							?required="${this.required}"
 							?skeleton="${this.skeleton}"
 							time-default-value="startOfDay"
@@ -270,6 +276,7 @@ class InputDateTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMi
 							max-value="${ifDefined(this.maxValue)}"
 							min-value="${ifDefined(this.minValue)}"
 							?opened="${this.endOpened}"
+							?prefer-fixed-positioning="${this.preferFixedPositioning}"
 							?required="${this.required}"
 							?skeleton="${this.skeleton}"
 							time-default-value="endOfDay"

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -77,6 +77,11 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 			 */
 			opened: { type: Boolean },
 			/**
+			 * Temporary.
+			 * @ignore
+			 */
+			preferFixedPositioning: { type: Boolean, attribute: 'prefer-fixed-positioning' },
+			/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
@@ -248,6 +253,7 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 				label-hidden
 				.labelRequired="${false}"
 				max-height="430"
+				?prefer-fixed-positioning="${this.preferFixedPositioning}"
 				?required="${this.required}"
 				?skeleton="${this.skeleton}"
 				.value="${parsedValue}">
@@ -277,6 +283,7 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 						max-value="${ifDefined(this._maxValueLocalized)}"
 						min-value="${ifDefined(this._minValueLocalized)}"
 						?opened="${dateOpened}"
+						?prefer-fixed-positioning="${this.preferFixedPositioning}"
 						?required="${this.required}"
 						?skeleton="${this.skeleton}"
 						style="${styleMap(dateStyle)}"

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -74,6 +74,11 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 			 */
 			opened: { type: Boolean, reflect: true },
 			/**
+			 * Temporary.
+			 * @ignore
+			 */
+			preferFixedPositioning: { type: Boolean, attribute: 'prefer-fixed-positioning' },
+			/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
@@ -256,7 +261,8 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 				trap-focus
 				no-auto-focus
 				mobile-tray="bottom"
-				no-padding>
+				no-padding
+				?prefer-fixed-positioning="${this.preferFixedPositioning}">
 				<d2l-calendar
 					@d2l-calendar-selected="${this._handleDateSelected}"
 					label="${ifDefined(this.label)}"
@@ -277,7 +283,7 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 				<div>${this.emptyText}</div>
 			</div>
 			${errorTooltip}
-			<d2l-dropdown ?disabled="${this.disabled || this.skeleton}" no-auto-open>
+			<d2l-dropdown ?disabled="${this.disabled || this.skeleton}" no-auto-open ?prefer-fixed-positioning="${this.preferFixedPositioning}">
 				<d2l-input-text
 					?novalidate="${this.noValidate}"
 					aria-invalid="${this.invalid ? 'true' : 'false'}"

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -96,6 +96,11 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
 			/**
+			 * Temporary.
+			 * @ignore
+			 */
+			preferFixedPositioning: { type: Boolean, attribute: 'prefer-fixed-positioning' },
+			/**
 			 * Indicates that values are required
 			 * @type {boolean}
 			 */
@@ -248,6 +253,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 						label="${startLabel}"
 						?label-hidden="${this.childLabelsHidden}"
 						?opened="${this.startOpened}"
+						?prefer-fixed-positioning="${this.preferFixedPositioning}"
 						?required="${this.required}"
 						?skeleton="${this.skeleton}"
 						slot="left"
@@ -266,6 +272,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 						label="${endLabel}"
 						?label-hidden="${this.childLabelsHidden}"
 						?opened="${this.endOpened}"
+						?prefer-fixed-positioning="${this.preferFixedPositioning}"
 						?required="${this.required}"
 						?skeleton="${this.skeleton}"
 						slot="right"

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -155,6 +155,11 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 			 */
 			opened: { type: Boolean },
 			/**
+			 * Temporary.
+			 * @ignore
+			 */
+			preferFixedPositioning: { type: Boolean, attribute: 'prefer-fixed-positioning' },
+			/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
@@ -339,7 +344,7 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 				class="${this.label && !this.labelHidden && !this.labelledBy ? 'd2l-input-label d2l-skeletize' : 'd2l-offscreen'}"
 				for="${this._dropdownId}-input"
 				id="${this._dropdownId}-label">${this.label}</label>
-			<d2l-dropdown class="d2l-skeletize" ?disabled="${disabled}">
+			<d2l-dropdown class="d2l-skeletize" ?disabled="${disabled}" ?prefer-fixed-positioning="${this.preferFixedPositioning}">
 				<input
 					aria-invalid="${this.invalid ? 'true' : 'false'}"
 					aria-controls="${this._dropdownId}"
@@ -363,7 +368,8 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 					no-padding-footer
 					max-height="${ifDefined(this.maxHeight)}"
 					min-width="195"
-					?opened="${opened}">
+					?opened="${opened}"
+					?prefer-fixed-positioning="${this.preferFixedPositioning}">
 					<d2l-menu
 						aria-labelledby="${this._dropdownId}-label"
 						class="d2l-input-time-menu"


### PR DESCRIPTION
Part of [Jira ticket](https://desire2learn.atlassian.net/jira/software/c/projects/GAUD/boards/330?selectedIssue=GAUD-6474)

This adds a `prefer-fixed-positioning` attribute to all the date and time range components and passes it down to the base `input-date` and `input-time` components to be added to the dropdown-content and dropdown components in order to enable that behaviour when the flag is also true.

I added this to `input-time-range` as well even though it's not in scope for the filter work since it seems like it would be needed eventually.

Let me know if there would be a preferred way of doing this rather than passing it all the way through the components.