### PR TITLE
Update fixed position dropdown so that the height is not updated as the user scrolls

### DIFF
--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -148,7 +148,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 			this.maxHeight = this._maxHeightNonTray;
 		}
 
-		this.__position(!this._initializingHeight, e.detail);
+		this.__position(e.detail, { updateAboveBelow: this._initializingHeight });
 		this._initializingHeight = false;
 
 		const menu = this.__getMenuElement();

--- a/components/dropdown/dropdown-tabs.js
+++ b/components/dropdown/dropdown-tabs.js
@@ -46,7 +46,7 @@ class DropdownTabs extends DropdownContentMixin(LitElement) {
 			height: e.detail.height + tabListRect.height + 52,
 			width: e.detail.width
 		};
-		this.__position(!this._initializingHeight, rect);
+		this.__position(rect, { updateAboveBelow: this._initializingHeight });
 		this._initializingHeight = false;
 	}
 
@@ -56,7 +56,7 @@ class DropdownTabs extends DropdownContentMixin(LitElement) {
 	}
 
 	_onTabSelected() {
-		this.__position(false);
+		this.__position();
 	}
 
 }


### PR DESCRIPTION
[GAUD-6558](https://desire2learn.atlassian.net/browse/GAUD-6558)

This PR updates the fixed position dropdown contents so that their container height is not updated as the user scrolls.

[GAUD-6558]: https://desire2learn.atlassian.net/browse/GAUD-6558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ