### PR TITLE
[a11y docn] Update switch component's readme for accessibility project

### DIFF
--- a/components/switch/README.md
+++ b/components/switch/README.md
@@ -43,7 +43,7 @@ The `d2l-switch` element is a generic switch with on/off semantics.
 
 | Property | Type | Description |
 |---|---|---|
-| `text` | String, required | Acts as the [primary label](https://www.w3.org/WAI/tutorials/forms/labels/) for the switch. Visible unless text-position is `hidden`. |
+| `text` | String, required | Acts as the primary label for the switch. Visible unless text-position is `hidden`. |
 | `disabled` | Boolean | Disables the switch |
 | `on` | Boolean | Whether the switch is "on" or "off" |
 | `text-position` | String | Valid values are: `start`, `end` (default), and `hidden` |
@@ -106,3 +106,4 @@ If an activity is set to `Visible` but also has other conditions affecting its v
 ## Accessbility
 
 - When `text-position` is set to `hidden`, the required `text` will be used for the switch's hidden label so that it is [accessible](https://www.w3.org/WAI/WCAG22/quickref/#name-role-value) to non-sighted users.
+- `d2l-switch-visibility` is a notable exception to the best practice of having a static term as the label, this was done to provide more clarity in situations where there are external conditions that could influence whether or not the content in question is visible.

--- a/components/switch/README.md
+++ b/components/switch/README.md
@@ -43,7 +43,7 @@ The `d2l-switch` element is a generic switch with on/off semantics.
 
 | Property | Type | Description |
 |---|---|---|
-| `text` | String, required | Accessible text for the switch |
+| `text` | String, required | Acts as a  [primary label](https://www.w3.org/WAI/tutorials/forms/labels/) on the switch. Visible unless text-position is `hidden`. |
 | `disabled` | Boolean | Disables the switch |
 | `on` | Boolean | Whether the switch is "on" or "off" |
 | `text-position` | String | Valid values are: `start`, `end` (default), and `hidden` |
@@ -51,14 +51,6 @@ The `d2l-switch` element is a generic switch with on/off semantics.
 
 - `change`: dispatched when the `on` property is updated
 <!-- docs: end hidden content -->
-
-### Accessibility Properties
-
-To make your usage of `d2l-switch` accessible, use the following property:
-
-| Attribute | Description |
-|---|---|
-| `text` | **REQUIRED** [Acts as a primary label on the switch](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless text-position is `hidden`. |
 
 ## Visibility Switch [d2l-switch-visibility]
 
@@ -110,3 +102,7 @@ If an activity is set to `Visible` but also has other conditions affecting its v
   </ul>
 </d2l-switch-visibility>
 ```
+
+## Accessbility
+
+- When `text-position` is set to `hidden`, the switch will still make use of the `text` property as it is used to set the [`aria-label`](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA6) of the component, so that screen readers can still pick up what the text of the component is.

--- a/components/switch/README.md
+++ b/components/switch/README.md
@@ -105,4 +105,4 @@ If an activity is set to `Visible` but also has other conditions affecting its v
 
 ## Accessbility
 
-- When `text-position` is set to `hidden`, the required `text` will be used for the switch's hidden label so that it is [accessible](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA14) to non-sighted users.
+- When `text-position` is set to `hidden`, the required `text` will be used for the switch's hidden label so that it is [accessible](https://www.w3.org/WAI/WCAG22/quickref/#name-role-value) to non-sighted users.

--- a/components/switch/README.md
+++ b/components/switch/README.md
@@ -106,4 +106,4 @@ If an activity is set to `Visible` but also has other conditions affecting its v
 ## Accessbility
 
 - When `text-position` is set to `hidden`, the required `text` will be used for the switch's hidden label so that it is [accessible](https://www.w3.org/WAI/WCAG22/quickref/#name-role-value) to non-sighted users.
-- `d2l-switch-visibility` is a notable exception to the best practice of having a static term as the label, this was done to provide more clarity in situations where there are external conditions that could influence whether or not the content in question is visible.
+- `d2l-switch-visibility` is a notable exception to the best practice of having a static term as the label; this was done to provide more clarity in situations where there are external conditions that could influence whether or not the content in question is visible.

--- a/components/switch/README.md
+++ b/components/switch/README.md
@@ -105,4 +105,4 @@ If an activity is set to `Visible` but also has other conditions affecting its v
 
 ## Accessbility
 
-- When `text-position` is set to `hidden`, the required `text` will be used for the switch's hidden label so that it is accessible to non-sighted users.
+- When `text-position` is set to `hidden`, the required `text` will be used for the switch's hidden label so that it is [accessible](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA14) to non-sighted users.

--- a/components/switch/README.md
+++ b/components/switch/README.md
@@ -43,7 +43,7 @@ The `d2l-switch` element is a generic switch with on/off semantics.
 
 | Property | Type | Description |
 |---|---|---|
-| `text` | String, required | Acts as a  [primary label](https://www.w3.org/WAI/tutorials/forms/labels/) on the switch. Visible unless text-position is `hidden`. |
+| `text` | String, required | Acts as the [primary label](https://www.w3.org/WAI/tutorials/forms/labels/) for the switch. Visible unless text-position is `hidden`. |
 | `disabled` | Boolean | Disables the switch |
 | `on` | Boolean | Whether the switch is "on" or "off" |
 | `text-position` | String | Valid values are: `start`, `end` (default), and `hidden` |
@@ -105,4 +105,4 @@ If an activity is set to `Visible` but also has other conditions affecting its v
 
 ## Accessbility
 
-- When `text-position` is set to `hidden`, the switch will still make use of the `text` property as it is used to set the [`aria-label`](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA6) of the component, so that screen readers can still pick up what the text of the component is.
+- When `text-position` is set to `hidden`, the required `text` will be used for the switch's hidden label so that it is accessible to non-sighted users.

--- a/components/switch/switch.js
+++ b/components/switch/switch.js
@@ -6,7 +6,7 @@ import { SwitchMixin } from './switch-mixin.js';
 
 /**
  * A generic switch with on/off semantics.
- * @attr {string} text - ACCESSIBILITY: REQUIRED: Acts as a  [primary label](https://www.w3.org/WAI/tutorials/forms/labels/) on the switch. Visible unless text-position is `hidden`.
+ * @attr {string} text - ACCESSIBILITY: REQUIRED: Acts as the [primary label](https://www.w3.org/WAI/tutorials/forms/labels/) for the switch. Visible unless text-position is `hidden`.
  */
 class Switch extends SwitchMixin(LitElement) {
 

--- a/components/switch/switch.js
+++ b/components/switch/switch.js
@@ -6,7 +6,7 @@ import { SwitchMixin } from './switch-mixin.js';
 
 /**
  * A generic switch with on/off semantics.
- * @attr {string} text - REQUIRED: The text that is displayed for the switch label.
+ * @attr {string} text - ACCESSIBILITY: REQUIRED: Acts as a  [primary label](https://www.w3.org/WAI/tutorials/forms/labels/) on the switch. Visible unless text-position is `hidden`.
  */
 class Switch extends SwitchMixin(LitElement) {
 

--- a/components/switch/switch.js
+++ b/components/switch/switch.js
@@ -6,7 +6,7 @@ import { SwitchMixin } from './switch-mixin.js';
 
 /**
  * A generic switch with on/off semantics.
- * @attr {string} text - ACCESSIBILITY: REQUIRED: Acts as the [primary label](https://www.w3.org/WAI/tutorials/forms/labels/) for the switch. Visible unless text-position is `hidden`.
+ * @attr {string} text - ACCESSIBILITY: REQUIRED: Acts as the primary label for the switch. Visible unless text-position is `hidden`.
  */
 class Switch extends SwitchMixin(LitElement) {
 


### PR DESCRIPTION
One of the current initiatives of the Accessibility Llamas is to improve the Daylight site's documentation when it comes to accessibility, which includes adding a new [accessibility icon](https://github.com/BrightspaceUI/core/blob/main/components/icons/images/tier3/accessibility.svg) whenever `ACCESSIBILITY:` is added and decided to move the Accessibility Properties table into the main table. In addition, we've decided to create a new Accessibility section below everything else and include some helpful information about the component. This PR is obviously just for the Switch component, there will be changes to other components when we find more time to do other ones as well.

Currently this is waiting for https://github.com/BrightspaceUI/documentation/pull/1697 to be merged in so that it actually shows the Accessibility Icon instead of just `ACCESSIBILITY:`.