### PR TITLE
fix: Filter dates: Change custom range demo text

### DIFF
--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -166,7 +166,7 @@
 			<template>
 				<d2l-filter id="filter-single">
 					<d2l-filter-dimension-set key="dates" text="Dates">
-						<d2l-filter-dimension-set-value key="lastweek" text="Last 7 days"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="60days" text="Last 60 days"></d2l-filter-dimension-set-value>
 						<d2l-filter-dimension-set-date-text-value key="lastHour" range="lastHour" ></d2l-filter-dimension-set-date-text-value>
 						<d2l-filter-dimension-set-date-text-value key="48hours" range="48hours" disabled></d2l-filter-dimension-set-date-text-value>
 						<d2l-filter-dimension-set-date-text-value key="today" range="today"></d2l-filter-dimension-set-date-text-value>


### PR DESCRIPTION
There is a "Last 7 days" option for the precanned date filter ranges, so this changes the text to be something that isn't already available for the custom option.