### PR TITLE
feat: Button > A11y docs improvements

### DIFF
--- a/components/button/README.md
+++ b/components/button/README.md
@@ -53,16 +53,6 @@ The `d2l-button` element can be used just like the native button element, but al
 | `primary` | Boolean | Styles the button as a primary button |
 <!-- docs: end hidden content -->
 
-### Accessibility Properties
-
-To make your `d2l-button` accessible, use the following properties when applicable:
-
-| Attribute | Description |
-|---|---|
-| `aria-expanded` | [Indicate expansion state of a collapsible element](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-expanded). Example: [d2l-more-less](https://github.com/BrightspaceUI/core/blob/f9f30d0975ee5a8479263a84541fc3b781e8830f/components/more-less/more-less.js#L158). |
-| `aria-haspopup` | [Indicate clicking the button opens a menu](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-haspopup). Example: [d2l-dropdown](https://github.com/BrightspaceUI/core/blob/main/components/dropdown/dropdown-opener-mixin.js#L46). |
-| `description` | Use when text on button does not provide enough context. |
-
 ## Subtle Button [d2l-button-subtle]
 
 The `d2l-button-subtle` element can be used just like the native `button`, but for advanced or de-emphasized actions.
@@ -90,16 +80,6 @@ The `d2l-button-subtle` element can be used just like the native `button`, but f
 | `icon` | String | [Preset icon key](../../components/icons#preset-icons) (e.g. `tier1:gear`) |
 | `icon-right` | Boolean | Render the icon on the right of the button |
 <!-- docs: end hidden content -->
-
-### Accessibility Properties
-
-To make your `d2l-button-subtle` accessible, use the following properties when applicable:
-
-| Attribute | Description |
-|---|---|
-| `aria-expanded` | [Indicate expansion state of a collapsible element](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-expanded). Example: [d2l-more-less](https://github.com/BrightspaceUI/core/blob/f9f30d0975ee5a8479263a84541fc3b781e8830f/components/more-less/more-less.js#L158). |
-| `aria-haspopup` | [Indicate clicking the button opens a menu](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-haspopup). Example: [d2l-dropdown](https://github.com/BrightspaceUI/core/blob/main/components/dropdown/dropdown-opener-mixin.js#L46). |
-| `description` | Use when text on button does not provide enough context. |
 
 ### Subtle Button with Custom Icon
 
@@ -145,18 +125,6 @@ The `d2l-button-icon` element can be used just like the native `button`, for ins
 | `translucent` | Boolean | Indicates to display translucent (ex. on rich backgrounds) |
 <!-- docs: end hidden content -->
 
-### Accessibility Properties
-
-To make your `d2l-button-icon` accessible, use the following properties when applicable:
-
-| Attribute | Description |
-|---|---|
-| `text` | **REQUIRED**. Acts as a primary label and tooltip. |
-| `aria-expanded` | [Indicate expansion state of a collapsible element](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-expanded). Example: [d2l-more-less](https://github.com/BrightspaceUI/core/blob/f9f30d0975ee5a8479263a84541fc3b781e8830f/components/more-less/more-less.js#L158). |
-| `aria-haspopup` | [Indicate clicking the button opens a menu](https://www.w3.org/WAI/PF/aria/states_and_properties#aria-haspopup). Example: [d2l-dropdown](https://github.com/BrightspaceUI/core/blob/main/components/dropdown/dropdown-opener-mixin.js#L46). |
-| `aria-label` | Acts as a primary label. If `text` AND `aria-label` are provided, `aria-label` is used as the primary label, `text` is used as the tooltip. |
-| `description` | Use when text on button does not provide enough context. |
-
 ### Icon Button with Custom Icon
 
 <!-- docs: demo code  -->
@@ -177,7 +145,7 @@ To make your `d2l-button-icon` accessible, use the following properties when app
 
 ## Add Button [d2l-button-add]
 
-The `d2l-button-add` element is for quickly adding new items inline (for example in a list).
+The `d2l-button-add` is for quickly adding new items at a specific location, such as when adding items to a curated list. Since the Add button is meant to be subtle, it should always be used in combination with more obvious methods to add items (like a menu or primary button).
 
 <!-- docs: demo code properties name:d2l-button-add display:block autoSize:false size:xsmall -->
 ```html
@@ -198,7 +166,21 @@ The `d2l-button-add` element is for quickly adding new items inline (for example
 
 ## Floating Buttons [d2l-floating-buttons]
 
-See [floating buttons](https://github.com/BrightspaceUI/core/tree/main/components/button/floating-buttons.md).
+See [floating buttons](../../components/floating-buttons).
+
+## Accessibility
+
+Daylight buttons rely on standard button semantics to ensure a smooth experience for all assistive technologies, but there are a few interesting details to note:
+
+* If the button's context is implied by visual layout, then `description` can be used to add missing context
+  * Example: if multiple page sections have an Edit button relying on visual layout to indicate which section it edits, there could be extra information in the `description` to help differentiate the Edit buttons for non-sighted users
+
+* For icon buttons where there is no visible, `text` will be displayed in tooltip
+  * If both `text` and `aria-label` are used, then `aria-label` will be used as the primary label while `text` will be used in a [tooltip](../../components/tooltip)
+
+* When buttons are used to expand more content or to display a menu or dropdown, [aria-expanded](https://www.w3.org/TR/wai-aria/states_and_properties#aria-expanded) and [aria-haspopup](https://www.w3.org/TR/wai-aria/states_and_properties#aria-haspopup) attributes should be used in accordance with best practices — follow the links to learn more
+
+* Disabled buttons are normally not focusable as per web standards, but if the disabled state needs explaining you can use `disabled-tooltip` to provide an explanation that appears in a [tooltip](../../components/tooltip) via [aria-describedby](https://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby)
 
 <!-- docs: start hidden content -->
 ## Future Improvements

--- a/components/button/button-add.js
+++ b/components/button/button-add.js
@@ -28,7 +28,7 @@ class ButtonAdd extends RtlMixin(PropertyRequiredMixin(FocusMixin(LocalizeCoreEl
 			 */
 			mode: { type: String, reflect: true },
 			/**
-			 * The text associated with the button. When mode is `icon-and-text` this text is displayed next to the icon, otherwise this text is in a tooltip.
+			 * ACCESSIBILITY: The text associated with the button. When mode is `icon-and-text` this text is displayed next to the icon, otherwise this text is in a tooltip.
 			 * @type {string}
 			 */
 			text: { type: String, required: true }

--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -20,7 +20,7 @@ class ButtonIcon extends ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(
 	static get properties() {
 		return {
 			/**
-			 * A description to be added to the button for accessibility when text on button does not provide enough context
+			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
 			description: { type: String },
@@ -38,7 +38,7 @@ class ButtonIcon extends ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(
 			icon: { type: String, reflect: true },
 
 			/**
-			 * REQUIRED: Accessible text for the button
+			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true },

--- a/components/button/button-move.js
+++ b/components/button/button-move.js
@@ -44,7 +44,7 @@ class ButtonMove extends ThemeMixin(FocusMixin(RtlMixin(LitElement))) {
 			// eslint-disable-next-line lit/no-native-attributes
 			autofocus: { type: Boolean, reflect: true },
 			/**
-			 * A description to be added to the button for accessibility when text on button does not provide enough context
+			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
 			description: { type: String },
@@ -79,7 +79,7 @@ class ButtonMove extends ThemeMixin(FocusMixin(RtlMixin(LitElement))) {
 			 */
 			disabledUp: { type: Boolean, attribute: 'disabled-up', reflect: true },
 			/**
-			 * REQUIRED: Accessible text for the button
+			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true }

--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -18,7 +18,7 @@ class ButtonSubtle extends ButtonMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * A description to be added to the button for accessibility when text on button does not provide enough context
+			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
 			description: { type: String },
@@ -48,7 +48,7 @@ class ButtonSubtle extends ButtonMixin(LitElement) {
 			slim: { type: Boolean, reflect: true },
 
 			/**
-			 * REQUIRED: Text for the button
+			 * ACCESSIBILITY: REQUIRED: Text for the button
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true },

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -16,7 +16,7 @@ class Button extends ButtonMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
-			 * A description to be added to the button for accessibility when text on button does not provide enough context
+			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
 			description: { type: String },

--- a/components/button/floating-buttons.md
+++ b/components/button/floating-buttons.md
@@ -58,3 +58,9 @@ Floating workflow buttons behavior can be added by using the `<d2l-floating-butt
 |--|--|--|
 | `always-float` | Boolean | Indicates to display buttons as always floating |
 <!-- docs: end hidden content -->
+
+## Accessibility
+
+Despite visually floating or sticking to the bottom of the viewport, floating buttons maintain their position in the document's structure, typically at the bottom of the content. This means the tab order is unaffected when the buttons float and the effect is invisible to screen reader users.
+
+Be cautious if using `always-float`.   since screen magnifier users may find it difficult to locate the buttons at the bottom of a large viewport, especially when the content is short enough to expect to find the buttons inline.


### PR DESCRIPTION
Accessibility documentation improvements in collaboration with Llamas. Adds a new top-level section to replace all the individual sections, and flags relevant properties as accessibility.

Also updated the Floating Buttons link (was pointing to GitHub) and improved the Add Button description while I was in there.