### PR TITLE
fix: Date filters: Input date: down arrow should open date input dropdown

### DIFF
--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -469,6 +469,7 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 			this._openedOnKeydown = true;
 			this.opened = true;
 			e.preventDefault();
+			e.stopPropagation();
 		}
 	}
 

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -469,7 +469,6 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 			this._openedOnKeydown = true;
 			this.opened = true;
 			e.preventDefault();
-			e.stopPropagation();
 		}
 	}
 

--- a/mixins/interactive/interactive-mixin.js
+++ b/mixins/interactive/interactive-mixin.js
@@ -124,7 +124,7 @@ export const InteractiveMixin = superclass => class extends LocalizeCoreElement(
 	}
 
 	async _handleInteractiveKeyDown(e) {
-		if (this._interactive && e.keyCode === 9) e.stopPropagation(); // tab
+		if (this._interactive && e.keyCode !== 27) e.stopPropagation(); // stop propagation for any key other than escape
 	}
 
 	_handleInteractiveToggleBlur() {


### PR DESCRIPTION
Part of [Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-6576)

**Problem:**
When navigating the date filter with keyboard, down arrow sometimes opens the date dropdown (usually first time when empty) and sometimes moves focus to the next radio button.

**Expected Behaviour:**
Down arrow always opens date input dropdown when focus is on date input.