### PR TITLE
fix: Dropdown: When using mobile tray if minWidthOverride > maxWidthOverride use maxWidthOverride [GAUD-6588]

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -1030,6 +1030,9 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 			leftOverride = `${Math.max(window.innerWidth - window.screen.width, 0)}px`;
 		}
 
+		if (minWidthOverride > maxWidthOverride) {
+			minWidthOverride = maxWidthOverride;
+		}
 		const widthStyle = {
 			maxWidth: maxWidthOverride,
 			minWidth: minWidthOverride,

--- a/components/dropdown/test/dropdown-content.vdiff.js
+++ b/components/dropdown/test/dropdown-content.vdiff.js
@@ -119,6 +119,16 @@ describe('dropdown-content', () => {
 		});
 	});
 
+	[
+		{ name: 'mobile-right-tray-max-width-large', content: html`<d2l-dropdown-content mobile-tray="right" max-width="375" opened>${basicText}</d2l-dropdown-content>` },
+		{ name: 'mobile-left-tray-max-width-large', content: html`<d2l-dropdown-content mobile-tray="left" max-width="375" opened>${basicText}</d2l-dropdown-content>` }
+	].forEach(({ name, content }) => {
+		it(name, async() => {
+			await fixture(createDropdown(content), { viewport: { width: 300, height: 500 }, pagePadding: false });
+			await expect(document).to.be.golden();
+		});
+	});
+
 	it('scroll-top-shadow', async() => {
 		const elem = await fixture(createDropdown(html`<d2l-dropdown-content opened>${scroll}</d2l-dropdown-content>`), { viewport: { height: 400 }, pagePadding: false });
 		const content = elem.querySelector('d2l-dropdown-content');

--- a/components/filter/test/filter.vdiff.js
+++ b/components/filter/test/filter.vdiff.js
@@ -178,6 +178,14 @@ describe('filter', () => {
 					await expect(document).to.be.golden();
 				});
 			});
+
+			it('dates-custom-selected-small-mobile', async() => {
+				const elem = await fixture(createSingleDimDateCustom({ customSelected: true }), { rtl, viewport: { width: 320, height: 500 } });
+				sendKeysElem(elem, 'press', 'Enter');
+				await oneEvent(elem, 'd2l-filter-dimension-first-open');
+				await nextFrame();
+				await expect(document).to.be.golden();
+			});
 		});
 
 		it('custom-empty', async() => {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/jira/software/c/projects/GAUD/boards/330?selectedIssue=GAUD-6588)

This is technically an issue with date filters, where we override dropdown min-width with 375px but when width is less than that we actually want min-width to be less than that. I could fix this more at the filter level with a matchMedia change listener but it seemed to make sense to prevent this at the dropdown level. Let me know thoughts on this.

Redo of https://github.com/BrightspaceUI/core/pull/4784