### PR TITLE
Add auto-close/light-dismiss to popover.

### DIFF
--- a/components/popover/demo/popover.html
+++ b/components/popover/demo/popover.html
@@ -25,9 +25,9 @@
 					<d2l-button-subtle id="close1" text="Close"></d2l-button-subtle>
 				</d2l-test-popover>
 				<script>
-					const popover = document.querySelector('#popover1');
-					document.querySelector('#open1').addEventListener('click', () => popover.opened = true);
-					document.querySelector('#close1').addEventListener('click', () => popover.opened = false);
+					const popover1 = document.querySelector('#popover1');
+					document.querySelector('#open1').addEventListener('click', () => popover1.opened = !popover1.opened);
+					document.querySelector('#close1').addEventListener('click', () => popover1.opened = false);
 				</script>
 			</template>
 		</d2l-demo-snippet>

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -1,5 +1,7 @@
 import '../colors/colors.js';
 import { css, html } from 'lit';
+import { getComposedActiveElement } from '../../helpers/focus.js';
+import { isComposedAncestor } from '../../helpers/dom.js';
 
 const isSupported = ('popover' in HTMLElement.prototype);
 
@@ -15,7 +17,12 @@ export const PopoverMixin = superclass => class extends superclass {
 			 * @type {boolean}
 			 */
 			opened: { type: Boolean, reflect: true },
-			_useNativePopover: { type: Boolean, reflect: true, attribute: 'popover' }
+			/**
+			 * Whether to disable auto-close/light-dismiss
+			 * @type {boolean}
+			 */
+			noAutoClose: { type: Boolean, reflect: true, attribute: 'no-auto-close' },
+			_useNativePopover: { type: String, reflect: true, attribute: 'popover' }
 		};
 	}
 
@@ -62,34 +69,107 @@ export const PopoverMixin = superclass => class extends superclass {
 
 	constructor() {
 		super();
+		this.noAutoClose = false;
 		this.opened = false;
-		this._useNativePopover = isSupported;
+		this._useNativePopover = isSupported ? 'manual' : undefined;
+		this._handleAutoCloseClick = this._handleAutoCloseClick.bind(this);
+		this._handleAutoCloseFocus = this._handleAutoCloseFocus.bind(this);
 	}
 
 	connectedCallback() {
 		super.connectedCallback();
+		if (this.opened) this._addAutoCloseHandlers();
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
+		this._removeAutoCloseHandlers();
 	}
 
 	updated(changedProperties) {
 		super.updated(changedProperties);
 		if (changedProperties.has('opened')) {
 
-			if (this.opened) {
-				this.dispatchEvent(new CustomEvent('d2l-popover-open', { bubbles: true, composed: true }));
-			} else if (changedProperties.get('opened') !== undefined) {
-				this.dispatchEvent(new CustomEvent('d2l-popover-close', { bubbles: true, composed: true }));
-			}
-
 			if (this._useNativePopover) {
 				if (this.opened) this.showPopover();
 				else this.hidePopover();
 			}
 
+			//this._previousFocusableAncestor =
+			//	newValue === true
+			//		? getPreviousFocusableAncestor(this, false, false)
+			//		: null;
+
+			if (this.opened) {
+				this._opener = getComposedActiveElement();
+				this._addAutoCloseHandlers();
+				this.dispatchEvent(new CustomEvent('d2l-popover-open', { bubbles: true, composed: true }));
+			} else if (changedProperties.get('opened') !== undefined) {
+				this._removeAutoCloseHandlers();
+				this.dispatchEvent(new CustomEvent('d2l-popover-close', { bubbles: true, composed: true }));
+			}
+
 		}
+	}
+
+	_addAutoCloseHandlers() {
+		this.addEventListener('blur', this._handleAutoCloseFocus, { capture: true });
+		document.body.addEventListener('focus', this._handleAutoCloseFocus, { capture: true });
+		document.addEventListener('click', this._handleAutoCloseClick, { capture: true });
+	}
+
+	_close() {
+		const hide = () => {
+			this.opened = false;
+		};
+
+		hide();
+	}
+
+	_handleAutoCloseClick(e) {
+
+		if (!this.opened || this.noAutoClose) return;
+
+		const rootTarget = e.composedPath()[0];
+		if (isComposedAncestor(this.shadowRoot.querySelector('.content'), rootTarget)
+			|| isComposedAncestor(this._opener, rootTarget)) {
+			return;
+		}
+
+		this._close();
+	}
+
+	_handleAutoCloseFocus() {
+
+		// timeout needed to work around lack of support for relatedTarget
+		setTimeout(() => {
+			if (!this.opened
+				|| this.noAutoClose
+				|| !document.activeElement
+				|| document.activeElement === this._previousFocusableAncestor
+				|| document.activeElement === document.body) {
+				return;
+			}
+
+			const activeElement = getComposedActiveElement();
+			if (isComposedAncestor(this.shadowRoot.querySelector('.content'), activeElement)
+				|| activeElement === this._opener) {
+				return;
+			}
+
+			this._close();
+		}, 0);
+
+	}
+
+	async _open() {
+		this.opened = true;
+	}
+
+	_removeAutoCloseHandlers() {
+		this.removeEventListener('blur', this._handleAutoCloseFocus, { capture: true });
+		document.body?.removeEventListener('focus', this._handleAutoCloseFocus, { capture: true }); // DE41322: document.body can be null in some scenarios
+		document.removeEventListener('click', this._handleAutoCloseClick, { capture: true });
 	}
 
 	_renderPopover() {


### PR DESCRIPTION
[GAUD-6560](https://desire2learn.atlassian.net/browse/GAUD-6560)

This PR adds auto-close/light-dismiss behaviour to the `PopoverMixin`.

This light-dismiss logic was mostly copied from the `DropdownContentMixin`, with a couple of small differences to not assume the dropdown-specific opener DOM structure.

This does not include dismissing via `[Escape]` key... we have a separate story for that.