### PR TITLE
Update popover to be dismissible using Escape key.

### DIFF
--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -1,4 +1,5 @@
 import '../colors/colors.js';
+import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { css, html } from 'lit';
 import { getComposedActiveElement, getPreviousFocusableAncestor } from '../../helpers/focus.js';
 import { isComposedAncestor } from '../../helpers/dom.js';
@@ -84,6 +85,7 @@ export const PopoverMixin = superclass => class extends superclass {
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this._removeAutoCloseHandlers();
+		this._clearDismissible();
 	}
 
 	updated(changedProperties) {
@@ -100,9 +102,11 @@ export const PopoverMixin = superclass => class extends superclass {
 			if (this.opened) {
 				this._opener = getComposedActiveElement();
 				this._addAutoCloseHandlers();
+				this._dismissibleId = setDismissible(() => this._close());
 				this.dispatchEvent(new CustomEvent('d2l-popover-open', { bubbles: true, composed: true }));
 			} else if (changedProperties.get('opened') !== undefined) {
 				this._removeAutoCloseHandlers();
+				this._clearDismissible();
 				this.dispatchEvent(new CustomEvent('d2l-popover-close', { bubbles: true, composed: true }));
 			}
 
@@ -113,6 +117,12 @@ export const PopoverMixin = superclass => class extends superclass {
 		this.addEventListener('blur', this._handleAutoCloseFocus, { capture: true });
 		document.body.addEventListener('focus', this._handleAutoCloseFocus, { capture: true });
 		document.addEventListener('click', this._handleAutoCloseClick, { capture: true });
+	}
+
+	_clearDismissible() {
+		if (!this._dismissibleId) return;
+		clearDismissible(this._dismissibleId);
+		this._dismissibleId = null;
 	}
 
 	_close() {

--- a/components/popover/test/popover-mixin.test.js
+++ b/components/popover/test/popover-mixin.test.js
@@ -135,6 +135,20 @@ describe('popover-mixin', () => {
 			expect(popover.opened).to.be.true;
 		});
 
+		it('should close when ESC key is pressed', async() => {
+			popover.opened = true;
+			await oneEvent(popover, 'd2l-popover-open');
+
+			const eventObj = document.createEvent('Events');
+			eventObj.initEvent('keydown', true, true);
+			eventObj.keyCode = 27;
+
+			setTimeout(() => document.dispatchEvent(eventObj));
+			await oneEvent(popover, 'd2l-popover-close');
+
+			expect(popover.opened).to.be.false;
+		});
+
 	});
 
 });


### PR DESCRIPTION
[GAUD-6561](https://desire2learn.atlassian.net/browse/GAUD-6561)

This PR updates the `PopoverMixin` so that they can be dismissed using the `[Escape]` key.

[GAUD-6561]: https://desire2learn.atlassian.net/browse/GAUD-6561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ