### PR TITLE
NIM-3037 - Add deselect all pages logic to selection mixin, add select all pages event

### DIFF
--- a/components/selection/selection-select-all-pages.js
+++ b/components/selection/selection-select-all-pages.js
@@ -7,6 +7,7 @@ import { SelectionObserverMixin } from './selection-observer-mixin.js';
 
 /**
  * A subtle button that selects all items for all pages.
+ * @fires d2l-selection-select-all-pages-click - Dispatched when the user clicks the "Select All <x> Items" button
  * @fires d2l-selection-observer-subscribe - Internal event
  */
 class SelectAllPages extends FocusMixin(LocalizeCoreElement(SelectionObserverMixin(LitElement))) {

--- a/components/selection/selection-select-all-pages.js
+++ b/components/selection/selection-select-all-pages.js
@@ -40,6 +40,8 @@ class SelectAllPages extends FocusMixin(LocalizeCoreElement(SelectionObserverMix
 	}
 
 	_handleClick() {
+		this.dispatchEvent(new CustomEvent('d2l-selection-select-all-pages-click', { bubbles: true, composed: true }));
+
 		if (!this._provider) return;
 
 		this._provider.setSelectionForAll(true, true);

--- a/components/selection/selection-select-all-pages.js
+++ b/components/selection/selection-select-all-pages.js
@@ -32,6 +32,7 @@ class SelectAllPages extends FocusMixin(LocalizeCoreElement(SelectionObserverMix
 		if (!this._provider.itemCount) return;
 		if (this._provider.selectionSingle) return;
 		if (this.selectionInfo.state !== SelectionInfo.states.all) return;
+		if (this.selectionInfo.state === SelectionInfo.states.all && this.selectionInfo.allPages) return;
 
 		return html`
 			<d2l-button-subtle

--- a/components/selection/selection-summary.js
+++ b/components/selection/selection-summary.js
@@ -71,7 +71,7 @@ class Summary extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) {
 			}
 		}
 
-		const count = (this._provider && this.selectionInfo.state === SelectionInfo.states.allPages) ?
+		const count = (this._provider && this.selectionInfo.state === SelectionInfo.states.all && this.selectionInfo.allPages) ?
 			this._provider.itemCount : this.selectionInfo.keys.length;
 
 		if (this.selectionInfo.state === SelectionInfo.states.none && this.noSelectionText) {


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/NIM-3037

These changes are related to [this thread](https://d2l.slack.com/archives/C036FJMD4P7/p1720029143526439). These changes do not resolve all issues with the selection-mixin and lazy loading, but gets us to an "okay" state until a more permanent solution is developed. 

1. As a consumer we need to know if the `'none'` state came from deselect-all (the [selection-select-all](https://github.com/BrightspaceUI/core/blob/main/components/selection/selection-select-all.js) component) or from deselecting the last loaded list item.
   - ex. we have 4 items that are selected, 2 are loaded, 2 are not. We deselect the two loaded items so the state becomes 'none', but we don't want to deselect the two unloaded items.
   - In the above scenario, instead of deselecting the two loaded items, we use the `selection-select-all` component to deselect-all. In this case we do want to deselect the two unloaded items. 
   - Now we have a way to know the difference between the two scenarios.

2. As a consumer we need to know when "Select All x Items" ([selection-select-all-pages](https://github.com/BrightspaceUI/core/blob/main/components/selection/selection-select-all-pages.js)) is pressed, even if no selection changes happen
   - This is so that we can toggle any unloaded items, even if all the loaded items are already toggled.
   - The best way I could think of doing this was through an event, but let me know if there is a better idea.


TODO: see if any tests can be updated/added