### PR TITLE
Fix dropdown fixed positioning for mobile positioning (non-tray).

### DIFF
--- a/components/dropdown/dropdown-content-styles.js
+++ b/components/dropdown/dropdown-content-styles.js
@@ -49,9 +49,6 @@ export const dropdownContentStyles = css`
 		bottom: calc(100% + var(--d2l-dropdown-verticaloffset, 16px));
 		top: auto;
 	}
-	:host([_fixed-positioning][opened-above]) {
-		bottom: 0;
-	}
 
 	:host([data-mobile][opened]:not([mobile-tray])) {
 		animation: var(--d2l-dropdown-animation-name) 300ms ease;
@@ -62,6 +59,11 @@ export const dropdownContentStyles = css`
 		animation: var(--d2l-dropdown-above-animation-name) 300ms ease;
 		bottom: calc(100% + var(--d2l-dropdown-verticaloffset, 16px));
 		top: auto;
+	}
+
+	:host([_fixed-positioning][opened-above]),
+	:host([_fixed-positioning][data-mobile][opened-above]:not([mobile-tray])) {
+		bottom: 0;
 	}
 
 	.d2l-dropdown-content-pointer {


### PR DESCRIPTION
[GAUD-6626](https://desire2learn.atlassian.net/browse/GAUD-6626)

This PR fixes an issue with fixed positioned dropdowns where they would disappear if opened above and the view-port is narrower than the mobile breakpoint (616px). The root cause is that we have some styles that override the `bottom` CSS property when not rendering as the `mobile-tray`.

[GAUD-6626]: https://desire2learn.atlassian.net/browse/GAUD-6626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ