### PR TITLE
fix: Focus on collapsible panel out of view port doesn't scroll it into view

### DIFF
--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -434,7 +434,6 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 					<button
 						class="d2l-collapsible-panel-opener"
 						aria-expanded="${this.expanded}"
-						tabindex="0"
 						type="button"
 						@click="${this._handleHeaderClick}"
 						@focus="${this._onFocus}"

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -217,6 +217,8 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			.d2l-collapsible-panel-opener {
 				align-self: self-start;
 				margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
+				order: 1;
+				outline: none;
 			}
 			.d2l-collapsible-panel-opener > d2l-icon-custom {
 				height: 0.9rem;
@@ -307,7 +309,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 	}
 
 	static get focusElementSelector() {
-		return 'button.d2l-offscreen';
+		return '.d2l-collapsible-panel-opener';
 	}
 
 	disconnectedCallback() {
@@ -324,17 +326,8 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			'scrolled': this._scrolled,
 			'no-bottom-border': this._noBottomBorder,
 		};
-		const expandCollapseLabel = this.expandCollapseLabel || this.panelTitle;
 
 		return html`
-			<button
-				aria-expanded="${this.expanded}"
-				class="d2l-offscreen"
-				type="button"
-				@click="${this._toggleExpand}"
-				@focus="${this._onFocus}"
-				@blur="${this._onBlur}"
-			>${expandCollapseLabel}</button>
 			<div class="${classMap(classes)}" @click="${this._handlePanelClick}">
 				<div class="d2l-collapsible-panel-top-sentinel"></div>
 				${this._renderHeader()}
@@ -427,22 +420,33 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 	}
 
 	_renderHeader() {
+		const expandCollapseLabel = this.expandCollapseLabel || this.panelTitle;
 		return html`
 			<div class="d2l-collapsible-panel-header" @click="${this._handleHeaderClick}">
 				<div class="d2l-collapsible-panel-before">
 					<slot name="before" @slotchange="${this._handleBeforeSlotChange}"></slot>
 				</div>
 				<div class="d2l-collapsible-panel-header-primary">
-					${this._renderPanelTitle()}
-					<div class="d2l-collapsible-panel-header-actions" @click="${this._handleActionsClick}">
-						<slot name="actions"></slot>
-					</div>
-					<div class="d2l-collapsible-panel-opener">
+
+					<div
+						class="d2l-collapsible-panel-opener"
+						aria-expanded="${this.expanded}"
+						tabindex="0"
+						role="button"
+						@click="${this._handleHeaderClick}"
+						@focus="${this._onFocus}"
+						@blur="${this._onBlur}"
+						aria-label="${expandCollapseLabel}"
+						>
 						<d2l-icon-custom size="tier1" class="d2l-skeletize">
 							<svg xmlns="http://www.w3.org/2000/svg" width="10" height="18" fill="none" viewBox="0 0 10 18">
 								<path stroke="var(--d2l-color-tungsten)" stroke-linejoin="round" stroke-width="2" d="m9 9-8 8V1l8 8Z"/>
 							</svg>
 						</d2l-icon-custom>
+					</div>
+					${this._renderPanelTitle()}
+					<div class="d2l-collapsible-panel-header-actions" @click="${this._handleActionsClick}">
+						<slot name="actions"></slot>
 					</div>
 				</div>
 				<div class="d2l-collapsible-panel-header-secondary" @click="${this._handleHeaderSecondaryClick}">

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -216,9 +216,13 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			}
 			.d2l-collapsible-panel-opener {
 				align-self: self-start;
+				background-color: transparent;
+				border: none;
 				margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
 				order: 1;
 				outline: none;
+				padding-block: 0;
+				padding-inline: 0;
 			}
 			.d2l-collapsible-panel-opener > d2l-icon-custom {
 				height: 0.9rem;
@@ -427,12 +431,11 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 					<slot name="before" @slotchange="${this._handleBeforeSlotChange}"></slot>
 				</div>
 				<div class="d2l-collapsible-panel-header-primary">
-
-					<div
+					<button
 						class="d2l-collapsible-panel-opener"
 						aria-expanded="${this.expanded}"
 						tabindex="0"
-						role="button"
+						type="button"
 						@click="${this._handleHeaderClick}"
 						@focus="${this._onFocus}"
 						@blur="${this._onBlur}"
@@ -443,7 +446,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 								<path stroke="var(--d2l-color-tungsten)" stroke-linejoin="round" stroke-width="2" d="m9 9-8 8V1l8 8Z"/>
 							</svg>
 						</d2l-icon-custom>
-					</div>
+					</button>
 					${this._renderPanelTitle()}
 					<div class="d2l-collapsible-panel-header-actions" @click="${this._handleActionsClick}">
 						<slot name="actions"></slot>

--- a/components/collapsible-panel/test/collapsible-panel.test.js
+++ b/components/collapsible-panel/test/collapsible-panel.test.js
@@ -19,8 +19,8 @@ describe('d2l-collapsible-panel', () => {
 				</d2l-collapsible-panel>
 			`);
 
-			const button = elem.shadowRoot.querySelector('button.d2l-offscreen');
-			expect(button.textContent).to.equal('Panel Title');
+			const button = elem.shadowRoot.querySelector('.d2l-collapsible-panel-opener');
+			expect(button.ariaLabel).to.equal('Panel Title');
 		});
 
 		it('should be expand-collapse-label if provided', async() => {
@@ -30,8 +30,8 @@ describe('d2l-collapsible-panel', () => {
 				</d2l-collapsible-panel>
 			`);
 
-			const button = elem.shadowRoot.querySelector('button.d2l-offscreen');
-			expect(button.textContent).to.equal('Label describing panel');
+			const button = elem.shadowRoot.querySelector('.d2l-collapsible-panel-opener');
+			expect(button.ariaLabel).to.equal('Label describing panel');
 		});
 	});
 
@@ -139,7 +139,7 @@ describe('d2l-collapsible-panel', () => {
 				'.d2l-collapsible-panel-header',
 				'.d2l-collapsible-panel-header-actions',
 				'.d2l-collapsible-panel-header-secondary',
-				'button.d2l-offscreen'
+				'.d2l-collapsible-panel-opener'
 			];
 
 			for (const selector of selectors) {


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-5115)

### From the ticket
The collapsible panel uses an offscreen button with the same label as the panel that when focused/blurred applies the focus styles to the actual container. The browser likely doesn’t know what to do when something offscreen gets focus like that, and certainly doesn’t know to scroll so that the container is visible.

### Other tested solutions
- `scrollIntoView`: breaks the page layout when component is inside an iframe
- Using the header as a focus: Will read aloud the contents of the header + should not focuse on non-interactive components
- Move the offset button somewhere else in the component to hopefully scroll into its container: no dice