### PR TITLE
[a11y docn] Update the input-search docn for a11y project

### DIFF
--- a/components/inputs/docs/input-search.md
+++ b/components/inputs/docs/input-search.md
@@ -56,7 +56,7 @@ For text searches use `<d2l-input-search>`, which wraps the native `<input type=
 | Property | Type | Description |
 |---|---|---|
 | `label` | String, required | Acts as the primary label for the input. Not visible. |
-| `description` | String | Additional information communicated to screenreaders when users focus on the input |
+| `description` | String | Additional information communicated to screenreader users when they focus on the input |
 | `disabled` | Boolean | Disables the input |
 | `maxlength` | Number | Imposes an upper character limit |
 | `no-clear` | Boolean | Prevents the "clear" button from appearing |

--- a/components/inputs/docs/input-search.md
+++ b/components/inputs/docs/input-search.md
@@ -55,8 +55,8 @@ For text searches use `<d2l-input-search>`, which wraps the native `<input type=
 
 | Property | Type | Description |
 |---|---|---|
-| `label` | String, required | Accessible label for the input |
-| `description` | String | Additional information communicated in the `aria-describedby` on the input |
+| `label` | String, required | Acts as the primary label for the input. Not visible. |
+| `description` | String | Additional information communicated to screenreaders when users focus on the input |
 | `disabled` | Boolean | Disables the input |
 | `maxlength` | Number | Imposes an upper character limit |
 | `no-clear` | Boolean | Prevents the "clear" button from appearing |
@@ -82,11 +82,11 @@ When the input is cleared, the same event will be fired with an empty value.
 * `inline-help`: Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
 <!-- docs: end hidden content -->
 
-### Accessibility Properties
+## Accessbility
 
-To make your usage of `d2l-input-search` accessible, use the following property when applicable:
-
-| Attribute | Description |
-|---|---|
-| `description` | Use when label on input does not provide enough context. |
-| `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Not visible. |
+- While the component does not have a visible label, the use of a search icon helps make clear what its purpose is.
+	- While not required to meet WCAG, this [pattern](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o1p07-icons-used/) is a great way to help individual with cognitive accessibility needs.
+	- This also allows the component to not have to worry about the contrast ratio of the placeholder text, as the contrast of the search icon meets that criteria.
+- It is important to note that `placeholder` is not a suitable replacement for using `label` or `description`, as once something is typed in, users will lose the context the placeholder provided.
+- Using a helper like [`announce`](https://github.com/BrightspaceUI/core/blob/main/helpers/announce.js) to inform screenreaders when search results have been returned helps vision-impaired users to inform them that they can start looking through the results.
+	- It can also be used to help confirm what exactly was searched, along with how many results were found.

--- a/components/inputs/docs/input-search.md
+++ b/components/inputs/docs/input-search.md
@@ -84,9 +84,9 @@ When the input is cleared, the same event will be fired with an empty value.
 
 ## Accessbility
 
-- While the component does not have a visible label, the use of a search icon helps make clear what its purpose is.
-	- While not required to meet WCAG, this [pattern](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o1p07-icons-used/) is a great way to help individual with cognitive accessibility needs.
-	- This also allows the component to not have to worry about the contrast ratio of the placeholder text, as the contrast of the search icon meets that criteria.
+- While the component does not have a visible label, the search icon clearly indicates its purpose.
+	- While not required to meet WCAG, this [pattern](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o1p07-icons-used/) is a great way to help individuals with cognitive accessibility needs.
+	- The contrast ratio of the placeholder text can be safely ignored since the search icon serves the same purpose, and meets that criteria.
 - It is important to note that `placeholder` is not a suitable replacement for using `label` or `description`, as once something is typed in, users will lose the context the placeholder provided.
 - Using a helper like [`announce`](https://github.com/BrightspaceUI/core/blob/main/helpers/announce.js) to inform screenreaders when search results have been returned helps vision-impaired users to inform them that they can start looking through the results.
 	- It can also be used to help confirm what exactly was searched, along with how many results were found.

--- a/components/inputs/docs/input-search.md
+++ b/components/inputs/docs/input-search.md
@@ -84,9 +84,9 @@ When the input is cleared, the same event will be fired with an empty value.
 
 ## Accessbility
 
-- While the component does not have a visible label, the search icon clearly indicates its purpose.
-	- While not required to meet WCAG, this [pattern](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o1p07-icons-used/) is a great way to help individuals with cognitive accessibility needs.
-	- The contrast ratio of the placeholder text can be safely ignored since the search icon serves the same purpose, and meets that criteria.
-- It is important to note that `placeholder` is not a suitable replacement for using `label` or `description`, as once something is typed in, users will lose the context the placeholder provided.
-- Using a helper like [`announce`](https://github.com/BrightspaceUI/core/blob/main/helpers/announce.js) to inform screenreaders when search results have been returned helps vision-impaired users to inform them that they can start looking through the results.
-	- It can also be used to help confirm what exactly was searched, along with how many results were found.
+- While the component does not have a visible label, the search icon clearly indicates its purpose
+	- While not required to meet WCAG, this [pattern](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o1p07-icons-used/) is a great way to help individuals with cognitive accessibility needs
+	- The contrast ratio of the placeholder text can be safely ignored since the search icon serves the same purpose, and meets that criteria
+- It is important to note that `placeholder` is not a suitable replacement for `label` or `description`, since it only applies when the input is empty, and not all users will be able to read it in the first place
+- Search results should be announced to screen reader users using a live region around the result summary or by using the [`announce`](https://github.com/BrightspaceUI/core/blob/main/helpers/announce.js) helper
+	- It can also be used to help confirm what exactly was searched, along with how many results were found

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -21,7 +21,7 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 	static get properties() {
 		return {
 			/**
-			 * Additional information communicated in the aria-describedby on the input
+			 * ACCESSIBILITY: Additional information communicated to screenreaders when users focus on the input
 			 * @type {string}
 			 */
 			description: { type: String, reflect: true },
@@ -31,7 +31,7 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * REQUIRED: Accessible label for the input
+			 * ACCESSIBILITY: REQUIRED: Acts as the primary label for the input. Not visible.
 			 * @type {string}
 			 */
 			label: { type: String },

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -21,7 +21,7 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 	static get properties() {
 		return {
 			/**
-			 * ACCESSIBILITY: Additional information communicated to screenreaders when users focus on the input
+			 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
 			 * @type {string}
 			 */
 			description: { type: String, reflect: true },


### PR DESCRIPTION
One of the current initiatives of the Accessibility Llamas is to improve the Daylight site's documentation when it comes to accessibility, which includes adding a new [accessibility icon](https://github.com/BrightspaceUI/core/blob/main/components/icons/images/tier3/accessibility.svg) whenever `ACCESSIBILITY:` is added and decided to move the Accessibility Properties table into the main table. In addition, we've decided to create a new Accessibility section below everything else and include some helpful information about the component.

This PR is obviously just for the `d2l-input-search` component, changes to other ones will come when we get more time to review them.