### PR TITLE
[DON'T MERGE] [MAN-3161] - WIP

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -450,7 +450,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 				let nestedList;
 				do {
 					// this check needs to account for standard list-items as well as custom
-					nestedList = previousElement.querySelector('[slot="nested"]') || previousElement.shadowRoot.querySelector('d2l-list');
+					nestedList = previousElement.shadowRoot.querySelector('d2l-list');
+
 					if (nestedList) {
 						const nestedListItems = [...nestedList.children].filter(node => node.role === 'rowgroup');
 						if (nestedListItems.length) {


### PR DESCRIPTION
Jira ticket: https://desire2learn.atlassian.net/browse/MAN-3161

Here are the current changes that I've done in the outcomes repo:
https://github.com/Brightspace/d2l-outcomes/pull/1445

Please don't merge this. I am simply doing this to show what I am seeing.

When we enable `grid` mode on `d2l-list` in our component `course-achievement-overview-tree` the following issue occurs. The issue only occurs when we navigate using the Up arrow key during keyboard navigation. What's happening is that we get stuck in an infinite loop because when we query the DOM we can always find a `previousElement` with `slot="nested"`. This results in `nestedList` never being `null` and the loop will not exit.

This is the issue happening on our demo page (in the Default View fullscreen demo):
https://live.d2l.dev/prs/Brightspace/d2l-outcomes/pr-1445/course-achievement-overview.html
![outcomes_demo_page](https://github.com/user-attachments/assets/52f156c3-5202-40e5-b4f8-65ff8672469b)

I made a small change below to show/prove that I could drop out of the loop to fix the behaviour. I don't think that we can commit this change but it's simply there to show how behaviour would work if the loop exited. 

We can now drop out of the list with the temporary change that I made below.
![d2l-list-don't-check-slot-nested](https://github.com/user-attachments/assets/c8275e29-fcc0-4468-8c96-44446d7436d5)

Currently, the DOM contains multiple nested lists. 
https://github.com/Brightspace/d2l-outcomes/blob/main/src/components/course-achievement-overview/course-achievement-overview-tree.js#L119
https://github.com/Brightspace/d2l-outcomes/blob/main/src/components/course-achievement-overview/course-achievement-overview-tree.js#L236-L243
https://github.com/Brightspace/d2l-outcomes/blob/main/src/components/course-achievement-overview/course-achievement-overview-tree.js#L188-L200

This results in `nestedList = previousElement.querySelector('[slot="nested"]')` always returning a valid `d2l-list` item which is why we are stuck in an infinite loop.

The question I am now wondering is do we make a change here or do we fix the structure of our lit component? Are we doing something that is unsupported in the way that are using `d2l-list`?