### PR TITLE
fix: make text and icon required attributes on button-icon

### DIFF
--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -8,6 +8,7 @@ import { buttonStyles } from './button-styles.js';
 import { getFocusPseudoClass } from '../../helpers/focus.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { ThemeMixin } from '../../mixins/theme/theme-mixin.js';
 
@@ -15,7 +16,7 @@ import { ThemeMixin } from '../../mixins/theme/theme-mixin.js';
  * A button component that can be used just like the native button for instances where only an icon is displayed.
  * @slot icon - Optional slot for a custom icon
  */
-class ButtonIcon extends ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement)))) {
+class ButtonIcon extends PropertyRequiredMixin(ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement))))) {
 
 	static get properties() {
 		return {
@@ -35,13 +36,13 @@ class ButtonIcon extends ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(
 			 * REQUIRED: Preset icon key (e.g. "tier1:gear")
 			 * @type {string}
 			 */
-			icon: { type: String, reflect: true },
+			icon: { type: String, reflect: true, required: true },
 
 			/**
 			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true },
+			text: { type: String, reflect: true, required: true },
 
 			/**
 			 * Indicates to display translucent (e.g., on rich backgrounds)

--- a/components/button/test/button-icon.test.js
+++ b/components/button/test/button-icon.test.js
@@ -1,5 +1,6 @@
 import '../button-icon.js';
-import { fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { createMessage } from '../../../mixins/property-required/property-required-mixin.js';
 
 describe('d2l-button-icon', () => {
 
@@ -7,6 +8,22 @@ describe('d2l-button-icon', () => {
 
 		it('should construct', () => {
 			runConstructor('d2l-button-icon');
+		});
+
+	});
+
+	describe('errors', () => {
+
+		it('throws error when no icon', async() => {
+			const el = await fixture(html`<d2l-button-icon text="Icon Button"></d2l-button-icon>`);
+			expect(() => el.flushRequiredPropertyErrors())
+				.to.throw(TypeError, createMessage(el, 'icon'));
+		});
+
+		it('throws error when no text', async() => {
+			const el = await fixture(html`<d2l-button-icon icon="tier1:gear"></d2l-button-icon>`);
+			expect(() => el.flushRequiredPropertyErrors())
+				.to.throw(TypeError, createMessage(el, 'text'));
 		});
 
 	});


### PR DESCRIPTION
This morning, an automated accessibility test failed because text wasn't being provided to a `d2l-dropdown-context-menu`, which internally uses `d2l-button-icon`.

This change makes `text` required, which will cause a delayed exception to be thrown in the console and hopefully help developers catch this problem earlier. I specifically didn't also make it required on `d2l-dropdown-context-menu` since then there'd be two errors tied to the same issue, but am open to doing that if others think it would be useful.