### PR TITLE
Delete `.licensechecker.json`

### DIFF
--- a/.licensechecker.json
+++ b/.licensechecker.json
@@ -1,5 +1,0 @@
-{
-  "acceptedScopes": [
-    "d2l"
-  ]
-}


### PR DESCRIPTION
Not needed anymore. Default accepted scope is already `d2l`.