### PR TITLE
Fix infinite loop issue in list grid mode containing empty nested lists

### DIFF
--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -455,6 +455,8 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 						const nestedListItems = [...nestedList.children].filter(node => node.role === 'rowgroup');
 						if (nestedListItems.length) {
 							previousElement = nestedListItems[nestedListItems.length - 1];
+						} else {
+							break;
 						}
 					}
 				}	while (nestedList);

--- a/components/list/test/list-item-generic-layout.test.js
+++ b/components/list/test/list-item-generic-layout.test.js
@@ -99,6 +99,26 @@ const longFixture = html`
 	</d2l-list>
 `;
 
+const nestedFixture = html`
+	<d2l-list grid>
+		<d2l-list-item label="Test Label" href="http://d2l.com" key="item1">
+			<div class="d2l-list-item-text d2l-body-compact">Root item 1.</div>
+			<d2l-list grid slot="nested">
+				<d2l-list-item label="Test Label" href="http://d2l.com" key="item1a">
+					<div class="d2l-list-item-text d2l-body-compact">Nested item 1a.</div>
+				</d2l-list-item>
+			</d2l-list>
+		</d2l-list-item>
+		<d2l-list-item label="Test Label" href="http://d2l.com" key="item2">
+			<div class="d2l-list-item-text d2l-body-compact">Root item 2.</div>
+			<d2l-list grid></d2l-list>
+		</d2l-list-item>
+		<d2l-list-item label="Test Label" href="http://d2l.com" key="item3">
+			<div class="d2l-list-item-text d2l-body-compact">Root item 3.</div>
+		</d2l-list-item>
+	</d2l-list>
+`;
+
 describe('d2l-list-item-generic-layout', () => {
 	const keyCodes = {
 		DOWN: 40,
@@ -151,305 +171,359 @@ describe('d2l-list-item-generic-layout', () => {
 
 		let el, layout;
 
-		beforeEach(async() => {
-			el = await fixture(longFixture);
-		});
-
-		const tests = [
-			{
-				key: { name: 'ArrowRight', code: keyCodes.RIGHT },
-				desc: 'focuses the next item in the next area',
-				itemKey: 'item1',
-				initial: () => layout.querySelector('d2l-selection-input'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(layout, 'focusin'),
-				expected: () => layout.querySelector('[slot="content-action"] a')
-			},
-			{
-				key: { name: 'ArrowRight', code: keyCodes.RIGHT },
-				desc: 'focuses the next item within the action area',
-				itemKey: 'item4',
-				initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(1)'),
-				activeElement: () => document.activeElement,
-				event: () => oneEvent(layout, 'focusin'),
-				expected: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)')
-			},
-			{
-				key: { name: 'ArrowRight', code: keyCodes.RIGHT },
-				desc: 'focuses wraps to first item',
-				itemKey: 'item4',
-				initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(4)'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(layout, 'focusin'),
-				expected: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
-			},
-			{
-				key: { name: 'ArrowLeft', code: keyCodes.LEFT },
-				desc: 'focuses the previous item in the previous area',
-				itemKey: 'item1',
-				initial: () => layout.querySelector('[slot="content-action"] a'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(layout, 'focusin'),
-				expected: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
-			},
-			{
-				key: { name: 'ArrowLeft', code: keyCodes.LEFT },
-				desc: 'focuses the previous item within the action area',
-				itemKey: 'item4',
-				initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'),
-				activeElement: () => document.activeElement,
-				event: () => oneEvent(layout, 'focusin'),
-				expected: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(1)')
-			},
-			{
-				key: { name: 'ArrowLeft', code: keyCodes.LEFT },
-				desc: 'focuses wraps to last item',
-				itemKey: 'item4',
-				initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
-				activeElement: () => document.activeElement,
-				event: () => oneEvent(layout, 'focusin'),
-				expected: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(4)')
-			},
-			{
-				key: { name: 'ArrowUp', code: keyCodes.UP },
-				desc: 'focuses the item in the same cell of the above row',
-				itemKey: 'item2',
-				initial: () => layout.querySelector('[slot="content-action"] a'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(el.querySelector('[key="item1"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a'), 'focusin'),
-				expected: () => el.querySelector('[key="item1"]')
-					.shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a')
-			},
-			{
-				key: { name: 'ArrowUp', code: keyCodes.UP },
-				desc: 'focuses item in same position of same cell of above row',
-				itemKey: 'item4',
-				initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'),
-				activeElement: () => document.activeElement,
-				event: () => oneEvent(el.querySelector('[key="item3"] d2l-button-icon:nth-child(2)'), 'focusin'),
-				expected: () => el.querySelector('[key="item3"] d2l-button-icon:nth-child(2)')
-			},
-			{
-				key: { name: 'ArrowUp', code: keyCodes.UP },
-				desc: 'focuses last item in same cell of above row if position not available',
-				itemKey: 'item4',
-				initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(4)'),
-				activeElement: () => document.activeElement,
-				event: () => oneEvent(el.querySelector('[key="item3"] d2l-button-icon:last-child'), 'focusin'),
-				expected: () => el.querySelector('[key="item3"] d2l-button-icon:last-child')
-			},
-			{
-				key: { name: 'ArrowDown', code: keyCodes.DOWN },
-				desc: 'focuses item in same cell of below row',
-				itemKey: 'item1',
-				initial: () => layout.querySelector('[slot="content-action"] a'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(el.querySelector('[key="item2"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a'), 'focusin'),
-				expected: () => el.querySelector('[key="item2"]')
-					.shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a')
-			},
-			{
-				key: { name: 'ArrowDown', code: keyCodes.DOWN },
-				desc: 'focuses item in same position of same cell of below row',
-				itemKey: 'item3',
-				initial: () => el.querySelector('[key="item3"] d2l-button-icon:nth-child(2)'),
-				activeElement: () => document.activeElement,
-				event: () => oneEvent(el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'), 'focusin'),
-				expected: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)')
-			},
-			{
-				key: { name: 'ArrowDown', code: keyCodes.DOWN },
-				desc: 'focuses last item in same cell of below row if position not available',
-				itemKey: 'item4',
-				initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(4)'),
-				activeElement: () => document.activeElement,
-				event: () => oneEvent(el.querySelector('[key="item5"] d2l-button-icon:last-child'), 'focusin'),
-				expected: () => el.querySelector('[key="item5"] d2l-button-icon:last-child')
-			},
-			{
-				key: { name: 'Home', code: keyCodes.HOME },
-				desc: 'focuses first item in current row',
-				itemKey: 'item4',
-				initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(layout, 'focusin'),
-				expected: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
-			},
-			{
-				key: { name: 'Home+CTRL', code: keyCodes.HOME, ctrl: true },
-				desc: 'focuses first item of first row',
-				itemKey: 'item4',
-				initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(el.querySelector('[key="item1"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
-				expected: () => el.querySelector('[key="item1"]')
-					.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
-			},
-			{
-				key: { name: 'End', code: keyCodes.END },
-				desc: 'focuses last item in current row',
-				itemKey: 'item4',
-				initial: () => layout.querySelector('d2l-selection-input'),
-				activeElement: () => document.activeElement,
-				event: () => oneEvent(layout, 'focusin'),
-				expected: () => el.querySelector('[key="item4"] d2l-button-icon:last-child')
-			},
-			{
-				key: { name: 'End+CTRL', code: keyCodes.END, ctrl: true },
-				desc: 'focuses last item of last row',
-				itemKey: 'item4',
-				initial: () => layout.querySelector('d2l-selection-input'),
-				activeElement: () => document.activeElement,
-				event: () => oneEvent(el.querySelector('[key="item7"] d2l-button-icon:last-child'), 'focusin'),
-				expected: () => el.querySelector('[key="item7"] d2l-button-icon:last-child')
-			},
-			{
-				key: { name: 'PageUp', code: keyCodes.PAGEUP },
-				desc: 'focuses item in same cell five rows up',
-				itemKey: 'item7',
-				initial: () => layout.querySelector('d2l-selection-input'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(el.querySelector('[key="item2"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
-				expected: () => el.querySelector('[key="item2"]')
-					.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
-			},
-			{
-				key: { name: 'PageUp', code: keyCodes.PAGEUP },
-				desc: 'focuses item in same cell of first row if fewer than five rows above',
-				itemKey: 'item4',
-				initial: () => layout.querySelector('d2l-selection-input'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(el.querySelector('[key="item1"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
-				expected: () => el.querySelector('[key="item1"]')
-					.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
-			},
-			{
-				key: { name: 'PageDown', code: keyCodes.PAGEDOWN },
-				desc: 'focuses item in same cell five rows down',
-				itemKey: 'item1',
-				initial: () => layout.querySelector('d2l-selection-input'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(el.querySelector('[key="item6"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
-				expected: () => el.querySelector('[key="item6"]')
-					.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
-			},
-			{
-				key: { name: 'PageDown', code: keyCodes.PAGEDOWN },
-				desc: 'focuses item in same cell of last row if fewer than five rows below',
-				itemKey: 'item4',
-				initial: () => layout.querySelector('d2l-selection-input'),
-				activeElement: getComposedActiveElement,
-				event: () => oneEvent(el.querySelector('[key="item7"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
-				expected: () => el.querySelector('[key="item7"]')
-					.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
-			}
-		];
-
-		for (const test of tests) {
-			it(`${test.desc} when ${test.key.name} pressed`, async() => {
-				layout = el.querySelector(`[key="${test.itemKey}"]`)
-					.shadowRoot.querySelector('d2l-list-item-generic-layout');
-				await new Promise(resolve => {
-					// wait a frame for d2l-selection-input to fully initialize
-					requestAnimationFrame(resolve);
-				});
-				test.initial().focus();
-				let event = null;
-				setTimeout(() => event = dispatchKeyEvent(layout, test.key));
-				await test.event();
-				expect(test.activeElement()).to.equal(test.expected());
-				expect(event.preventDefault).to.have.been.calledOnce;
-			});
-		}
-
-		it('does not preventDefault when Tab is pressed', async() => {
-			el = el.querySelector('[key="item4"]');
-			layout = el.shadowRoot.querySelector('d2l-list-item-generic-layout');
+		const runFocusTest = async(el, test) => {
+			layout = el.querySelector(`[key="${test.itemKey}"]`).shadowRoot.querySelector('d2l-list-item-generic-layout');
 			await new Promise(resolve => {
 				// wait a frame for d2l-selection-input to fully initialize
 				requestAnimationFrame(resolve);
 			});
-			layout.querySelector('d2l-selection-input').focus();
-			setTimeout(() => dispatchKeyEvent(layout, { code: keyCodes.TAB }));
-			const event = await oneEvent(layout, 'keydown');
-			expect(event.preventDefault).to.not.have.been.called;
-		});
+			test.initial().focus();
+			let event = null;
+			setTimeout(() => event = dispatchKeyEvent(layout, test.key));
+			await test.event();
+			expect(test.activeElement()).to.equal(test.expected());
+			expect(event.preventDefault).to.have.been.calledOnce;
+		};
 
-		describe('preventing focus move for end of content', () => {
+		describe('non-nested', () => {
+
+			beforeEach(async() => {
+				el = await fixture(longFixture);
+			});
+
 			const tests = [
 				{
-					key: { name: 'ArrowUp', code: keyCodes.UP },
-					desc: 'does not move focus when first row already focused',
+					key: { name: 'ArrowRight', code: keyCodes.RIGHT },
+					desc: 'focuses the next item in the next area',
 					itemKey: 'item1',
+					initial: () => layout.querySelector('d2l-selection-input'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(layout, 'focusin'),
+					expected: () => layout.querySelector('[slot="content-action"] a')
+				},
+				{
+					key: { name: 'ArrowRight', code: keyCodes.RIGHT },
+					desc: 'focuses the next item within the action area',
+					itemKey: 'item4',
+					initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(1)'),
+					activeElement: () => document.activeElement,
+					event: () => oneEvent(layout, 'focusin'),
+					expected: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)')
+				},
+				{
+					key: { name: 'ArrowRight', code: keyCodes.RIGHT },
+					desc: 'focuses wraps to first item',
+					itemKey: 'item4',
+					initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(4)'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(layout, 'focusin'),
+					expected: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
+				},
+				{
+					key: { name: 'ArrowLeft', code: keyCodes.LEFT },
+					desc: 'focuses the previous item in the previous area',
+					itemKey: 'item1',
+					initial: () => layout.querySelector('[slot="content-action"] a'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(layout, 'focusin'),
+					expected: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
+				},
+				{
+					key: { name: 'ArrowLeft', code: keyCodes.LEFT },
+					desc: 'focuses the previous item within the action area',
+					itemKey: 'item4',
+					initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'),
+					activeElement: () => document.activeElement,
+					event: () => oneEvent(layout, 'focusin'),
+					expected: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(1)')
+				},
+				{
+					key: { name: 'ArrowLeft', code: keyCodes.LEFT },
+					desc: 'focuses wraps to last item',
+					itemKey: 'item4',
 					initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
-					activeElement: getComposedActiveElement
+					activeElement: () => document.activeElement,
+					event: () => oneEvent(layout, 'focusin'),
+					expected: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(4)')
+				},
+				{
+					key: { name: 'ArrowUp', code: keyCodes.UP },
+					desc: 'focuses the item in the same cell of the above row',
+					itemKey: 'item2',
+					initial: () => layout.querySelector('[slot="content-action"] a'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item1"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a'), 'focusin'),
+					expected: () => el.querySelector('[key="item1"]')
+						.shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a')
+				},
+				{
+					key: { name: 'ArrowUp', code: keyCodes.UP },
+					desc: 'focuses item in same position of same cell of above row',
+					itemKey: 'item4',
+					initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'),
+					activeElement: () => document.activeElement,
+					event: () => oneEvent(el.querySelector('[key="item3"] d2l-button-icon:nth-child(2)'), 'focusin'),
+					expected: () => el.querySelector('[key="item3"] d2l-button-icon:nth-child(2)')
+				},
+				{
+					key: { name: 'ArrowUp', code: keyCodes.UP },
+					desc: 'focuses last item in same cell of above row if position not available',
+					itemKey: 'item4',
+					initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(4)'),
+					activeElement: () => document.activeElement,
+					event: () => oneEvent(el.querySelector('[key="item3"] d2l-button-icon:last-child'), 'focusin'),
+					expected: () => el.querySelector('[key="item3"] d2l-button-icon:last-child')
 				},
 				{
 					key: { name: 'ArrowDown', code: keyCodes.DOWN },
-					desc: 'does not move focus when last row already focused',
-					itemKey: 'item7',
-					initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
-					activeElement: getComposedActiveElement
+					desc: 'focuses item in same cell of below row',
+					itemKey: 'item1',
+					initial: () => layout.querySelector('[slot="content-action"] a'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item2"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a'), 'focusin'),
+					expected: () => el.querySelector('[key="item2"]')
+						.shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a')
+				},
+				{
+					key: { name: 'ArrowDown', code: keyCodes.DOWN },
+					desc: 'focuses item in same position of same cell of below row',
+					itemKey: 'item3',
+					initial: () => el.querySelector('[key="item3"] d2l-button-icon:nth-child(2)'),
+					activeElement: () => document.activeElement,
+					event: () => oneEvent(el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'), 'focusin'),
+					expected: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)')
+				},
+				{
+					key: { name: 'ArrowDown', code: keyCodes.DOWN },
+					desc: 'focuses last item in same cell of below row if position not available',
+					itemKey: 'item4',
+					initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(4)'),
+					activeElement: () => document.activeElement,
+					event: () => oneEvent(el.querySelector('[key="item5"] d2l-button-icon:last-child'), 'focusin'),
+					expected: () => el.querySelector('[key="item5"] d2l-button-icon:last-child')
 				},
 				{
 					key: { name: 'Home', code: keyCodes.HOME },
-					desc: 'does not move focus when first area in row already focused',
-					itemKey: 'item3',
-					initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
-					activeElement: getComposedActiveElement
+					desc: 'focuses first item in current row',
+					itemKey: 'item4',
+					initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(layout, 'focusin'),
+					expected: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
 				},
 				{
 					key: { name: 'Home+CTRL', code: keyCodes.HOME, ctrl: true },
-					desc: 'does not move focus when first area in first row already focused',
-					itemKey: 'item1',
-					initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
-					activeElement: getComposedActiveElement
+					desc: 'focuses first item of first row',
+					itemKey: 'item4',
+					initial: () => el.querySelector('[key="item4"] d2l-button-icon:nth-child(2)'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item1"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
+					expected: () => el.querySelector('[key="item1"]')
+						.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
 				},
 				{
 					key: { name: 'End', code: keyCodes.END },
-					desc: 'does not move focus when last area in row already focused',
+					desc: 'focuses last item in current row',
 					itemKey: 'item4',
-					initial: () => el.querySelector('[key="item4"] d2l-button-icon:last-child'),
-					activeElement: () => document.activeElement
+					initial: () => layout.querySelector('d2l-selection-input'),
+					activeElement: () => document.activeElement,
+					event: () => oneEvent(layout, 'focusin'),
+					expected: () => el.querySelector('[key="item4"] d2l-button-icon:last-child')
 				},
 				{
 					key: { name: 'End+CTRL', code: keyCodes.END, ctrl: true },
-					desc: 'does not move focus when last area in last row already focused',
-					itemKey: 'item7',
-					initial: () => el.querySelector('[key="item7"] d2l-button-icon:last-child'),
-					activeElement: () => document.activeElement
+					desc: 'focuses last item of last row',
+					itemKey: 'item4',
+					initial: () => layout.querySelector('d2l-selection-input'),
+					activeElement: () => document.activeElement,
+					event: () => oneEvent(el.querySelector('[key="item7"] d2l-button-icon:last-child'), 'focusin'),
+					expected: () => el.querySelector('[key="item7"] d2l-button-icon:last-child')
 				},
 				{
 					key: { name: 'PageUp', code: keyCodes.PAGEUP },
-					desc: 'does not move focus when first row already focused',
-					itemKey: 'item1',
-					initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
-					activeElement: getComposedActiveElement
+					desc: 'focuses item in same cell five rows up',
+					itemKey: 'item7',
+					initial: () => layout.querySelector('d2l-selection-input'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item2"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
+					expected: () => el.querySelector('[key="item2"]')
+						.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
+				},
+				{
+					key: { name: 'PageUp', code: keyCodes.PAGEUP },
+					desc: 'focuses item in same cell of first row if fewer than five rows above',
+					itemKey: 'item4',
+					initial: () => layout.querySelector('d2l-selection-input'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item1"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
+					expected: () => el.querySelector('[key="item1"]')
+						.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
 				},
 				{
 					key: { name: 'PageDown', code: keyCodes.PAGEDOWN },
-					desc: 'does not move focus when last row already focused',
-					itemKey: 'item7',
-					initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
-					activeElement: getComposedActiveElement
+					desc: 'focuses item in same cell five rows down',
+					itemKey: 'item1',
+					initial: () => layout.querySelector('d2l-selection-input'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item6"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
+					expected: () => el.querySelector('[key="item6"]')
+						.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
 				},
+				{
+					key: { name: 'PageDown', code: keyCodes.PAGEDOWN },
+					desc: 'focuses item in same cell of last row if fewer than five rows below',
+					itemKey: 'item4',
+					initial: () => layout.querySelector('d2l-selection-input'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item7"]').shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'), 'focusin'),
+					expected: () => el.querySelector('[key="item7"]')
+						.shadowRoot.querySelector('d2l-list-item-generic-layout d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox')
+				}
 			];
 
 			for (const test of tests) {
 				it(`${test.desc} when ${test.key.name} pressed`, async() => {
-					layout = el.querySelector(`[key="${test.itemKey}"]`)
-						.shadowRoot.querySelector('d2l-list-item-generic-layout');
-					await new Promise(resolve => {
-						// wait a frame for d2l-selection-input to fully initialize
-						requestAnimationFrame(resolve);
-					});
-					test.initial().focus();
-					setTimeout(() => dispatchKeyEvent(layout, test.key));
-					await aTimeout(1);
-					expect(test.activeElement()).to.equal(test.initial());
+					return runFocusTest(el, test);
 				});
 			}
+
+			it('does not preventDefault when Tab is pressed', async() => {
+				el = el.querySelector('[key="item4"]');
+				layout = el.shadowRoot.querySelector('d2l-list-item-generic-layout');
+				await new Promise(resolve => {
+					// wait a frame for d2l-selection-input to fully initialize
+					requestAnimationFrame(resolve);
+				});
+				layout.querySelector('d2l-selection-input').focus();
+				setTimeout(() => dispatchKeyEvent(layout, { code: keyCodes.TAB }));
+				const event = await oneEvent(layout, 'keydown');
+				expect(event.preventDefault).to.not.have.been.called;
+			});
+
+			describe('preventing focus move for end of content', () => {
+				const tests = [
+					{
+						key: { name: 'ArrowUp', code: keyCodes.UP },
+						desc: 'does not move focus when first row already focused',
+						itemKey: 'item1',
+						initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
+						activeElement: getComposedActiveElement
+					},
+					{
+						key: { name: 'ArrowDown', code: keyCodes.DOWN },
+						desc: 'does not move focus when last row already focused',
+						itemKey: 'item7',
+						initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
+						activeElement: getComposedActiveElement
+					},
+					{
+						key: { name: 'Home', code: keyCodes.HOME },
+						desc: 'does not move focus when first area in row already focused',
+						itemKey: 'item3',
+						initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
+						activeElement: getComposedActiveElement
+					},
+					{
+						key: { name: 'Home+CTRL', code: keyCodes.HOME, ctrl: true },
+						desc: 'does not move focus when first area in first row already focused',
+						itemKey: 'item1',
+						initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
+						activeElement: getComposedActiveElement
+					},
+					{
+						key: { name: 'End', code: keyCodes.END },
+						desc: 'does not move focus when last area in row already focused',
+						itemKey: 'item4',
+						initial: () => el.querySelector('[key="item4"] d2l-button-icon:last-child'),
+						activeElement: () => document.activeElement
+					},
+					{
+						key: { name: 'End+CTRL', code: keyCodes.END, ctrl: true },
+						desc: 'does not move focus when last area in last row already focused',
+						itemKey: 'item7',
+						initial: () => el.querySelector('[key="item7"] d2l-button-icon:last-child'),
+						activeElement: () => document.activeElement
+					},
+					{
+						key: { name: 'PageUp', code: keyCodes.PAGEUP },
+						desc: 'does not move focus when first row already focused',
+						itemKey: 'item1',
+						initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
+						activeElement: getComposedActiveElement
+					},
+					{
+						key: { name: 'PageDown', code: keyCodes.PAGEDOWN },
+						desc: 'does not move focus when last row already focused',
+						itemKey: 'item7',
+						initial: () => layout.querySelector('d2l-selection-input').shadowRoot.querySelector('d2l-input-checkbox').shadowRoot.querySelector('input.d2l-input-checkbox'),
+						activeElement: getComposedActiveElement
+					},
+				];
+
+				for (const test of tests) {
+					it(`${test.desc} when ${test.key.name} pressed`, async() => {
+						layout = el.querySelector(`[key="${test.itemKey}"]`)
+							.shadowRoot.querySelector('d2l-list-item-generic-layout');
+						await new Promise(resolve => {
+							// wait a frame for d2l-selection-input to fully initialize
+							requestAnimationFrame(resolve);
+						});
+						test.initial().focus();
+						setTimeout(() => dispatchKeyEvent(layout, test.key));
+						await aTimeout(1);
+						expect(test.activeElement()).to.equal(test.initial());
+					});
+				}
+			});
+
 		});
+
+		describe('nested', () => {
+
+			beforeEach(async() => {
+				el = await fixture(nestedFixture);
+			});
+
+			// todo: add tests for the other interesting nested list grid focus management scenarios
+
+			const tests = [
+				{
+					key: { name: 'ArrowUp', code: keyCodes.UP },
+					desc: 'focuses the same cell of the parent item',
+					itemKey: 'item1a',
+					initial: () => layout.querySelector('[slot="content-action"] a'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item1"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a'), 'focusin'),
+					expected: () => el.querySelector('[key="item1"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a')
+				},
+				{
+					key: { name: 'ArrowUp', code: keyCodes.UP },
+					desc: 'focuses the same cell of the last item in the previous item\'s nested list',
+					itemKey: 'item2',
+					initial: () => layout.querySelector('[slot="content-action"] a'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item1a"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a'), 'focusin'),
+					expected: () => el.querySelector('[key="item1a"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a')
+				},
+				{
+					key: { name: 'ArrowUp', code: keyCodes.UP },
+					desc: 'focuses the same cell of the previous item if it contains an empty nested list',
+					itemKey: 'item3',
+					initial: () => layout.querySelector('[slot="content-action"] a'),
+					activeElement: getComposedActiveElement,
+					event: () => oneEvent(el.querySelector('[key="item2"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a'), 'focusin'),
+					expected: () => el.querySelector('[key="item2"]').shadowRoot.querySelector('d2l-list-item-generic-layout [slot="content-action"] a')
+				}
+			];
+
+			for (const test of tests) {
+				it(`${test.desc} when ${test.key.name} pressed`, async() => {
+					return runFocusTest(el, test);
+				});
+			}
+
+		});
+
 	});
 
 });

--- a/components/list/test/list-item-generic-layout.test.js
+++ b/components/list/test/list-item-generic-layout.test.js
@@ -111,7 +111,7 @@ const nestedFixture = html`
 		</d2l-list-item>
 		<d2l-list-item label="Test Label" href="http://d2l.com" key="item2">
 			<div class="d2l-list-item-text d2l-body-compact">Root item 2.</div>
-			<d2l-list grid></d2l-list>
+			<d2l-list grid slot="nested"></d2l-list>
 		</d2l-list-item>
 		<d2l-list-item label="Test Label" href="http://d2l.com" key="item3">
 			<div class="d2l-list-item-text d2l-body-compact">Root item 3.</div>


### PR DESCRIPTION
[GAUD-6690](https://desire2learn.atlassian.net/browse/GAUD-6690)

This PR fixes an issue where the `d2l-list-item-generic-layout` could enter an infinite loop when trying to find the previous flattened list item to apply focus when the previous item contains an empty nested list. This infinite loop would result in the browser becoming unresponsive.

Without this fix, this code would result in an infinite loop using the `up` arrow key.
```html
<d2l-list grid>
	<d2l-list-item label="Test Label" href="http://d2l.com" key="item2">
		<div class="d2l-list-item-text d2l-body-compact">Root item 2.</div>
		<d2l-list grid slot="nested"></d2l-list>
	</d2l-list-item>
	<d2l-list-item label="Test Label" href="http://d2l.com" key="item3">
		<div class="d2l-list-item-text d2l-body-compact">Root item 3.</div>
	</d2l-list-item>
</d2l-list>
```

While this scenario is somewhat unexpected (normally we'd expect consumers to optimize to not render `d2l-list` unnecessarily), it is a valid scenario nonetheless, and we should handle it without making the browser unresponsive.

This PR also adds tests for this case. The keyboard interaction tests for nested grid mode were completely non-existent. Further work should be done to expand on them.

[GAUD-6690]: https://desire2learn.atlassian.net/browse/GAUD-6690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ