### PR TITLE
Make a11y section title not all caps & rearrange the bullet points

### DIFF
--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -271,9 +271,9 @@ Nested menus can be defined by placing a `d2l-menu` inside a `d2l-menu-item`.  F
 </d2l-menu>
 ```
 
-## ACCESSIBILITY
+## Accessibility
 
-- The `label` property for `d2l-menu` is only required for the root menu
-	- For nested menus, the label is automatically applied based on its parent menu-item
 - The `d2l-menu` component and its items all follow W3C's [menu](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/) pattern best practices
 	- This includes the expected keyboard behaviour, which allows for seamless navigation within the menu and any submenus within it
+- The `label` property for `d2l-menu` is only required for the root menu
+	- For nested menus, the label is automatically applied based on its parent menu-item


### PR DESCRIPTION
After being brought up by someone else, I've made some small fixes to the menu a11y section:

- Made the section title not all uppercase
- Switched the order of the bullet points in the a11y section since the second point is more significant.