### PR TITLE
fix: increase height of button-move icons

### DIFF
--- a/components/button/button-move.js
+++ b/components/button/button-move.js
@@ -113,7 +113,7 @@ class ButtonMove extends ThemeMixin(FocusMixin(RtlMixin(LitElement))) {
 					flex-direction: column;
 					gap: 2px;
 					margin: 0;
-					min-height: 1.8rem;
+					min-height: auto;
 					padding: 0;
 					position: relative;
 					width: 0.9rem;
@@ -144,16 +144,16 @@ class ButtonMove extends ThemeMixin(FocusMixin(RtlMixin(LitElement))) {
 
 				.up-layer,
 				.down-layer {
-					height: 1.1rem;
+					height: 1.2rem;
 					left: -0.2rem;
 					position: absolute;
 					width: 1.3rem;
 				}
 				.up-layer {
-					top: -0.25rem;
+					top: -0.35rem;
 				}
 				.down-layer {
-					bottom: -0.25rem;
+					bottom: -0.35rem;
 				}
 				:host([dir="rtl"]) .up-layer,
 				:host([dir="rtl"]) .down-layer {


### PR DESCRIPTION
It was [noticed here](https://d2l.slack.com/archives/C0PHG3QB0/p1722466706352229) that the click target for these "move buttons" is only `26px` wide by `22px` high, while WCAG 2.2 criteria 2.5.8 for minimum target size requires at least 24x24.

If you dig into the details, since we have a `2px` gap between the up/down click targets, there does appear to be an exemption that covers this case:
> Spacing: Undersized targets (those less than 24 by 24 CSS pixels) are positioned so that if a 24 CSS pixel diameter circle is centered on the [bounding box](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html#dfn-minimum-bounding-box) of each, the circles do not intersect another target or the circle for another undersized target;

However, we'd rather not fall into an exemption case if it's easy for us to just increase the height by `2px`, which is what this does.