### PR TITLE
fix: add sort direction to the label of table sort buttons

### DIFF
--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -3,7 +3,7 @@ import '../dropdown/dropdown.js';
 import '../dropdown/dropdown-menu.js';
 import '../icons/icon.js';
 import '../menu/menu.js';
-import { css, html, LitElement, unsafeCSS } from 'lit';
+import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { getFocusPseudoClass } from '../../helpers/focus.js';
@@ -138,6 +138,8 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 		this.sourceType = 'unknown';
 
 		this._describedById = getUniqueId();
+		this._labelledById = getUniqueId();
+		this._labelledBySortedId = getUniqueId();
 		this._hasDropdownItems = false;
 	}
 
@@ -166,13 +168,21 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 			html`<d2l-icon icon="${this.desc ? 'tier1:arrow-toggle-down' : 'tier1:arrow-toggle-up'}"></d2l-icon>` :
 			null;
 
+		let sortedView = nothing;
+		let labelledBy = this._labelledById;
+		if (buttonTitle !== undefined) {
+			sortedView = html`<span id="${this._labelledBySortedId}" hidden>${buttonTitle}</span>`;
+			labelledBy = `${this._labelledById} ${this._labelledBySortedId}`;
+		}
+
 		const button = html`<button
 				aria-describedby="${this._describedById}"
+				aria-labelledby="${labelledBy}"
 				class="${classMap({ 'd2l-dropdown-opener': this._hasDropdownItems })}"
 				title="${ifDefined(buttonTitle)}"
 				type="button">
-				<slot></slot>${iconView}
-			</button><span id="${this._describedById}" hidden>${buttonDescription}</span>`;
+				<span id="${this._labelledById}"><slot></slot></span>${iconView}
+			</button><span id="${this._describedById}" hidden>${buttonDescription}</span>${sortedView}`;
 		if (this._hasDropdownItems) {
 			return html`<d2l-dropdown>
 					${button}

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -138,8 +138,7 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 		this.sourceType = 'unknown';
 
 		this._describedById = getUniqueId();
-		this._labelledById = getUniqueId();
-		this._labelledBySortedId = getUniqueId();
+		this._describedBySortedId = getUniqueId();
 		this._hasDropdownItems = false;
 	}
 
@@ -169,19 +168,18 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 			null;
 
 		let sortedView = nothing;
-		let labelledBy = this._labelledById;
+		let describedBy = this._describedById;
 		if (buttonTitle !== undefined) {
-			sortedView = html`<span id="${this._labelledBySortedId}" hidden>${buttonTitle}</span>`;
-			labelledBy = `${this._labelledById} ${this._labelledBySortedId}`;
+			sortedView = html`<span id="${this._describedBySortedId}" hidden>${buttonTitle},</span>`;
+			describedBy = `${this._describedBySortedId} ${this._describedById}`;
 		}
 
 		const button = html`<button
-				aria-describedby="${this._describedById}"
-				aria-labelledby="${labelledBy}"
+				aria-describedby="${describedBy}"
 				class="${classMap({ 'd2l-dropdown-opener': this._hasDropdownItems })}"
 				title="${ifDefined(buttonTitle)}"
 				type="button">
-				<span id="${this._labelledById}"><slot></slot></span>${iconView}
+				<slot></slot>${iconView}
 			</button><span id="${this._describedById}" hidden>${buttonDescription}</span>${sortedView}`;
 		if (this._hasDropdownItems) {
 			return html`<d2l-dropdown>


### PR DESCRIPTION
When rendering our table sort buttons, the sort direction is placed as a `title` (OS tooltip) on the `<button>` element, which is only inconsistently read by screen readers.

While we experimented with putting the sort direction in `aria-label`, it became part of the column's label. That's nice when you're navigating the columns themselves, but when you're down navigating table cells in that column, having it repeat the sort direction each time isn't appropriate.

This alternate solution uses `aria-describedby` instead.