### PR TITLE
include custom-elements.json in static sites

### DIFF
--- a/rollup/rollup.config.js
+++ b/rollup/rollup.config.js
@@ -19,6 +19,7 @@ const nonJsGlob = [
 	'*.*',
 	'!**/*.@(js|md|json)',
 	'!**/golden/**/*',
+	'./custom-elements.json',
 ];
 
 export default {


### PR DESCRIPTION
I think it would be cool/useful to include `custom-elements.json` in the "live" sites that we generate. That way automation that doesn't have access to NPM could always grab the latest and easily get a list of elements.