### PR TITLE
Add getFocusables helper.

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -127,7 +127,7 @@ getComposedActiveElement()
 getFirstFocusableDescendant(node, includeHidden, predicate, includeTabbablesOnly)
 
 // gets the focusable elements within the specified element
-getFocusables(node, { deep: false, disabled: false, hidden: false, predicate: elem => false, tabbablesOnly: true })
+getFocusableDescendants(node, { deep: false, disabled: false, hidden: false, predicate: elem => false, tabbablesOnly: true })
 
 // gets the focus pseudo-class to used in selectors (focus-visible if supported, or focus)
 // Usage:

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -126,6 +126,9 @@ getComposedActiveElement()
 // gets the first focusable descendant given a node, including those within the shadow DOM
 getFirstFocusableDescendant(node, includeHidden, predicate, includeTabbablesOnly)
 
+// gets the focusable elements within the specified element
+getFocusables(node, { deep: false, disabled: false, hidden: false, predicate: elem => false, tabbablesOnly: true })
+
 // gets the focus pseudo-class to used in selectors (focus-visible if supported, or focus)
 // Usage:
 //	css`

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -40,6 +40,25 @@ export function getFirstFocusableDescendant(node, includeHidden, predicate, incl
 	return null;
 }
 
+export function getFocusables(node, options) {
+	let focusables = [];
+
+	const composedChildren = getComposedChildren(node);
+	composedChildren.forEach(elem => {
+		if (elem.tagName === 'svg') return;
+		if (options?.predicate) {
+			if (!options.predicate(elem)) return;
+		}
+
+		if (isFocusable(elem, options?.hidden, options?.tabbablesOnly, options?.disabled)) focusables.push(elem);
+		if (options?.deep) {
+			focusables = [...focusables, ...getFocusables(elem, options)];
+		}
+	});
+
+	return focusables;
+}
+
 export function getFocusPseudoClass() {
 	return isFocusVisibleSupported() ? 'focus-visible' : 'focus';
 }

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -40,19 +40,19 @@ export function getFirstFocusableDescendant(node, includeHidden, predicate, incl
 	return null;
 }
 
-export function getFocusables(node, options) {
+export function getFocusableDescendants(node, options) {
 	let focusables = [];
 
 	const composedChildren = getComposedChildren(node);
-	composedChildren.forEach(elem => {
-		if (elem.tagName === 'svg') return;
+	composedChildren.forEach(child => {
+		if (child.tagName === 'svg') return;
 		if (options?.predicate) {
-			if (!options.predicate(elem)) return;
+			if (!options.predicate(child)) return;
 		}
 
-		if (isFocusable(elem, options?.hidden, options?.tabbablesOnly, options?.disabled)) focusables.push(elem);
+		if (isFocusable(child, options?.hidden, options?.tabbablesOnly, options?.disabled)) focusables.push(child);
 		if (options?.deep) {
-			focusables = [...focusables, ...getFocusables(elem, options)];
+			focusables = [...focusables, ...getFocusableDescendants(child, options)];
 		}
 	});
 

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -1,8 +1,8 @@
 import { defineCE, expect, fixture, html } from '@brightspace-ui/testing';
 import {
 	getComposedActiveElement,
-	getFocusables,
 	getFirstFocusableDescendant,
+	getFocusables,
 	getLastFocusableDescendant,
 	getNextFocusable,
 	getPreviousFocusable,

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -1,6 +1,7 @@
 import { defineCE, expect, fixture, html } from '@brightspace-ui/testing';
 import {
 	getComposedActiveElement,
+	getFocusables,
 	getFirstFocusableDescendant,
 	getLastFocusableDescendant,
 	getNextFocusable,
@@ -96,6 +97,53 @@ describe('focus', () => {
 			const expected = elem.getShadow1();
 			expected.focus();
 			expect(getComposedActiveElement()).to.equal(expected);
+		});
+
+	});
+
+	describe('getFocusables', () => {
+
+		const focusablesFixture = html`
+			<div>
+				<span></span>
+				<button id="1a"></button>
+				<button id="1b"></button>
+				<button id="1c" disabled></button>
+				<button id="1d" hidden></button>
+				<span id="1e" tabindex="-1"></span>
+				<div id="1f">
+					<button id="2a"></button>
+				</div>
+				<div>
+					<button id="2a"></button>
+				</div>
+				<svg><a xlink:href="javascript:void(0);"></a></svg>
+			</div>
+		`;
+
+		[
+			{ name: 'returns focusables by default', options: undefined, expected: ['1a', '1b'] },
+			{ name: 'returns only immediate focusables using deep: false', options: { deep: false }, expected: ['1a', '1b'] },
+			{ name: 'returns immediate and deep focusables using deep: true', options: { deep: true }, expected: ['1a', '1b', '2a', '2a'] },
+			{ name: 'returns only enabled focusables using disabled: false', options: { disabled: false }, expected: ['1a', '1b'] },
+			{ name: 'returns enabled and disabled focusables using disabled: true', options: { disabled: true }, expected: ['1a', '1b', '1c'] },
+			{ name: 'returns only visible focusables using hidden: false', options: { hidden: false }, expected: ['1a', '1b'] },
+			{ name: 'returns visible and hidden focusables using hidden: true', options: { hidden: true }, expected: ['1a', '1b', '1d'] },
+			{ name: 'returns only tabbable focusables using tabbablesOnly: true', options: { tabbablesOnly: true }, expected: ['1a', '1b'] },
+			{ name: 'returns non-tabblable and tabbable focusables using tabbablesOnly: false', options: { tabbablesOnly: false }, expected: ['1a', '1b', '1e'] },
+			{ name: 'returns immediate focusables that meet predicate condition', options: { predicate: elem => elem.id === '1a' }, expected: ['1a'] },
+			{ name: 'returns deep focusables that meet predicate condition', options: { deep: true, predicate: elem => elem.id === '1f' || elem.id === '2a' }, expected: ['2a'] }
+		].forEach(info => {
+
+			it(info.name, async() => {
+				const elem = await fixture(focusablesFixture);
+				const focusables = getFocusables(elem, info.options);
+				expect(focusables.length).to.equal(info.expected.length);
+				info.expected.forEach((id, i) => {
+					expect(focusables[i].id).to.equal(id);
+				});
+			});
+
 		});
 
 	});

--- a/helpers/test/focus.test.js
+++ b/helpers/test/focus.test.js
@@ -2,7 +2,7 @@ import { defineCE, expect, fixture, html } from '@brightspace-ui/testing';
 import {
 	getComposedActiveElement,
 	getFirstFocusableDescendant,
-	getFocusables,
+	getFocusableDescendants,
 	getLastFocusableDescendant,
 	getNextFocusable,
 	getPreviousFocusable,
@@ -137,7 +137,7 @@ describe('focus', () => {
 
 			it(info.name, async() => {
 				const elem = await fixture(focusablesFixture);
-				const focusables = getFocusables(elem, info.options);
+				const focusables = getFocusableDescendants(elem, info.options);
 				expect(focusables.length).to.equal(info.expected.length);
 				info.expected.forEach((id, i) => {
 					expect(focusables[i].id).to.equal(id);


### PR DESCRIPTION
This PR adds a `getFocusables` helper that will be used as part of the fix for defects in `d2l-list` `grid` mode keyboard behaviour when list-item content contains various focusable arrangements ([GAUD-6697](https://desire2learn.atlassian.net/browse/GAUD-6697)).

[GAUD-6697]: https://desire2learn.atlassian.net/browse/GAUD-6697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ