### PR TITLE
Update d2l-pager-load-more to wait a frame before locating and applying focus

### DIFF
--- a/components/paging/pager-load-more.js
+++ b/components/paging/pager-load-more.js
@@ -124,6 +124,9 @@ class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(Rt
 		});
 		this._loading = false;
 
+		// wait a frame for async sub-components to render
+		await new Promise(resolve => requestAnimationFrame(resolve));
+
 		const item = pageable._getItemByIndex(lastItemIndex + 1);
 
 		if (!item) return;


### PR DESCRIPTION
[GAUD-6833](https://desire2learn.atlassian.net/browse/GAUD-6833)

This PR updates `d2l-pager-load-more` to wait a frame before locating the element to apply focus. This improves the resiliency of the focus behaviour by allowing sub-components (for example `d2l-selection-input` inside of a `<tr>...</tr>` to fully render. While consumers can/should wait for their component to update, they aren't necessarily aware of sub-components.

[GAUD-6833]: https://desire2learn.atlassian.net/browse/GAUD-6833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ