### PR TITLE
Call updated after embeds are processed

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -244,7 +244,7 @@ class HtmlBlock extends LitElement {
 
 	async updated(changedProperties) {
 		super.updated(changedProperties);
-		if ((changedProperties.has('html') || changedProperties.has('_context')) && this.html !== undefined && this.html !== null && !this.noDeferredRendering) {
+		if (changedProperties.has('embeds') && this.html !== undefined && this.html !== null && !this.noDeferredRendering) {
 			await this._updateRenderContainer();
 		}
 	}
@@ -261,6 +261,7 @@ class HtmlBlock extends LitElement {
 	async _processEmbeds() {
 		const htmlFragment = document.createRange().createContextualFragment(this.html);
 		await renderEmbeds(htmlFragment);
+		this.updated(new Map([['embeds']]));
 		return htmlFragment;
 	}
 

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -216,7 +216,10 @@ class HtmlBlock extends LitElement {
 
 		const contextValsPromise = contextKeysPromise.then(contextKeys => {
 			return Promise.allSettled(contextKeys.map(key => {
-				return tryGet(key, undefined, ctx => this._context.set(key, ctx));
+				return tryGet(key, undefined, ctx => {
+					this._context.set(key, ctx);
+					this.updated(new Map([['_context']]));
+				});
 			}));
 		});
 
@@ -244,7 +247,7 @@ class HtmlBlock extends LitElement {
 
 	async updated(changedProperties) {
 		super.updated(changedProperties);
-		if (changedProperties.has('embeds') && this.html !== undefined && this.html !== null && !this.noDeferredRendering) {
+		if ((changedProperties.has('embeds') || changedProperties.has('_context')) && this.html !== undefined && this.html !== null && !this.noDeferredRendering) {
 			await this._updateRenderContainer();
 		}
 	}

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -234,19 +234,12 @@ class HtmlBlock extends LitElement {
 			'd2l-html-block-compact': this.compact
 		};
 
-		if (this._embedsFeatureEnabled()) {
-			return html`
-				<div class="${classMap(renderContainerClasses)}">
-					${!this.noDeferredRendering ? until(this._processEmbeds(), nothing) : nothing}
-				</div>
-				${this.noDeferredRendering ? html`<slot @slotchange="${this._handleSlotChange}"></slot>` : ''}
-			`;
-		} else {
-			return html`
-				<div class="${classMap(renderContainerClasses)}"></div>
-				${this.noDeferredRendering ? html`<slot @slotchange="${this._handleSlotChange}"></slot>` : ''}
-			`;
-		}
+		return html`
+			<div class="${classMap(renderContainerClasses)}">
+				${!this.noDeferredRendering ? until(this._processEmbeds(), nothing) : nothing}
+			</div>
+			${this.noDeferredRendering ? html`<slot @slotchange="${this._handleSlotChange}"></slot>` : ''}
+		`;
 	}
 
 	async updated(changedProperties) {
@@ -258,10 +251,6 @@ class HtmlBlock extends LitElement {
 
 	async getLoadingComplete() {
 		return this._renderersProcessedPromise;
-	}
-
-	_embedsFeatureEnabled() {
-		return window.D2L?.LP?.Web?.UI?.Flags.Flag('shield-7574-enable-embed-rendering-framework', true);
 	}
 
 	async _handleSlotChange(e) {
@@ -315,7 +304,6 @@ class HtmlBlock extends LitElement {
 
 	async _updateRenderContainer() {
 		const renderContainer = this.shadowRoot.querySelector('.d2l-html-block-rendered');
-		if (!this._embedsFeatureEnabled()) renderContainer.innerHTML = this.html;
 		await this._processRenderers(renderContainer);
 	}
 

--- a/components/html-block/test/html-block.vdiff.js
+++ b/components/html-block/test/html-block.vdiff.js
@@ -149,8 +149,16 @@ describe('d2l-html-block', () => {
 
 	it('update-content', async() => {
 		const elem = await fixture(html`<d2l-html-block html="before update"></d2l-html-block>`, { viewport });
+
+		let resolve, runCount = 0;
+		const elemUpdated = new Promise(r => resolve = r);
+		elem.updated = async function(changedProperties) {
+			await Object.getPrototypeOf(elem).updated.call(elem, changedProperties);
+			if (++runCount === 2) resolve();
+		};
+
 		elem.html = 'after update';
-		await elem.updateComplete;
+		await elemUpdated;
 		await expect(elem).to.be.golden();
 	});
 


### PR DESCRIPTION
Targets #4922

This is an alternative to "[Reset renderer processing state on update](https://github.com/BrightspaceUI/core/pull/4922/commits/a5d5a91d62e1fe71c84f3e65215777834638033c)".


Note that I reset this branch to undo that commit, but it would need to be done again in the target branch if we want to merge this. Or I can re-apply it here to keep the history.