### PR TITLE
Move @font-face CSS so that we can eliminate duplicated CSS.

### DIFF
--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -318,3 +318,65 @@ export const blockquoteStyles = css`
 		}
 	}
 `;
+
+const importUrl = 'https://s.brightspace.com/lib/fonts/0.6.1/assets/';
+const fonts = {
+	LatoRegular: 'Lato-400',
+	LatoBold: 'Lato-700',
+	BCSansLight: 'BCSans-Light',
+	BCSansRegular: 'BCSans-Regular',
+	BCSansBold: 'BCSans-Bold',
+	BCSansLightItalic: 'BCSans-LightItalic',
+	BCSansItalic: 'BCSans-Italic',
+	BCSansBoldItalic: 'BCSans-BoldItalic'
+};
+export const fontFacesCss = `
+	@font-face {
+		font-family: 'Lato';
+		font-style: normal;
+		font-weight: 400;
+		src: local('Lato Regular'), local('Lato-Regular'), url(${new URL(`${fonts.LatoRegular}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.LatoRegular}.woff`, importUrl)}) format('woff'), url(${new URL(`${fonts.LatoRegular}.ttf`, importUrl)}) format('truetype');
+	}
+	@font-face {
+		font-family: 'Lato';
+		font-style: normal;
+		font-weight: 700;
+		src: local('Lato Bold'), local('Lato-Bold'), url(${new URL(`${fonts.LatoBold}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.LatoBold}.woff`, importUrl)}) format('woff'), url(${new URL(`${fonts.LatoBold}.ttf`, importUrl)}) format('truetype');
+	}
+	@font-face {
+		font-family: 'BC Sans';
+		font-style: normal;
+		font-weight: 300;
+		src: url(${new URL(`${fonts.BCSansLight}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansLight}.woff`, importUrl)}) format('woff');
+	}
+	@font-face {
+		font-family: 'BC Sans';
+		font-style: normal;
+		font-weight: 400;
+		src: url(${new URL(`${fonts.BCSansRegular}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansRegular}.woff`, importUrl)}) format('woff');
+	}
+	@font-face {
+		font-family: 'BC Sans';
+		font-style: normal;
+		font-weight: 700;
+		src: url(${new URL(`${fonts.BCSansBold}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansBold}.woff`, importUrl)}) format('woff');
+	}
+	@font-face {
+		font-family: 'BC Sans';
+		font-style: italic;
+		font-weight: 300;
+		src: url(${new URL(`${fonts.BCSansLightItalic}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansLightItalic}.woff`, importUrl)}) format('woff');
+	}
+	@font-face {
+		font-family: 'BC Sans';
+		font-style: italic;
+		font-weight: 400;
+		src: url(${new URL(`${fonts.BCSansItalic}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansItalic}.woff`, importUrl)}) format('woff');
+	}
+	@font-face {
+		font-family: 'BC Sans';
+		font-style: italic;
+		font-weight: 700;
+		src: url(${new URL(`${fonts.BCSansBoldItalic}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansBoldItalic}.woff`, importUrl)}) format('woff');
+	}
+`;

--- a/components/typography/typography.js
+++ b/components/typography/typography.js
@@ -1,16 +1,5 @@
 import '../colors/colors.js';
-
-export const importUrl = 'https://s.brightspace.com/lib/fonts/0.6.1/assets/';
-export const fonts = {
-	LatoRegular: 'Lato-400',
-	LatoBold: 'Lato-700',
-	BCSansLight: 'BCSans-Light',
-	BCSansRegular: 'BCSans-Regular',
-	BCSansBold: 'BCSans-Bold',
-	BCSansLightItalic: 'BCSans-LightItalic',
-	BCSansItalic: 'BCSans-Italic',
-	BCSansBoldItalic: 'BCSans-BoldItalic'
-};
+import { fontFacesCss } from './styles.js';
 
 if (!document.head.querySelector('#d2l-typography-font-face')) {
 	const style = document.createElement('style');
@@ -24,54 +13,7 @@ if (!document.head.querySelector('#d2l-typography-font-face')) {
 			--d2l-document-direction: rtl;
 		}
 
-		@font-face {
-			font-family: 'Lato';
-			font-style: normal;
-			font-weight: 400;
-			src: local('Lato Regular'), local('Lato-Regular'), url(${new URL(`${fonts.LatoRegular}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.LatoRegular}.woff`, importUrl)}) format('woff'), url(${new URL(`${fonts.LatoRegular}.ttf`, importUrl)}) format('truetype');
-		}
-		@font-face {
-			font-family: 'Lato';
-			font-style: normal;
-			font-weight: 700;
-			src: local('Lato Bold'), local('Lato-Bold'), url(${new URL(`${fonts.LatoBold}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.LatoBold}.woff`, importUrl)}) format('woff'), url(${new URL(`${fonts.LatoBold}.ttf`, importUrl)}) format('truetype');
-		}
-		@font-face {
-			font-family: 'BC Sans';
-			font-style: normal;
-			font-weight: 300;
-			src: url(${new URL(`${fonts.BCSansLight}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansLight}.woff`, importUrl)}) format('woff');
-		}
-		@font-face {
-			font-family: 'BC Sans';
-			font-style: normal;
-			font-weight: 400;
-			src: url(${new URL(`${fonts.BCSansRegular}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansRegular}.woff`, importUrl)}) format('woff');
-		}
-		@font-face {
-			font-family: 'BC Sans';
-			font-style: normal;
-			font-weight: 700;
-			src: url(${new URL(`${fonts.BCSansBold}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansBold}.woff`, importUrl)}) format('woff');
-		}
-		@font-face {
-			font-family: 'BC Sans';
-			font-style: italic;
-			font-weight: 300;
-			src: url(${new URL(`${fonts.BCSansLightItalic}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansLightItalic}.woff`, importUrl)}) format('woff');
-		}
-		@font-face {
-			font-family: 'BC Sans';
-			font-style: italic;
-			font-weight: 400;
-			src: url(${new URL(`${fonts.BCSansItalic}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansItalic}.woff`, importUrl)}) format('woff');
-		}
-		@font-face {
-			font-family: 'BC Sans';
-			font-style: italic;
-			font-weight: 700;
-			src: url(${new URL(`${fonts.BCSansBoldItalic}.woff2`, importUrl)}) format('woff2'), url(${new URL(`${fonts.BCSansBoldItalic}.woff`, importUrl)}) format('woff');
-		}
+		${fontFacesCss}
 
 		.d2l-typography {
 			color: var(--d2l-color-ferrite);


### PR DESCRIPTION
[GAUD-6877](https://desire2learn.atlassian.net/browse/GAUD-6877)

This PR simply moves the existing `@font-face` declarations from `typography.js` to `styles.js` so that we can eliminate the duplicate and out of date (albeit deprecated) version of these from [BrightspaceUI/typography](https://github.com/BrightspaceUI/typography).