### PR TITLE
remove plural-rules from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,3 @@ updates:
       # update-package-lock workflow aready handles minor/patch updates
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "@formatjs/intl-pluralrules"


### PR DESCRIPTION
This dependency was [recently moved to the Intl library](https://github.com/BrightspaceUI/core/pull/4932).