### PR TITLE
fix: icon is not required if slotted custom icon is provided

### DIFF
--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -36,7 +36,13 @@ class ButtonIcon extends PropertyRequiredMixin(ThemeMixin(ButtonMixin(VisibleOnA
 			 * REQUIRED: Preset icon key (e.g. "tier1:gear")
 			 * @type {string}
 			 */
-			icon: { type: String, reflect: true, required: true },
+			icon: {
+				type: String,
+				reflect: true,
+				required: {
+					validator: (_value, elem, hasValue) => hasValue || elem._hasCustomIcon
+				}
+			},
 
 			/**
 			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
@@ -162,6 +168,8 @@ class ButtonIcon extends PropertyRequiredMixin(ThemeMixin(ButtonMixin(VisibleOnA
 		this._buttonId = getUniqueId();
 		/** @internal */
 		this._describedById = getUniqueId();
+		/** @internal */
+		this._hasCustomIcon = false;
 	}
 
 	render() {
@@ -185,11 +193,17 @@ class ButtonIcon extends PropertyRequiredMixin(ThemeMixin(ButtonMixin(VisibleOnA
 				name="${ifDefined(this.name)}"
 				title="${ifDefined(this.text)}"
 				type="${this._getType()}">
-				<slot name="icon">${icon}</slot>
+				<slot name="icon" @slotchange="${this._handleSlotChange}">${icon}</slot>
 		</button>
 		${this.description ? html`<span id="${this._describedById}" hidden>${this.description}</span>` : null}
 		${this.disabled && this.disabledTooltip ? html`<d2l-tooltip for="${this._buttonId}">${this.disabledTooltip}</d2l-tooltip>` : ''}
 		`;
+	}
+
+	_handleSlotChange(e) {
+		this._hasCustomIcon = e.target.assignedNodes().find(
+			node => node.nodeType === 1 && node.tagName.toLowerCase() === 'd2l-icon-custom'
+		) !== undefined;
 	}
 
 }

--- a/components/button/test/button-icon.test.js
+++ b/components/button/test/button-icon.test.js
@@ -26,6 +26,21 @@ describe('d2l-button-icon', () => {
 				.to.throw(TypeError, createMessage(el, 'text'));
 		});
 
+		it('does not throw error when custom icon is provided', async() => {
+			const el = await fixture(html`
+				<d2l-button-icon text="Icon Button">
+					<d2l-icon-custom slot="icon">
+						<svg xmlns="http://www.w3.org/2000/svg" mirror-in-rtl="true">
+							<path fill="#494c4e" d="M18 12v5a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-5a1 1 0 0 1 2 0v4h14v-4a1 1 0 0 1 2 0z"/>
+							<path fill="#494c4e" d="M13.85 3.15l-2.99-3A.507.507 0 0 0 10.5 0H5.4A1.417 1.417 0 0 0 4 1.43v11.14A1.417 1.417 0 0 0 5.4 14h7.2a1.417 1.417 0 0 0 1.4-1.43V3.5a.47.47 0 0 0-.15-.35zM7 2h1a1 1 0 0 1 0 2H7a1 1 0 0 1 0-2zm4 10H7a1 1 0 0 1 0-2h4a1 1 0 0 1 0 2zm0-4H7a1 1 0 0 1 0-2h4a1 1 0 0 1 0 2z"/>
+						</svg>
+					</d2l-icon-custom>
+				</d2l-button-icon>
+			`);
+			expect(() => el.flushRequiredPropertyErrors())
+				.to.not.throw();
+		});
+
 	});
 
 	describe('events', () => {


### PR DESCRIPTION
When we added error checking to ensure that the `icon` attribute on `<d2l-button-icon>` was always provided, the fact that a custom icon can be provided in a slot was overlooked. This includes a custom validator to allow that case to pass.