### PR TITLE
Update the internal max-width of the demo-snippets code-view

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -101,7 +101,7 @@ class DemoSnippet extends LitElement {
 				border-top-left-radius: 0;
 				border-top-right-radius: 0;
 				margin: 0;
-				max-width: inherit;
+				max-width: 100%;
 			}
 			:host([code-view-hidden]) d2l-code-view {
 				display: none;

--- a/components/demo/demo/demo-snippet.html
+++ b/components/demo/demo/demo-snippet.html
@@ -19,6 +19,12 @@
 					<d2l-button-icon icon="tier1:gear" text="Icon Button"></d2l-button-icon>
 			</d2l-demo-snippet>
 
+			<h2>Demo Snippet (custom width)</h2>
+
+			<d2l-demo-snippet style="max-width: 80%;">
+					<d2l-button-icon icon="tier1:gear" text="Icon Button"></d2l-button-icon>
+			</d2l-demo-snippet>
+
 			<h2>Demo Snippet (using template)</h2>
 
 			<d2l-demo-snippet>


### PR DESCRIPTION
[GAUD-6924](https://desire2learn.atlassian.net/browse/GAUD-6924)

Update the internal `max-width` of the code-view from `inherit` to `100%` so that relative widths can be used.

**Before:**
![image](https://github.com/user-attachments/assets/69f316ef-480b-4909-8857-fd4577967048)

**After:**
![image](https://github.com/user-attachments/assets/2753787c-ccd8-41dc-92b7-4fd7e1380640)
