### PR TITLE
Position tooltip on right side correctly

### DIFF
--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -194,6 +194,9 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 				:host([hidden]) {
 					display: none;
 				}
+				d2l-input-text:not([skeleton]) {
+					width:auto
+				}
 			`
 		];
 	}

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -195,7 +195,7 @@ class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixi
 					display: none;
 				}
 				d2l-input-text:not([skeleton]) {
-					width:auto
+					width: auto;
 				}
 			`
 		];


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-5091)

Adjusting the width of the internal `d2l-input-text` makes the tooltip display next to the input rather than the very end of the component. This change maintains the external `width` at 100%.