### PR TITLE
fix: Dropdown opener: remove aria-haspopup

### DIFF
--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -132,7 +132,6 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		if (!opener) {
 			return;
 		}
-		opener.setAttribute('aria-haspopup', 'true');
 		opener.setAttribute('aria-expanded', (content && content.opened || false).toString());
 	}
 


### PR DESCRIPTION
[Jira task](https://desire2learn.atlassian.net/browse/GAUD-6944)
Part 2 of [this Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-6886)

**Problem:**
Dropdown menus when interacted with with VoiceOver do not announce expand/collapse state. This is due to the use of `aria-haspopup` in addition to the `aria-expanded` state. When only `aria-expanded` is present, its state is properly read.

**Solution:**
This removes `aria-haspopup`. Jeff found [this article](https://www.accessibility-developer-guide.com/examples/sensible-aria-usage/expanded/#adding-haspopup-optional) which recommends against the usage of `aria-haspopup` in cases like this since it does not add anything (and in this case actually removes useful information).
Also worth noting is that when testing with Firefox + NVDA, it only reads out the `aria-expanded` state and ignores `aria-haspopup`.