### PR TITLE
Update the dialog content container to 100% height when full-height is used.

### DIFF
--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -136,6 +136,11 @@ export const dialogStyles = css`
 		position: relative; /* make this the positioned parent for absolute positioned elements like d2l-template-primary-secondary */
 	}
 
+	:host([full-height]) .d2l-dialog-content > div {
+		box-sizing: border-box;
+		height: 100%;
+	}
+
 	.d2l-dialog-outer-scroll .d2l-dialog-content {
 		overflow: auto;
 	}


### PR DESCRIPTION
This PR applies `height: 100%` to the content container element when `full-height` is used. This enables consumers to place an element in the dialog with `height: 100%` so that it actually fills the available space defined by the vertical flex layout.