### PR TITLE
feat: [a11y docs] Date and time inputs: Improve accessibility documentation

### DIFF
--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -277,12 +277,14 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 
 ## Accessibility
 
-The date and time components generally follow the W3C's best practice recommendations for a [Date picker dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). For details on the accessibility of the calendar within the date input components, see [Calendar Accessibility](../calendar#accessibility). A few notable accessibility-related features of these components are:
+The date and time components generally follow the W3C's best practice recommendations for a [Date picker dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). For details on the accessibility of the calendar within the date input components, see [Calendar Accessibility](../calendar#accessibility). 
 
-* Explicitly stating the expected date format in both the description tooltip and the placeholder text
-* Trapping focus in the date input dropdown
+A few notable accessibility-related features of these components are:
+
+* The expected date format is indicated both in placeholder text and a tooltip available on hover and focus
+* Focus is trapped in the date input dropdown
 * When the date input is opened with the keyboard, focus goes to either selected date, today, or earliest valid date if today is prior to `min-date`
-* Extensive intuitive keyboard interaction support built into the components
+* Extensive intuitive keyboard interaction support
 
 ## Timezone
 

--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -65,16 +65,6 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 * `inline-help`: Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
 <!-- docs: end hidden content -->
 
-### Accessibility Properties
-
-To make your usage of `d2l-input-date` accessible, use the following properties when applicable:
-
-| Attribute | Description |
-|--|--|
-| `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
-| `label-hidden` | Use if label should be visually hidden but available for screen reader users |
-| `labelled-by` | String | Use when another visible element should act as the label |
-
 ## Date Range Input [d2l-input-date-range]
 
 Use the `<d2l-input-date-range>` component when users need to enter two dates in a range, like a course start and end date. The component consists of two input-date components - one for the start of a range and one for the end of a range. Values specified for these components (through the `start-value` and/or `end-value` attributes) are displayed if specified, and selected values are reflected.
@@ -120,17 +110,6 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 * `inline-help`: Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
 <!-- docs: end hidden content -->
 
-### Accessibility Properties
-
-To make your usage of `d2l-input-date-range` accessible, use the following properties when applicable:
-
-| Attribute | Description |
-|--|--|
-| `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
-| `label-hidden` | Use if label should be visually hidden but available for screen reader users |
-| `end-label` | Accessible label for the second date input |
-| `start-label` | Accessible label for the first date input |
-
 ## Time Input [d2l-input-time]
 
 Use the `<d2l-input-time>` component when users need to enter a time, without a date. The component consists of a text input field for typing a time and an attached dropdown for time selection. The dropdown opens on click of the text input, or on enter or down arrow press if the text input is focused. It displays the `value` if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
@@ -170,16 +149,6 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 
 * `inline-help`: Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
 <!-- docs: end hidden content -->
-
-### Accessibility Properties
-
-To make your usage of `d2l-input-time` accessible, use the following properties when applicable:
-
-| Attribute | Description |
-|--|--|
-| `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
-| `label-hidden` | Use if label should be visually hidden but available for screen reader users |
-| `labelled-by` | Use when another visible element should act as the label |
 
 ## Time Range Input [d2l-input-time-range]
 
@@ -222,17 +191,6 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 * `inline-help`: Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
 <!-- docs: end hidden content -->
 
-### Accessibility Properties
-
-To make your usage of `d2l-input-time-range` accessible, use the following properties when applicable:
-
-| Attribute | Description |
-|--|--|
-| `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
-| `label-hidden` | Use if label should be visually hidden but available for screen reader users |
-| `end-label` | Accessible label for the second time input |
-| `start-label` | Accessible label for the first time input |
-
 ## Date-Time Input [d2l-input-date-time]
 
 Use the `<d2l-input-date-time>` component when users need to enter a single date and time, like a due date. The component consists of a `<d2l-input-date>` and a `<d2l-input-time>` component. The time input only appears once a date is selected. This component displays the `value` if one is specified, and reflects the selected value when one is selected or entered.
@@ -273,16 +231,6 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 
 * `inline-help`: Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
 <!-- docs: end hidden content -->
-
-### Accessibility Properties
-
-To make your usage of `d2l-input-date-time` accessible, use the following property:
-
-| Attribute | Description |
-|--|--|
-| `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/) |
-| `label-hidden` | Use if label should be visually hidden but available for screen reader users |
-| `labelled-by` | String | Use when another visible element should act as the label |
 
 ## Date-Time Range Input [d2l-input-date-time-range]
 
@@ -327,16 +275,14 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 * `inline-help`: Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
 <!-- docs: end hidden content -->
 
-### Accessibility Properties
+## Accessibility
 
-To make your usage of `d2l-input-date-time-range` accessible, use the following properties when applicable:
+The date and time components generally follow the W3C's best practice recommendations for a [Date picker dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). For details on the accessibility of the calendar within the date input components, see [Calendar Accessibility](../calendar#accessibility). A few notable accessibility-related features of these components are:
 
-| Attribute | Description |
-|--|--|
-| `label` | **REQUIRED** [Acts as a primary label on the input](https://www.w3.org/WAI/tutorials/forms/labels/). Visible unless `label-hidden` is also used. |
-| `label-hidden` | Use if label should be visually hidden but available for screen reader users |
-| `end-label` | Accessible label for the second date-time input |
-| `start-label` | Accessible label for the first date-time input |
+* Explicitly stating the expected date format in both the description tooltip and the placeholder text
+* Trapping focus in the date input dropdown
+* When the date input is opened with the keyboard, focus goes to either selected date, today, or earliest valid date if today is prior to `min-date`
+* Extensive intuitive keyboard interaction support built into the components
 
 ## Timezone
 

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -43,7 +43,7 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 			 */
 			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
 			/**
-			 * ACCESSIBILITY: Hides the start and end labels visually
+			 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
 			 * @type {boolean}
 			 */
 			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
@@ -53,7 +53,7 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * ACCESSIBILITY: Accessible label for the end date input. Defaults to localized "End Date".
+			 * ACCESSIBILITY: Label for the end date input. Defaults to localized "End Date".
 			 * @type {string}
 			 * @default "End Date"
 			 */
@@ -74,12 +74,12 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 			 */
 			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
 			/**
-			 * ACCESSIBILITY: REQUIRED: Accessible label for the input fieldset that wraps the date inputs
+			 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date inputs
 			 * @type {string}
 			 */
 			label: { type: String, reflect: true },
 			/**
-			 * ACCESSIBILITY: Hides the fieldset label visually
+			 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
@@ -104,7 +104,7 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * ACCESSIBILITY: Accessible label for the start date input. Defaults to localized "Start Date".
+			 * ACCESSIBILITY: Label for the start date input. Defaults to localized "Start Date".
 			 * @type {string}
 			 * @default "Start Date"
 			 */

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -43,7 +43,7 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 			 */
 			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
 			/**
-			 * Hides the start and end labels visually
+			 * ACCESSIBILITY: Hides the start and end labels visually
 			 * @type {boolean}
 			 */
 			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
@@ -53,7 +53,7 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the end date input. Defaults to localized "End Date".
+			 * ACCESSIBILITY: Accessible label for the end date input. Defaults to localized "End Date".
 			 * @type {string}
 			 * @default "End Date"
 			 */
@@ -74,12 +74,12 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 			 */
 			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
 			/**
-			 * REQUIRED: Accessible label for the input fieldset that wraps the date inputs
+			 * ACCESSIBILITY: REQUIRED: Accessible label for the input fieldset that wraps the date inputs
 			 * @type {string}
 			 */
 			label: { type: String, reflect: true },
 			/**
-			 * Hides the fieldset label visually
+			 * ACCESSIBILITY: Hides the fieldset label visually
 			 * @type {boolean}
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
@@ -104,7 +104,7 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the start date input. Defaults to localized "Start Date".
+			 * ACCESSIBILITY: Accessible label for the start date input. Defaults to localized "Start Date".
 			 * @type {string}
 			 * @default "Start Date"
 			 */

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -76,7 +76,7 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 			 */
 			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
 			/**
-			 * ACCESSIBILITY: Hides the start and end labels visually
+			 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
 			 * @type {boolean}
 			 */
 			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
@@ -86,7 +86,7 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * ACCESSIBILITY: Accessible label for the end date-time input. Defaults to localized "End Date".
+			 * ACCESSIBILITY: Label for the end date-time input. Defaults to localized "End Date".
 			 * @type {string}
 			 * @default "End Date"
 			 */
@@ -107,12 +107,12 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 			 */
 			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
 			/**
-			 * ACCESSIBILITY: REQUIRED: Accessible label for the input fieldset that wraps the date-time inputs
+			 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date-time inputs
 			 * @type {string}
 			 */
 			label: { type: String, reflect: true },
 			/**
-			 * ACCESSIBILITY: Hides the fieldset label visually
+			 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
@@ -142,7 +142,7 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * ACCESSIBILITY: Accessible label for the start date-time input. Defaults to localized "Start Date".
+			 * ACCESSIBILITY: Label for the start date-time input. Defaults to localized "Start Date".
 			 * @type {string}
 			 * @default "Start Date"
 			 */

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -76,7 +76,7 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 			 */
 			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
 			/**
-			 * Hides the start and end labels visually
+			 * ACCESSIBILITY: Hides the start and end labels visually
 			 * @type {boolean}
 			 */
 			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
@@ -86,7 +86,7 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the end date-time input. Defaults to localized "End Date".
+			 * ACCESSIBILITY: Accessible label for the end date-time input. Defaults to localized "End Date".
 			 * @type {string}
 			 * @default "End Date"
 			 */
@@ -107,12 +107,12 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 			 */
 			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
 			/**
-			 * REQUIRED: Accessible label for the input fieldset that wraps the date-time inputs
+			 * ACCESSIBILITY: REQUIRED: Accessible label for the input fieldset that wraps the date-time inputs
 			 * @type {string}
 			 */
 			label: { type: String, reflect: true },
 			/**
-			 * Hides the fieldset label visually
+			 * ACCESSIBILITY: Hides the fieldset label visually
 			 * @type {boolean}
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
@@ -142,7 +142,7 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the start date-time input. Defaults to localized "Start Date".
+			 * ACCESSIBILITY: Accessible label for the start date-time input. Defaults to localized "Start Date".
 			 * @type {string}
 			 * @default "Start Date"
 			 */

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -52,7 +52,7 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * Hides the fieldset label visually
+			 * ACCESSIBILITY: Hides the fieldset label visually
 			 * @type {boolean}
 			 */
 			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -52,7 +52,7 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 			 */
 			disabled: { type: Boolean },
 			/**
-			 * ACCESSIBILITY: Hides the fieldset label visually
+			 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
 			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -49,7 +49,7 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 			 */
 			hasNow: { attribute: 'has-now', type: Boolean },
 			/**
-			 * Hides the label visually (moves it to the input's "aria-label" attribute)
+			 * ACCESSIBILITY: Hides the label visually
 			 * @type {boolean}
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -49,7 +49,7 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 			 */
 			hasNow: { attribute: 'has-now', type: Boolean },
 			/**
-			 * ACCESSIBILITY: Hides the label visually
+			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -50,7 +50,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			autoShiftTimes: { attribute: 'auto-shift-times', reflect: true, type: Boolean },
 			/**
-			 * Hides the start and end labels visually
+			 * ACCESSIBILITY: Hides the start and end labels visually
 			 * @type {boolean}
 			 */
 			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
@@ -60,7 +60,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the end time input. Defaults to localized "End Time".
+			 * ACCESSIBILITY: Accessible label for the end time input. Defaults to localized "End Time".
 			 * @type {string}
 			 * @default "End Time"
 			 */
@@ -86,12 +86,12 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			inclusiveTimeRange: { attribute: 'inclusive-time-range', reflect: true, type: Boolean },
 			/**
-			 * REQUIRED: Accessible label for the input fieldset that wraps the time inputs
+			 * ACCESSIBILITY: REQUIRED: Accessible label for the input fieldset that wraps the time inputs
 			 * @type {string}
 			 */
 			label: { type: String, reflect: true },
 			/**
-			 * Hides the fieldset label visually
+			 * ACCESSIBILITY: Hides the fieldset label visually
 			 * @type {boolean}
 			 */
 			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
@@ -106,7 +106,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * Accessible label for the start time input. Defaults to localized "Start Time".
+			 * ACCESSIBILITY: Accessible label for the start time input. Defaults to localized "Start Time".
 			 * @type {string}
 			 * @default "Start Time"
 			 */

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -50,7 +50,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			autoShiftTimes: { attribute: 'auto-shift-times', reflect: true, type: Boolean },
 			/**
-			 * ACCESSIBILITY: Hides the start and end labels visually
+			 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
 			 * @type {boolean}
 			 */
 			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
@@ -60,7 +60,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			disabled: { type: Boolean, reflect: true },
 			/**
-			 * ACCESSIBILITY: Accessible label for the end time input. Defaults to localized "End Time".
+			 * ACCESSIBILITY: Label for the end time input. Defaults to localized "End Time".
 			 * @type {string}
 			 * @default "End Time"
 			 */
@@ -86,12 +86,12 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			inclusiveTimeRange: { attribute: 'inclusive-time-range', reflect: true, type: Boolean },
 			/**
-			 * ACCESSIBILITY: REQUIRED: Accessible label for the input fieldset that wraps the time inputs
+			 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the time inputs
 			 * @type {string}
 			 */
 			label: { type: String, reflect: true },
 			/**
-			 * ACCESSIBILITY: Hides the fieldset label visually
+			 * Hides the fieldset label visually.  Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
 			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
@@ -106,7 +106,7 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(RtlMixin(
 			 */
 			required: { type: Boolean, reflect: true },
 			/**
-			 * ACCESSIBILITY: Accessible label for the start time input. Defaults to localized "Start Time".
+			 * ACCESSIBILITY: Label for the start time input. Defaults to localized "Start Time".
 			 * @type {string}
 			 * @default "Start Time"
 			 */

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -140,7 +140,7 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 			 */
 			enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
 			/**
-			 * Hides the label visually (moves it to the input's "aria-label" attribute)
+			 * ACCESSIBILITY: Hides the label visually
 			 * @type {boolean}
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -140,7 +140,7 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 			 */
 			enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
 			/**
-			 * ACCESSIBILITY: Hides the label visually
+			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
 			labelHidden: { type: Boolean, attribute: 'label-hidden' },

--- a/mixins/labelled/labelled-mixin.js
+++ b/mixins/labelled/labelled-mixin.js
@@ -80,12 +80,12 @@ export const LabelledMixin = superclass => class extends PropertyRequiredMixin(s
 	static get properties() {
 		return {
 			/**
-			 * The id of element that provides the label for this element
+			 * ACCESSIBILITY: The id of element that provides the label for this element. Use when another visible element should act as the label.
 			 * @type {string}
 			 */
 			labelledBy: { type: String, reflect: true, attribute: 'labelled-by' },
 			/**
-			 * REQUIRED: Explicitly defined label for the element
+			 * ACCESSIBILITY: REQUIRED: Explicitly defined label for the element
 			 * @type {string}
 			 */
 			label: {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/DAYL-97)

Adds `ACCESSIBILITY: ` prefix to accessibility-related properties and adds Accessibility section.