### PR TITLE
fix: Focus trap: remove delay when focusing on first/last item when wrapping focus

### DIFF
--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -118,7 +118,7 @@ class FocusTrap extends FocusMixin(LitElement) {
 			const firstFocusable = getNextFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-start'));
 			if (firstFocusable) {
 				// Delay to re-apply the focus effects as a visual clue when there is only one focusable element
-				setTimeout(() => firstFocusable.focus(), 50);
+				firstFocusable.focus();
 				return;
 			}
 		}
@@ -142,7 +142,7 @@ class FocusTrap extends FocusMixin(LitElement) {
 			const lastFocusable = getPreviousFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-end'));
 			if (lastFocusable) {
 				// Delay to re-apply the focus effects as a visual clue when there is only one focusable element
-				setTimeout(() => lastFocusable.focus(), 50);
+				lastFocusable.focus();
 				return;
 			}
 		}

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -117,7 +117,6 @@ class FocusTrap extends FocusMixin(LitElement) {
 			// user is exiting trap via forward tabbing...
 			const firstFocusable = getNextFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-start'));
 			if (firstFocusable) {
-				// Delay to re-apply the focus effects as a visual clue when there is only one focusable element
 				firstFocusable.focus();
 				return;
 			}
@@ -141,7 +140,6 @@ class FocusTrap extends FocusMixin(LitElement) {
 			// user is exiting trap via back tabbing...
 			const lastFocusable = getPreviousFocusable(this.shadowRoot.querySelector('.d2l-focus-trap-end'));
 			if (lastFocusable) {
-				// Delay to re-apply the focus effects as a visual clue when there is only one focusable element
 				lastFocusable.focus();
 				return;
 			}

--- a/components/focus-trap/test/focus-trap.test.js
+++ b/components/focus-trap/test/focus-trap.test.js
@@ -106,14 +106,12 @@ describe('d2l-focus-trap', () => {
 				it('wraps to first', async() => {
 					focusTrap.querySelector('#last').focus();
 					focusTrap.shadowRoot.querySelector('.d2l-focus-trap-end').focus();
-					clock.tick(50);
 					expect(document.activeElement).to.equal(elem.querySelector('#first'));
 				});
 
 				it('wraps to last', () => {
 					focusTrap.querySelector('#first').focus();
 					focusTrap.shadowRoot.querySelector('.d2l-focus-trap-start').focus();
-					clock.tick(50);
 					expect(document.activeElement).to.equal(elem.querySelector('#last'));
 				});
 


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-6775)

**Context:**
It was found in the accessibility audit that with NVDA (and possible other screen readers; not VoiceOver) when the focus wraps to either the start or end (depending on focus direction), NVDA would read "blank" because of the brief focus on `d2l-focus-trap-start` or `d2l-focus-trap-end`. NVDA does this in order to communicate to a user that their focus action was successful.

After some discussion and consideration of options (e.g., an announced wrapping label) it was decided to remove the `setTimeout` since the case where there is only one item in the focus trap should be fairly rare. Jeff has added extensive notes to the Jira ticket for further reading if wanted.