### PR TITLE
Fix form panel demo

### DIFF
--- a/components/form/demo/form-panel-demo.js
+++ b/components/form/demo/form-panel-demo.js
@@ -5,6 +5,7 @@ import '../../expand-collapse/expand-collapse-content.js';
 import '../../inputs/input-number.js';
 import '../../inputs/input-text.js';
 import '../form.js';
+import '../../collapsible-panel/collapsible-panel.js'
 import { css, html, LitElement } from 'lit';
 import { heading3Styles } from '../../typography/styles.js';
 import { inputStyles } from '../../inputs/input-styles.js';
@@ -63,33 +64,27 @@ class FormPanelDemo extends LitElement {
 
 	render() {
 		return html`
-			<div class="d2l-form-panel-demo-panel">
-				<div class="d2l-form-panel-demo-header" @click=${this._toggleExpandCollapse}>
-					<h3 class="d2l-form-panel-demo-text d2l-heading-3">Personal Information</h3>
-					<d2l-button-icon
-						aria-expanded=${this._expanded ? 'true' : 'false'}
-						icon=${this._expanded ? 'tier1:arrow-collapse-small' : 'tier1:arrow-expand-small'}
-						@click=${this._toggleExpandCollapse}>
-					</d2l-button-icon>
-				</div>
-				<hr>
-				<d2l-expand-collapse-content ?expanded=${this._expanded}>
-					<d2l-form @d2l-form-invalid=${this._onInvalid} @d2l-form-submit=${this._onSubmit}>
-						<div class="d2l-form-panel-demo-container">
-							<d2l-input-text label="First Name" name="first-name" required minlength="4" maxlength="15"></d2l-input-text>
-						</div>
-						<div class="d2l-form-panel-demo-container">
-							<d2l-input-text label="Middle Name" name="middle-name" minlength="4" maxlength="8"></d2l-input-text>
-						</div>
-						<div class="d2l-form-panel-demo-container">
-							<d2l-input-text label="Last Name" name="last-name" required minlength="4" maxlength="15"></d2l-input-text>
-						</div>
-						<div class="d2l-form-panel-demo-container">
-							<d2l-input-number label="Age" name="age" required min="18" max="23"></d2l-input-number>
-						</div>
-					</d2l-form>
-				</d2l-expand-collapse-content>
-			</div>
+			<d2l-collapsible-panel
+				panel-title="Personal Information"
+				type="subtle"
+				?expanded=${this._expanded}
+				@d2l-collapsible-panel-expand=${this._onExpand}
+				@d2l-collapsible-panel-collapse=${this._onCollapse}>
+				<d2l-form @d2l-form-invalid=${this._onInvalid} @d2l-form-submit=${this._onSubmit}>
+					<div class="d2l-form-panel-demo-container">
+						<d2l-input-text label="First Name" name="first-name" required minlength="4" maxlength="15"></d2l-input-text>
+					</div>
+					<div class="d2l-form-panel-demo-container">
+						<d2l-input-text label="Middle Name" name="middle-name" minlength="4" maxlength="8"></d2l-input-text>
+					</div>
+					<div class="d2l-form-panel-demo-container">
+						<d2l-input-text label="Last Name" name="last-name" required minlength="4" maxlength="15"></d2l-input-text>
+					</div>
+					<div class="d2l-form-panel-demo-container">
+						<d2l-input-number label="Age" name="age" required min="18" max="23"></d2l-input-number>
+					</div>
+				</d2l-form>
+			</d2l-collapsible-panel>
 		`;
 	}
 
@@ -102,10 +97,12 @@ class FormPanelDemo extends LitElement {
 		console.log(e.detail.formData);
 	}
 
-	_toggleExpandCollapse(e) {
-		e.stopPropagation();
-		this._expanded = !this._expanded;
+	_onExpand() {
+		this._expanded = true;
 	}
 
+	_onCollapse() {
+		this._expanded = false;
+	}
 }
 customElements.define('d2l-form-panel-demo', FormPanelDemo);

--- a/components/form/demo/form-panel-demo.js
+++ b/components/form/demo/form-panel-demo.js
@@ -5,7 +5,7 @@ import '../../expand-collapse/expand-collapse-content.js';
 import '../../inputs/input-number.js';
 import '../../inputs/input-text.js';
 import '../form.js';
-import '../../collapsible-panel/collapsible-panel.js'
+import '../../collapsible-panel/collapsible-panel.js';
 import { css, html, LitElement } from 'lit';
 import { heading3Styles } from '../../typography/styles.js';
 import { inputStyles } from '../../inputs/input-styles.js';
@@ -88,6 +88,14 @@ class FormPanelDemo extends LitElement {
 		`;
 	}
 
+	_onCollapse() {
+		this._expanded = false;
+	}
+
+	_onExpand() {
+		this._expanded = true;
+	}
+
 	_onInvalid() {
 		this._expanded = true;
 	}
@@ -95,14 +103,6 @@ class FormPanelDemo extends LitElement {
 	_onSubmit(e) {
 		// eslint-disable-next-line no-console
 		console.log(e.detail.formData);
-	}
-
-	_onExpand() {
-		this._expanded = true;
-	}
-
-	_onCollapse() {
-		this._expanded = false;
 	}
 }
 customElements.define('d2l-form-panel-demo', FormPanelDemo);


### PR DESCRIPTION
The form panel demo was using a stand alone collapsible panel that was throwing errors due to missing text value. This PR replaces it with a `d2l-collapsible-panel`