### PR TITLE
Focus fixes for collapsible panel.

### DIFF
--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -178,15 +178,24 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 				margin-inline-start: 0.75rem;
 			}
 
-			.d2l-collapsible-panel.focused {
-				outline: var(--d2l-collapsible-panel-focus-outline);
-			}
+			.d2l-collapsible-panel.focused,
 			:host([expanded]) .d2l-collapsible-panel.focused .d2l-collapsible-panel-header {
 				outline: var(--d2l-collapsible-panel-focus-outline);
+			}
+			@supports selector(:has(a, b)) {
+				.d2l-collapsible-panel.focused,
+				:host([expanded]) .d2l-collapsible-panel.focused .d2l-collapsible-panel-header {
+					outline: none;
+				}
+				.d2l-collapsible-panel.focused:has(:focus-visible),
+				:host([expanded]) .d2l-collapsible-panel.focused:has(:focus-visible) .d2l-collapsible-panel-header {
+					outline: var(--d2l-collapsible-panel-focus-outline);
+				}
 			}
 			:host([expanded]) .d2l-collapsible-panel {
 				outline: none;
 			}
+
 			.d2l-collapsible-panel-header-primary {
 				align-items: center;
 				display: flex;
@@ -218,6 +227,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 				align-self: self-start;
 				background-color: transparent;
 				border: none;
+				cursor: pointer;
 				margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
 				order: 1;
 				outline: none;
@@ -338,8 +348,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 				<d2l-expand-collapse-content
 					?expanded="${this.expanded}"
 					@d2l-expand-collapse-content-collapse="${this._handleExpandCollapse}"
-					@d2l-expand-collapse-content-expand="${this._handleExpandCollapse}"
-				>
+					@d2l-expand-collapse-content-expand="${this._handleExpandCollapse}">
 					<div class="d2l-collapsible-panel-content">
 						<slot></slot>
 					</div>
@@ -505,7 +514,9 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 	_toggleExpand() {
 		if (this.skeleton) return;
 		this.expanded = !this.expanded;
+		this.focus();
 	}
+
 }
 
 customElements.define('d2l-collapsible-panel', CollapsiblePanel);

--- a/components/collapsible-panel/demo/collapsible-panel.html
+++ b/components/collapsible-panel/demo/collapsible-panel.html
@@ -113,7 +113,7 @@
 			<d2l-demo-snippet>
 					<d2l-collapsible-panel panel-title="Session: January 1, 2021: 10:00 AM" expand-collapse-label="Session on January 1">
 						<d2l-icon icon="tier3:assignments" slot="before"></d2l-icon>
-						<d2l-button-icon slot="actions" icon="tier1:fullscreen"></d2l-button-icon><d2l-button-icon slot="actions" icon="tier1:download"></d2l-button-icon><d2l-dropdown-more slot="actions">
+						<d2l-button-icon slot="actions" icon="tier1:fullscreen" text="Fullscreen"></d2l-button-icon><d2l-button-icon slot="actions" icon="tier1:download" text="Download"></d2l-button-icon><d2l-dropdown-more slot="actions" text="More">
 							<d2l-dropdown-menu>
 								<d2l-menu>
 									<d2l-menu-item text="Duplicate"></d2l-menu-item>
@@ -134,7 +134,7 @@
 			<h2>With long title</h2>
 			<d2l-demo-snippet>
 					<d2l-collapsible-panel panel-title="https://en.wikipedia.org/wiki/William_Thomson,_1st_Baron_Kelvin (the guy who invented absolute zero and some other cool thermodynamics stuff)" expand-collapse-label="Session on January 1">
-						<d2l-button-icon slot="actions" icon="tier1:fullscreen"></d2l-button-icon><d2l-button-icon slot="actions" icon="tier1:download"></d2l-button-icon><d2l-dropdown-more slot="actions">
+						<d2l-button-icon slot="actions" icon="tier1:fullscreen" text="Fullscreen"></d2l-button-icon><d2l-button-icon slot="actions" icon="tier1:download" text="Download"></d2l-button-icon><d2l-dropdown-more slot="actions" text="More">
 							<d2l-dropdown-menu>
 								<d2l-menu>
 									<d2l-menu-item text="Duplicate"></d2l-menu-item>
@@ -205,5 +205,14 @@
 					</d2l-collapsible-panel>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
+
+		<script>
+			document.body.addEventListener('d2l-collapsible-panel-expand', e => {
+				console.log('d2l-collapsible-panel-expand', e);
+			}, true);
+			document.body.addEventListener('d2l-collapsible-panel-collapse', e => {
+				console.log('d2l-collapsible-panel-collapse', e);
+			}, true);
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
[GAUD-6986](https://desire2learn.atlassian.net/browse/GAUD-6986)

This PR fixes 3 things:
1. Pointer cursor not being applied on the opener
2. Header styles not honouring `:focus-visible`
3. `[space]` and `[enter]` keys not working as expected after clicking on the header

[GAUD-6986]: https://desire2learn.atlassian.net/browse/GAUD-6986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ