### PR TITLE
fix: Meter demo title (remove)

### DIFF
--- a/components/meter/README.md
+++ b/components/meter/README.md
@@ -103,7 +103,7 @@ Circle meters display data in a compact circle format, so they're useful when ho
 ## Light Foreground
 All `meter` components have a `foreground-light` style that ensures accessible contrast levels when displayed against a dark background.
 
-<!-- docs: demo code darkMode:true sandboxTitle:'Meter - Light Foreground' -->
+<!-- docs: demo code darkMode:true -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/meter/meter-linear.js';


### PR DESCRIPTION
Daylight is currently not building (https://github.com/BrightspaceUI/documentation/pull/1803) so this fixes that. Currently there isn't the infrastructure to support demos with a sandboxTitle but no name. We can likely look into doing that if desired but this just quickly gets Daylight back to building.

FYI @geurts 