### PR TITLE
POC for linear list item

### DIFF
--- a/components/icons/images/tier1/arrow-expand-small.svg
+++ b/components/icons/images/tier1/arrow-expand-small.svg
@@ -1,3 +1,3 @@
-<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" mirror-in-rtl="true">
+<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 1 18 18" mirror-in-rtl="true">
 	<path fill="#494c4e" d="M6 14V6c0-.4.2-.8.6-.9s.8-.1 1.1.2l4 4c.4.4.4 1 0 1.4l-4 4c-.3.3-.7.4-1.1.2-.4-.1-.6-.5-.6-.9zm2-5.6v3.2L9.6 10 8 8.4z"/>
 </svg>

--- a/components/list/demo/demo-list-nested.js
+++ b/components/list/demo/demo-list-nested.js
@@ -32,6 +32,7 @@ class ListDemoNested extends LitElement {
 			showLoadMore: { type: Boolean, attribute: 'show-load-more' },
 			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
 			disableListGrid: { type: Boolean, attribute: 'disable-list-grid' },
+			linear: { type: Boolean },
 			_items: { state: true },
 			_loadedItems: { state: true },
 			_remainingItemCount: { state: true },
@@ -201,6 +202,7 @@ class ListDemoNested extends LitElement {
 		const hasChildren = item?.items?.length > 0;
 		return html`
 			<d2l-list-item
+				?linear="${this.linear}"
 				action-href="${this.includeActionHref ? 'http://www.d2l.com' : ''}"
 				?draggable="${this.isDraggable}"
 				drag-handle-text="${item.primaryText}"

--- a/components/list/demo/list-drag-and-drop-position.js
+++ b/components/list/demo/list-drag-and-drop-position.js
@@ -14,7 +14,8 @@ class ListDemoDragAndDropPosition extends LitElement {
 			// below are for demonstration only
 			grid: { type: Boolean },
 			hrefs: { type: Boolean },
-			selectable: { type: Boolean }
+			selectable: { type: Boolean },
+			linear: { type: Boolean }
 		};
 	}
 
@@ -77,6 +78,7 @@ class ListDemoDragAndDropPosition extends LitElement {
 				${repeat(this.list, (item) => item.key, (item) => html`
 					<d2l-list-item
 						key="${ifDefined(item.key)}"
+						?linear="${this.linear}"
 						draggable
 						?selectable="${this.selectable}"
 						drag-handle-text="${item.name}"

--- a/components/list/demo/list-drag-and-drop.html
+++ b/components/list/demo/list-drag-and-drop.html
@@ -46,7 +46,15 @@
 			</template>
 		</d2l-demo-snippet>
 
-		<h2>Linear Items</h2>
+		<h2>Linear Grid</h2>
+
+		<d2l-demo-snippet>
+			<template>
+				<d2l-demo-list-drag-and-drop-position hrefs add-button demo-item-key="imgPrimaryAndSupporting" is-draggable selectable linear include-secondary-actions></d2l-demo-list-drag-and-drop-position>
+			</template>
+		</d2l-demo-snippet>
+
+		<h2>Linear Nested Grid</h2>
 
 		<d2l-demo-snippet>
 			<template>

--- a/components/list/demo/list-drag-and-drop.html
+++ b/components/list/demo/list-drag-and-drop.html
@@ -46,6 +46,14 @@
 			</template>
 		</d2l-demo-snippet>
 
+		<h2>Linear Items</h2>
+
+		<d2l-demo-snippet>
+			<template>
+				<d2l-demo-list-nested add-button demo-item-key="imgPrimaryAndSupporting" is-draggable selectable linear include-secondary-actions></d2l-demo-list-nested>
+			</template>
+		</d2l-demo-snippet>
+
 
 	</d2l-demo-page>
 

--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -47,6 +47,21 @@ class ListItemContent extends LitElement {
 			.d2l-list-item-content-text-supporting-info ::slotted(*) {
 				margin-top: 0.15rem;
 			}
+
+			:host-context(d2l-list-item[linear]) .d2l-list-item-content-text {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			:host-context(d2l-list-item[linear]) .d2l-list-item-content-text * {
+				display: inline;
+			}
+
+			:host-context(d2l-list-item[linear]) slot[name] {
+				display: none;
+			}
+
 		`];
 	}
 

--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -10,6 +10,12 @@ import { css, html, LitElement } from 'lit';
  */
 class ListItemContent extends LitElement {
 
+	static get properties() {
+		return {
+			linear: { type: Boolean, reflect: true }
+		}
+	}
+
 	static get styles() {
 		return [ bodySmallStyles, bodyCompactStyles, css`
 			:host {
@@ -18,6 +24,13 @@ class ListItemContent extends LitElement {
 
 			.d2l-list-item-content-text {
 				margin: 0;
+			}
+
+			:host([linear]) .d2l-list-item-content-text > div,
+			:host([linear]) .d2l-list-item-content-text ::slotted(*) {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 
 			.d2l-list-item-content-text > div {
@@ -48,28 +61,16 @@ class ListItemContent extends LitElement {
 				margin-top: 0.15rem;
 			}
 
-			:host-context(d2l-list-item[linear]) .d2l-list-item-content-text {
-				overflow: hidden;
-				text-overflow: ellipsis;
-				white-space: nowrap;
-			}
-
-			:host-context(d2l-list-item[linear]) .d2l-list-item-content-text * {
-				display: inline;
-			}
-
-			:host-context(d2l-list-item[linear]) slot[name] {
-				display: none;
-			}
-
 		`];
 	}
 
 	render() {
 		return html`
 			<div class="d2l-list-item-content-text d2l-body-compact"><div><slot></slot></div></div>
+			${this.linear ? null : html`
 			<div class="d2l-list-item-content-text-secondary d2l-body-small"><slot name="secondary"></slot></div>
 			<div class="d2l-list-item-content-text-supporting-info d2l-body-small"><slot name="supporting-info"></slot></div>
+			`}
 		`;
 	}
 

--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -12,8 +12,11 @@ class ListItemContent extends LitElement {
 
 	static get properties() {
 		return {
+			/**
+			 * @ignore
+			 */
 			linear: { type: Boolean, reflect: true }
-		}
+		};
 	}
 
 	static get styles() {

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -40,11 +40,6 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			 */
 			alignNested: { type: String, reflect: true, attribute: 'align-nested' },
 			/**
-			 * Specifies whether lineat mode is active or not
-			 * @type {boolean}
-			 */
-			linear: { type: Boolean, attribute: 'linear' },
-			/**
 			 * Whether to constrain actions so they do not fill the item. Required if slotted content is interactive.
 			 * @type {boolean}
 			 */

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -40,6 +40,11 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			 */
 			alignNested: { type: String, reflect: true, attribute: 'align-nested' },
 			/**
+			 * Specifies whether lineat mode is active or not
+			 * @type {boolean}
+			 */
+			linear: { type: Boolean, attribute: 'linear' },
+			/**
 			 * Whether to constrain actions so they do not fill the item. Required if slotted content is interactive.
 			 * @type {boolean}
 			 */

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -140,6 +140,19 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				bottom: -1px;
 			}
 
+			:host([linear]) d2l-list-item-generic-layout > [slot] {
+				align-content: center;
+				padding-block: 0px;
+			}
+
+			:host([linear]) [slot="content"] {
+				align-items: center;
+			}
+
+			:host([linear]) [slot="content"] ::slotted([slot="illustration"]) {
+				max-height: 1.5rem;
+			}
+
 			:host(:first-of-type[_separators="between"]) [slot="control-container"]::before,
 			:host(:last-of-type[_separators="between"]) [slot="control-container"]::after,
 			:host([_separators="none"]) [slot="control-container"]::before,

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -151,7 +151,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 
 			:host([linear]) d2l-list-item-generic-layout > [slot] {
 				align-content: center;
-				padding-block: 0px;
+				padding-block: 0;
 			}
 
 			:host([linear]) [slot="content"] {
@@ -159,7 +159,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			}
 
 			:host([linear]) [slot="content"] ::slotted([slot="illustration"]) {
-				max-height: calc(100% - .5rem);
+				max-height: calc(100% - 0.5rem);
 				overflow: hidden;
 			}
 

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -70,6 +70,11 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			 */
 			dragTargetHandleOnly: { type: Boolean, attribute: 'drag-target-handle-only' },
 			/**
+			 * Whether to display the list item on a single line
+			 * @type {boolean}
+			 */
+			linear: { type: Boolean, attribute: 'linear' },
+			/**
 			 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
 			 * @type {boolean}
 			 */
@@ -140,6 +145,10 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				bottom: -1px;
 			}
 
+			:host([linear]) d2l-list-item-generic-layout > [slot="content"] {
+				height: 2.6rem;
+			}
+
 			:host([linear]) d2l-list-item-generic-layout > [slot] {
 				align-content: center;
 				padding-block: 0px;
@@ -150,7 +159,8 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			}
 
 			:host([linear]) [slot="content"] ::slotted([slot="illustration"]) {
-				max-height: 1.5rem;
+				max-height: calc(100% - .5rem);
+				overflow: hidden;
 			}
 
 			:host(:first-of-type[_separators="between"]) [slot="control-container"]::before,
@@ -479,6 +489,10 @@ export const ListItemMixin = superclass => class extends composeMixins(
 	willUpdate(changedProperties) {
 		if (changedProperties.has('_siblingHasColor') || changedProperties.has('color')) {
 			this._hasColorSlot = this.color || this._siblingHasColor;
+		}
+		if (changedProperties.has('linear')) {
+			const content = this.querySelector('d2l-list-item-content');
+			if (content) content.linear = this.linear;
 		}
 	}
 


### PR DESCRIPTION
We recently had [a discussion](https://d2l.slack.com/archives/G03Q166G2/p1726764788802369) about basic list items appearing out of alignment.

This is a POC for a `linear` mode for list items to force them to display on a single, center-aligned line with no stacked content and no line wrapping.

Style details are obviously flexible.

[Demo at the bottom of list drag and drop page](https://live.d2l.dev/prs/BrightspaceUI/core/pr-5009/components/list/demo/list-drag-and-drop.html)

Bonus fix: The `arrow-expand-small` icon has bothered me for years:

![Screenshot 2024-09-25 at 8 52 57 PM](https://github.com/user-attachments/assets/a31f8e52-43e3-43d3-9cb6-4d731926dd08)

Before
![Screenshot 2024-09-25 at 8 45 19 PM](https://github.com/user-attachments/assets/3524c494-8077-4e52-a8cc-a29bedc4b231)

After
![Screenshot 2024-09-25 at 8 45 06 PM](https://github.com/user-attachments/assets/ccd331f7-9f02-4a1b-80e9-abfbec15feab)
