### PR TITLE
Add showYearAndMonth method to d2l-calendar.

### DIFF
--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -32,7 +32,7 @@ Note: All `*-value` properties should be in ISO 8601 calendar date format (`YYYY
 
 ### Methods
 
-- `showYearAndMonth(year, month)`: show a specific year and month. Note: `month` is 0-based (i.e. 0 to 11).
+- `showYearAndMonth(date)`: show a specific year and month
 
 ## Accessibility
 

--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -30,6 +30,10 @@ Note: All `*-value` properties should be in ISO 8601 calendar date format (`YYYY
 * `d2l-calendar-selected`: dispatched when a date is selected through click, space, or enter. `e.detail.date` is in ISO 8601 calendar date format (`YYYY-MM-DD`).
 <!-- docs: end hidden content -->
 
+### Methods
+
+- `showYearAndMonth(year, month)`: show a specific year and month. Note: `month` is 0-based (i.e. 0 to 11).
+
 ## Accessibility
 
 The Daylight calendar (`d2l-calendar`) generally follows the W3C's best practice recommendations for a [Date picker dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). Of note is the keyboard behaviour following the [grid pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/).

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -630,6 +630,12 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		await this._updateFocusDate(date, false, allowDisabled);
 	}
 
+	showYearAndMonth(year, month) {
+		if (year === undefined || month === undefined) return;
+		this._shownYear = year;
+		this._shownMonth = month;
+	}
+
 	_computeText(month) {
 		return this.localize(`${this._namespace}.show`, { month: calendarData.descriptor.calendar.months.long[month] });
 	}

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -631,7 +631,7 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 	}
 
 	showYearAndMonth(year, month) {
-		if (year === undefined || month === undefined) return;
+		if (year === undefined || !(month > -1 && month < 12)) return;
 		this._shownYear = year;
 		this._shownMonth = month;
 	}

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -630,10 +630,10 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		await this._updateFocusDate(date, false, allowDisabled);
 	}
 
-	showYearAndMonth(year, month) {
-		if (year === undefined || !(month > -1 && month < 12)) return;
-		this._shownYear = year;
-		this._shownMonth = month;
+	showYearAndMonth(date) {
+		if (!date || !(date instanceof Date)) return;
+		this._shownYear = date.getFullYear();
+		this._shownMonth = date.getMonth();
 	}
 
 	_computeText(month) {

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -609,7 +609,9 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			composed: false,
 			detail: {
 				maxValue: dates[dates.length - 1][6],
-				minValue: dates[0][0]
+				month: this._shownMonth,
+				minValue: dates[0][0],
+				year: this._shownYear
 			}
 		}));
 

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -358,6 +358,20 @@ describe('d2l-calendar', () => {
 			});
 		});
 
+		describe('showYearAndMonth', () => {
+
+			it('changes the month in view', async() => {
+				const calendar = await fixture(normalFixture);
+				setTimeout(() => {
+					calendar.showYearAndMonth(2015, 10);
+				});
+				const { detail } = await oneEvent(calendar, 'd2l-calendar-view-change');
+				expect(detail.minValue).to.deep.equal(new Date(2015, 10, 1));
+				expect(detail.maxValue).to.deep.equal(new Date(2015, 11, 5));
+			});
+
+		});
+
 		describe('getDatesInMonthArray', () => {
 			it('returns expected array for Feb 2020 (days from prev month, no days from next month', () => {
 				const dates = [[

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -370,6 +370,18 @@ describe('d2l-calendar', () => {
 				expect(detail.maxValue).to.deep.equal(new Date(2015, 11, 5));
 			});
 
+			it('does not change the month in view if year or month are invalid', async() => {
+				let dispatched = false;
+				const calendar = await fixture(normalFixture);
+				calendar.addEventListener('d2l-calendar-view-change', () => dispatched = true);
+				calendar.showYearAndMonth(undefined, 10);
+				calendar.showYearAndMonth(2015, undefined);
+				calendar.showYearAndMonth(2015, -1);
+				calendar.showYearAndMonth(2015, 12);
+				await calendar.updateComplete;
+				expect(dispatched).to.equal(false);
+			});
+
 		});
 
 		describe('getDatesInMonthArray', () => {

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -101,6 +101,8 @@ describe('d2l-calendar', () => {
 			const { detail } = await oneEvent(calendar, 'd2l-calendar-view-change');
 			expect(detail.minValue).to.deep.equal(new Date(2015, 6, 26));
 			expect(detail.maxValue).to.deep.equal(new Date(2015, 8, 5));
+			expect(detail.month).to.equal(7);
+			expect(detail.year).to.equal(2015);
 		});
 
 		it('dispatches d2l-calendar-view-change event when user changes to next month', async() => {
@@ -110,6 +112,8 @@ describe('d2l-calendar', () => {
 			const { detail } = await oneEvent(calendar, 'd2l-calendar-view-change');
 			expect(detail.minValue).to.deep.equal(new Date(2015, 8, 27));
 			expect(detail.maxValue).to.deep.equal(new Date(2015, 9, 31));
+			expect(detail.month).to.equal(9);
+			expect(detail.year).to.equal(2015);
 		});
 
 		it('does not dispatch d2l-calendar-view-change event initially', async() => {

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -363,7 +363,7 @@ describe('d2l-calendar', () => {
 			it('changes the month in view', async() => {
 				const calendar = await fixture(normalFixture);
 				setTimeout(() => {
-					calendar.showYearAndMonth(2015, 10);
+					calendar.showYearAndMonth(new Date(2015, 10));
 				});
 				const { detail } = await oneEvent(calendar, 'd2l-calendar-view-change');
 				expect(detail.minValue).to.deep.equal(new Date(2015, 10, 1));
@@ -374,10 +374,8 @@ describe('d2l-calendar', () => {
 				let dispatched = false;
 				const calendar = await fixture(normalFixture);
 				calendar.addEventListener('d2l-calendar-view-change', () => dispatched = true);
-				calendar.showYearAndMonth(undefined, 10);
-				calendar.showYearAndMonth(2015, undefined);
-				calendar.showYearAndMonth(2015, -1);
-				calendar.showYearAndMonth(2015, 12);
+				calendar.showYearAndMonth(undefined);
+				calendar.showYearAndMonth('not a date');
 				await calendar.updateComplete;
 				expect(dispatched).to.equal(false);
 			});


### PR DESCRIPTION
[GAUD-6912](https://desire2learn.atlassian.net/browse/GAUD-6912)

This PR adds a new `showYearAndMonth(year, month)` method to `d2l-calendar`. This method is a programmatic way to change the year and month like if the user clicked next/previous month buttons. This will be needed by Calendar MVC tool when using the iterator buttons in "Month" view.

[GAUD-6912]: https://desire2learn.atlassian.net/browse/GAUD-6912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ