### PR TITLE
fix: input-time docs: remove reference to a placeholder [GAUD-7028]

### DIFF
--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -111,7 +111,7 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 
 ## Time Input [d2l-input-time]
 
-Use the `<d2l-input-time>` component when users need to enter a time, without a date. The component consists of a text input field for typing a time and an attached dropdown for time selection. The dropdown opens on click of the text input, or on enter or down arrow press if the text input is focused. It displays the `value` if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
+Use the `<d2l-input-time>` component when users need to enter a time, without a date. The component consists of a text input field for typing a time and an attached dropdown for time selection. The dropdown opens on click of the text input, or on enter or down arrow press if the text input is focused. It displays the `value` if one is specified, or a fallback time if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
 
 Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's timezone](#timezone) (if applicable).
 

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -116,7 +116,7 @@ function initIntervals(size, enforceTimeIntervals) {
 }
 
 /**
- * A component that consists of a text input field for typing a time and an attached dropdown for time selection. It displays the "value" if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
+ * A component that consists of a text input field for typing a time and an attached dropdown for time selection. It displays the "value" if one is specified, or a fallback time if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
  * @slot inline-help - Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
  * @fires change - Dispatched when there is a change to selected time. `value` corresponds to the selected value and is formatted in ISO 8601 time format (`hh:mm:ss`).
  */


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7028)

Removes reference to a placeholder in `input-time` since `input-time` does not use a placeholder. Let me know wording alternative ideas or thoughts on if I should more specifically define how the fallback time is calculated.