### PR TITLE
Switch from Lit-managed rendering to direct DOM manipulation in html-block to avoid conflicts with MathJax

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -297,6 +297,7 @@ class HtmlBlock extends LoadingCompleteMixin(LitElement) {
 	}
 
 	async _updateRenderContainer() {
+		if (!this._renderContainerRef.value) return;
 		this._renderContainerRef.value.innerHTML = '';
 		this._renderContainerRef.value.append(await this._processEmbeds());
 		await this._processRenderers(this._renderContainerRef.value);

--- a/components/html-block/test/html-block.vdiff.js
+++ b/components/html-block/test/html-block.vdiff.js
@@ -149,16 +149,8 @@ describe('d2l-html-block', () => {
 
 	it('update-content', async() => {
 		const elem = await fixture(html`<d2l-html-block html="before update"></d2l-html-block>`, { viewport });
-
-		let resolve;
-		const elemUpdated = new Promise(r => resolve = r);
-		elem.updated = async function(changedProperties) {
-			await Object.getPrototypeOf(elem).updated.call(elem, changedProperties);
-			if (changedProperties.has('embeds')) resolve();
-		};
-
 		elem.html = 'after update';
-		await elemUpdated;
+		await elem.loadingComplete;
 		await expect(elem).to.be.golden();
 	});
 


### PR DESCRIPTION
Backport of this PR: https://github.com/BrightspaceUI/core/pull/5032

Note: There is a 3.39.x branch, but I'm not sure what purpose it serves. BSI is using 3.38.x for 20.24.10. Either way, I'm going to align this with 20.24.10 BSI for now, with the expectation that the Lessons FRA can either update core to align with what BSI is using, or do whatever other backports they may need.