### PR TITLE
Rework col-sort-button :last-child padding styles for performance

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -123,13 +123,14 @@ export const tableStyles = css`
 		.d2l-table th:has(d2l-table-col-sort-button:not(:only-child)) d2l-table-col-sort-button {
 			--d2l-table-col-sort-button-width: unset;
 		}
-		/* has at least one d2l-table-col-sort-button with [nosort], does not have d2l-table-col-sort-button without nosort */
-		.d2l-table > * > tr > * > d2l-table-col-sort-button[nosort] ~ :last-child {
-			padding-inline-end: calc(0.6rem + 18px);
-		}
-		.d2l-table > * > tr > * > d2l-table-col-sort-button:not([nosort]) ~ :last-child {
-			padding-inline-end: unset;
-		}
+	}
+
+	/* has at least one d2l-table-col-sort-button with [nosort], does not have d2l-table-col-sort-button without nosort */
+	.d2l-table th d2l-table-col-sort-button[nosort] ~ :last-child {
+		padding-inline-end: calc(0.6rem + 18px);
+	}
+	.d2l-table th d2l-table-col-sort-button:not([nosort]) ~ :last-child {
+		padding-inline-end: unset;
 	}
 
 	/* border radiuses */

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -124,8 +124,11 @@ export const tableStyles = css`
 			--d2l-table-col-sort-button-width: unset;
 		}
 		/* has at least one d2l-table-col-sort-button with [nosort], does not have d2l-table-col-sort-button without nosort */
-		.d2l-table > * > tr > :has(d2l-table-col-sort-button[nosort]:not(:only-child)):not(:has(d2l-table-col-sort-button:not([nosort]))) :last-child {
+		.d2l-table > * > tr > * > d2l-table-col-sort-button[nosort] ~ :last-child {
 			padding-inline-end: calc(0.6rem + 18px);
+		}
+		.d2l-table > * > tr > * > d2l-table-col-sort-button:not([nosort]) ~ :last-child {
+			padding-inline-end: unset;
 		}
 	}
 


### PR DESCRIPTION
[GAUD-7064](https://desire2learn.atlassian.net/browse/GAUD-7064): Table style updates causing performance issues

Details in [Slack thread](https://d2l.slack.com/archives/C0PHG3QB0/p1725475530489959)

This particular selector was creating performance issues in larger tables for somewhat obvious reasons, given how CSS processes selectors. Instead of forcing it to jump up and down the tree we can instead use a general sibling selector to set the property, then `unset` the property when a separate sibling selector matches.

[GAUD-7064]: https://desire2learn.atlassian.net/browse/GAUD-7064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ