### PR TITLE
feat: DAYL-96 Update Count Badge a11y docn

### DIFF
--- a/components/count-badge/README.md
+++ b/components/count-badge/README.md
@@ -24,30 +24,21 @@ The `d2l-count-badge` element is a web component to display a number count, depe
 </script>
 <d2l-count-badge size="small" type="notification" text="100 new notifications" number="100" has-tooltip tab-stop></d2l-count-badge>
 ```
-
-### Accessibility Properties
-| Attribute | Description |
-|---|---|
-| `text`  | REQUIRED: Only the text will be read by screen-readers (not the number), so include the number in the text. |
-| `tab-stop` | A tab stop allows screen-reader users to easily tab to the badge. Otherwise, screen-reader users will need to arrow through to the badge. |
-| `announce-changes` | Use "announce-changes" if screen-reader users should be notified that the badge has been updated, such as a new notification. The "text" property will be read as soon as the screen-reader is idle. |
-| `has-tooltip` | The tooltip will be visible on hover/tab-stop, and read out by screen-readers. |
-
 <!-- docs: start hidden content -->
 ### Properties
 
 | Property | Type | Description |
 |---|---|---|
 | `number` | Number, required | The number to display on the badge.  Must be a positive integer. |
-| `size`, default: `small` | String | The size of the badge. Valid options are `"small"` and `"large"`. |
-| `type`, default: `count` | String | The type of the badge. Valid options are `"notification"` and `"count"`. Notification badges are orange and count badges are grey. |
-| `max-digits`, default: `2` when `type="notification"`, `5` when `type="count"` | Number | Optionally specify a digit limit, after which numbers are truncated. Defaults to two for `"notification"` type and five for `"count"` type. Must be between 1-5.
-| `hide-zero`, default: `false` | Boolean | Optionally choose not to show the count badge when the number is zero. |
-| `text`, required | String | Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled. |
-| `tab-stop`, default: `false` | Boolean | Optionally choose to make the badge a tab stop. |
-| `announce-changes`, default: `false` | Boolean | Optionally choose to announce changes to the badge with an aria-live region. If the text property is changed, the text will be read by screen-readers. |
-| `has-tooltip`, default: `false` | Boolean | Optionally choose to have a tooltip below the badge. |
-| `focus-ring`, default: `false` | Boolean | Optionally force a focus ring around the badge. This property can be used to highlight the badge when the parent element is focused. |
+| `size` | String, default: `small` | The size of the badge. Valid options are `"small"` and `"large"`. |
+| `type` | String, default: `count` | The type of the badge. Valid options are `"notification"` and `"count"`. Notification badges are orange and count badges are grey. |
+| `max-digits` | Number, default: `2` when `type="notification"`, `5` when `type="count"` | Specifies a digit limit, after which numbers are truncated. Defaults to two for `"notification"` type and five for `"count"` type. Must be between 1-5.
+| `hide-zero` | Boolean, default: `false` | Hides the count badge when `number` is zero. |
+| `text` | String, required | Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled. |
+| `tab-stop` | Boolean, default: `false` | Adds a tab stop to the badge, which allows screen-reader users to easily tab to the badge. |
+| `announce-changes` | Boolean, default: `false` | Announces changes to the badge with an `aria-live` region. If the number property is changed, the text will be read by screenreaders. |
+| `has-tooltip` | Boolean, default: `false` | Adds a tooltip on the badge, which will be visible on hover/tab-stop, and read out by screen-readers. |
+| `focus-ring` | Boolean, default: `false` | Forces the focus ring around the badge. This property can be used to highlight the badge when the parent element is focused. |
 <!-- docs: end hidden content -->
 
 ## Count Badge: Icon [d2l-count-badge-icon]
@@ -62,28 +53,28 @@ The `d2l-count-badge-icon` element is a web component to display a number count,
 <d2l-count-badge-icon size="small" icon="tier1:gear" type="notification" text="100 new settings applied." number="100" tab-stop has-tooltip></d2l-count-badge-icon>
 ```
 
-### Accessibility Properties
-| Attribute | Description |
-|---|---|
-| `text` | REQUIRED: Only the text will be read by screen-readers (not the number), so include the number in the text. |
-| `tab-stop` | A tab stop allows screen-reader users to easily tab to the badge. Otherwise, screen-reader users will need to arrow through to the badge. |
-| `announce-changes` | Use "announce-changes" if screen-reader users should be notified that the badge has been updated, such as a new notification. The "text" property will be read as soon as the screen-reader is idle. |
-| `has-tooltip` | The tooltip will be visible on hover/tab-stop, and read out by screen-readers. |
-
 <!-- docs: start hidden content -->
 ### Properties
 
 | Property | Type | Description |
 |--|--|--|
-| `number` | Number | Required: The number to display on the badge.  Must be a positive integer. |
-| `icon` | String | Required: [Preset icon key](../icons#preset-icons) (e.g. `tier1:gear`) |
-| `size`, default: `small` | String | The size of the badge. Valid options are `"small"` and `"large"`. |
-| `type`, default: `count` | String | The type of the badge. Valid options are `"notification"` and `"count"`. Notification badges are orange and count badges are grey. |
-| `max-digits`, default: `2` when `type="notification"`, `5` when `type="count"` | Number | Optionally specify a digit limit, after which numbers are truncated. Defaults to two for `"notification"` type and five for `"count"` type. Must be between 1-5.
-| `hide-zero`, default: `false` | Boolean | Optionally choose not to show the count badge when the number is zero. |
-| `text`  | String | REQUIRED: Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled. |
-| `tab-stop`, default: `false` | Boolean | Optionally choose to make the badge a tab stop. |
-| `announce-changes`, default: `false` | Boolean | Optionally choose to announce changes to the badge with an aria-live region. If the text property is changed, the text will be read by screen-readers. |
-| `has-tooltip`, default: `false` | Boolean | Optionally choose to have a tooltip below the badge. |
-| `focus-ring`, default: `false` | Boolean | Optionally force a focus ring around the badge. This property can be used to highlight the badge when the parent element is focused. |
+| `number` | Number, required | The number to display on the badge.  Must be a positive integer. |
+| `icon` | String, required | [Preset icon key](../icons#preset-icons) (e.g. `tier1:gear`) |
+| `size` | String, default: `small` | The size of the badge. Valid options are `"small"` and `"large"`. |
+| `type` | String, default: `count` | The type of the badge. Valid options are `"notification"` and `"count"`. Notification badges are orange and count badges are grey. |
+| `max-digits` | Number, default: `2` when `type="notification"`, `5` when `type="count"` | Specifies a digit limit, after which numbers are truncated. Defaults to two for `"notification"` type and five for `"count"` type. Must be between 1-5.
+| `hide-zero` | Boolean, default: `false` | Hides the count badge when `number` is zero. |
+| `text` | String, required | Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled. |
+| `tab-stop` | Boolean, default: `false` |  Adds a tab stop to the badge, which allows screen-reader users to easily tab to the badge. |
+| `announce-changes` | Boolean, default: `false` | Announces changes to the badge with an `aria-live` region. If the number property is changed, the text will be read by screenreaders. |
+| `has-tooltip` | Boolean, default: `false` | Adds a tooltip on the badge, which will be visible on hover/tab-stop, and read out by screen-readers. |
+| `focus-ring` | Boolean, default: `false` | Forces a focus ring around the badge. This property can be used to highlight the badge when the parent element is focused. |
 <!-- docs: end hidden content -->
+
+## Accessibility
+
+- While non-interactable components traditionally shouldn't be focusable, the `tab-stop` property greatly helps screen-reader users find the the count badge
+  - Otherwise, screen-reader users would have to use the arrow keys to get to the badge, which can take considerably longer
+  - If the optional tooltip is used, then `tab-stop` isn't necessary, as the count-badge becomes focusable to render the tooltip
+- The optional tooltip makes use of the [`d2l-toolip`](../../components/tooltip), which follows the [W3C best practices for Tooltips](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)
+  - The use of this tooltip can help provide additional context such as providing the exact number, if it were to go above the limit set in `max-digits`

--- a/components/count-badge/count-badge-mixin.js
+++ b/components/count-badge/count-badge-mixin.js
@@ -16,7 +16,7 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 	static get properties() {
 		return {
 			/**
-			 * Optionally choose to announce changes to the badge with an aria-live region. If the number property is changed, the text will be read by screenreaders. Defaults to false.
+			 * ACCESSIBILITY: Announces changes to the badge with an `aria-live` region. If the number property is changed, the text will be read by screenreaders.
 			 * @type {boolean}
 			 */
 			announceChanges: {
@@ -24,7 +24,7 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 				attribute: 'announce-changes'
 			},
 			/**
-			 * Optionally choose to force the focus ring around the badge. Defaults to false.
+			 * Forces the focus ring around the badge.
 			 * @type {boolean}
 			 */
 			forceFocusRing: {
@@ -33,7 +33,7 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 				reflect: true
 			},
 			/**
-			 * Optionally add a tooltip on the badge. Defaults to false.
+			 * ACCESSIBILITY: Adds a tooltip on the badge, which will be visible on hover/tab-stop, and read out by screen-readers.
 			 * @type {boolean}
 			 */
 			hasTooltip: {
@@ -41,7 +41,7 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 				attribute: 'has-tooltip'
 			},
 			/**
-			 * Optionally choose to not render the count badge when the number is zero. Defaults to false.
+			 * Hides the count badge when `number` is zero.
 			 * @type {boolean}
 			 */
 			hideZero: {
@@ -49,7 +49,7 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 				attribute: 'hide-zero'
 			},
 			/**
-			 * Optionally specify a digit limit, after which numbers are truncated.
+			 * Specifies a digit limit, after which numbers are truncated.
 			 * Defaults to two for "notification" type and five for "count" type.
 			 * @type {number}
 			 */
@@ -66,7 +66,7 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 				attribute: 'number'
 			},
 			/**
-			 * The size of the badge. Defaults to "small".
+			 * The size of the badge.
 			 * @type {'small'|'large'}
 			 */
 			size: {
@@ -75,7 +75,7 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 				attribute: 'size'
 			},
 			/**
-			 * Optionally choose to add a tab stop to the badge. Defaults to false.
+			 * ACCESSIBILITY: Adds a tab stop to the badge, which allows screen-reader users to easily tab to the badge.
 			 * @type {boolean}
 			 */
 			tabStop: {
@@ -83,14 +83,14 @@ export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(S
 				attribute: 'tab-stop'
 			},
 			/**
-			 * REQUIRED: Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled.
+			 * ACCESSIBILITY: REQUIRED: Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled.
 			 * @type {string}
 			 */
 			text: {
 				type: String
 			},
 			/**
-			 * The type of the badge. Defaults to "count".
+			 * The type of the badge.
 			 * @type {'count'|'notification'}
 			 */
 			type: {


### PR DESCRIPTION
Context for [DAYL-96](https://desire2learn.atlassian.net/browse/DAYL-96): Count Badge > Improve a11y doc'n

The purpose of this PR is to update the a11y documentation for the `d2l-count-badge` and `d2l-count-badge-icon` components. This primarily includes adding the `ACCESSIBILITY:` prefix in front of accessibility-based components and adding a section at the end of the readme with some a11y considerations.

I also had to update the properties tables in the readme, due to them being formatted differently than other readmes, so I've made them more consistent (the `default` and `required` fields are with the type now)