### PR TITLE
fix: input-time/hierarchical mixin: add rootView property to allow menus to specify that they are the root view

### DIFF
--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -130,7 +130,8 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 		// reset to root view
 		const menu = this.__getMenuElement();
-		if (!menu.rootView) menu.show({ preventFocus: true });
+		const activeView = menu.getActiveView();
+		if (menu !== activeView) menu.show({ preventFocus: true });
 	}
 
 	_onFocus(e) {

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -135,7 +135,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 		// reset to root view
 		const menu = this.__getMenuElement();
-		if(!this.ignoreHierarchy) menu.show({ preventFocus: true });
+		if (!this.ignoreHierarchy) menu.show({ preventFocus: true });
 	}
 
 	_onFocus(e) {

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -130,7 +130,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 		// reset to root view
 		const menu = this.__getMenuElement();
-		if (!menu.hasAttribute('data-root-view')) menu.show({ preventFocus: true });
+		if (!menu.rootView) menu.show({ preventFocus: true });
 	}
 
 	_onFocus(e) {

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -16,10 +16,6 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 	static get properties() {
 		return {
-			/**
-			 * @ignore
-			 */
-			ignoreHierarchy: { type: Boolean, attribute: 'ignore-hierarchy' },
 			_closeRadio: {
 				type: Boolean,
 				reflect: true,
@@ -65,7 +61,6 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 	constructor() {
 		super();
-		this.ignoreHierarchy = false;
 		this.noAutoFocus = true;
 		this.noPadding = true;
 		this._closeRadio = false;
@@ -135,7 +130,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 		// reset to root view
 		const menu = this.__getMenuElement();
-		if (!this.ignoreHierarchy) menu.show({ preventFocus: true });
+		if (!menu.hasAttribute('data-root-view')) menu.show({ preventFocus: true });
 	}
 
 	_onFocus(e) {

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -130,8 +130,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 		// reset to root view
 		const menu = this.__getMenuElement();
-		const activeView = menu.getActiveView();
-		if (menu !== activeView) menu.show({ preventFocus: true });
+		menu.show({ preventFocus: true });
 	}
 
 	_onFocus(e) {

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -16,6 +16,10 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 	static get properties() {
 		return {
+			/**
+			 * @ignore
+			 */
+			ignoreHierarchy: { type: Boolean, attribute: 'ignore-hierarchy' },
 			_closeRadio: {
 				type: Boolean,
 				reflect: true,
@@ -61,6 +65,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 	constructor() {
 		super();
+		this.ignoreHierarchy = false;
 		this.noAutoFocus = true;
 		this.noPadding = true;
 		this._closeRadio = false;
@@ -130,7 +135,7 @@ class DropdownMenu extends ThemeMixin(DropdownContentMixin(LitElement)) {
 
 		// reset to root view
 		const menu = this.__getMenuElement();
-		menu.show({ preventFocus: true });
+		if(!this.ignoreHierarchy) menu.show({ preventFocus: true });
 	}
 
 	_onFocus(e) {

--- a/components/filter/demo/filter.html
+++ b/components/filter/demo/filter.html
@@ -16,7 +16,7 @@
 		import './filter-load-more-demo.js';
 	</script>
 	<script>
-		window.D2L = { LP: { Web: { UI: { Flags: { Flag: () => true } } } } };
+		window.D2L = { LP: { Web: { UI: { Flags: { Flag: () => false } } } } };
 	</script>
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1.0">
     <meta charset="UTF-8">
@@ -172,7 +172,12 @@
 						<d2l-filter-dimension-set-date-text-value key="today" range="today"></d2l-filter-dimension-set-date-text-value>
 						<d2l-filter-dimension-set-date-text-value key="6months" range="6months"></d2l-filter-dimension-set-date-text-value>
 						<d2l-filter-dimension-set-date-time-range-value key="custom" type="date"></d2l-filter-dimension-set-date-time-range-value>
-						<d2l-filter-dimension-set-date-time-range-value key="custom2" text="Custom Date Range with Time"></d2l-filter-dimension-set-date-time-range-value>
+						<d2l-filter-dimension-set-date-time-range-value key="custom2" text="Custom Date Range with Time" start-value="2024-10-12T12:00:00Z"></d2l-filter-dimension-set-date-time-range-value>
+					</d2l-filter-dimension-set>
+					<d2l-filter-dimension-set key="role" text="Role" selected-first>
+						<d2l-filter-dimension-set-value key="admin" text="Admin" count="0"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="instructor" text="Instructor" count="22"></d2l-filter-dimension-set-value>
+						<d2l-filter-dimension-set-value key="student" text="Student" count="50"></d2l-filter-dimension-set-value>
 					</d2l-filter-dimension-set>
 				</d2l-filter>
 			</template>

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -257,13 +257,6 @@ class Filter extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) {
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 		this.addEventListener('d2l-filter-dimension-data-change', this._handleDimensionDataChange);
-
-		// Prevent these events from bubbling out of the filter
-		this.addEventListener('d2l-hierarchical-view-hide-complete', this._stopPropagation);
-		this.addEventListener('d2l-hierarchical-view-hide-start', this._stopPropagation);
-		this.addEventListener('d2l-hierarchical-view-show-complete', this._stopPropagation);
-		this.addEventListener('d2l-hierarchical-view-show-start', this._stopPropagation);
-		this.addEventListener('d2l-hierarchical-view-resize', this._stopPropagation);
 	}
 
 	render() {

--- a/components/filter/test/filter.axe.js
+++ b/components/filter/test/filter.axe.js
@@ -60,12 +60,13 @@ describe('d2l-filter', () => {
 	it('Multiple dimensions drilling in', async() => {
 		const elem = await fixture(multiDimensionFixture);
 		const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
+		const menu = elem.shadowRoot.querySelector('d2l-menu');
 		const menuItem = elem.shadowRoot.querySelector('d2l-menu-item');
 
 		elem.opened = true;
 		await oneEvent(dropdown, 'd2l-dropdown-open');
 		menuItem.click();
-		await oneEvent(dropdown, 'd2l-hierarchical-view-show-complete');
+		await oneEvent(menu, 'd2l-hierarchical-view-show-complete');
 		await expect(elem).to.be.accessible({ ignoredRules: ['aria-roles', 'aria-required-children', 'aria-required-parent'] }); // d2l-list's grid mode does not apply the grid roles because of lack of iOS support
 	});
 

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -172,6 +172,7 @@ describe('d2l-filter', () => {
 				</d2l-filter>
 			`);
 			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
+			const menu = elem.shadowRoot.querySelector('d2l-menu');
 			const dimensions = elem.shadowRoot.querySelectorAll('d2l-menu-item');
 
 			elem.opened = true;
@@ -189,9 +190,9 @@ describe('d2l-filter', () => {
 			expect(value2.shouldBubble).to.be.false;
 
 			setTimeout(() => dimensions[1].click());
-			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
+			await oneEvent(menu, 'd2l-hierarchical-view-show-complete');
 			setTimeout(() => dimensions[0].click());
-			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
+			await oneEvent(menu, 'd2l-hierarchical-view-show-complete');
 
 			await waitUntil(() => value2.shouldBubble, 'shouldBubble recalculated', { timeout: 3000 });
 			expect(value1.shouldBubble).to.be.true;
@@ -294,13 +295,14 @@ describe('d2l-filter', () => {
 		it('sets introductory text on a dimension in a multi-dimensional filter', async() => {
 			const elem = await fixture('<d2l-filter><d2l-filter-dimension-set introductory-text="Intro" key="dim"></d2l-filter-dimension-set><d2l-filter-dimension-set introductory-text="intro" key="dim"></d2l-filter-dimension-set></d2l-filter>');
 			const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
+			const menu = elem.shadowRoot.querySelector('d2l-menu');
 			const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
 
 			elem.opened = true;
 			await oneEvent(dropdown, 'd2l-dropdown-open');
 
 			setTimeout(() => dimension.click());
-			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
+			await oneEvent(menu, 'd2l-hierarchical-view-show-complete');
 
 			expect(elem._dimensions[0].introductoryText).to.equal('Intro');
 			const introText = elem.shadowRoot.querySelector('.d2l-filter-dimension-intro-text');
@@ -940,6 +942,7 @@ describe('d2l-filter', () => {
 				const elem = await fixture(multiDimensionFixture);
 				const eventSpy = spy(elem, 'dispatchEvent');
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
+				const menu = elem.shadowRoot.querySelector('d2l-menu');
 				const dimensions = elem.shadowRoot.querySelectorAll('d2l-menu-item');
 
 				elem.opened = true;
@@ -957,7 +960,7 @@ describe('d2l-filter', () => {
 				expect(eventSpy).to.be.calledTwice;
 
 				setTimeout(() => dimensions[0].click());
-				await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
+				await oneEvent(menu, 'd2l-hierarchical-view-show-complete');
 				expect(eventSpy).to.be.calledTwice;
 			});
 
@@ -1499,6 +1502,7 @@ describe('d2l-filter', () => {
 			it(`clicking ${testCase.key} in the header goes back to the dimension list`, async() => {
 				const elem = await fixture(multiDimensionFixture);
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
+				const menu = elem.shadowRoot.querySelector('d2l-menu');
 				const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
 				const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
 
@@ -1506,7 +1510,7 @@ describe('d2l-filter', () => {
 				await oneEvent(dropdown, 'd2l-dropdown-open');
 
 				setTimeout(() => dimension.click());
-				await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
+				await oneEvent(menu, 'd2l-hierarchical-view-show-complete');
 				expect(elem._activeDimensionKey).to.not.be.null;
 
 				const event = new CustomEvent('keydown', {
@@ -1520,7 +1524,7 @@ describe('d2l-filter', () => {
 
 				const returnButton = elem.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]');
 				setTimeout(() => returnButton.dispatchEvent(event));
-				await oneEvent(elem, 'd2l-hierarchical-view-hide-complete');
+				await oneEvent(menu, 'd2l-hierarchical-view-hide-complete');
 				expect(elem._activeDimensionKey).to.be.null;
 				expect(elem.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]')).to.be.null;
 				expect(elem.shadowRoot.querySelector('d2l-button-subtle[slot="header"]')).to.not.be.null;
@@ -1531,6 +1535,7 @@ describe('d2l-filter', () => {
 			it(`set dimension - clicking ${testCase.key} in the content goes back to the dimension list`, async() => {
 				const elem = await fixture(multiDimensionFixture);
 				const dropdown = elem.shadowRoot.querySelector('d2l-dropdown');
+				const menu = elem.shadowRoot.querySelector('d2l-menu');
 				const dropdownContent = elem.shadowRoot.querySelector('d2l-dropdown-menu');
 				const dimension = elem.shadowRoot.querySelector('d2l-menu-item');
 
@@ -1538,7 +1543,7 @@ describe('d2l-filter', () => {
 				await oneEvent(dropdown, 'd2l-dropdown-open');
 
 				setTimeout(() => dimension.click());
-				await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
+				await oneEvent(menu, 'd2l-hierarchical-view-show-complete');
 				expect(elem._activeDimensionKey).to.not.be.null;
 
 				const event = new CustomEvent('keydown', {
@@ -1553,7 +1558,7 @@ describe('d2l-filter', () => {
 				const firstListItem = elem.shadowRoot.querySelector('d2l-list-item');
 				firstListItem.focus();
 				setTimeout(() => firstListItem.dispatchEvent(event));
-				await oneEvent(elem, 'd2l-hierarchical-view-hide-complete');
+				await oneEvent(menu, 'd2l-hierarchical-view-hide-complete');
 				expect(elem._activeDimensionKey).to.be.null;
 				expect(elem.shadowRoot.querySelector('d2l-button-icon[icon="tier1:chevron-left"]')).to.be.null;
 				expect(elem.shadowRoot.querySelector('d2l-button-subtle[slot="header"]')).to.not.be.null;

--- a/components/hierarchical-view/demo/hierarchical-view.html
+++ b/components/hierarchical-view/demo/hierarchical-view.html
@@ -7,6 +7,11 @@
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import '../hierarchical-view.js';
+			import '../../dropdown/dropdown-menu.js';
+			import '../../dropdown/dropdown-button.js';
+			import '../../menu/menu.js';
+			import '../../menu/menu-item.js';
+
 		</script>
 		<style>
 			#view1, #view2a, #view2b, #view3, #view4 {
@@ -77,6 +82,30 @@
 									<div class="buttons">
 										<button id="btn-parent-view-2a">view 1 (parent)</button>
 										<button id="btn-view-3">view 3</button>
+										<d2l-dropdown-button text="Open!" primary>
+											<d2l-dropdown-menu >
+											  <d2l-menu label="Astronomy" root-view >
+												<d2l-menu-item text="Introduction"></d2l-menu-item>
+												<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+												<d2l-menu-item text="The Solar System">
+													<d2l-menu>
+														<d2l-menu-item text="Formation"></d2l-menu-item>
+														<d2l-menu-item text="Modern Solar System"></d2l-menu-item>
+														<d2l-menu-item text="Future Solar System"></d2l-menu-item>
+														<d2l-menu-item text="The Planets"></d2l-menu-item>
+														<d2l-menu-item text="The Sun"></d2l-menu-item>
+														<d2l-menu-item text="Solar &amp; Lunar Eclipses"></d2l-menu-item>
+														<d2l-menu-item text="Meteors &amp; Meteorites"></d2l-menu-item>
+														<d2l-menu-item text="Asteroids"></d2l-menu-item>
+														<d2l-menu-item text="Comets"></d2l-menu-item>
+													</d2l-menu>
+													</d2l-menu-item>
+													<d2l-menu-item text="Stars &amp; Galaxies"></d2l-menu-item>
+													<d2l-menu-item text="The Night Sky"></d2l-menu-item>
+													<d2l-menu-item text="The Universe"></d2l-menu-item>
+												</d2l-menu>
+											</d2l-dropdown-menu>
+										</d2l-dropdown-button>
 									</div>
 									view 2a
 									<div class="info">min-height: 400</div>

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -182,6 +182,12 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 		this.__updateRootView();
 
+		if (!this.rootView) return;
+		this.addEventListener('d2l-hierarchical-view-hide-complete', this.__stopPropagation);
+		this.addEventListener('d2l-hierarchical-view-hide-start', this.__stopPropagation);
+		this.addEventListener('d2l-hierarchical-view-show-complete', this.__stopPropagation);
+		this.addEventListener('d2l-hierarchical-view-show-start', this.__stopPropagation);
+		this.addEventListener('d2l-hierarchical-view-resize', this.__stopPropagation);
 	}
 
 	getActiveView() {
@@ -423,8 +429,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__onHideStart(e) {
-		if (this.rootView) e.stopPropagation();
-
 		// re-enable focusable ancestor
 		this.__resetAncestorTabIndicies(e.detail.sourceView);
 
@@ -485,8 +489,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__onShowStart(e) {
-		if (this.rootView) e.stopPropagation();
-
 		// disable focusable ancestors so they can't steal focus from custom views
 		this.__removeAncestorTabIndicies(e.detail.sourceView);
 
@@ -526,7 +528,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__onViewResize(e) {
-		if (this.rootView) e.stopPropagation();
 		if (this._height !== e.detail.height) {
 			this._height = e.detail.height;
 			this.style.height = `${e.detail.height}px`;
@@ -556,6 +557,10 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.__resizeObserver = this.__resizeObserver || new ResizeObserver(this.__bound_dispatchViewResize);
 		this.__resizeObserver.disconnect();
 		this.__resizeObserver.observe(content);
+	}
+
+	__stopPropagation(e) {
+		e.stopPropagation();
 	}
 
 	__updateAncestorTabIndicies(view, sourceAttribute, targetAttribute) {

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -166,7 +166,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
-		if(this.ignoreHierarchy) {
+		if (this.ignoreHierarchy) {
 			this.childView = false;
 			return;
 		}
@@ -432,7 +432,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__isChildView() {
-		if(this.ignoreHierarchy) {
+		if (this.ignoreHierarchy) {
 			this.childView = false;
 			return;
 		}

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -14,6 +14,10 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 			/**
 			 * @ignore
 			 */
+			ignoreHierarchy: { type: Boolean, attribute: 'ignore-hierarchy' },
+			/**
+			 * @ignore
+			 */
 			childView: { type: Boolean, reflect: true, attribute: 'child-view' },
 			/**
 			 * @ignore
@@ -106,6 +110,8 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.__isAutoSized = false;
 		this.__resizeObserver = null;
 		this.__hideAnimations = [];
+
+		this.ignoreHierarchy = false;
 	}
 
 	connectedCallback() {
@@ -159,6 +165,11 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
+
+		if(this.ignoreHierarchy) {
+			this.childView = false;
+			return;
+		}
 
 		this.addEventListener('keydown', this.__onKeyDown);
 		this.addEventListener('d2l-hierarchical-view-hide-start', this.__onHideStart);
@@ -421,6 +432,10 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__isChildView() {
+		if(this.ignoreHierarchy) {
+			this.childView = false;
+			return;
+		}
 		const parentView = findComposedAncestor(
 			this.parentNode,
 			(node) => { return node.hierarchicalView; }

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -113,7 +113,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	connectedCallback() {
 		super.connectedCallback();
 
-		this.__isChildView();
+		this.__updateRootView();
 
 		if (typeof(IntersectionObserver) === 'function') {
 			this.__intersectionObserver = new IntersectionObserver((entries) => {
@@ -180,7 +180,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.addEventListener('keyup', stopPropagation);
 		this.addEventListener('keypress', stopPropagation);
 
-		this.__isChildView();
+		this.__updateRootView();
 
 	}
 
@@ -206,12 +206,9 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		const rootView = findComposedAncestor(
 			this.parentNode,
 			(node) => {
-				return node.rootView || (node.hierarchicalView && !node._childView);
+				return node.rootView;
 			}
 		);
-		if (rootView) {
-			rootView.rootView = true;
-		}
 		return rootView;
 	}
 
@@ -425,21 +422,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		}
 	}
 
-	__isChildView() {
-		if (this.rootView) {
-			this._childView = false;
-			return;
-		}
-		const parentView = findComposedAncestor(
-			this.parentNode,
-			(node) => { return node.hierarchicalView; }
-		);
-
-		if (parentView) {
-			this._childView = true;
-		}
-	}
-
 	__onHideStart(e) {
 		// re-enable focusable ancestor
 		this.__resetAncestorTabIndicies(e.detail.sourceView);
@@ -584,6 +566,17 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 			}
 			node = getComposedParent(node);
 		}
+	}
+
+	__updateRootView() {
+		if (!this.hasAttribute('root-view')) {
+			const parentView = findComposedAncestor(
+				this.parentNode,
+				(node) => { return node.hierarchicalView; }
+			);
+			this.rootView = !parentView;
+		}
+		this._childView = !this.rootView;
 	}
 
 };

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -423,6 +423,8 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__onHideStart(e) {
+		if (this.rootView) e.stopPropagation();
+
 		// re-enable focusable ancestor
 		this.__resetAncestorTabIndicies(e.detail.sourceView);
 
@@ -483,6 +485,8 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__onShowStart(e) {
+		if (this.rootView) e.stopPropagation();
+
 		// disable focusable ancestors so they can't steal focus from custom views
 		this.__removeAncestorTabIndicies(e.detail.sourceView);
 
@@ -522,6 +526,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__onViewResize(e) {
+		if (this.rootView) e.stopPropagation();
 		if (this._height !== e.detail.height) {
 			this._height = e.detail.height;
 			this.style.height = `${e.detail.height}px`;

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -14,10 +14,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 			/**
 			 * @ignore
 			 */
-			ignoreHierarchy: { type: Boolean, attribute: 'ignore-hierarchy' },
-			/**
-			 * @ignore
-			 */
 			childView: { type: Boolean, reflect: true, attribute: 'child-view' },
 			/**
 			 * @ignore
@@ -110,8 +106,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 		this.__isAutoSized = false;
 		this.__resizeObserver = null;
 		this.__hideAnimations = [];
-
-		this.ignoreHierarchy = false;
 	}
 
 	connectedCallback() {
@@ -166,11 +160,6 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
-		if (this.ignoreHierarchy) {
-			this.childView = false;
-			return;
-		}
-
 		this.addEventListener('keydown', this.__onKeyDown);
 		this.addEventListener('d2l-hierarchical-view-hide-start', this.__onHideStart);
 		this.addEventListener('d2l-hierarchical-view-show-start', this.__onShowStart);
@@ -209,7 +198,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	getRootView() {
-		if (!this.childView) {
+		if (!this.childView || this.hasAttribute('data-root-view')) {
 			return this;
 		}
 		const rootView = findComposedAncestor(
@@ -432,7 +421,7 @@ export const HierarchicalViewMixin = superclass => class extends superclass {
 	}
 
 	__isChildView() {
-		if (this.ignoreHierarchy) {
+		if (this.hasAttribute('data-root-view')) {
 			this.childView = false;
 			return;
 		}

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -363,6 +363,7 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 					class="vdiff-target"
 					@d2l-dropdown-close="${this._handleDropdownClose}"
 					@d2l-dropdown-open="${this._handleDropdownOpen}"
+					ignore-hierarchy
 					no-padding-footer
 					max-height="${ifDefined(this.maxHeight)}"
 					min-width="195"
@@ -373,6 +374,7 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 						class="d2l-input-time-menu"
 						@d2l-menu-item-change="${this._handleDropdownChange}"
 						id="${this._dropdownId}"
+						ignore-hierarchy
 						role="listbox">
 						${menuItems}
 					</d2l-menu>

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -363,7 +363,6 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 					class="vdiff-target"
 					@d2l-dropdown-close="${this._handleDropdownClose}"
 					@d2l-dropdown-open="${this._handleDropdownOpen}"
-					ignore-hierarchy
 					no-padding-footer
 					max-height="${ifDefined(this.maxHeight)}"
 					min-width="195"
@@ -374,8 +373,8 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 						class="d2l-input-time-menu"
 						@d2l-menu-item-change="${this._handleDropdownChange}"
 						id="${this._dropdownId}"
-						ignore-hierarchy
-						role="listbox">
+						role="listbox"
+						data-root-view>
 						${menuItems}
 					</d2l-menu>
 					<div class="d2l-input-time-timezone d2l-body-small" id="${dropdownIdTimezone}" slot="footer">${this._timezone}</div>

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -374,7 +374,7 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 						@d2l-menu-item-change="${this._handleDropdownChange}"
 						id="${this._dropdownId}"
 						role="listbox"
-						data-root-view>
+						root-view>
 						${menuItems}
 					</d2l-menu>
 					<div class="d2l-input-time-timezone d2l-body-small" id="${dropdownIdTimezone}" slot="footer">${this._timezone}</div>

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -128,7 +128,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 		changedProperties.forEach((oldValue, propName) => {
 			if (propName === 'label') this._labelChanged();
 
-			if (propName === '_childView' && this._childView) {
+			if (propName === 'rootView' && !this.rootView) {
 				const items = this.shadowRoot.querySelector('.d2l-menu-items');
 				items.insertBefore(this._createReturnItem(), items.childNodes[0]);
 
@@ -276,7 +276,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 			return;
 		}
 
-		if (this._childView && e.keyCode === keyCodes.LEFT) {
+		if (!this.rootView && e.keyCode === keyCodes.LEFT) {
 			e.stopPropagation();
 			this.hide();
 			return;
@@ -343,7 +343,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 	}
 
 	_onViewResize(e) {
-		if (this._childView) return;
+		if (!this.rootView) return;
 
 		const eventDetails = {
 			bubbles: true,

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -128,7 +128,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 		changedProperties.forEach((oldValue, propName) => {
 			if (propName === 'label') this._labelChanged();
 
-			if (propName === 'childView' && this.childView) {
+			if (propName === '_childView' && this._childView) {
 				const items = this.shadowRoot.querySelector('.d2l-menu-items');
 				items.insertBefore(this._createReturnItem(), items.childNodes[0]);
 
@@ -276,7 +276,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 			return;
 		}
 
-		if (this.childView && e.keyCode === keyCodes.LEFT) {
+		if (this._childView && e.keyCode === keyCodes.LEFT) {
 			e.stopPropagation();
 			this.hide();
 			return;
@@ -343,7 +343,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 	}
 
 	_onViewResize(e) {
-		if (this.childView) return;
+		if (this._childView) return;
 
 		const eventDetails = {
 			bubbles: true,


### PR DESCRIPTION
[Jira task](https://desire2learn.atlassian.net/browse/GAUD-7124)

**Problem:**
When the `input-time` component is nested in a hierarchical-mixin (as in a nested filter dimension set) it doesn't open properly. This is due to it being a child-view and the logic of the dropdown menu and hierarchical mixin for child views taking over.

**PR Notes:**
I added `ignore-hierarchy` attributes to `dropdown-menu` and `hierarchical-mixin` for this case and used this in `input-time`. A safer option if we want to reduce risk would be to also pass this through from `d2l-filter-dimension-set-date-time-range-value` all the way to the nested `input-time`, though I believe we would want this behaviour to always be the case.

This is a bit of a complex situation and I'm very open to other thoughts on how to handle this.