### PR TITLE
fix: load-more pager should fall back to focusing on item

### DIFF
--- a/components/paging/pager-load-more.js
+++ b/components/paging/pager-load-more.js
@@ -136,7 +136,12 @@ class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(Rt
 			requestAnimationFrame(() => item.focus());
 		} else {
 			const firstFocusable = getFirstFocusableDescendant(item);
-			if (firstFocusable) firstFocusable.focus();
+			if (firstFocusable) {
+				firstFocusable.focus();
+			} else if (item.focus === nativeFocus) {
+				item.tabIndex = -1;
+				requestAnimationFrame(() => item.focus());
+			}
 		}
 	}
 

--- a/components/paging/test/pager-load-more.test.js
+++ b/components/paging/test/pager-load-more.test.js
@@ -1,37 +1,58 @@
 import '../pager-load-more.js';
-import { defineCE, expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { clickElem, defineCE, expect, fixture, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
 import { html, LitElement } from 'lit';
+import { reset, stub } from 'sinon';
+import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { PageableMixin } from '../pageable-mixin.js';
 
 const tagName = defineCE(
 	class extends PageableMixin(LitElement) {
 		render() {
-			return html`${this._renderPagerContainer()}`;
+			return html`${this._renderPagerContainer()}<slot></slot>`;
 		}
 		_getItemByIndex() { return null; }
 		_getItemShowingCount() { return 10; }
 	}
 );
 
+const focusableTag = defineCE(
+	class extends LitElement {
+		render() { return html`<button>focusable</button>`; }
+		focus() { this.shadowRoot.querySelector('button').focus();}
+	}
+);
+
 describe('d2l-pager-load-more', () => {
+
+	let el, getItemByIndexStub, pager, pagerButton;
+	beforeEach(async() => {
+		el = await fixture(`
+			<${tagName} item-count="30">
+				<d2l-pager-load-more slot="pager" has-more page-size="5"></d2l-pager-load-more>
+				<${focusableTag}></${focusableTag}>
+				<div id="focusable-descendant"><button>focusable descendant</button></div>
+				<div id="no-focusable-descendant">no focusable descendant</div>
+			</${tagName}>
+		`);
+		getItemByIndexStub = stub(el, '_getItemByIndex');
+		pager = el.querySelector('d2l-pager-load-more');
+		pagerButton = el.querySelector('d2l-pager-load-more').shadowRoot.querySelector('button');
+	});
+
+	afterEach(() => reset);
 
 	it('should construct', () => {
 		runConstructor('d2l-pager-load-more');
 	});
 
 	it('dispatches d2l-pager-load-more event when clicked', async() => {
-		const el = await fixture(`<${tagName} item-count="30"><d2l-pager-load-more slot="pager" has-more page-size="5"></d2l-pager-load-more></${tagName}`);
-		const pager = el.querySelector('d2l-pager-load-more');
-
-		setTimeout(() => pager.shadowRoot.querySelector('button').click());
+		clickElem(pagerButton);
 		await oneEvent(pager, 'd2l-pager-load-more');
 	});
 
 	it('does not dispatch d2l-pager-load-more event while loading', async() => {
-		const el = await fixture(`<${tagName} item-count="30"><d2l-pager-load-more slot="pager" has-more page-size="5"></d2l-pager-load-more></${tagName}`);
-		const pager = el.querySelector('d2l-pager-load-more');
 
-		setTimeout(() => pager.shadowRoot.querySelector('button').click());
+		clickElem(pagerButton);
 		await oneEvent(pager, 'd2l-pager-load-more');
 
 		// in loading state since e.detail.complete() was never called
@@ -49,9 +70,45 @@ describe('d2l-pager-load-more', () => {
 	});
 
 	it('should have the right initial item counts', async() => {
-		const el = await fixture(`<${tagName} item-count="30"><d2l-pager-load-more slot="pager" has-more page-size="5"></d2l-pager-load-more></${tagName}`);
-		const pager = el.querySelector('d2l-pager-load-more');
-
 		expect(pager._pageableInfo).to.eql({ itemCount: 30, itemShowingCount: 10 });
 	});
+
+	describe('focus', () => {
+
+		it('should not move focus when no item is provided', async() => {
+			getItemByIndexStub.returns(null);
+			clickElem(pagerButton);
+			const e = await oneEvent(pager, 'd2l-pager-load-more');
+			e.detail.complete();
+			expect(getComposedActiveElement()).to.equal(pagerButton);
+		});
+
+		it('should delegate focus when it implements its own focus method', async() => {
+			const focusableElem = el.querySelector(focusableTag);
+			getItemByIndexStub.returns(focusableElem);
+			clickElem(pagerButton);
+			const e = await oneEvent(pager, 'd2l-pager-load-more');
+			e.detail.complete();
+			await waitUntil(() => getComposedActiveElement() === focusableElem.shadowRoot.querySelector('button'));
+		});
+
+		it('should focus on first focusable descendant when no focus method is implemented', async() => {
+			getItemByIndexStub.returns(el.querySelector('#focusable-descendant'));
+			clickElem(pagerButton);
+			const e = await oneEvent(pager, 'd2l-pager-load-more');
+			e.detail.complete();
+			await waitUntil(() => getComposedActiveElement() === el.querySelector('#focusable-descendant > button'));
+		});
+
+		it('should focus on item if no other focus target can be found', async() => {
+			const focusableElem = el.querySelector('#no-focusable-descendant');
+			getItemByIndexStub.returns(focusableElem);
+			clickElem(pagerButton);
+			const e = await oneEvent(pager, 'd2l-pager-load-more');
+			e.detail.complete();
+			await waitUntil(() => getComposedActiveElement() === focusableElem);
+		});
+
+	});
+
 });


### PR DESCRIPTION
Discovered this in the Movie Tool where the rows in the table currently have no focusable descendants, so the load-more pager was simply leaving focus on the "load more" button.

After chatting with @dbatiste, we decided that focusing on the "first new item" that was loaded is the best we can do here.