### PR TITLE
feat: add event to load-more-pager for when new items are loaded

### DIFF
--- a/components/paging/README.md
+++ b/components/paging/README.md
@@ -101,3 +101,4 @@ pager.addEventListener('d2l-pager-load-more', e => {
 | Event | Description |
 |---|---|
 | `d2l-pager-load-more` | Dispatched when the user clicks the Load More button. The `pageSize` can be accessed from the event `target`. The consumer must call the `complete()` method on the event detail to signal completion after the new items have been loaded. |
+| `d2l-pager-load-more-loaded` | Dispatched after more items have been loaded.

--- a/components/paging/pager-load-more.js
+++ b/components/paging/pager-load-more.js
@@ -152,10 +152,7 @@ class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(Rt
 		}
 
 		await new Promise(requestAnimationFrame);
-		this.dispatchEvent(new CustomEvent('d2l-pager-load-more-loaded', {
-			bubbles: false,
-			composed: false
-		}));
+		this.dispatchEvent(new CustomEvent('d2l-pager-load-more-loaded'));
 
 	}
 

--- a/components/paging/pager-load-more.js
+++ b/components/paging/pager-load-more.js
@@ -126,7 +126,7 @@ class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(Rt
 		this._loading = false;
 
 		// wait a frame for async sub-components to render
-		await new Promise(resolve => requestAnimationFrame(resolve));
+		await new Promise(requestAnimationFrame);
 
 		const item = pageable._getItemByIndex(lastItemIndex + 1);
 
@@ -151,7 +151,7 @@ class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(Rt
 			itemToFocus.focus();
 		}
 
-		await new Promise(setTimeout);
+		await new Promise(requestAnimationFrame);
 		this.dispatchEvent(new CustomEvent('d2l-pager-load-more-loaded', {
 			bubbles: false,
 			composed: false

--- a/components/paging/pager-load-more.js
+++ b/components/paging/pager-load-more.js
@@ -17,6 +17,7 @@ const nativeFocus = document.createElement('div').focus;
 /**
  *  A pager component for load-more paging.
  * @fires d2l-pager-load-more - Dispatched when the user clicks the load-more button. Consumers must call the provided "complete" method once items have been loaded.
+ * @fires d2l-pager-load-more-loaded - Dispatched after more items have been loaded.
  */
 class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(RtlMixin(LitElement)))) {
 
@@ -129,20 +130,33 @@ class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(Rt
 
 		const item = pageable._getItemByIndex(lastItemIndex + 1);
 
-		if (!item) return;
-		if (item.updateComplete) await item.updateComplete;
-
-		if (item.focus !== nativeFocus) {
-			requestAnimationFrame(() => item.focus());
-		} else {
-			const firstFocusable = getFirstFocusableDescendant(item);
-			if (firstFocusable) {
-				firstFocusable.focus();
-			} else if (item.focus === nativeFocus) {
-				item.tabIndex = -1;
-				requestAnimationFrame(() => item.focus());
+		let itemToFocus;
+		if (item) {
+			if (item.updateComplete) await item.updateComplete;
+			if (item.focus !== nativeFocus) {
+				itemToFocus = item;
+			} else {
+				const firstFocusable = getFirstFocusableDescendant(item);
+				if (firstFocusable) {
+					itemToFocus = firstFocusable;
+				} else if (item.focus === nativeFocus) {
+					item.tabIndex = -1;
+					itemToFocus = item;
+				}
 			}
 		}
+
+		if (itemToFocus) {
+			await new Promise(requestAnimationFrame);
+			itemToFocus.focus();
+		}
+
+		await new Promise(setTimeout);
+		this.dispatchEvent(new CustomEvent('d2l-pager-load-more-loaded', {
+			bubbles: false,
+			composed: false
+		}));
+
 	}
 
 }

--- a/components/paging/test/pager-load-more.test.js
+++ b/components/paging/test/pager-load-more.test.js
@@ -1,5 +1,5 @@
 import '../pager-load-more.js';
-import { clickElem, defineCE, expect, fixture, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
+import { clickElem, defineCE, expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { html, LitElement } from 'lit';
 import { reset, stub } from 'sinon';
 import { getComposedActiveElement } from '../../../helpers/focus.js';

--- a/components/paging/test/pager-load-more.test.js
+++ b/components/paging/test/pager-load-more.test.js
@@ -45,32 +45,36 @@ describe('d2l-pager-load-more', () => {
 		runConstructor('d2l-pager-load-more');
 	});
 
-	it('dispatches d2l-pager-load-more event when clicked', async() => {
-		clickElem(pagerButton);
-		await oneEvent(pager, 'd2l-pager-load-more');
-	});
-
-	it('does not dispatch d2l-pager-load-more event while loading', async() => {
-
-		clickElem(pagerButton);
-		await oneEvent(pager, 'd2l-pager-load-more');
-
-		// in loading state since e.detail.complete() was never called
-		let dispatched = false;
-		pager.addEventListener('d2l-pager-load-more', () => dispatched = true);
-		pager.shadowRoot.querySelector('button').click();
-
-		// make sure pager has a chance to dispatch the event
-		await new Promise(resolve => {
-			setTimeout(() => {
-				expect(dispatched).to.be.false;
-				resolve();
-			});
-		});
-	});
-
 	it('should have the right initial item counts', async() => {
 		expect(pager._pageableInfo).to.eql({ itemCount: 30, itemShowingCount: 10 });
+	});
+
+	describe('events', () => {
+
+		it('dispatches d2l-pager-load-more event when clicked', async() => {
+			clickElem(pagerButton);
+			await oneEvent(pager, 'd2l-pager-load-more');
+		});
+
+		it('does not dispatch d2l-pager-load-more event while loading', async() => {
+
+			clickElem(pagerButton);
+			await oneEvent(pager, 'd2l-pager-load-more');
+
+			// in loading state since e.detail.complete() was never called
+			let dispatched = false;
+			pager.addEventListener('d2l-pager-load-more', () => dispatched = true);
+			pager.shadowRoot.querySelector('button').click();
+
+			// make sure pager has a chance to dispatch the event
+			await new Promise(resolve => {
+				setTimeout(() => {
+					expect(dispatched).to.be.false;
+					resolve();
+				});
+			});
+		});
+
 	});
 
 	describe('focus', () => {
@@ -80,6 +84,7 @@ describe('d2l-pager-load-more', () => {
 			clickElem(pagerButton);
 			const e = await oneEvent(pager, 'd2l-pager-load-more');
 			e.detail.complete();
+			await oneEvent(pager, 'd2l-pager-load-more-loaded');
 			expect(getComposedActiveElement()).to.equal(pagerButton);
 		});
 
@@ -89,7 +94,8 @@ describe('d2l-pager-load-more', () => {
 			clickElem(pagerButton);
 			const e = await oneEvent(pager, 'd2l-pager-load-more');
 			e.detail.complete();
-			await waitUntil(() => getComposedActiveElement() === focusableElem.shadowRoot.querySelector('button'));
+			await oneEvent(pager, 'd2l-pager-load-more-loaded');
+			expect(getComposedActiveElement()).to.equal(focusableElem.shadowRoot.querySelector('button'));
 		});
 
 		it('should focus on first focusable descendant when no focus method is implemented', async() => {
@@ -97,7 +103,8 @@ describe('d2l-pager-load-more', () => {
 			clickElem(pagerButton);
 			const e = await oneEvent(pager, 'd2l-pager-load-more');
 			e.detail.complete();
-			await waitUntil(() => getComposedActiveElement() === el.querySelector('#focusable-descendant > button'));
+			await oneEvent(pager, 'd2l-pager-load-more-loaded');
+			expect(getComposedActiveElement()).to.equal(el.querySelector('#focusable-descendant > button'));
 		});
 
 		it('should focus on item if no other focus target can be found', async() => {
@@ -106,7 +113,8 @@ describe('d2l-pager-load-more', () => {
 			clickElem(pagerButton);
 			const e = await oneEvent(pager, 'd2l-pager-load-more');
 			e.detail.complete();
-			await waitUntil(() => getComposedActiveElement() === focusableElem);
+			await oneEvent(pager, 'd2l-pager-load-more-loaded');
+			expect(getComposedActiveElement()).to.equal(focusableElem);
 		});
 
 	});

--- a/components/paging/test/pager-load-more.vdiff.js
+++ b/components/paging/test/pager-load-more.vdiff.js
@@ -43,7 +43,7 @@ describe('pager-load-more', () => {
 			e.detail.complete();
 		});
 		clickElem(pager);
-		await oneEvent(pager, 'd2l-pager-load-more');
+		await oneEvent(pager, 'd2l-pager-load-more-loaded');
 		await expect(elem).to.be.golden();
 	});
 


### PR DESCRIPTION
I found myself needing to know when the items had actually loaded when writing a vdiff test.