### PR TITLE
Fix the order of private members for linting.

### DIFF
--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -34,16 +34,6 @@ class FocusTrap extends FocusMixin(LitElement) {
 		`;
 	}
 
-	static #exemptSelectors = [
-		'.d2l-focus-trap-exempt',
-		'.equatio-toolbar-wrapper',
-		'.equatio-toolbar-shadow-root-container'
-	].join(', ');
-
-	static #isExempt(target) {
-		return !!target?.closest(this.#exemptSelectors);
-	}
-
 	constructor() {
 		super();
 		this.trap = false;
@@ -90,6 +80,12 @@ class FocusTrap extends FocusMixin(LitElement) {
 			traps.splice(trapIndex, 1);
 		}
 	}
+
+	static #exemptSelectors = [
+		'.d2l-focus-trap-exempt',
+		'.equatio-toolbar-wrapper',
+		'.equatio-toolbar-shadow-root-container'
+	].join(', ');
 
 	_focusFirst() {
 		const focusable = this.shadowRoot &&
@@ -145,6 +141,10 @@ class FocusTrap extends FocusMixin(LitElement) {
 			}
 		}
 		this._focusFirst();
+	}
+
+	static #isExempt(target) {
+		return !!target?.closest(this.#exemptSelectors);
 	}
 
 }

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -2,13 +2,6 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends superclass {
 
-	#loadingCompleteResolve;
-
-	// eslint-disable-next-line sort-class-members/sort-class-members
-	#loadingCompletePromise = !Object.prototype.hasOwnProperty.call(this.constructor.prototype, 'getLoadingComplete')
-		? new Promise(resolve => this.#loadingCompleteResolve = resolve)
-		: Promise.resolve();
-
 	get loadingComplete() {
 		return this.getLoadingComplete();
 	}
@@ -26,5 +19,12 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 		await super.getLoadingComplete?.();
 		return this.#loadingCompletePromise;
 	}
+
+	#loadingCompleteResolve;
+
+	// eslint-disable-next-line sort-class-members/sort-class-members
+	#loadingCompletePromise = !Object.prototype.hasOwnProperty.call(this.constructor.prototype, 'getLoadingComplete')
+		? new Promise(resolve => this.#loadingCompleteResolve = resolve)
+		: Promise.resolve();
 
 });

--- a/mixins/localize/localize-mixin.js
+++ b/mixins/localize/localize-mixin.js
@@ -5,8 +5,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinBaseClass extends getLocalizeClass(superclass) {
 
-	#updatedProperties = new Map();
-
 	constructor() {
 		super();
 		super.constructor.setLocalizeMarkup(localizeMarkup);
@@ -62,6 +60,8 @@ export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinB
 	onLocalizeResourcesChange() {
 		this.requestUpdate('localize');
 	}
+
+	#updatedProperties = new Map();
 
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4863,11 +4863,10 @@
       }
     },
     "node_modules/eslint-config-brightspace": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-brightspace/-/eslint-config-brightspace-1.1.1.tgz",
-      "integrity": "sha512-VuSnruCizrPkAoWmsse/3Umy4lFlg9S+ucBt4kiP90ZQbnNsbywUBq9Hic0yLwBqMMwjwm7UNyFwdG92t4dpWg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-brightspace/-/eslint-config-brightspace-1.2.0.tgz",
+      "integrity": "sha512-zR49K7TocPhlaRCRtwB116KWSCeKl/sFZjpKLslrM5gOEhQz5LfesEdqKWtNSHImYne4laW+fbLqKhhBlpp8vQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@babel/eslint-parser": ">= 7",
         "eslint": ">= 7",


### PR DESCRIPTION
This PR bumps `eslint-config-brightspace` to v1.2.0 so that private members defined with `#` are identified as private for linting. Otherwise, eslint will expect these private members to be sorted among the public properties and methods.