### PR TITLE
Avoid unnecessary demo/code-view rerendering

### DIFF
--- a/components/count-badge/demo/count-badge.html
+++ b/components/count-badge/demo/count-badge.html
@@ -27,6 +27,12 @@
 				<template>
 					<d2l-count-badge id="badge-announce-changes"size="small" announce-changes tab-stop text=" 1 new notification." type="notification" number="1"></d2l-count-badge>
 					<d2l-button id="increment-count">Increment Count</d2l-button>
+					<script type="module">
+						document.getElementById('increment-count').addEventListener('click', () => {
+							document.getElementById('badge-announce-changes').number += 1;
+							document.getElementById('badge-announce-changes').text = `${document.getElementById('badge-announce-changes').number} new notifications.`;
+						});
+					</script>
 				</template>
 			</d2l-demo-snippet>
 
@@ -61,12 +67,7 @@
 					<d2l-count-badge size="small" has-tooltip text=" 2 new notifications." type="notification" number="2"></d2l-count-badge>
 				</template>
 			</d2l-demo-snippet>
+
 		</d2l-demo-page>
-		<script type="module">
-			document.getElementById('increment-count').addEventListener('click', () => {
-				document.getElementById('badge-announce-changes').number += 1;
-				document.getElementById('badge-announce-changes').text = `${document.getElementById('badge-announce-changes').number} new notifications.`;
-			});
-		</script>
 	</body>
 </html>

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -36,10 +36,6 @@ class CodeView extends LitElement {
 		super.attributeChangedCallback(name, oldval, newval);
 	}
 
-	firstUpdated() {
-		this._updateCode(this.shadowRoot.querySelector('slot'));
-	}
-
 	render() {
 		return html`
 			<div class="d2l-code-view-src"><slot @slotchange="${this._handleSlotChange}"></slot></div>

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -117,10 +117,6 @@ class DemoSnippet extends LitElement {
 		this._skeletonOn = false;
 	}
 
-	firstUpdated() {
-		this._updateCode(this.shadowRoot.querySelector('slot:not([name="_demo"])'));
-	}
-
 	render() {
 		const skeleton = this._hasSkeleton ? html`<d2l-switch text="Skeleton" ?on="${this._skeletonOn}" @change="${this._handleSkeletonChange}"></d2l-switch>` : null;
 		const switches = html`
@@ -137,7 +133,7 @@ class DemoSnippet extends LitElement {
 				<div class="d2l-demo-snippet-demo">
 					<div class="d2l-demo-snippet-demo-padding">
 						<slot name="_demo"></slot>
-						<slot></slot>
+						<slot @slotchange="${this._handleSlotChange}"></slot>
 					</div>
 				</div>
 				${settings}
@@ -152,13 +148,8 @@ class DemoSnippet extends LitElement {
 		changedProperties.forEach((_, prop) => {
 			if (prop === '_code') {
 				if (this.shadowRoot) this.shadowRoot.querySelector('d2l-code-view').forceUpdate();
-				this._updateHasSkeleton();
 			}
 		});
-	}
-
-	forceCodeUpdate() {
-		if (this.shadowRoot) this._updateCode(this.shadowRoot.querySelector('slot:not([name="_demo"])'));
 	}
 
 	_applyAttr(name, value, applyToShadowRoot) {
@@ -239,6 +230,10 @@ class DemoSnippet extends LitElement {
 		this._applyAttr('skeleton', this._skeletonOn, false);
 	}
 
+	_handleSlotChange(e) {
+		this._updateCode(e.target);
+	}
+
 	_removeImportedDemo() {
 		if (!this.shadowRoot) return;
 		const nodes = this.shadowRoot.querySelector('slot[name="_demo"]').assignedNodes();
@@ -276,6 +271,8 @@ class DemoSnippet extends LitElement {
 		}
 		const textNode = document.createTextNode(this._formatCode(tempContainer.innerHTML));
 		this._code = textNode.textContent;
+
+		this._updateHasSkeleton();
 	}
 
 	_updateHasSkeleton() {


### PR DESCRIPTION
[GAUD-7138](https://desire2learn.atlassian.net/browse/GAUD-7138)

This PR aims to eliminate the warnings arising from `d2l-demo-snippet` and `d2l-code-view` in demos. I chose to address these because they clutter up the console in all of our demo pages, and updating them is relatively low risk. We should address these warnings for other components as well, but changes to them carry a bit more risk so I didn't go down that rabbit hole for this change.

![image](https://github.com/user-attachments/assets/716385e6-cb94-45c8-8b99-e29fcc1eae00)


[GAUD-7138]: https://desire2learn.atlassian.net/browse/GAUD-7138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ