### PR TITLE
Add d2l-switch-before-change event to give consumers control of state

### DIFF
--- a/components/switch/demo/switch.html
+++ b/components/switch/demo/switch.html
@@ -74,7 +74,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-switch id="switch-with-confirm" text="Dark Mode"></d2l-switch>
-					<d2l-dialog-confirm id="confirm" title-text="Confirm" text="Are you sure? It's really dark.">
+					<d2l-dialog-confirm id="confirm" title-text="Confirm" text="Are you sure you want to change?">
 						<d2l-button slot="footer" primary data-dialog-action="yes">Yes</d2l-button>
 						<d2l-button slot="footer" data-dialog-action="no">No</d2l-button>
 					</d2l-dialog-confirm>
@@ -83,7 +83,7 @@
 						elem.addEventListener('d2l-switch-before-change', async e => {
 							e.preventDefault();
 							const confirmResult = await document.querySelector('#confirm').open();
-							e.detail.update(confirmResult === 'yes');
+							if (confirmResult === 'yes') e.detail.update(!elem.on);
 						});
 					</script>
 				</template>

--- a/components/switch/demo/switch.html
+++ b/components/switch/demo/switch.html
@@ -85,6 +85,7 @@
 							const confirmResult = await document.querySelector('#confirm').open();
 							if (confirmResult === 'yes') e.detail.update(!elem.on);
 						});
+						elem.addEventListener('change', e => console.log('switch changed', e.target.on));
 					</script>
 				</template>
 			</d2l-demo-snippet>

--- a/components/switch/demo/switch.html
+++ b/components/switch/demo/switch.html
@@ -6,6 +6,7 @@
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
 		<script type="module">
 			import '../../demo/demo-page.js';
+			import '../../dialog/dialog-confirm.js';
 			import '../switch.js';
 			import '../switch-visibility.js';
 		</script>
@@ -65,6 +66,26 @@
 							<li> Condition 3 </li>
 						</ul>
 					</d2l-switch-visibility>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>On/Off (confirm)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-switch id="switch-with-confirm" text="Dark Mode"></d2l-switch>
+					<d2l-dialog-confirm id="confirm" title-text="Confirm" text="Are you sure? It's really dark.">
+						<d2l-button slot="footer" primary data-dialog-action="yes">Yes</d2l-button>
+						<d2l-button slot="footer" data-dialog-action="no">No</d2l-button>
+					</d2l-dialog-confirm>
+					<script>
+						const elem = document.querySelector('#switch-with-confirm');
+						elem.addEventListener('d2l-switch-before-change', async e => {
+							e.preventDefault();
+							const confirmResult = await document.querySelector('#confirm').open();
+							e.detail.update(confirmResult === 'yes');
+						});
+					</script>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -252,8 +252,20 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 
 	_toggleState() {
 		if (this.disabled) return;
+
+		const beforeChangeEvent = new CustomEvent('d2l-switch-before-change', {
+			detail: {
+				update: on => this.on = on
+			},
+			cancelable: true
+		});
+
+		this.dispatchEvent(beforeChangeEvent);
+		if (beforeChangeEvent.defaultPrevented) return;
+
 		this.on = !this.on;
 		/** Dispatched when the `on` property is updated */
 		this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
 	}
+
 };

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -219,15 +219,6 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 		`;
 	}
 
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		if (changedProperties.get('on') === undefined) return;
-
-		/** Dispatched when the `on` property is updated */
-		this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
-	}
-
 	get _labelContent() {
 		return html`<span
 			@click='${this._handleClick}'
@@ -263,14 +254,21 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 		if (this.disabled) return;
 
 		const beforeChangeEvent = new CustomEvent('d2l-switch-before-change', {
-			detail: { update: on => this.on = on },
+			detail: { update: on => this._updateState(on) },
 			cancelable: true
 		});
 
 		this.dispatchEvent(beforeChangeEvent);
 		if (beforeChangeEvent.defaultPrevented) return;
 
-		this.on = !this.on;
+		this._updateState(!this.on);
+	}
+
+	_updateState(value) {
+		this.on = value;
+
+		/** Dispatched when the `on` property is updated */
+		this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
 	}
 
 };

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -219,13 +219,22 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 		`;
 	}
 
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		if (changedProperties.get('on') === undefined) return;
+
+		/** Dispatched when the `on` property is updated */
+		this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+	}
+
 	get _labelContent() {
 		return html`<span
-						@click='${this._handleClick}'
-						@mouseenter='${this._handleSwitchHover}'
-						@mouseleave='${this._handleSwitchHoverLeave}'>
-						${this.text}
-					</span>`;
+			@click='${this._handleClick}'
+			@mouseenter='${this._handleSwitchHover}'
+			@mouseleave='${this._handleSwitchHoverLeave}'>
+			${this.text}
+		</span>`;
 	}
 
 	_handleClick() {
@@ -254,9 +263,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 		if (this.disabled) return;
 
 		const beforeChangeEvent = new CustomEvent('d2l-switch-before-change', {
-			detail: {
-				update: on => this.on = on
-			},
+			detail: { update: on => this.on = on },
 			cancelable: true
 		});
 
@@ -264,8 +271,6 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 		if (beforeChangeEvent.defaultPrevented) return;
 
 		this.on = !this.on;
-		/** Dispatched when the `on` property is updated */
-		this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
 	}
 
 };

--- a/components/switch/switch-visibility.js
+++ b/components/switch/switch-visibility.js
@@ -8,6 +8,7 @@ import { SwitchMixin } from './switch-mixin.js';
 /**
  * A variant of the generic switch configured with special icons and default text for toggling "visibility".
  * @slot - Optional content that will be displayed within the "conditions" opener tooltip when the switch is on.
+ * @fires d2l-switch-before-change - Dispatched before on-state is updated. Can be canceled to allow the consumer to handle switching the on-state. This is useful if something needs to happen prior to the on-state being switched.
  */
 class VisibilitySwitch extends LocalizeCoreElement(SwitchMixin(LitElement)) {
 

--- a/components/switch/switch.js
+++ b/components/switch/switch.js
@@ -7,6 +7,7 @@ import { SwitchMixin } from './switch-mixin.js';
 /**
  * A generic switch with on/off semantics.
  * @attr {string} text - ACCESSIBILITY: REQUIRED: Acts as the primary label for the switch. Visible unless text-position is `hidden`.
+ * @fires d2l-switch-before-change - Dispatched before on-state is updated. Can be canceled to allow the consumer to handle switching the on-state. This is useful if something needs to happen prior to the on-state being switched.
  */
 class Switch extends SwitchMixin(LitElement) {
 

--- a/components/switch/test/switch.test.js
+++ b/components/switch/test/switch.test.js
@@ -1,5 +1,5 @@
 import '../switch.js';
-import { expect, fixture, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 
 const switchFixture = html`<d2l-switch text="some text"></d2l-switch>`;
@@ -43,6 +43,31 @@ describe('d2l-switch', () => {
 			await oneEvent(elem, 'change');
 			expect(elem.on).to.be.true;
 		});
+	});
+
+	describe('consumer manages state', () => {
+
+		it('click with no state management', async() => {
+			const elem = await fixture(switchFixture);
+			const clickTarget = elem.shadowRoot.querySelector('.d2l-switch-container');
+			elem.addEventListener('d2l-switch-before-change', e => {
+				e.preventDefault();
+			});
+			await clickElem(clickTarget);
+			expect(elem.on).to.be.false;
+		});
+
+		it('click with state management', async() => {
+			const elem = await fixture(switchFixture);
+			const clickTarget = elem.shadowRoot.querySelector('.d2l-switch-container');
+			elem.addEventListener('d2l-switch-before-change', e => {
+				e.preventDefault();
+				e.detail.update(true);
+			});
+			await clickElem(clickTarget);
+			expect(elem.on).to.be.true;
+		});
+
 	});
 
 });

--- a/components/switch/test/switch.test.js
+++ b/components/switch/test/switch.test.js
@@ -49,22 +49,21 @@ describe('d2l-switch', () => {
 
 		it('click with no state management', async() => {
 			const elem = await fixture(switchFixture);
-			const clickTarget = elem.shadowRoot.querySelector('.d2l-switch-container');
 			elem.addEventListener('d2l-switch-before-change', e => {
 				e.preventDefault();
 			});
-			await clickElem(clickTarget);
+			await clickElem(elem);
 			expect(elem.on).to.be.false;
 		});
 
 		it('click with state management', async() => {
 			const elem = await fixture(switchFixture);
-			const clickTarget = elem.shadowRoot.querySelector('.d2l-switch-container');
 			elem.addEventListener('d2l-switch-before-change', e => {
 				e.preventDefault();
 				e.detail.update(true);
 			});
-			await clickElem(clickTarget);
+			clickElem(elem);
+			await oneEvent(elem, 'change');
 			expect(elem.on).to.be.true;
 		});
 


### PR DESCRIPTION
[GAUD-7204](https://desire2learn.atlassian.net/browse/GAUD-7204)

This PR adds the `d2l-switch-before-change` event to give consumers the ability to control the state. For instance, the consumer may display a confirmation dialog, and then toggle the switch state depending on the user's choice.

This approach mirrors what we recently did for `d2l-button-toggle` for the same type of scenario.

The demo page shows it in action.



[GAUD-7204]: https://desire2learn.atlassian.net/browse/GAUD-7204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ