### PR TITLE
fix: don't hide backdrop elements until focus is inside target

### DIFF
--- a/components/backdrop/README.md
+++ b/components/backdrop/README.md
@@ -1,6 +1,6 @@
 # Backdrops
 
-The `d2l-backdrop` element is a web component to display a semi-transparent backdrop behind a specified sibling element. It also hides elements other than the target from assistive technologies by applying `role="presentation"` and `aria-hidden="true"`.
+The `d2l-backdrop` element displays a semi-transparent backdrop behind a specified sibling target element. It also hides elements other than the target from assistive technologies by applying `aria-hidden="true"`.
 
 ## Backdrop [d2l-backdrop]
 
@@ -9,7 +9,6 @@ The `d2l-backdrop` element is a web component to display a semi-transparent back
 <script type="module">
   import '@brightspace-ui/core/components/button/button.js';
   import '@brightspace-ui/core/components/backdrop/backdrop.js';
-  import '@brightspace-ui/core/components/switch/switch.js';
 
   const backdrop = document.querySelector('d2l-backdrop');
   document.querySelector('#target > d2l-button').addEventListener('click', () => {
@@ -36,3 +35,11 @@ The `d2l-backdrop` element is a web component to display a semi-transparent back
 | `shown` | Boolean | Used to control whether the backdrop is shown |
 | `slow-transition` | Boolean | Increases the fade transition time to 1200ms (default is 200ms) |
 <!-- docs: end hidden content -->
+
+### Focus Management
+
+Elements with `aria-hidden` applied (as well as their descendants) are completely hidden from assistive technologies. It's therefore very important that the element with active focus be within the backdrop target.
+
+**When showing a backdrop**: first move focus inside the target, then set the `shown` attribute on the backdrop.
+
+**When hiding a backdrop**: first remove the `shown` attribute on the backdrop, then if appropriate move focus outside the target.


### PR DESCRIPTION
Recently, Chrome & Edge starting putting errors in the console if an element has `aria-hidden="true"` applied while focus is somewhere inside. Since `aria-hidden` hides an element and all its descendants, it seems like browsers were always applying some kind of exception when elements had focus -- but now they're notifying us of this.

The fix here to `<d2l-backdrop>` is to wait a short period of time for the consuming component to move focus inside the target before applying `aria-hidden`. After `200ms` if focus is still outside the target, we just hide them anyway and the developer may get a console error to investigate.

There are still a lot of consumers of `<d2l-backdrop>` that are using it purely as a specialized loading spinner, where the target has no focusable elements inside. In these cases, focus may simply be getting lost. I've added some notes about focus management to the `README`, and hopefully we can guide those consumers to a better solution.

