### PR TITLE
Switch to using d2l-link in object-property-item-link

### DIFF
--- a/components/object-property-list/demo/object-property-list.html
+++ b/components/object-property-list/demo/object-property-list.html
@@ -35,6 +35,7 @@
 						<d2l-object-property-list-item text="Example item"></d2l-object-property-list-item>
 						<d2l-object-property-list-item text="Example item with icon" icon="tier1:grade"></d2l-object-property-list-item>
 						<d2l-object-property-list-item-link text="Example link" href="https://www.d2l.com/"></d2l-object-property-list-item-link>
+						<d2l-object-property-list-item-link target="_blank" text="Example new tab link" href="https://www.d2l.com/"></d2l-object-property-list-item-link>
 						<d2l-object-property-list-item-link text="Example link with icon" href="https://www.d2l.com/" icon="tier1:alert"></d2l-object-property-list-item-link>
 					</d2l-object-property-list>
 				</template>

--- a/components/object-property-list/object-property-list-item-link.js
+++ b/components/object-property-list/object-property-list-item-link.js
@@ -38,7 +38,6 @@ class ObjectPropertyListItemLink extends FocusMixin(ObjectPropertyListItem) {
 			${this._renderIcon()}
 			${!this.skeleton ? html`
 				<d2l-link
-					aria-label="${this.text}"
 					?download="${this.download}"
 					href="${ifDefined(this.href)}"
 					target="${ifDefined(this.target)}">

--- a/components/object-property-list/object-property-list-item-link.js
+++ b/components/object-property-list/object-property-list-item-link.js
@@ -1,7 +1,7 @@
+import '../link/link.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { linkStyles } from '../link/link.js';
 import { ObjectPropertyListItem } from './object-property-list-item.js';
 
 /**
@@ -29,29 +29,21 @@ class ObjectPropertyListItemLink extends FocusMixin(ObjectPropertyListItem) {
 		};
 	}
 
-	static get styles() {
-		return [
-			...super.styles,
-			linkStyles
-		];
-	}
-
 	static get focusElementSelector() {
-		return '.d2l-link';
+		return 'd2l-link';
 	}
 
 	render() {
 		return html`
 			${this._renderIcon()}
 			${!this.skeleton ? html`
-				<a
+				<d2l-link
+					aria-label="${this.text}"
 					?download="${this.download}"
-					class="d2l-link"
 					href="${ifDefined(this.href)}"
-					target="${ifDefined(this.target)}"
-				>
+					target="${ifDefined(this.target)}">
 					${this._renderText()}
-				</a>
+				</d2l-link>
 			` : this._renderText()}
 			${this._renderSeparator()}
 		`;


### PR DESCRIPTION
[GAUD-7228](https://desire2learn.atlassian.net/browse/GAUD-7228)

Due to not using the `d2l-link` component, when `target="_blank"`, we weren't showing the "open in a new tab" functionality, so I've switched the `object-property-item-link` to use the `d2l-link` component instead of just the styling.

[GAUD-7228]: https://desire2learn.atlassian.net/browse/GAUD-7228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ