### PR TITLE
Prevent MathJax from reaching into html-block shadowDOM for rendering

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -98,7 +98,10 @@ export function loadMathJax(mathJaxConfig) {
 		options: {
 			menuOptions: {
 				settings: { zoom: 'None' }
-			}
+			},
+			skipHtmlTags: [
+				'd2l-html-block' // Prevents MathJax from reaching into the html-block to try to parse what's inside; we leave that to the custom renderer
+			]
 		},
 		loader: {
 			load: ['ui/menu']


### PR DESCRIPTION
This PR aims to (partially) address an issue we see when MathJax contexts end up nested. A good example of this is when an `html-block` ends up nested within a Content file that already has our MathJax helper injected. The helper tries to reach into the html-block and render the math, but fails horribly because of the shadowDOM boundary. This change forces the outer renderer to skip any `html-block`s when trying to render.

It's important to note that this doesn't fully solve the problem. MathJax still gets the styling wrong in this case because (unfortunately) the outer renderer ends up setting some kind of internal global configuration that causes the renderer running inside the `html-block` to miscalculate its styles.

I think a more robust solution would also require having the outer page wait for rendering to be finished, then purging any of MathJax's state, then going ahead and letting the outer rendering run. Even then, I'm not sure that would solve the problem, but it's certainly the best idea I can think of for isolating the two renderers.

Anyways, putting up what's here now because it's still closer to correct and it's at least worth a discussion of whether it's worth doing.