### PR TITLE
Update d2l-dialog describe-content doc comment

### DIFF
--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -35,7 +35,7 @@ class Dialog extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMix
 			critical: { type: Boolean },
 
 			/**
-			 * Whether to read the contents of the dialog on open
+			 * Whether to read the contents of the dialog on open. Only use if the content is relatively concise and contains only text since more complex HTML semantics will be ignored.
 			 */
 			describeContent: { type: Boolean, attribute: 'describe-content' },
 

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -35,7 +35,7 @@ class Dialog extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMix
 			critical: { type: Boolean },
 
 			/**
-			 * Whether to read the contents of the dialog on open. Only use if the content is relatively concise and contains only text since more complex HTML semantics will be ignored.
+			 * Causes screen readers to announce the content of the dialog on open. Only use if the content is concise and contains only text since screen readers ignore HTML semantics and some have a ~250 character limit.
 			 */
 			describeContent: { type: Boolean, attribute: 'describe-content' },
 


### PR DESCRIPTION
[GAUD-7337](https://desire2learn.atlassian.net/browse/GAUD-7337)

We need to provide more guidance on when to use `describe-content` because:

* users do not want a wall of text announced to them upon entering dialogs
* `describe-content` uses `aria-describedby` under the covers so...
  * browsers ignore complex HTML semantics in `aria-describedby` - they expect text content
  * some screenreaders seemingly have limits/bugs on the amount of `aria-describedby` content that it will announce (ex. [Jaws](https://github.com/FreedomScientific/standards-support/issues/705) limits to 267)

[GAUD-7337]: https://desire2learn.atlassian.net/browse/GAUD-7337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ