### PR TITLE
[GAUD 7145] - panel support tabs api

### DIFF
--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -1,0 +1,161 @@
+import '../colors/colors.js';
+import { css, html, unsafeCSS } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { getFocusPseudoClass } from '../../helpers/focus.js';
+import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
+
+const keyCodes = {
+	ENTER: 13,
+	SPACE: 32
+};
+
+export const TabMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			selected: { type: Boolean, reflect: true },
+			tabIndex: { type: Number },
+		};
+	};
+
+	static styles = css`
+        :host {
+            box-sizing: border-box;
+            display: inline-block;
+            max-width: 200px;
+            outline: none;
+            position: relative;
+            vertical-align: middle;
+        }
+        .d2l-tab-text {
+            margin: 0.5rem;
+            overflow: hidden;
+            padding: 0.1rem;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        :host(:first-child) .d2l-tab-text {
+            margin-left: 0;
+        }
+        .d2l-tab-selected-indicator {
+            border-top: 4px solid var(--d2l-color-celestine);
+            border-top-left-radius: 4px;
+            border-top-right-radius: 4px;
+            bottom: 0;
+            display: none;
+            margin: 1px 0.6rem 0 0.6rem;
+            position: absolute;
+            transition: box-shadow 0.2s;
+            width: calc(100% - 1.2rem);
+        }
+        :host(:first-child) .d2l-tab-selected-indicator {
+			margin-left: 0;
+			width: calc(100% - 0.6rem);
+		}
+        :host(:${unsafeCSS(getFocusPseudoClass())}) > .d2l-tab-text {
+            border-radius: 0.3rem;
+            box-shadow: 0 0 0 2px var(--d2l-color-celestine);
+            color: var(--d2l-color-celestine);
+        }
+        :host([aria-selected="true"]:focus) {
+            text-decoration: none;
+        }
+        :host(:hover) {
+            color: var(--d2l-color-celestine);
+            cursor: pointer;
+        }
+        :host([aria-selected="true"]:hover) {
+            color: inherit;
+            cursor: default;
+        }
+		:host([aria-selected="true"]) .d2l-tab-selected-indicator {
+			display: block;
+		}
+    `;
+
+	constructor() {
+		super();
+		this.role = 'tab';
+		this.selected = false;
+		this.tabIndex = -1;
+
+		this._handleResize = this._handleResize.bind(this);
+		this._resizeObserver = null;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.addEventListener('click', this._handleClick);
+		this.addEventListener('keydown', this._handleKeydown);
+		this.addEventListener('keyup', this._handleKeyup);
+
+		this.resizeObserver = new ResizeObserver(() => {
+			this.dispatchEvent(new CustomEvent('d2l-tab-resize', { bubbles: true, composed: true }));
+		});
+		this.resizeObserver.observe(this);
+	}
+
+	disconnectedCallback() {
+		if (this.resizeObserver) {
+			this.resizeObserver.disconnect();
+			this.resizeObserver = null;
+		}
+		removeEventListener('click', this._handleClick);
+		removeEventListener('keydown', this._handleKeydown);
+		removeEventListener('keyup', this._handleKeyup);
+		super.disconnectedCallback();
+	}
+
+	render() {
+		const contentClasses = {
+			'd2l-tab-text': true,
+		};
+
+		return html`
+			<div
+				class="${classMap(contentClasses)}"
+				aria-selected="${this.selected}"
+				role="tab"
+				tabindex=${this.tabIndex}>
+				${this.renderContent}
+			</div>
+			<div class="d2l-tab-selected-indicator"></div>
+		`;
+	}
+
+	update(changedProperties) {
+		super.update(changedProperties);
+		changedProperties.forEach((oldVal, prop) => {
+			if (prop === 'selected' && this.selected === 'true') {
+				this.dispatchEvent(new CustomEvent(
+					'd2l-tab-selected', { bubbles: true, composed: true }
+				));
+			} else if (prop === 'text') {
+				this.title = this.text;
+			}
+		});
+	}
+
+	renderContent() {
+		console.warn('Subclasses to implement/override renderContent');
+		return html`<div>Default Tab Content</div>`;
+	}
+
+	_handleClick() {
+		this.selected = true;
+	}
+
+	_handleKeydown(e) {
+		if (e.keyCode === keyCodes.SPACE || e.keyCode === keyCodes.ENTER) {
+			e.stopPropagation();
+			e.preventDefault();
+		}
+	}
+
+	_handleKeyup(e) {
+		if (e.keyCode === keyCodes.SPACE || e.keyCode === keyCodes.ENTER) {
+			this._handleClick();
+		}
+	}
+
+};

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -1,7 +1,5 @@
 import '../colors/colors.js';
-import { css, html, unsafeCSS } from 'lit';
-import { classMap } from 'lit/directives/class-map.js';
-import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { css, html } from 'lit';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 const keyCodes = {
@@ -10,6 +8,7 @@ const keyCodes = {
 };
 
 export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
+
 	static get properties() {
 		return {
 			selected: { type: Boolean, reflect: true },
@@ -24,17 +23,6 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 			outline: none;
 			position: relative;
 			vertical-align: middle;
-		}
-		.d2l-tab-text {
-			margin: 0.5rem;
-			overflow: hidden;
-			padding: 0.1rem;
-			text-overflow: ellipsis;
-			white-space: nowrap;
-		}
-		:host(:first-child) .d2l-tab-text {
-			margin-inline-end: 0.6rem;
-			margin-inline-start: 0;
 		}
 		.d2l-tab-selected-indicator {
 			border-top: 4px solid var(--d2l-color-celestine);
@@ -51,11 +39,6 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 			margin-inline-end: 0.6rem;
 			margin-inline-start: 0;
 			width: calc(100% - 0.6rem);
-		}
-		:host(:${unsafeCSS(getFocusPseudoClass())}) > .d2l-tab-text {
-			border-radius: 0.3rem;
-			box-shadow: 0 0 0 2px var(--d2l-color-celestine);
-			color: var(--d2l-color-celestine);
 		}
 		:host([aria-selected="true"]:focus) {
 			text-decoration: none;
@@ -104,15 +87,8 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	}
 
 	render() {
-		const overrideSkeletonText = this.skeleton && (!this.text || this.text.length === 0);
-		const contentClasses = {
-			'd2l-tab-text': true,
-			'd2l-skeletize': true,
-			'd2l-tab-text-skeletize-override': overrideSkeletonText
-		};
-
 		return html`
-			<div class="${classMap(contentClasses)}">
+			<div class="d2l-skeletize">
 				${this.renderContent()}
 			</div>
 			<div class="d2l-tab-selected-indicator d2l-skeletize-container"></div>
@@ -129,8 +105,6 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 						'd2l-tab-selected', { bubbles: true, composed: true }
 					));
 				}
-			} else if (prop === 'text') {
-				this.title = this.text;
 			}
 		});
 	}

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -12,11 +12,7 @@ const keyCodes = {
 export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	static get properties() {
 		return {
-			ariaSelected: { type: String, reflect: true, attribute: 'aria-selected' },
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
 			selected: { type: Boolean, reflect: true },
-			tabIndex: { type: Number, reflect: true },
 		};
 	}
 
@@ -79,38 +75,14 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 
 	constructor() {
 		super();
+		this.ariaSelected = false;
 		this.role = 'tab';
-		this.#selected = false;
+		this.selected = false;
 		this.tabIndex = -1;
 
 		this.#handleClickBound = this.#handleClick.bind(this);
 		this.#handleKeydownBound = this.#handleKeydown.bind(this);
 		this.#handleKeyupBound = this.#handleKeyup.bind(this);
-	}
-
-	get ariaSelected() {
-		return this.selected;
-	}
-
-	set ariaSelected(_) {
-		// ariaSelected is a derivative of `selected` and should not be set directly
-	}
-
-	get selected() {
-		return this.#selected;
-	}
-
-	set selected(value) {
-		const oldVal = this.#selected;
-		const newVal = Boolean(value);
-		if (oldVal !== newVal) {
-			this.#selected = newVal;
-			this.requestUpdate('selected', oldVal);
-			this.setAttribute('aria-selected', this.ariaSelected);
-			if (newVal) {
-				this.dispatchEvent(new CustomEvent('d2l-tab-selected', { bubbles: true, composed: true }));
-			}
-		}
 	}
 
 	connectedCallback() {
@@ -154,10 +126,13 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	update(changedProperties) {
 		super.update(changedProperties);
 		changedProperties.forEach((oldVal, prop) => {
-			if (prop === 'selected' && this.selected === 'true') {
-				this.dispatchEvent(new CustomEvent(
-					'd2l-tab-selected', { bubbles: true, composed: true }
-				));
+			if (prop === 'selected') {
+				this.ariaSelected = this.selected;
+				if (this.selected === 'true') {
+					this.dispatchEvent(new CustomEvent(
+						'd2l-tab-selected', { bubbles: true, composed: true }
+					));
+				}
 			} else if (prop === 'text') {
 				this.title = this.text;
 			}
@@ -169,7 +144,6 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		return html`<div>Default Tab Content</div>`;
 	}
 
-	#selected;
 	#handleClickBound;
 	#handleKeydownBound;
 	#handleKeyupBound;

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -160,13 +160,9 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	};
 
 	#addEventHandlers() {
-		if (!this._eventListenersAdded) {
-			this.addEventListener('click', this.#handleClick);
-			this.addEventListener('keydown', this.#handleKeydown);
-			this.addEventListener('keyup', this.#handleKeyup);
-
-			this._eventListenersAdded = true;
-		}
+		this.addEventListener('click', this.#handleClick);
+		this.addEventListener('keydown', this.#handleKeydown);
+		this.addEventListener('keyup', this.#handleKeyup);
 	}
 
 	#handleResize() {
@@ -174,13 +170,9 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	}
 
 	#removeEventHandlers() {
-		if (this._eventListenersAdded) {
-			this.removeEventListener('click', this.#handleClick);
-			this.removeEventListener('keydown', this.#handleKeydown);
-			this.removeEventListener('keyup', this.#handleKeyup);
-
-			this._eventListenersAdded = false;
-		}
+		this.removeEventListener('click', this.#handleClick);
+		this.removeEventListener('keydown', this.#handleKeydown);
+		this.removeEventListener('keyup', this.#handleKeyup);
 	}
 
 };

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -2,13 +2,14 @@ import '../colors/colors.js';
 import { css, html, unsafeCSS } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 const keyCodes = {
 	ENTER: 13,
 	SPACE: 32
 };
 
-export const TabMixin = superclass => class extends superclass {
+export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	#selected;
 	#handleClickBound;
 	#handleKeydownBound;
@@ -43,6 +44,7 @@ export const TabMixin = superclass => class extends superclass {
         }
         :host(:first-child) .d2l-tab-text {
         	margin-inline-start: 0;
+			margin-inline-end: 0.6rem;
         }
         .d2l-tab-selected-indicator {
             border-top: 4px solid var(--d2l-color-celestine);
@@ -57,6 +59,7 @@ export const TabMixin = superclass => class extends superclass {
         }
         :host(:first-child) .d2l-tab-selected-indicator {
 			margin-inline-start: 0;
+			margin-inline-end: 0.6rem;
 			width: calc(100% - 0.6rem);
 		}
         :host(:${unsafeCSS(getFocusPseudoClass())}) > .d2l-tab-text {
@@ -89,11 +92,6 @@ export const TabMixin = superclass => class extends superclass {
 		this.#handleClickBound = this.#handleClick.bind(this);
 		this.#handleKeydownBound = this.#handleKeydown.bind(this);
 		this.#handleKeyupBound = this.#handleKeyup.bind(this);
-
-		this.#resizeObserver = new ResizeObserver(() => {
-			this.#handleResize();
-		});
-		this.#resizeObserver.observe(this);
 	}
 
 	get selected() {
@@ -124,15 +122,23 @@ export const TabMixin = superclass => class extends superclass {
 	connectedCallback() {
 		super.connectedCallback();
 		this.#addEventHandlers();
+
+		if (!this.#resizeObserver) {
+			this.#resizeObserver = new ResizeObserver(() => {
+				this.#handleResize();
+			});
+			this.#resizeObserver.observe(this);
+		}
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
+		this.#removeEventHandlers();
+
 		if (this.#resizeObserver) {
 			this.#resizeObserver.disconnect();
 			this.#resizeObserver = null;
 		}
-		this.#removeEventHandlers();
 	}
 
 	render() {
@@ -170,9 +176,13 @@ export const TabMixin = superclass => class extends superclass {
 	}
 
 	#addEventHandlers() {
-		this.addEventListener('click', this.#handleClickBound);
-		this.addEventListener('keydown', this.#handleKeydownBound);
-		this.addEventListener('keyup', this.#handleKeyupBound);
+		if (!this._eventListenersAdded) {
+			this.addEventListener('click', this.#handleClickBound);
+			this.addEventListener('keydown', this.#handleKeydownBound);
+			this.addEventListener('keyup', this.#handleKeyupBound);
+
+			this._eventListenersAdded = true;
+		}
 	}
 
 	#handleClick() {
@@ -197,9 +207,13 @@ export const TabMixin = superclass => class extends superclass {
 	}
 
 	#removeEventHandlers() {
-		this.removeEventListener('click', this.#handleClickBound);
-		this.removeEventListener('keydown', this.#handleKeydownBound);
-		this.removeEventListener('keyup', this.#handleKeyupBound);
+		if (!!this._eventListenersAdded) {
+			this.removeEventListener('click', this.#handleClickBound);
+			this.removeEventListener('keydown', this.#handleKeydownBound);
+			this.removeEventListener('keyup', this.#handleKeyupBound);
+
+			this._eventListenersAdded = false;
+		}
 	}
 
 };

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -10,12 +10,6 @@ const keyCodes = {
 };
 
 export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
-	#selected;
-	#handleClickBound;
-	#handleKeydownBound;
-	#handleKeyupBound;
-	#resizeObserver;
-
 	static get properties() {
 		return {
 			ariaSelected: { type: String, reflect: true, attribute: 'aria-selected' },
@@ -24,7 +18,7 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 			selected: { type: Boolean, reflect: true },
 			tabIndex: { type: Number, reflect: true },
 		};
-	};
+	}
 
 	static styles = css`
         :host {
@@ -94,30 +88,30 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		this.#handleKeyupBound = this.#handleKeyup.bind(this);
 	}
 
-	get selected() {
-        return this.#selected;
-    }
-
-    set selected(value) {
-        const oldVal = this.#selected;
-        const newVal = Boolean(value);
-        if (oldVal !== newVal) {
-            this.#selected = newVal;
-            this.requestUpdate('selected', oldVal);
-            this.setAttribute('aria-selected', this.ariaSelected);
-            if (newVal) {
-                this.dispatchEvent(new CustomEvent('d2l-tab-selected', { bubbles: true, composed: true }));
-            }
-        }
+	get ariaSelected() {
+		return this.selected;
 	}
 
-    get ariaSelected() {
-        return this.selected;
-    }
+	set ariaSelected(_) {
+		// ariaSelected is a derivative of `selected` and should not be set directly
+	}
 
-    set ariaSelected(_) {
-        // ariaSelected is a derivative of `selected` and should not be set directly
-    }
+	get selected() {
+		return this.#selected;
+	}
+
+	set selected(value) {
+		const oldVal = this.#selected;
+		const newVal = Boolean(value);
+		if (oldVal !== newVal) {
+			this.#selected = newVal;
+			this.requestUpdate('selected', oldVal);
+			this.setAttribute('aria-selected', this.ariaSelected);
+			if (newVal) {
+				this.dispatchEvent(new CustomEvent('d2l-tab-selected', { bubbles: true, composed: true }));
+			}
+		}
+	}
 
 	connectedCallback() {
 		super.connectedCallback();
@@ -175,6 +169,12 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		return html`<div>Default Tab Content</div>`;
 	}
 
+	#selected;
+	#handleClickBound;
+	#handleKeydownBound;
+	#handleKeyupBound;
+	#resizeObserver;
+
 	#addEventHandlers() {
 		if (!this._eventListenersAdded) {
 			this.addEventListener('click', this.#handleClickBound);
@@ -207,7 +207,7 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	}
 
 	#removeEventHandlers() {
-		if (!!this._eventListenersAdded) {
+		if (this._eventListenersAdded) {
 			this.removeEventListener('click', this.#handleClickBound);
 			this.removeEventListener('keydown', this.#handleKeydownBound);
 			this.removeEventListener('keyup', this.#handleKeyupBound);

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -17,57 +17,57 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	}
 
 	static styles = css`
-        :host {
-            box-sizing: border-box;
-            display: inline-block;
-            max-width: 200px;
-            outline: none;
-            position: relative;
-            vertical-align: middle;
-        }
-        .d2l-tab-text {
-            margin: 0.5rem;
-            overflow: hidden;
-            padding: 0.1rem;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-        :host(:first-child) .d2l-tab-text {
-        	margin-inline-start: 0;
+		:host {
+			box-sizing: border-box;
+			display: inline-block;
+			max-width: 200px;
+			outline: none;
+			position: relative;
+			vertical-align: middle;
+		}
+		.d2l-tab-text {
+			margin: 0.5rem;
+			overflow: hidden;
+			padding: 0.1rem;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+		:host(:first-child) .d2l-tab-text {
 			margin-inline-end: 0.6rem;
-        }
-        .d2l-tab-selected-indicator {
-            border-top: 4px solid var(--d2l-color-celestine);
-            border-top-left-radius: 4px;
-            border-top-right-radius: 4px;
-            bottom: 0;
-            display: none;
-            margin: 1px 0.6rem 0 0.6rem;
-            position: absolute;
-            transition: box-shadow 0.2s;
-            width: calc(100% - 1.2rem);
-        }
-        :host(:first-child) .d2l-tab-selected-indicator {
 			margin-inline-start: 0;
+		}
+		.d2l-tab-selected-indicator {
+			border-top: 4px solid var(--d2l-color-celestine);
+			border-top-left-radius: 4px;
+			border-top-right-radius: 4px;
+			bottom: 0;
+			display: none;
+			margin: 1px 0.6rem 0 0.6rem;
+			position: absolute;
+			transition: box-shadow 0.2s;
+			width: calc(100% - 1.2rem);
+		}
+		:host(:first-child) .d2l-tab-selected-indicator {
 			margin-inline-end: 0.6rem;
+			margin-inline-start: 0;
 			width: calc(100% - 0.6rem);
 		}
-        :host(:${unsafeCSS(getFocusPseudoClass())}) > .d2l-tab-text {
-            border-radius: 0.3rem;
-            box-shadow: 0 0 0 2px var(--d2l-color-celestine);
-            color: var(--d2l-color-celestine);
-        }
-        :host([aria-selected="true"]:focus) {
-            text-decoration: none;
-        }
-        :host(:hover) {
-            color: var(--d2l-color-celestine);
-            cursor: pointer;
-        }
-        :host([aria-selected="true"]:hover) {
-            color: inherit;
-            cursor: default;
-        }
+		:host(:${unsafeCSS(getFocusPseudoClass())}) > .d2l-tab-text {
+			border-radius: 0.3rem;
+			box-shadow: 0 0 0 2px var(--d2l-color-celestine);
+			color: var(--d2l-color-celestine);
+		}
+		:host([aria-selected="true"]:focus) {
+			text-decoration: none;
+		}
+		:host(:hover) {
+			color: var(--d2l-color-celestine);
+			cursor: pointer;
+		}
+		:host([aria-selected="true"]:hover) {
+			color: inherit;
+			cursor: default;
+		}
 		:host([aria-selected="true"]) .d2l-tab-selected-indicator {
 			display: block;
 		}

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -79,10 +79,6 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		this.role = 'tab';
 		this.selected = false;
 		this.tabIndex = -1;
-
-		this.#handleClickBound = this.#handleClick.bind(this);
-		this.#handleKeydownBound = this.#handleKeydown.bind(this);
-		this.#handleKeyupBound = this.#handleKeyup.bind(this);
 	}
 
 	connectedCallback() {
@@ -144,35 +140,32 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		return html`<div>Default Tab Content</div>`;
 	}
 
-	#handleClickBound;
-	#handleKeydownBound;
-	#handleKeyupBound;
 	#resizeObserver;
 
-	#addEventHandlers() {
-		if (!this._eventListenersAdded) {
-			this.addEventListener('click', this.#handleClickBound);
-			this.addEventListener('keydown', this.#handleKeydownBound);
-			this.addEventListener('keyup', this.#handleKeyupBound);
-
-			this._eventListenersAdded = true;
-		}
-	}
-
-	#handleClick() {
+	#handleClick = () => {
 		this.selected = true;
-	}
+	};
 
-	#handleKeydown(e) {
+	#handleKeydown = e => {
 		if (e.keyCode === keyCodes.SPACE || e.keyCode === keyCodes.ENTER) {
 			e.stopPropagation();
 			e.preventDefault();
 		}
-	}
+	};
 
-	#handleKeyup(e) {
+	#handleKeyup = e => {
 		if (e.keyCode === keyCodes.SPACE || e.keyCode === keyCodes.ENTER) {
 			this.#handleClick();
+		}
+	};
+
+	#addEventHandlers() {
+		if (!this._eventListenersAdded) {
+			this.addEventListener('click', this.#handleClick);
+			this.addEventListener('keydown', this.#handleKeydown);
+			this.addEventListener('keyup', this.#handleKeyup);
+
+			this._eventListenersAdded = true;
 		}
 	}
 
@@ -182,9 +175,9 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 
 	#removeEventHandlers() {
 		if (this._eventListenersAdded) {
-			this.removeEventListener('click', this.#handleClickBound);
-			this.removeEventListener('keydown', this.#handleKeydownBound);
-			this.removeEventListener('keyup', this.#handleKeyupBound);
+			this.removeEventListener('click', this.#handleClick);
+			this.removeEventListener('keydown', this.#handleKeydown);
+			this.removeEventListener('keyup', this.#handleKeyup);
 
 			this._eventListenersAdded = false;
 		}

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -113,7 +113,7 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 
 		return html`
 			<div class="${classMap(contentClasses)}">
-				${this.renderContent}
+				${this.renderContent()}
 			</div>
 			<div class="d2l-tab-selected-indicator d2l-skeletize-container"></div>
 		`;

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -6,6 +6,11 @@ export const TabPanelMixin = superclass => class extends superclass {
 	static get properties() {
 		return {
 			/**
+			 * Hooks tab-panel to associated tab
+			 * @type {string}
+			 */
+			labelledBy: { type: String },
+			/**
 			 * Opt out of default padding/whitespace around the panel
 			 * @type {boolean}
 			 */
@@ -76,6 +81,8 @@ export const TabPanelMixin = superclass => class extends superclass {
 				this.dispatchEvent(new CustomEvent(
 					'd2l-tab-panel-text-changed', { bubbles: true, composed: true, detail: { text: this.text } }
 				));
+			} else if (prop === 'labelledBy') {
+				this.setAttribute('aria-labelledby', this.labelledBy);
 			}
 		});
 	}

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -1,0 +1,10 @@
+import { LitElement } from 'lit';
+import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
+import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
+import { TabMixin } from './tab-mixin.js';
+
+class Tab extends TabMixin(SkeletonMixin(RtlMixin(LitElement))) {
+
+}
+
+customElements.define('d2l-tab-wip', Tab);

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -5,6 +5,17 @@ import { TabMixin } from './tab-mixin.js';
 
 class Tab extends TabMixin(SkeletonMixin(RtlMixin(LitElement))) {
 
+	renderContent() {
+		return html`<slot></slot>`;
+	}
+
+	render() {
+		return html`
+			<div class="tab-handler">
+				${this.renderContent()}
+			</div>
+		`;
+	}
 }
 
 customElements.define('d2l-tab-wip', Tab);

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -1,13 +1,42 @@
-import { html, LitElement } from 'lit';
+import { css, html, LitElement, unsafeCSS } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { getFocusPseudoClass } from '../../helpers/focus.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { TabMixin } from './tab-mixin.js';
 
 class Tab extends TabMixin(SkeletonMixin(RtlMixin(LitElement))) {
 
+	static styles = css`
+		.d2l-tab-text {
+			margin: 0.5rem;
+			overflow: hidden;
+			padding: 0.1rem;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+		:host(:first-child) .d2l-tab-text {
+			margin-inline-end: 0.6rem;
+			margin-inline-start: 0;
+		}
+		:host(:${unsafeCSS(getFocusPseudoClass())}) > .d2l-tab-text {
+			border-radius: 0.3rem;
+			box-shadow: 0 0 0 2px var(--d2l-color-celestine);
+			color: var(--d2l-color-celestine);
+		}
+	`;
+
 	renderContent() {
+		const overrideSkeletonText = this.skeleton && (!this.text || this.text.length === 0);
+		const contentClasses = {
+			'd2l-tab-handler': true,
+			'd2l-tab-text': true,
+			'd2l-skeletize': true,
+			'd2l-tab-text-skeletize-override': overrideSkeletonText
+		};
+
 		return html`
-			<div class="tab-handler">
+			<div class="${classMap(contentClasses)}">
 				<slot></slot>
 			</div>
 		`;

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -5,15 +5,12 @@ import { TabMixin } from './tab-mixin.js';
 
 class Tab extends TabMixin(SkeletonMixin(RtlMixin(LitElement))) {
 
-	render() {
+	renderContent() {
 		return html`
 			<div class="tab-handler">
-				${this.renderContent()}
+				<slot></slot>
 			</div>
 		`;
-	}
-	renderContent() {
-		return html`<slot></slot>`;
 	}
 
 }

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -1,13 +1,9 @@
-import { LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { TabMixin } from './tab-mixin.js';
 
 class Tab extends TabMixin(SkeletonMixin(RtlMixin(LitElement))) {
-
-	renderContent() {
-		return html`<slot></slot>`;
-	}
 
 	render() {
 		return html`
@@ -16,6 +12,10 @@ class Tab extends TabMixin(SkeletonMixin(RtlMixin(LitElement))) {
 			</div>
 		`;
 	}
+	renderContent() {
+		return html`<slot></slot>`;
+	}
+
 }
 
 customElements.define('d2l-tab-wip', Tab);


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/GAUD-7145
- added `labelledBy` and sprouting `aria-labelledBy` from the prop as referenced in the ticket

@dbatiste , when it comes to the last point 

> Review updated . Some consumers are relying on d2l-tab-panel-selected so we probably need to keep this event. However, hopefully we only need to dispatch d2l-tab-panel-text-changed if text is provided, and we no longer need to dispatch that event with the new API.

We can't prune that part of the code until the new version is fully in place - just call out of scope for this story?

- Also, I originally pulled this down off of 7140's branch but I can rebase to main after realizing what the workload was