### PR TITLE
[GAUD-7145] tab-panel > add labelledBy support

### DIFF
--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -6,6 +6,11 @@ export const TabPanelMixin = superclass => class extends superclass {
 	static get properties() {
 		return {
 			/**
+			 * Hooks tab-panel to associated tab
+			 * @type {string}
+			 */
+			labelledBy: { type: String },
+			/**
 			 * Opt out of default padding/whitespace around the panel
 			 * @type {boolean}
 			 */
@@ -61,7 +66,9 @@ export const TabPanelMixin = superclass => class extends superclass {
 		super.updated(changedProperties);
 
 		changedProperties.forEach((oldVal, prop) => {
-			if (prop === 'selected') {
+			if (prop === 'labelledBy') {
+				this.setAttribute('aria-labelledby', this.labelledBy);
+			} else if (prop === 'selected') {
 				if (this.selected) {
 					requestAnimationFrame(() => {
 						/** Dispatched when a tab is selected */


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/GAUD-7145
- added `labelledBy` and sprouting `aria-labelledBy` from the prop as referenced in the ticket

@dbatiste , when it comes to the last point 

> Review updated . Some consumers are relying on d2l-tab-panel-selected so we probably need to keep this event. However, hopefully we only need to dispatch d2l-tab-panel-text-changed if text is provided, and we no longer need to dispatch that event with the new API.

We can't prune that part of the code until the new version is fully in place - just call out of scope for this story?

- Also, I originally pulled this down off of 7140's branch but I can rebase to main after realizing what the workload was