### PR TITLE
fix: add getLoadingComplete support to empty-state-illustrated

### DIFF
--- a/components/empty-state/empty-state-illustrated.js
+++ b/components/empty-state/empty-state-illustrated.js
@@ -113,7 +113,7 @@ class EmptyStateIllustrated extends LoadingCompleteMixin(PropertyRequiredMixin(L
 		};
 		const asyncVal = runAsync(
 			this.illustrationName,
-			async() => this.#getIllustration(this.illustrationName),
+			() => this.#getIllustration(this.illustrationName),
 			{
 				success: illustration => {
 					this.resolveLoadingComplete();

--- a/components/empty-state/test/empty-state-illustrated.vdiff.js
+++ b/components/empty-state/test/empty-state-illustrated.vdiff.js
@@ -1,7 +1,7 @@
 import '../empty-state-action-button.js';
 import '../empty-state-action-link.js';
 import '../empty-state-illustrated.js';
-import { expect, fixture, html, nextFrame } from '@brightspace-ui/testing';
+import { expect, fixture, html } from '@brightspace-ui/testing';
 import { nothing } from 'lit';
 
 function createEmptyState(opts) {
@@ -31,7 +31,6 @@ describe('empty-state-illustrated', () => {
 		].forEach(({ name, opts }) => {
 			it(`${size}-${name}`, async() => {
 				const elem = await fixture(createEmptyState(opts), { viewport: { width } });
-				await nextFrame();
 				await expect(elem).to.be.golden();
 			});
 		});


### PR DESCRIPTION
I noticed when using the illustrated empty state in a vdiff that it didn't wait for the SVG to render.