### PR TITLE
fix: use private variables for selection info

### DIFF
--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -16,21 +16,21 @@ export class SelectionInfo {
 		if (!allEnabledSelected) allEnabledSelected = false;
 		if (!keys) keys = [];
 		if (!state) state = SelectionInfo.states.none;
-		this._allEnabledSelected = allEnabledSelected;
-		this._keys = keys;
-		this._state = state;
+		this.#allEnabledSelected = allEnabledSelected;
+		this.#keys = keys;
+		this.#state = state;
 	}
 
 	get allEnabledSelected() {
-		return this._allEnabledSelected;
+		return this.#allEnabledSelected;
 	}
 
 	get keys() {
-		return this._keys;
+		return this.#keys;
 	}
 
 	get state() {
-		return this._state;
+		return this.#state;
 	}
 
 	static get states() {
@@ -41,6 +41,10 @@ export class SelectionInfo {
 			allPages: 'all-pages'
 		};
 	}
+
+	#allEnabledSelected;
+	#keys;
+	#state;
 
 }
 


### PR DESCRIPTION
I noticed that when you `console.log` the `SelectionInfo` class in dev tools, the "private" `_keys` and `_state` variables bubble to the top and make it less obvious that you shouldn't be using them.

<img width="535" alt="Screenshot 2025-01-06 at 4 37 22 PM" src="https://github.com/user-attachments/assets/a0d6705b-5abc-4174-a5c6-275f8a20a560" />

This switches things over to actually use private variables. I've updated the 2 repos that were incorrectly accessing the `_` versions.