### PR TITLE
Show the backdrop while displaying the popover as mobile tray

### DIFF
--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -626,8 +626,7 @@ export const PopoverMixin = superclass => class extends superclass {
 		// add 2 to content width since scrollWidth does not include border
 		const containerWidth = `${widthOverride + 20}px`;
 
-		let maxHeightOverride = '';
-		if (this.#ifrauContextInfo) maxHeightOverride = `${this.#ifrauContextInfo.availableHeight}px`;
+		const maxHeightOverride = this.#ifrauContextInfo ? `${this.#ifrauContextInfo.availableHeight}px` : '';
 
 		let topOverride;
 		if (this.#ifrauContextInfo) {

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -585,8 +585,8 @@ export const PopoverMixin = superclass => class extends superclass {
 		};
 
 		return {
-			width : widthStyle,
-			content : contentStyle
+			width: widthStyle,
+			content: contentStyle
 		};
 	}
 
@@ -676,8 +676,8 @@ export const PopoverMixin = superclass => class extends superclass {
 		};
 
 		return {
-			width : widthStyle,
-			content : contentStyle
+			width: widthStyle,
+			content: contentStyle
 		};
 	}
 
@@ -814,8 +814,8 @@ export const PopoverMixin = superclass => class extends superclass {
 		};
 
 		return {
-			width : widthStyle,
-			content : contentStyle
+			width: widthStyle,
+			content: contentStyle
 		};
 	}
 

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -1,3 +1,4 @@
+import '../backdrop/backdrop.js';
 import '../colors/colors.js';
 import '../focus-trap/focus-trap.js';
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
@@ -6,6 +7,7 @@ import { getComposedActiveElement, getFirstFocusableDescendant, getPreviousFocus
 import { getComposedParent, isComposedAncestor } from '../../helpers/dom.js';
 import { _offscreenStyleDeclarations } from '../offscreen/offscreen.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import { tryGetIfrauBackdropService } from '../../helpers/ifrauBackdropService.js';
 
 const defaultPreferredPosition = {
 	location: 'block-end', // block-start, block-end
@@ -46,6 +48,7 @@ export const PopoverMixin = superclass => class extends superclass {
 			_position: { state: true },
 			_preferredPosition: { state: true },
 			_rtl: { state: true },
+			_showBackdrop: { state: true },
 			_trapFocus: { state: true },
 			_useNativePopover: { type: String, reflect: true, attribute: 'popover' },
 			_width: { state: true }
@@ -207,6 +210,7 @@ export const PopoverMixin = superclass => class extends superclass {
 		super();
 		this.configure();
 		this._mobile = false;
+		this._showBackdrop = false;
 		this._useNativePopover = isSupported ? 'manual' : undefined;
 		this.#handleAncestorMutationBound = this.#handleAncestorMutation.bind(this);
 		this.#handleAutoCloseClickBound = this.#handleAutoCloseClick.bind(this);
@@ -236,8 +240,9 @@ export const PopoverMixin = superclass => class extends superclass {
 	async close() {
 		if (!this._opened) return;
 
-		this._opened = false;
+		const ifrauBackdropService = await tryGetIfrauBackdropService();
 
+		this._opened = false;
 		if (this._useNativePopover) this.hidePopover();
 
 		this._previousFocusableAncestor = null;
@@ -245,6 +250,13 @@ export const PopoverMixin = superclass => class extends superclass {
 		this.#removeMediaQueryHandlers();
 		this.#removeRepositionHandlers();
 		this.#clearDismissible();
+
+		if (ifrauBackdropService && this._showBackdrop) {
+			ifrauBackdropService.hideBackdrop();
+			this.#ifrauContextInfo = null;
+		}
+		this._showBackdrop = false;
+
 		await this.updateComplete; // wait before applying focus to opener
 		this.#focusOpener();
 		this.dispatchEvent(new CustomEvent('d2l-popover-close', { bubbles: true, composed: true }));
@@ -281,6 +293,8 @@ export const PopoverMixin = superclass => class extends superclass {
 	async open(applyFocus = true) {
 		if (this._opened) return;
 
+		const ifrauBackdropService = await tryGetIfrauBackdropService();
+
 		this.#addMediaQueryHandlers();
 
 		this._rtl = document.documentElement.getAttribute('dir') === 'rtl';
@@ -296,6 +310,11 @@ export const PopoverMixin = superclass => class extends superclass {
 		this.#addAutoCloseHandlers();
 
 		await this.#position();
+
+		this._showBackdrop = this._mobile && this._mobileTrayLocation;
+		if (ifrauBackdropService && this._showBackdrop) {
+			this.#ifrauContextInfo = await ifrauBackdropService.showBackdrop();
+		}
 
 		this._dismissibleId = setDismissible(() => this.close());
 
@@ -323,7 +342,7 @@ export const PopoverMixin = superclass => class extends superclass {
 		const contentStyle = stylesMap['content'];
 
 		content = html`
-			<div class="content-width vdiff-target" style=${styleMap(widthStyle)}>
+			<div id="content-wrapper" class="content-width vdiff-target" style=${styleMap(widthStyle)}>
 				<div class="content-container" style=${styleMap(contentStyle)}>${content}</div>
 			</div>
 		`;
@@ -362,12 +381,17 @@ export const PopoverMixin = superclass => class extends superclass {
 			</div>
 		` : nothing;
 
-		return html`${content}${pointer}`;
+		return this._mobileTrayLocation ? html`
+			${content}
+			<d2l-backdrop for-target="content-wrapper" ?shown="${this._showBackdrop}"></d2l-backdrop>
+			${pointer}
+		` : html`${content}${pointer}`;
 
 	}
 
 	async resize() {
 		if (!this._opened) return;
+		this._showBackdrop = this._mobile && this._mobileTrayLocation;
 		await this.#position();
 	}
 
@@ -376,6 +400,7 @@ export const PopoverMixin = superclass => class extends superclass {
 		else return this.open(!this._noAutoFocus && applyFocus);
 	}
 
+	#ifrauContextInfo;
 	#mediaQueryList;
 	#handleAncestorMutationBound;
 	#handleAutoCloseClickBound;
@@ -520,7 +545,8 @@ export const PopoverMixin = superclass => class extends superclass {
 	#getMobileTrayBlockStyleMaps() {
 
 		let maxHeightOverride;
-		const availableHeight = Math.min(window.innerHeight, window.screen.height);
+		let availableHeight = Math.min(window.innerHeight, window.screen.height);
+		if (this.#ifrauContextInfo) availableHeight = this.#ifrauContextInfo.availableHeight;
 
 		// default maximum height for bottom tray (42px margin)
 		const mobileTrayMaxHeightDefault = availableHeight - minBackdropHeightMobile;
@@ -532,12 +558,20 @@ export const PopoverMixin = superclass => class extends superclass {
 		}
 		maxHeightOverride = `${maxHeightOverride}px`;
 
+		let bottomOverride;
+		if (this.#ifrauContextInfo) {
+			// the bottom override is measured as the distance from the bottom of the screen
+			const screenHeight = window.innerHeight - this.#ifrauContextInfo.availableHeight + Math.min(this.#ifrauContextInfo.top, 0);
+			bottomOverride = `${screenHeight}px`;
+		}
+
 		const widthOverride = '100vw';
 
 		const widthStyle = {
 			minWidth: widthOverride,
 			width: widthOverride,
 			maxHeight: maxHeightOverride,
+			bottom: bottomOverride
 		};
 
 		const contentWidthStyle = {
@@ -551,15 +585,16 @@ export const PopoverMixin = superclass => class extends superclass {
 		};
 
 		return {
-			width: widthStyle,
-			content: contentStyle,
+			width : widthStyle,
+			content : contentStyle
 		};
 	}
 
 	#getMobileTrayInlineStyleMaps() {
 
 		let maxWidthOverride = this._maxWidth;
-		const availableWidth = Math.min(window.innerWidth, window.screen.width);
+		let availableWidth = Math.min(window.innerWidth, window.screen.width);
+		if (this.#ifrauContextInfo) availableWidth = this.#ifrauContextInfo.availableWidth;
 
 		// default maximum width for tray (30px margin)
 		const mobileTrayMaxWidthDefault = Math.min(availableWidth - minBackdropWidthMobile, 420);
@@ -592,7 +627,17 @@ export const PopoverMixin = superclass => class extends superclass {
 		// add 2 to content width since scrollWidth does not include border
 		const containerWidth = `${widthOverride + 20}px`;
 
-		const topOverride = (window.innerHeight > window.screen.height) ? window.pageYOffset : undefined;
+		let maxHeightOverride = '';
+		if (this.#ifrauContextInfo) maxHeightOverride = `${this.#ifrauContextInfo.availableHeight}px`;
+
+		let topOverride;
+		if (this.#ifrauContextInfo) {
+			// if inside iframe, use ifrauContext top as top of screen
+			topOverride = `${this.#ifrauContextInfo.top < 0 ? -this.#ifrauContextInfo.top : 0}px`;
+		} else if (window.innerHeight > window.screen.height) {
+			// non-responsive page, manually override top to scroll distance
+			topOverride = window.pageYOffset;
+		}
 
 		let inlineEndOverride;
 		let inlineStartOverride;
@@ -614,6 +659,7 @@ export const PopoverMixin = superclass => class extends superclass {
 			minWidth: minWidthOverride,
 			width: containerWidth,
 			top: topOverride,
+			maxHeight: maxHeightOverride,
 			insetInlineStart: inlineStartOverride,
 			insetInlineEnd: inlineEndOverride
 		};
@@ -626,11 +672,12 @@ export const PopoverMixin = superclass => class extends superclass {
 
 		const contentStyle = {
 			...contentWidthStyle,
+			maxHeight: maxHeightOverride,
 		};
 
 		return {
 			width : widthStyle,
-			content : contentStyle,
+			content : contentStyle
 		};
 	}
 
@@ -824,7 +871,10 @@ export const PopoverMixin = superclass => class extends superclass {
 
 	async #handleMobileResize() {
 		this._mobile = this.#mediaQueryList.matches;
-		if (this._opened) await this.#position();
+		if (this._opened) {
+			this._showBackdrop = this._mobile && this._mobileTrayLocation;
+			await this.#position();
+		}
 	}
 
 	#handleResize() {

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -381,11 +381,10 @@ export const PopoverMixin = superclass => class extends superclass {
 			</div>
 		` : nothing;
 
-		return this._mobileTrayLocation ? html`
-			${content}
-			<d2l-backdrop for-target="content-wrapper" ?shown="${this._showBackdrop}"></d2l-backdrop>
-			${pointer}
-		` : html`${content}${pointer}`;
+		const backdrop = this._mobileTrayLocation ?
+			html`<d2l-backdrop for-target="content-wrapper" ?shown="${this._showBackdrop}"></d2l-backdrop>` :
+			nothing;
+		return html`${content}${backdrop}${pointer}`;
 
 	}
 


### PR DESCRIPTION
[GAUD-6563](https://desire2learn.atlassian.net/browse/GAUD-6563)

This PR adds the backdrop to the Popover mobile tray.

**inline-start**
![image](https://github.com/user-attachments/assets/aefa0ecb-7801-42bd-93b2-db5d0789f1e0)

**inline-end**
![image](https://github.com/user-attachments/assets/ba5af184-be4e-4f40-a44d-7812f7a63fb1)

**block-end**
![image](https://github.com/user-attachments/assets/108b544b-e3c9-48f6-ad20-84a3c4beedfb)


[GAUD-6563]: https://desire2learn.atlassian.net/browse/GAUD-6563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ