### PR TITLE
Fix demo snippet sanitation for target="_blank"

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -211,7 +211,7 @@ class DemoSnippet extends LitElement {
 
 		return lines.join('\n')
 			.replace(/ class=""/g, '') // replace empty class attributes (class="")
-			.replace(/_[^=]*="[^"]*"[^\s>]/, '') // replace private reflected properties (_attr, _attr="value", but not target="_blank")
+			.replace(/\s+_[^\s\/>"'=]*(=(?<q>['"]).*?(?<!\\)\k<q>)?/g, '') // replace private reflected properties (_attr, _attr="value", but not target="_blank")
 			.replace(/=""/g, ''); // replace empty strings for boolean attributes (="")
 	}
 

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -211,7 +211,7 @@ class DemoSnippet extends LitElement {
 
 		return lines.join('\n')
 			.replace(/ class=""/g, '') // replace empty class attributes (class="")
-			.replace(/_[^=]*="[^"]*"/, '') // replace private reflected properties (_attr="value")
+			.replace(/_[^=]*="[^"]*"[^\s>]/, '') // replace private reflected properties (_attr, _attr="value", but not target="_blank")
 			.replace(/=""/g, ''); // replace empty strings for boolean attributes (="")
 	}
 

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -211,7 +211,7 @@ class DemoSnippet extends LitElement {
 
 		return lines.join('\n')
 			.replace(/ class=""/g, '') // replace empty class attributes (class="")
-			.replace(/\s+_[^\s\/>"'=]*(=(?<q>['"]).*?(?<!\\)\k<q>)?/g, '') // replace private reflected properties (_attr, _attr="value", but not target="_blank")
+			.replace(/\s+_[^\s/>"'=]*(=(?<q>['"]).*?(?<!\\)\k<q>)?/g, '') // replace private reflected properties (_attr, _attr="value", but not target="_blank")
 			.replace(/=""/g, ''); // replace empty strings for boolean attributes (="")
 	}
 


### PR DESCRIPTION
This PR fixes the `d2l-demo-snippet` sanitation RegEx so that it doesn't get confused by `target="_blank"`. Background: the purpose of this replacement is to exclude sprouted private properties/attributes from the formatted code sample displayed in the demo-snippet. The original RegEx would replace too much in this case.

**Before:**
![image](https://github.com/user-attachments/assets/2780fff8-3916-457c-ae4b-5c5873f6d40a)

**After:**
![image](https://github.com/user-attachments/assets/17955933-789e-4457-b9a0-c74c5cdf7533)
