### PR TITLE
Fix Safari drag handle, maintaining clickable drag arrows

### DIFF
--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -72,7 +72,6 @@ class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(RtlMixin(LitElem
 			:host {
 				display: flex;
 				margin: 0.25rem;
-				pointer-events: auto; /* required since its parent may set point-events: none; (see generic layout) */
 			}
 			:host([hidden]) {
 				display: none;
@@ -115,6 +114,9 @@ class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(RtlMixin(LitElem
 			}
 			.d2l-list-item-drag-handle-tooltip-key {
 				font-weight: 700;
+			}
+			d2l-button-move {
+				pointer-events: auto; /* required since ancestors may set point-events: none; (see generic layout) */
 			}
 		`];
 	}

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -298,7 +298,7 @@ describe('d2l-list-item', () => {
 
 	});
 
-	it('has clickable drag arrows', async () => {
+	it('has clickable drag arrows', async() => {
 		const list = await fixture(html`
 		<d2l-list>
 			<d2l-list-item draggable key="1">Item 1</d2l-list-item>

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -317,6 +317,7 @@ describe('d2l-list-item', () => {
 		expect(downArrow).to.exist;
 		clickElem(downArrow);
 		await oneEvent(item, 'd2l-list-item-position-change');
+		expect(handleRealClicks).to.equal(0);
 	});
 
 });

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -298,6 +298,27 @@ describe('d2l-list-item', () => {
 
 	});
 
+	it('has clickable drag arrows', async () => {
+		const list = await fixture(html`
+		<d2l-list>
+			<d2l-list-item draggable key="1">Item 1</d2l-list-item>
+			<d2l-list-item draggable key="2">Item 2</d2l-list-item>
+		</d2l-list>`);
+
+		const item = list.children[0];
+		expect(item.innerText).to.equal('Item 1');
+		const handle = item.shadowRoot.querySelector('d2l-list-item-drag-handle');
+		let handleRealClicks = 0;
+		handle.addEventListener('click', () => ++handleRealClicks);
+		await clickElem(handle.shadowRoot.querySelector('button')); // focus drag handle
+		expect(handleRealClicks).to.equal(0);
+		await clickElem(handle.shadowRoot.querySelector('button')); // enable keyboard mode
+		const downArrow = handle.shadowRoot.querySelector('d2l-button-move').shadowRoot.querySelector('.down-layer');
+		expect(downArrow).to.exist;
+		clickElem(downArrow);
+		await oneEvent(item, 'd2l-list-item-position-change');
+	});
+
 });
 
 describe('d2l-list-item-button', () => {


### PR DESCRIPTION
[GAUD-7353](https://desire2learn.atlassian.net/browse/GAUD-7353): List drag handle is broken in Safari

In #4238, @dbatiste fixed an issue with the drag handle arrows no longer being clickable. I'm not sure why this caused different behavior between Chrome and Safari, but Safari started always placing the handle on top of the action layer (which actually seems more correct) while Chrome left it below but somehow also made the arrows clickable again. I've stopped trying to understand how/why.

[More details on the Safari behavior being perceived as a bug](https://d2l.slack.com/archives/C0PHG3QB0/p1734460877556369).

This moves Dave's `pointer-events` fix from the `d2l-list-item-drag-handle` host to _only_ the `d2l-button-move` handle (with the arrows) within. This appears to fix the Safari drag handle issue while maintaining clickability of the arrows in all browsers.

[GAUD-7353]: https://desire2learn.atlassian.net/browse/GAUD-7353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ