### PR TITLE
fix: additional waitForUpdateComplete in async dialogs

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -149,6 +149,12 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		});
 	}
 
+	async waitForUpdateComplete() {
+		const predicate = () => true;
+		const composedChildren = getComposedChildren(this, predicate);
+		await Promise.all(composedChildren.map(child => waitForElem(child, predicate)));
+	}
+
 	_addHandlers() {
 		window.addEventListener('resize', this._updateSize);
 		this.addEventListener('touchstart', this._handleTouchStart);
@@ -455,7 +461,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 
 			const flag = window.D2L?.LP?.Web?.UI?.Flags.Flag('GAUD-7397-dialog-resize-update-complete', true) ?? true;
 			if (flag) {
-				await this.#waitForUpdateComplete();
+				await this.waitForUpdateComplete();
 				await this._updateSize();
 			}
 			/** Dispatched when the dialog is opened */
@@ -587,9 +593,4 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		});
 	}
 
-	async #waitForUpdateComplete() {
-		const predicate = () => true;
-		const composedChildren = getComposedChildren(this, predicate);
-		await Promise.all(composedChildren.map(child => waitForElem(child, predicate)));
-	}
 };

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -205,7 +205,12 @@ class Dialog extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMix
 		super.updated(changedProperties);
 		if (!changedProperties.has('asyncState')) return;
 		if (this.asyncState === asyncStates.complete) {
-			this.resize();
+			const flag = window.D2L?.LP?.Web?.UI?.Flags.Flag('GAUD-7397-dialog-resize-update-complete', true) ?? true;
+			if (flag) {
+				this.waitForUpdateComplete().then(() => this.resize());
+			} else {
+				this.resize();
+			}
 		}
 	}
 


### PR DESCRIPTION
This handles the additional case where the dialog is `async` and the additional components that have just been loaded asynchronously need each of their `updateComplete`s (and `getLoadingComplete` if they have it) to be awaited.

Trying to rush this in before branching. I'll follow up with tests.