### PR TITLE
feat: DAYL-102 Update Expand-Collapse A11y Docn

### DIFF
--- a/components/expand-collapse/README.md
+++ b/components/expand-collapse/README.md
@@ -41,7 +41,8 @@ The `d2l-expand-collapse-content` element can be used to create expandable and c
 To make your usage of `d2l-expand-collapse-content` accessible, it should follow the [W3C Disclosure (Show/Hide) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/).
 
 To achieve this, the control that toggles the expanded state should:
- - Have the [`button`](https://w3c.github.io/aria/#button) role
- - Toggle between states when using the `Enter` and `Space` buttons
+ - Should use the [`d2l-button`](../button) or use an element with the [`button`](https://w3c.github.io/aria/#button) role
+ - Toggle between states when using the `Enter` and `Space` buttons and retain focus upon toggle
  - Have the [`aria-expanded`](https://www.w3.org/TR/wai-aria/#aria-expanded) attribute, so screen reader users will know what state it's in
+ - Be adjacent to the expanded/collapsed content
 

--- a/components/expand-collapse/README.md
+++ b/components/expand-collapse/README.md
@@ -36,7 +36,12 @@ The `d2l-expand-collapse-content` element can be used to create expandable and c
 - `d2l-expand-collapse-content-collapse`: dispatched when the content starts to collapse. The `detail` contains a `collapseComplete` promise that can be waited on to determine when the content has finished collapsing.
 <!-- docs: end hidden content -->
 
-### Accessibility Properties
+## Accessibility
 
-To make your usage of `d2l-expand-collapse-content` accessible, the [`aria-expanded` attribute](https://www.w3.org/TR/wai-aria/#aria-expanded) should be added to the element that controls expanding and collapsing the content with `"true"` or `"false"` to indicate that the content is expanded or collapsed.
+To make your usage of `d2l-expand-collapse-content` accessible, it should follow the [W3C Disclosure (Show/Hide) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/).
+
+To achieve this, the control that toggles the expanded state should:
+ - Have the [`button`](https://w3c.github.io/aria/#button) role
+ - Toggle between states when using the `Enter` and `Space` buttons
+ - Have the [`aria-expanded`](https://www.w3.org/TR/wai-aria/#aria-expanded) attribute, so screen reader users will know what state it's in
 

--- a/components/expand-collapse/README.md
+++ b/components/expand-collapse/README.md
@@ -41,8 +41,8 @@ The `d2l-expand-collapse-content` element can be used to create expandable and c
 To make your usage of `d2l-expand-collapse-content` accessible, it should follow the [W3C Disclosure (Show/Hide) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/).
 
 To achieve this, the control that toggles the expanded state should:
- - Should use the [`d2l-button`](../button) or use an element with the [`button`](https://w3c.github.io/aria/#button) role
+ - Use the [`d2l-button`](../button) or use an element with the [`button`](https://w3c.github.io/aria/#button) role
  - Toggle between states when using the `Enter` and `Space` buttons and retain focus upon toggle
- - Have the [`aria-expanded`](https://www.w3.org/TR/wai-aria/#aria-expanded) attribute, so screen reader users will know what state it's in
+ - Have the [`aria-expanded`](https://www.w3.org/TR/wai-aria/#aria-expanded) attribute set to `'true'` or `'false'` depending on expansion state so that screen reader users will know what state it's in
  - Be adjacent to the expanded/collapsed content
 


### PR DESCRIPTION
[Jira Story](https://desire2learn.atlassian.net/browse/DAYL-102)

Similarly to many of the other PRs, this is another improvement to the a11y docn of the `d2l-expand-collapse-content` component. Due to the nature of the component, the only changes are in the readme and mostly instruct the users how to implement the component in an accessibility-friendly way.