### PR TITLE
fix: tooltip: wrap when content is unbroken long string

### DIFF
--- a/components/tooltip/test/tooltip.vdiff.js
+++ b/components/tooltip/test/tooltip.vdiff.js
@@ -6,6 +6,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 const shortText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
 const longText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+const longTextNoSpaces = 'Loremipsumdolorsitamet,consecteturadipiscingelit,seddoeiusmodtemporincididuntutlaboreetdoloremagnaaliqua.';
 const additionalText = 'Aliquam ut porttitor leo a diam sollicitudin tempor id eu.';
 
 function createTooltip(tooltipOpts, target) {
@@ -96,7 +97,8 @@ describe('tooltip', () => {
 		{ name: 'dark-background-position-top', opts: { dark: true, content: longText, position: 'top' }, targetStyles: { left: mid, top: mid } },
 		{ name: 'dark-background-position-bottom', opts: { dark: true, content: longText, position: 'bottom', wrapped: true }, targetStyles: { left: mid, top: mid } },
 		{ name: 'dark-background-position-right', opts: { dark: true, content: longText, position: 'right' }, targetStyles: { left: mid, top: mid } },
-		{ name: 'dark-background-position-left', opts: { dark: true, content: longText, position: 'left', wrapped: true }, targetStyles: { left: mid, top: mid } }
+		{ name: 'dark-background-position-left', opts: { dark: true, content: longText, position: 'left', wrapped: true }, targetStyles: { left: mid, top: mid } },
+		{ name: 'long-text-wrap', opts: { content: longTextNoSpaces }, targetStyles: { left: mid, top: mid } }
 	].forEach(({ name, opts = {}, targetStyles = {}, rtl }) => {
 		it(name, async() => {
 			const elem = await fixture(createTooltip(opts, targetStyles), { rtl, viewport: { width: 400, height: 400 }, pagePadding: false });

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -331,6 +331,7 @@ class Tooltip extends RtlMixin(LitElement) {
 				min-width: 2.1rem;
 				outline: ${outlineSize}px solid var(--d2l-tooltip-outline-color);
 				overflow: hidden;
+				overflow-wrap: anywhere;
 				padding: ${11 - contentBorderSize}px ${contentHorizontalPadding - contentBorderSize}px;
 				position: absolute;
 			}


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7471)

This came up in [this PR](https://github.com/BrightspaceUI/labs/pull/501) and seemed that should be fixed in core.