### PR TITLE
GAUD-7562: remove flag

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -589,26 +589,23 @@ export class TableWrapper extends RtlMixin(PageableMixin(SelectionMixin(LitEleme
 	}
 
 	async _handleTableChange(mutationRecords) {
-		const flag = window.D2L?.LP?.Web?.UI?.Flags.Flag('table-update-filter-GAUD-6955', true) ?? true;
 		const updates = { count: true, classNames: true, sticky: true, syncWidths: true };
-		if (flag) {
-			if (mutationRecords) {
-				for (const key in updates) updates[key] = false;
-				for (const { type, removedNodes, addedNodes, target, attributeName } of mutationRecords) {
-					if (type === 'attributes') {
-						updates.classNames = attributeName === 'selected';
-						continue;
-					}
+		if (mutationRecords) {
+			for (const key in updates) updates[key] = false;
+			for (const { type, removedNodes, addedNodes, target, attributeName } of mutationRecords) {
+				if (type === 'attributes') {
+					updates.classNames = attributeName === 'selected';
+					continue;
+				}
 
-					updates.sticky ||= target.matches(SELECTORS.headers);
-					const affectedNodes = [...removedNodes, ...addedNodes];
-					for (const node of affectedNodes) {
-						if (!(node instanceof Element)) continue;
-						updates.classNames ||= node.matches('tr, td, th');
-						updates.syncWidths ||= node.matches('tr');
-						updates.sticky ||= node.matches(SELECTORS.headers);
-						updates.count ||= node.matches(SELECTORS.items);
-					}
+				updates.sticky ||= target.matches(SELECTORS.headers);
+				const affectedNodes = [...removedNodes, ...addedNodes];
+				for (const node of affectedNodes) {
+					if (!(node instanceof Element)) continue;
+					updates.classNames ||= node.matches('tr, td, th');
+					updates.syncWidths ||= node.matches('tr');
+					updates.sticky ||= node.matches(SELECTORS.headers);
+					updates.count ||= node.matches(SELECTORS.items);
 				}
 			}
 		}


### PR DESCRIPTION
Removes the "table-update-filter-GAUD-6955" flag from code, which was due in January.

Related:
- Removal from LMS: https://github.com/Brightspace/lms/pull/63414
- Recycle: https://github.com/Brightspace/lms-launch-darkly-flags/pull/16930