### PR TITLE
Support nested lists with no selectables

### DIFF
--- a/components/list/demo/list-selection.html
+++ b/components/list/demo/list-selection.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+		<script type="module">
+			import '../../demo/demo-page.js';
+			import '../list-item-content.js';
+			import '../list-item.js';
+			import '../list-controls.js';
+			import '../list.js';
+			import '../../selection/selection-action.js';
+		</script>
+		<style>
+			d2l-list::before {
+				box-sizing: border-box;
+				color: var(--d2l-color-tungsten);
+				content: attr(data-selection-info);
+				font-size: 0.7rem;
+				inset-block-start: 0;
+				inset-inline-end: 0;
+				margin: 0 0.4rem;
+				padding: 0;
+				position: absolute;
+			}
+		</style>
+	</head>
+	<body unresolved>
+
+		<d2l-demo-page page-title="d2l-list (selection)">
+
+			<h2>Nested - 1 - all selectable</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list grid>
+						<d2l-list-controls slot="controls">
+							<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+							<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+						</d2l-list-controls>
+						<d2l-list-item selectable key="Item-1" label="Label for Item-1">
+							<d2l-list-item-content>
+								<div>Item-1 - Earth Sciences</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+							<d2l-list slot="nested" grid separators="all">
+								<d2l-list-item selectable key="Item-1-1" label="Label for Item-1-1">
+									<d2l-list-item-content>
+										<div>Item-1-1 - Introductory Earth Sciences</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+								<d2l-list-item selectable key="Item-1-2" label="Label for Item-1-2">
+									<d2l-list-item-content>
+										<div>Item-1-2 - Flow and Transport Through Fractured Rocks</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+								<d2l-list-item selectable key="Item-1-3" label="Label for Item-1-3">
+									<d2l-list-item-content>
+										<div>Item-1-3 - Applied Wetland Science</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+							</d2l-list>
+						</d2l-list-item>
+						<d2l-list-item selectable key="Item-2" label="Label for Item-2">
+							<d2l-list-item-content>
+								<div>Item-2 - Biology</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item selectable key="Item-3" label="Label for Item-3">
+							<d2l-list-item-content>
+								<div>Item-3 - Computer Science</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Nested - 2 - L1 not selectable, L2 selectable</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list grid>
+						<d2l-list-controls slot="controls">
+							<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+							<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+						</d2l-list-controls>
+						<d2l-list-item key="Item-1" label="Label for Item-1">
+							<d2l-list-item-content>
+								<div>Item-1 - Earth Sciences</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+							<d2l-list slot="nested" grid separators="all">
+								<d2l-list-item selectable key="Item-1-1" label="Label for Item-1-1">
+									<d2l-list-item-content>
+										<div>Item-1-1 - Introductory Earth Sciences</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+								<d2l-list-item selectable key="Item-1-2" label="Label for Item-1-2">
+									<d2l-list-item-content>
+										<div>Item-1-2 - Flow and Transport Through Fractured Rocks</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+								<d2l-list-item selectable key="Item-1-3" label="Label for Item-1-3">
+									<d2l-list-item-content>
+										<div>Item-1-3 - Applied Wetland Science</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+							</d2l-list>
+						</d2l-list-item>
+						<d2l-list-item key="Item-2" label="Label for Item-2">
+							<d2l-list-item-content>
+								<div>Item-2 - Biology</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item key="Item-3" label="Label for Item-3">
+							<d2l-list-item-content>
+								<div>Item-3 - Computer Science</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Nested - 3 - L1 selectable, L2 not selectable</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list grid>
+						<d2l-list-controls slot="controls">
+							<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+							<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+						</d2l-list-controls>
+						<d2l-list-item selectable key="Item-1" label="Label for Item-1">
+							<d2l-list-item-content>
+								<div>Item-1 - Earth Sciences</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+							<d2l-list slot="nested" grid separators="all">
+								<d2l-list-item key="Item-1-1" label="Label for Item-1-1">
+									<d2l-list-item-content>
+										<div>Item-1-1 - Introductory Earth Sciences</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+								<d2l-list-item key="Item-1-2" label="Label for Item-1-2">
+									<d2l-list-item-content>
+										<div>Item-1-2 - Flow and Transport Through Fractured Rocks</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+								<d2l-list-item key="Item-1-3" label="Label for Item-1-3">
+									<d2l-list-item-content>
+										<div>Item-1-3 - Applied Wetland Science</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+							</d2l-list>
+						</d2l-list-item>
+						<d2l-list-item selectable key="Item-2" label="Label for Item-2">
+							<d2l-list-item-content>
+								<div>Item-2 - Biology</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item selectable key="Item-3" label="Label for Item-3">
+							<d2l-list-item-content>
+								<div>Item-3 - Computer Science</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Nested - 4 - L1 selectable, L2 not selectable, L3 selectable</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list grid>
+						<d2l-list-controls slot="controls">
+							<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+							<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+						</d2l-list-controls>
+						<d2l-list-item selectable key="Item-1" label="Label for Item-1">
+							<d2l-list-item-content>
+								<div>Item-1 - Earth Sciences</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+							<d2l-list slot="nested" grid separators="all">
+								<d2l-list-item key="Item-1-1" label="Label for Item-1-1">
+									<d2l-list-item-content>
+										<div>Item-1-1 - Introductory Earth Sciences</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+								<d2l-list-item key="Item-1-2" label="Label for Item-1-2">
+									<d2l-list-item-content>
+										<div>Item-1-2 - Flow and Transport Through Fractured Rocks</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+									<d2l-list slot="nested" grid separators="all">
+										<d2l-list-item selectable key="Item-1-2-1" label="Label for Item-1-2-1">
+											<d2l-list-item-content>
+												<div>Item-1-2-1 - Hydraulic Properties of Fractures</div>
+												<div slot="supporting-info">Supporting Info</div>
+											</d2l-list-item-content>
+										</d2l-list-item>
+										<d2l-list-item selectable key="Item-1-2-2" label="Label for Item-1-2-2">
+											<d2l-list-item-content>
+												<div>Item-1-2-2 - Contaminant Transport</div>
+												<div slot="supporting-info">Supporting Info</div>
+											</d2l-list-item-content>
+										</d2l-list-item>
+									</d2l-list>
+								</d2l-list-item>
+								<d2l-list-item key="Item-1-3" label="Label for Item-1-3">
+									<d2l-list-item-content>
+										<div>Item-1-3 - Applied Wetland Science</div>
+										<div slot="supporting-info">Supporting Info</div>
+									</d2l-list-item-content>
+								</d2l-list-item>
+							</d2l-list>
+						</d2l-list-item>
+						<d2l-list-item selectable key="Item-2" label="Label for Item-2">
+							<d2l-list-item-content>
+								<div>Item-2 - Biology</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item selectable key="Item-3" label="Label for Item-3">
+							<d2l-list-item-content>
+								<div>Item-3 - Computer Science</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Nested - 5 - L1 mixed</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list grid>
+						<d2l-list-controls slot="controls">
+							<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+							<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+						</d2l-list-controls>
+						<d2l-list-item selectable key="Item-1" label="Label for Item-1">
+							<d2l-list-item-content>
+								<div>Item-1 - Earth Sciences</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item key="Item-2" label="Label for Item-2">
+							<d2l-list-item-content>
+								<div>Item-2 - Biology</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+						<d2l-list-item selectable key="Item-3" label="Label for Item-3">
+							<d2l-list-item-content>
+								<div>Item-3 - Computer Science</div>
+								<div slot="supporting-info">Supporting Info</div>
+							</d2l-list-item-content>
+						</d2l-list-item>
+					</d2l-list>
+				</template>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+
+		<script>
+			function updateSelectionInfoText(list) {
+				const info = list.getSelectionInfo(true);
+				list.setAttribute('data-selection-info', `Selection Info: ${info.state}, ${info.keys.length}`);
+			}
+
+			setTimeout(() => {
+				document.querySelectorAll('d2l-list').forEach(list => {
+					list.addEventListener('d2l-list-selection-changes', (e) => {
+						updateSelectionInfoText(e.target);
+						console.log('d2l-list-selection-changes', e.detail);
+					});
+					updateSelectionInfoText(list);
+				});
+			}, 1000);
+		</script>
+	</body>
+</html>

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -70,7 +70,9 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 		const oldVal = this._selectionInfo;
 		if (oldVal !== val) {
 			this._selectionInfo = val;
-			this.setSelected(this._selectionInfo.state === SelectionInfo.states.all);
+			if (this._selectionInfo.state !== SelectionInfo.states.undefined) {
+				this.setSelected(this._selectionInfo.state === SelectionInfo.states.all);
+			}
 			this.requestUpdate('selectionInfo', oldVal);
 		}
 	}
@@ -86,7 +88,10 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 	updated(changedProperties) {
 		super.updated(changedProperties);
 		if (!this._selectionProvider || !changedProperties.has('selectionInfo')) return;
-		this.selected = (this.selectionInfo.state === SelectionInfo.states.all);
+		// TODO: consider moving this to willUpdate
+		if (this.selectionInfo.state !== SelectionInfo.states.undefined) {
+			this.selected = (this.selectionInfo.state === SelectionInfo.states.all);
+		}
 	}
 
 	willUpdate(changedProperties) {
@@ -174,8 +179,6 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 	}
 
 	_updateNestedSelectionProvider() {
-		if (!this.selectable) return;
-
 		const nestedList = this._getNestedList();
 		if (this._selectionProvider === nestedList) return;
 

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -651,9 +651,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 	}
 
 	_onNestedSlotChange() {
-		if (this.selectable) {
-			this._onNestedSlotChangeCheckboxMixin();
-		}
+		this._onNestedSlotChangeCheckboxMixin();
 		const nestedList = this._getNestedList();
 		if (this._hasNestedList !== !!nestedList) {
 			this._hasNestedList = !!nestedList;

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -311,7 +311,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 
 	setSelectionForAll(selected, selectAllPages) {
 		super.setSelectionForAll(selected, selectAllPages);
-		// list-specific logic to push selection state deeper into tree - required to support nested lists with no selectables
+		// list-specific logic to push selection state deeper into tree - required to support intermediate nested lists with no direct selectables but with their own nested lists containing selectables
 		this.getItems().forEach(item => {
 			if (!item.selectable && item._selectionProvider) {
 				item._selectionProvider.setSelectionForAll(selected, selectAllPages);

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -281,16 +281,11 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 			if (item._selectionProvider) {
 				const itemSelectionInfo = item._selectionProvider.getSelectionInfo(true);
 				if (state === SelectionInfo.states.undefined) {
-					// initialize to this item's state
 					state = itemSelectionInfo.state;
 				} else if (state === SelectionInfo.states.none && itemSelectionInfo.state !== SelectionInfo.states.undefined && itemSelectionInfo.state !== SelectionInfo.states.none) {
-					// if it is none and this is some or all, then we set to some
 					state = SelectionInfo.states.some;
 				} else if (state === SelectionInfo.states.all && (itemSelectionInfo.state === SelectionInfo.states.some || itemSelectionInfo.state === SelectionInfo.states.none)) {
-					// if it is all and this is some or none, then we set to some
 					state = SelectionInfo.states.some;
-				} else if (state === SelectionInfo.states.some) {
-					// if it is some, then we leave it as some
 				}
 				keys = [...keys, ...item._selectionProvider.getSelectionInfo(true).keys];
 			}
@@ -316,6 +311,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 
 	setSelectionForAll(selected, selectAllPages) {
 		super.setSelectionForAll(selected, selectAllPages);
+		// list-specific logic to push selection state deeper into tree - required to support nested lists with no selectables
 		this.getItems().forEach(item => {
 			if (!item.selectable && item._selectionProvider) {
 				item._selectionProvider.setSelectionForAll(selected, selectAllPages);

--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -16,6 +16,7 @@ export class SelectionInfo {
 		if (!allEnabledSelected) allEnabledSelected = false;
 		if (!keys) keys = [];
 		if (!state) state = SelectionInfo.states.none;
+
 		this.#allEnabledSelected = allEnabledSelected;
 		this.#keys = keys;
 		this.#state = state;
@@ -38,7 +39,8 @@ export class SelectionInfo {
 			none: 'none',
 			some: 'some',
 			all: 'all',
-			allPages: 'all-pages'
+			allPages: 'all-pages',
+			undefined: 'undefined'
 		};
 	}
 
@@ -98,12 +100,13 @@ export const SelectionMixin = superclass => class extends RtlMixin(CollectionMix
 
 	getSelectionInfo() {
 		let allEnabledSelected = true;
-		let state = SelectionInfo.states.none;
+		let state = (this._selectionSelectables.size > 0 ? SelectionInfo.states.none : SelectionInfo.states.undefined);
 		const keys = [];
 
 		if (this._selectAllPages) {
 			state = SelectionInfo.states.allPages;
 		} else {
+
 			this._selectionSelectables.forEach(selectable => {
 				if (selectable.selected) keys.push(selectable.key);
 				if (!selectable.disabled && !selectable.selected) allEnabledSelected = false;


### PR DESCRIPTION
[GAUD-7499](https://desire2learn.atlassian.net/browse/GAUD-7499)

This PR updates to support more complex nested selection scenarios. Specifically, the ability to have a nested list without selectables. Previously, intermediate lists without selectables would be interpreted as `none` when rolling up selection in nested lists, resulting in incorrect results returned from `getSelectionInfo(includeNested: true)`.  Also, Select-All would not properly traverse into the selectable sub-trees when the parent lists are not selectable. 

With this change, lists containing no selectables will be treated as `undefined` when rolling up the state to parent list-items. If the list contains at least one selectable, then it's selection state will be reported as `none`, `some`, or `all` as was the existing behaviour.

This is the example that was originally raised - root list not selectable, but nested list is.
![image](https://github.com/user-attachments/assets/ebd589a0-0c21-40a3-8c3b-ea8a3cc1139b)

But more complex scenarios are now possible:
![image](https://github.com/user-attachments/assets/a0024b77-d43a-46f0-8c00-2bd7df29954c)
