### PR TITLE
feat: DAYL-92 Update Card A11y Docn

### DIFF
--- a/components/card/README.md
+++ b/components/card/README.md
@@ -168,13 +168,13 @@ The `d2l-card` element is a container that provides specific layout using severa
 
 | Property | Type | Description |
 |--|--|--|
-| `text` | String, required | Accessible text for the card for screen reader users |
 | `align-center` | Boolean | Style the card's content and footer as centered horizontally |
 | `download` | Boolean | Download a URL instead of navigating to it |
 | `href` | String | Location for the primary action/navigation |
 | `rel` | String | Relationship of the target object to the link object |
 | `subtle` | Boolean | Subtle aesthetic on non-white backgrounds |
 | `target` | String | Where to display the linked URL |
+| `text` | String | Accessible text for the card |
 
 See the [anchor element docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) for more information on standard link attributes and their values.
 <!-- docs: end hidden content -->
@@ -292,7 +292,6 @@ The `d2l-card-footer-link` element is an icon link that can be placed in the `fo
 | Property | Type | Description |
 |--|--|--|
 | `icon` | String, required | Preset icon key (ex. "tier1:gear") |
-| `text` | String, required | Accessible text for the link for screen reader users |
 | `download` | Boolean | Download a URL instead of navigating to it |
 | `href` | String | Location for the primary action/navigation |
 | `rel` | String | Relationship of the target object to the link object |
@@ -300,9 +299,15 @@ The `d2l-card-footer-link` element is an icon link that can be placed in the `fo
 | `secondary-count-type` | String | Controls the style of the secondary count bubble; options are `notification` and `count` |
 | `secondary-count-max-digits` | Number | Overrides the default maximum digits of the secondary count bubble (2 for `notification` and no limit for `count` type) |
 | `target` | String | Where to display the linked URL |
+| `text` | String | Accessible text for the link |
 
 See the [anchor element docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) for more information on standard link attributes and their values.
+<!-- docs: end hidden content -->
 
+## Accessibility
+- The `text` property for the d2l-card and d2l-card-footer-link components is only required if actionable (i.e. the `href` property is used)
+
+<!-- docs: start hidden content -->
 ## Future Improvements
 
 * scroll API for the dialog content (see [#341](https://github.com/BrightspaceUI/core/issues/341))

--- a/components/card/README.md
+++ b/components/card/README.md
@@ -174,7 +174,7 @@ The `d2l-card` element is a container that provides specific layout using severa
 | `rel` | String | Relationship of the target object to the link object |
 | `subtle` | Boolean | Subtle aesthetic on non-white backgrounds |
 | `target` | String | Where to display the linked URL |
-| `text` | String | Accessible text for the card, required if `href` is set |
+| `text` | String | Accessible text for the card; required if `href` is set |
 
 See the [anchor element docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) for more information on standard link attributes and their values.
 <!-- docs: end hidden content -->

--- a/components/card/README.md
+++ b/components/card/README.md
@@ -168,13 +168,13 @@ The `d2l-card` element is a container that provides specific layout using severa
 
 | Property | Type | Description |
 |--|--|--|
+| `text` | String, required | Accessible text for the card for screen reader users |
 | `align-center` | Boolean | Style the card's content and footer as centered horizontally |
 | `download` | Boolean | Download a URL instead of navigating to it |
 | `href` | String | Location for the primary action/navigation |
 | `rel` | String | Relationship of the target object to the link object |
 | `subtle` | Boolean | Subtle aesthetic on non-white backgrounds |
 | `target` | String | Where to display the linked URL |
-| `text` | String | Accessible text for the card (will be announced when AT user focuses) |
 
 See the [anchor element docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) for more information on standard link attributes and their values.
 <!-- docs: end hidden content -->
@@ -292,7 +292,7 @@ The `d2l-card-footer-link` element is an icon link that can be placed in the `fo
 | Property | Type | Description |
 |--|--|--|
 | `icon` | String, required | Preset icon key (ex. "tier1:gear") |
-| `text` | String, required | Accessible text for the link (not visible, gets announced when user focuses) |
+| `text` | String, required | Accessible text for the link for screen reader users |
 | `download` | Boolean | Download a URL instead of navigating to it |
 | `href` | String | Location for the primary action/navigation |
 | `rel` | String | Relationship of the target object to the link object |

--- a/components/card/README.md
+++ b/components/card/README.md
@@ -174,7 +174,7 @@ The `d2l-card` element is a container that provides specific layout using severa
 | `rel` | String | Relationship of the target object to the link object |
 | `subtle` | Boolean | Subtle aesthetic on non-white backgrounds |
 | `target` | String | Where to display the linked URL |
-| `text` | String | Accessible text for the card |
+| `text` | String | Accessible text for the card, required if `href` is set |
 
 See the [anchor element docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) for more information on standard link attributes and their values.
 <!-- docs: end hidden content -->
@@ -292,6 +292,7 @@ The `d2l-card-footer-link` element is an icon link that can be placed in the `fo
 | Property | Type | Description |
 |--|--|--|
 | `icon` | String, required | Preset icon key (ex. "tier1:gear") |
+| `text` | String, required | Accessible text for the link |
 | `download` | Boolean | Download a URL instead of navigating to it |
 | `href` | String | Location for the primary action/navigation |
 | `rel` | String | Relationship of the target object to the link object |
@@ -299,15 +300,9 @@ The `d2l-card-footer-link` element is an icon link that can be placed in the `fo
 | `secondary-count-type` | String | Controls the style of the secondary count bubble; options are `notification` and `count` |
 | `secondary-count-max-digits` | Number | Overrides the default maximum digits of the secondary count bubble (2 for `notification` and no limit for `count` type) |
 | `target` | String | Where to display the linked URL |
-| `text` | String | Accessible text for the link |
 
 See the [anchor element docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) for more information on standard link attributes and their values.
-<!-- docs: end hidden content -->
 
-## Accessibility
-- The `text` property for the d2l-card and d2l-card-footer-link components is only required if actionable (i.e. the `href` property is used)
-
-<!-- docs: start hidden content -->
 ## Future Improvements
 
 * scroll API for the dialog content (see [#341](https://github.com/BrightspaceUI/core/issues/341))

--- a/components/card/card-footer-link.js
+++ b/components/card/card-footer-link.js
@@ -61,7 +61,7 @@ class CardFooterLink extends FocusMixin(RtlMixin(LitElement)) {
 			 */
 			target: { type: String, reflect: true },
 			/**
-			 * ACCESSIBILITY: REQUIRED: Accessible text for the link for screen reader users
+			 * ACCESSIBILITY: Accessible text for the link
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true },

--- a/components/card/card-footer-link.js
+++ b/components/card/card-footer-link.js
@@ -61,7 +61,7 @@ class CardFooterLink extends FocusMixin(RtlMixin(LitElement)) {
 			 */
 			target: { type: String, reflect: true },
 			/**
-			 * ACCESSIBILITY: Accessible text for the link
+			 * ACCESSIBILITY: REQUIRED: Accessible text for the link
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true },

--- a/components/card/card-footer-link.js
+++ b/components/card/card-footer-link.js
@@ -61,7 +61,7 @@ class CardFooterLink extends FocusMixin(RtlMixin(LitElement)) {
 			 */
 			target: { type: String, reflect: true },
 			/**
-			 * REQUIRED: Accessible text for the link (not visible, gets announced when user focuses)
+			 * ACCESSIBILITY: REQUIRED: Accessible text for the link for screen reader users
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true },

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -56,7 +56,7 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 			 */
 			target: { type: String, reflect: true },
 			/**
-			 * ACCESSIBILITY: Accessible text for the card, required if `href` is set
+			 * ACCESSIBILITY: Accessible text for the card; required if `href` is set
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true },

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -56,7 +56,7 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 			 */
 			target: { type: String, reflect: true },
 			/**
-			 * Accessible text for the card (will be announced when AT user focuses)
+			 * ACCESSIBILITY: REQUIRED: Accessible text for the card for screen reader users
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true },

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -56,7 +56,7 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 			 */
 			target: { type: String, reflect: true },
 			/**
-			 * ACCESSIBILITY: Accessible text for the card
+			 * ACCESSIBILITY: Accessible text for the card, required if `href` is set
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true },

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -56,7 +56,7 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 			 */
 			target: { type: String, reflect: true },
 			/**
-			 * ACCESSIBILITY: REQUIRED: Accessible text for the card for screen reader users
+			 * ACCESSIBILITY: Accessible text for the card
 			 * @type {string}
 			 */
 			text: { type: String, reflect: true },


### PR DESCRIPTION
[DAYL-92](https://desire2learn.atlassian.net/browse/DAYL-92)

Similar to other past stories, I'm updating the docn of the card component to include the `accessibility` tag in front of properties with a11y considerations. I've also updated the `text` property to be `Required`, an update to the component will be handled in [GAUD-7574](https://desire2learn.atlassian.net/browse/GAUD-7574) to have it use the required mixin, so that errors occur if the user doesn't have a value set for `text`

[DAYL-92]: https://desire2learn.atlassian.net/browse/DAYL-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GAUD-7574]: https://desire2learn.atlassian.net/browse/GAUD-7574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ