### PR TITLE
GAUD-7577: fix test flake

### DIFF
--- a/components/inputs/test/input-date-time-range.vdiff.js
+++ b/components/inputs/test/input-date-time-range.vdiff.js
@@ -390,6 +390,7 @@ describe('d2l-input-date-time-range', () => {
 					});
 
 					it('focus end', async() => {
+						await nextFrame();
 						focusElem(actualElem.shadowRoot.querySelector(endDateSelector));
 						await oneEvent(actualElem, 'd2l-tooltip-show');
 						await nextFrameGolden(elem);


### PR DESCRIPTION
Noticed this test flaked many times in a row during a recent PR. Testing this locally, it seems like the date inputs haven't finished rendering/positioning themselves when the tooltip is displayed. Waiting a bit before focusing fixed it locally, but I'll run a bunch of times in CI to confirm.