### PR TITLE
GAUD-7576: use overscroll-behavior on dropdowns

### DIFF
--- a/components/dropdown/dropdown-content-styles.js
+++ b/components/dropdown/dropdown-content-styles.js
@@ -152,6 +152,7 @@ export const dropdownContentStyles = css`
 		box-sizing: border-box;
 		max-width: 100%;
 		outline: none;
+		overscroll-behavior: contain;
 		overflow-y: auto;
 		padding: 1rem;
 	}

--- a/components/dropdown/dropdown-content-styles.js
+++ b/components/dropdown/dropdown-content-styles.js
@@ -152,8 +152,8 @@ export const dropdownContentStyles = css`
 		box-sizing: border-box;
 		max-width: 100%;
 		outline: none;
-		overscroll-behavior: contain;
 		overflow-y: auto;
+		overscroll-behavior: contain;
 		padding: 1rem;
 	}
 


### PR DESCRIPTION
This avoids scrolling the outer page (or outer container) when the scroll point reaches the bottom or top of the dropdown.