### PR TITLE
GAUD-7573: don't allow toggling when disabled

### DIFF
--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -210,7 +210,7 @@ class InputCheckbox extends InputInlineHelpMixin(FocusMixin(SkeletonMixin(LitEle
 					aria-label="${ifDefined(this.ariaLabel)}"
 					@change="${this.#handleChange}"
 					class="d2l-input-checkbox"
-					@click="${this._handleClick}"
+					@click="${this.#handleClick}"
 					.checked="${this.checked}"
 					?disabled="${disabled && !this.disabledTooltip}"
 					id="${this.#inputId}"
@@ -246,6 +246,10 @@ class InputCheckbox extends InputInlineHelpMixin(FocusMixin(SkeletonMixin(LitEle
 			'change',
 			{ bubbles: true, composed: false }
 		));
+	}
+
+	#handleClick(e) {
+		if (this.disabled) e.preventDefault();
 	}
 
 	#handleMouseEnter() {

--- a/components/inputs/test/input-checkbox.test.js
+++ b/components/inputs/test/input-checkbox.test.js
@@ -1,5 +1,5 @@
 import '../input-checkbox.js';
-import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 const uncheckedFixture = html`<d2l-input-checkbox aria-label="basic"></d2l-input-checkbox>`;
 const indeterminateCheckedFixture = html`<d2l-input-checkbox indeterminate checked></d2l-input-checkbox>`;
@@ -215,6 +215,22 @@ describe('d2l-input-checkbox', () => {
 			setTimeout(() => elem.simulateClick());
 			await oneEvent(elem, 'change');
 			expect(elem.checked).to.be.true;
+		});
+
+	});
+
+	describe('disabled', () => {
+
+		it('should not be toggleable when disabled without tooltip', async() => {
+			const elem = await fixture(html`<d2l-input-checkbox disabled aria-label="disabled"></d2l-input-checkbox>`);
+			await clickElem(getInput(elem));
+			expect(elem.checked).to.be.false;
+		});
+
+		it('should not be toggleable when disabled with tooltip', async() => {
+			const elem = await fixture(html`<d2l-input-checkbox disabled disabled-tooltip="tooltip" aria-label="disabled"></d2l-input-checkbox>`);
+			await clickElem(getInput(elem));
+			expect(elem.checked).to.be.false;
 		});
 
 	});


### PR DESCRIPTION
When I added the `disabled-tooltip` stuff I forgot that because the input isn't actually disabled anymore that it'll be toggle-able. 🤦 