### PR TITLE
[ignore; wip] feat: Tabs: Implement in d2l-tabs the ability to have a separate d2l-tab and d2l-panel

### DIFF
--- a/components/tabs/README.md
+++ b/components/tabs/README.md
@@ -35,7 +35,7 @@ Tabs are used to present related information in mutually exclusive panels, allow
 <!-- docs: end donts -->
 <!-- docs: end best practices -->
 
-## Tab [d2l-tabs]
+## Tabs [d2l-tabs]
 
 The `d2l-tabs` element is a web component for tabbed content. It provides the `d2l-tab-panel` component for the content, renders tabs responsively, and provides virtual scrolling for large tab lists.
 
@@ -65,6 +65,10 @@ The `d2l-tabs` element is a web component for tabbed content. It provides the `d
 | `max-to-show` | Number | Used to limit the max-width/number of tabs to initially display |
 
 <!-- docs: end hidden content -->
+
+## Tab [d2l-tab]
+
+Coming soon! This is currently in development and not quite ready for usage.
 
 ## Tab Panels [d2l-tab-panel]
 Selecting a tab in the tab bar causes the relevant tab panel to be displayed. Tab panels can contain text, form controls, rich media, or just about anything else. There is an optional “slot” available for related controls such as a Settings button.

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -64,6 +64,18 @@
 						<d2l-tab-panel text="Earth &amp; Planetary Sciences">Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
 						<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
 						<d2l-tab-panel text="Math">Tab content for Math</d2l-tab-panel>
+						<d2l-dropdown-button-subtle slot="ext" text="Explore Topics">
+							<d2l-dropdown-menu>
+								<d2l-menu label="Astronomy">
+									<d2l-menu-item text="Introduction"></d2l-menu-item>
+									<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+									<d2l-menu-item text="The Solar System"></d2l-menu-item>
+									<d2l-menu-item text="Stars &amp; Galaxies"></d2l-menu-item>
+									<d2l-menu-item text="The Night Sky"></d2l-menu-item>
+									<d2l-menu-item text="The Universe"></d2l-menu-item>
+								</d2l-menu>
+							</d2l-dropdown-menu>
+						</d2l-dropdown-button-subtle>
 					</d2l-tabs>
 				</template>
 			</d2l-demo-snippet>

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -11,6 +11,7 @@
 			import '../../dropdown/dropdown-menu.js';
 			import '../../menu/menu.js';
 			import '../../menu/menu-item.js';
+			import '../tab.js';
 			import '../tabs.js';
 			import '../tab-panel.js';
 		</script>
@@ -18,6 +19,39 @@
 	<body unresolved>
 
 		<d2l-demo-page page-title="d2l-tabs">
+
+			<h2>Tabs (new version)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-tabs>
+						<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+						<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+						<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+						<d2l-tab id="earth" text="Earth &amp; Planetary Sciences" slot="tabs"></d2l-tab>
+						<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
+						<d2l-tab id="math" text="Math" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="earth" slot="panels">Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for physics</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="math" slot="panels">Tab content for math</d2l-tab-panel>
+						<d2l-dropdown-button-subtle slot="ext" text="Explore Topics">
+							<d2l-dropdown-menu>
+								<d2l-menu label="Astronomy">
+									<d2l-menu-item text="Introduction"></d2l-menu-item>
+									<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+									<d2l-menu-item text="The Solar System"></d2l-menu-item>
+									<d2l-menu-item text="Stars &amp; Galaxies"></d2l-menu-item>
+									<d2l-menu-item text="The Night Sky"></d2l-menu-item>
+									<d2l-menu-item text="The Universe"></d2l-menu-item>
+								</d2l-menu>
+							</d2l-dropdown-menu>
+						</d2l-dropdown-button-subtle>
+					</d2l-tabs>
+				</template>
+			</d2l-demo-snippet>
 
 			<h2>Tabs</h2>
 

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -101,16 +101,15 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 
 	update(changedProperties) {
 		super.update(changedProperties);
-		changedProperties.forEach((oldVal, prop) => {
-			if (prop === 'selected') {
-				this.ariaSelected = this.selected;
-				if (this.selected === 'true') {
-					this.dispatchEvent(new CustomEvent(
-						'd2l-tab-selected', { bubbles: true, composed: true }
-					));
-				}
+
+		if (changedProperties.has('selected')) {
+			this.ariaSelected = this.selected;
+			if (this.selected) {
+				this.dispatchEvent(new CustomEvent(
+					'd2l-tab-selected', { bubbles: true, composed: true }
+				));
 			}
-		});
+		}
 	}
 
 	renderContent() {

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -9,7 +9,7 @@ export const TabPanelMixin = superclass => class extends superclass {
 			 * Id of the tab that labels this panel
 			 * @type {string}
 			 */
-			labelledBy: { type: String },
+			labelledBy: { type: String, attribute: 'labelled-by' },
 			/**
 			 * Opt out of default padding/whitespace around the panel
 			 * @type {boolean}
@@ -26,7 +26,7 @@ export const TabPanelMixin = superclass => class extends superclass {
 			 */
 			selected: { type: Boolean, reflect: true },
 			/**
-			 * ACCESSIBILITY: REQUIRED: The text used for the tab, as well as labelling the panel
+			 * ACCESSIBILITY: The text used for the tab, as well as labelling the panel. Required if not using d2l-tab/d2l-panel pair.
 			 * @type {string}
 			 */
 			text: { type: String }
@@ -65,11 +65,12 @@ export const TabPanelMixin = superclass => class extends superclass {
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
-		changedProperties.forEach((oldVal, prop) => {
+		changedProperties.forEach((_, prop) => {
 			if (prop === 'labelledBy') {
 				this.setAttribute('aria-labelledby', this.labelledBy);
 			} else if (prop === 'selected') {
-				if (this.selected) {
+				// assuming if this.text that we are using the old workflow
+				if (this.selected && this.text && !this.labelledBy) {
 					requestAnimationFrame(() => {
 						/** Dispatched when a tab is selected */
 						this.dispatchEvent(new CustomEvent(

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -5,6 +5,16 @@ import { TabMixin } from './tab-mixin.js';
 
 class Tab extends TabMixin(LitElement) {
 
+	static get properties() {
+		return {
+			/**
+			 * ACCESSIBILITY: REQUIRED: The text used for the tab, as well as labelling the panel.
+			 * @type {string}
+			 */
+			text: { type: String }
+		};
+	}
+
 	static get styles() {
 		const styles = [ css`
 			.d2l-tab-text {
@@ -17,7 +27,7 @@ class Tab extends TabMixin(LitElement) {
 			:host(:first-child) .d2l-tab-text {
 				margin-inline-start: 0;
 			}
-			:host(:${unsafeCSS(getFocusPseudoClass())}) > .d2l-tab-text {
+			:host(:${unsafeCSS(getFocusPseudoClass())}) .d2l-tab-text {
 				border-radius: 0.3rem;
 				box-shadow: 0 0 0 2px var(--d2l-color-celestine);
 				color: var(--d2l-color-celestine);
@@ -30,16 +40,15 @@ class Tab extends TabMixin(LitElement) {
 
 	renderContent() {
 		const contentClasses = {
-			'd2l-tab-handler': true,
 			'd2l-tab-text': true,
 		};
 
 		return html`
 			<div class="${classMap(contentClasses)}">
-				<slot></slot>
+				${this.text}
 			</div>
 		`;
 	}
 }
 
-customElements.define('d2l-tab-wip', Tab);
+customElements.define('d2l-tab', Tab);

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -333,7 +333,6 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 					</div>
 					${this.arrowKeysContainer(html`
 						<div class="d2l-tabs-container-list"
-							@d2l-tab-change="${this._handleTabChange}"
 							@d2l-tab-selected="${this._handleTabSelected}"
 							@focusout="${this._handleFocusOut}"
 							role="tablist"
@@ -870,12 +869,6 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			this.shadowRoot.querySelector('.d2l-tabs-scroll-next-container button').focus();
 		}
 
-	}
-
-	async _handleTabChange(e) {
-		e.stopPropagation();
-		this._updateMeasures();
-		await this._updateScrollVisibility(this._getMeasures());
 	}
 
 	async _handleTabSelected(e) {

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -233,7 +233,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 		super.firstUpdated(changedProperties);
 
 		this.arrowKeysFocusablesProvider = async() => {
-			return this._getTabs();
+			return this._defaultSlotBehavior ? [...this.shadowRoot.querySelectorAll('d2l-tab-internal')] : this._tabs;
 		};
 
 		this.arrowKeysOnBeforeFocus = async(tab) => {
@@ -413,7 +413,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 	}
 
 	_calculateScrollPosition(selectedTab, measures) {
-		const tabs = this._getTabs();
+		const tabs = this._tabs;
 		const selectedTabIndex = tabs.indexOf(selectedTab);
 
 		if (!measures.tabRects[selectedTabIndex]) return 0;
@@ -590,7 +590,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			return;
 		}
 
-		const selectedTab = this._getTabs().find(ti => ti.selected);
+		const selectedTab = this._tabs.find(ti => ti.selected);
 		if (!selectedTab) return;
 
 		await this._updateScrollPosition(selectedTab);
@@ -664,10 +664,6 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 	// remove after d2l-tab/d2l-tab-panel backport
 	_getTabInfo(id) {
 		return this._tabInfos.find((t) => t.id === id);
-	}
-
-	_getTabs() {
-		return this._defaultSlotBehavior ? [...this.shadowRoot.querySelectorAll('d2l-tab-internal')] : this._tabs;
 	}
 
 	// remove after d2l-tab/d2l-tab-panel backport
@@ -898,7 +894,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 		this._updateScrollPosition(selectedTab);
 
 		selectedPanel.selected = true;
-		this._getTabs().forEach(tab => {
+		this._tabs.forEach(tab => {
 			if (tab.id !== selectedTab.id) {
 				if (tab.selected) {
 					tab.selected = false;
@@ -1020,7 +1016,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			if (selectedTab) this._setFocusableDefaultSlotBehavior(selectedTab);
 			this.requestUpdate();
 		} else {
-			const selectedTab = this._getTabs().find(ti => ti.selected);
+			const selectedTab = this._tabs.find(ti => ti.selected);
 			if (selectedTab) this._setFocusable(selectedTab);
 			this.requestUpdate();
 		}
@@ -1048,7 +1044,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 	}
 
 	_setFocusable(tab) {
-		const currentFocusable = this._getTabs().find(tab => tab.tabIndex === 0);
+		const currentFocusable = this._tabs.find(tab => tab.tabIndex === 0);
 		if (currentFocusable) currentFocusable.tabIndex = -1;
 
 		tab.tabIndex = 0;
@@ -1112,7 +1108,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 		}
 		let totalTabsWidth = 0;
 		if (!this.shadowRoot) return;
-		const tabs = this._getTabs();
+		const tabs = this._tabs;
 
 		const tabRects = tabs.map((tab) => {
 			// tab.offsetLeft is relative to body rather than the slot container; this calculates it based on slot parent element
@@ -1219,7 +1215,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 	}
 
 	_updateTabsContainerWidth(selectedTab) {
-		const tabs = this._getTabs();
+		const tabs = this._tabs;
 		if (!this.maxToShow || this.maxToShow <= 0 || this.maxToShow >= tabs.length) return;
 		if (tabs.indexOf(selectedTab) > this.maxToShow - 1) return;
 		return this.#updateTabsContainerWidthLogic();

--- a/components/tabs/test/tabs.vdiff.js
+++ b/components/tabs/test/tabs.vdiff.js
@@ -1,20 +1,27 @@
 import '../../button/button.js';
+import '../tab.js';
 import '../tabs.js';
 import '../tab-panel.js';
 import { clickElem, expect, fixture, focusElem, html, sendKeysElem } from '@brightspace-ui/testing';
 
 const noPanelSelectedFixture = html`
 	<d2l-tabs>
-		<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-		<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-		<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+		<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+		<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+		<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+		<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+		<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+		<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 	</d2l-tabs>
 `;
 const panelSelectedFixture = html`
 	<d2l-tabs>
-		<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-		<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
-		<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+		<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+		<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+		<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+		<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+		<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+		<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 	</d2l-tabs>
 `;
 
@@ -37,7 +44,8 @@ describe('d2l-tabs', () => {
 		it('one tab', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
@@ -46,22 +54,29 @@ describe('d2l-tabs', () => {
 		it('skeleton', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs skeleton>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-					<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
-					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+					<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for Physics</d2l-tab-panel>
+					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
 		});
 
-		it('skeleton no text', async() => {
+		it.skip('skeleton no text', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs skeleton>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
 					<d2l-tab-panel>Tab content for Biology</d2l-tab-panel>
-					<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
-					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for Physics</d2l-tab-panel>
+					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
@@ -70,9 +85,12 @@ describe('d2l-tabs', () => {
 		it('ellipsis', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Earth &amp; Planetary Sciences" selected>Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
-					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="earth" text="Earth &amp; Planetary Sciences" slot="tabs" selected></d2l-tab>
+					<d2l-tab-panel labelled-by="earth" slot="panels">Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
+					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
@@ -93,8 +111,10 @@ describe('d2l-tabs', () => {
 		it('action slot', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
 					<d2l-button slot="ext">Search</d2l-button>
 				</d2l-tabs>
 			`, { viewport });
@@ -104,8 +124,10 @@ describe('d2l-tabs', () => {
 		it('no padding', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs>
-					<d2l-tab-panel text="All" no-padding style="background-color: orange;">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels" no-padding style="background-color: orange;">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
@@ -117,18 +139,26 @@ describe('d2l-tabs', () => {
 
 		const nextFixture = html`
 			<d2l-tabs>
-				<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
-				<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
-				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-				<d2l-tab-panel text="Geology">Tab content for Geology</d2l-tab-panel>
+				<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+				<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+				<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+				<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+				<d2l-tab id="geology" text="Geology" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="geology" slot="panels">Tab content for Geology</d2l-tab-panel>
 			</d2l-tabs>
 		`;
 		const previousFixture = html`
 			<d2l-tabs>
-				<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
-				<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-				<d2l-tab-panel text="Geology" selected>Tab content for Geology</d2l-tab-panel>
+				<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+				<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+				<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+				<d2l-tab id="geology" text="Geology" slot="tabs" selected></d2l-tab>
+				<d2l-tab-panel labelled-by="geology" slot="panels">Tab content for Geology</d2l-tab-panel>
 			</d2l-tabs>
 		`;
 
@@ -163,9 +193,12 @@ describe('d2l-tabs', () => {
 				it('action slot', async() => {
 					const elem = await fixture(html`
 						<d2l-tabs>
-							<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-							<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-							<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+							<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+							<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+							<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+							<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+							<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+							<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 							<d2l-button slot="ext">Search</d2l-button>
 						</d2l-tabs>
 					`, { viewport, rtl });
@@ -195,9 +228,12 @@ describe('d2l-tabs', () => {
 		beforeEach(async() => {
 			elem = await fixture(html`
 				<d2l-tabs max-to-show="2">
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
-					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 		});
@@ -222,9 +258,12 @@ describe('d2l-tabs', () => {
 
 		const keyboardFixture = html`
 			<d2l-tabs>
-				<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
-				<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
-				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+				<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+				<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+				<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+				<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 			</d2l-tabs>
 		`;
 
@@ -256,8 +295,10 @@ describe('d2l-tabs', () => {
 			it(`selects on ${key}`, async() => {
 				const elem = await fixture(html`
 					<d2l-tabs>
-						<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
-						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+						<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
 					</d2l-tabs>
 				`, { viewport });
 				await sendKeysElem(elem, 'press', `ArrowRight+${key}`);

--- a/components/tabs/test/tabs.vdiff.js
+++ b/components/tabs/test/tabs.vdiff.js
@@ -1,27 +1,20 @@
 import '../../button/button.js';
-import '../tab.js';
 import '../tabs.js';
 import '../tab-panel.js';
 import { clickElem, expect, fixture, focusElem, html, sendKeysElem } from '@brightspace-ui/testing';
 
 const noPanelSelectedFixture = html`
 	<d2l-tabs>
-		<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-		<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-		<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-		<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-		<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-		<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+		<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+		<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+		<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 	</d2l-tabs>
 `;
 const panelSelectedFixture = html`
 	<d2l-tabs>
-		<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-		<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-		<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
-		<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-		<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-		<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+		<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+		<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+		<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 	</d2l-tabs>
 `;
 
@@ -44,8 +37,7 @@ describe('d2l-tabs', () => {
 		it('one tab', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs>
-					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
@@ -54,29 +46,22 @@ describe('d2l-tabs', () => {
 		it('skeleton', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs skeleton>
-					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-					<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for Physics</d2l-tab-panel>
-					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+					<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
+					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
 		});
 
-		it.skip('skeleton no text', async() => {
+		it('skeleton no text', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs skeleton>
-					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 					<d2l-tab-panel>Tab content for Biology</d2l-tab-panel>
-					<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for Physics</d2l-tab-panel>
-					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
+					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
@@ -85,12 +70,9 @@ describe('d2l-tabs', () => {
 		it('ellipsis', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs>
-					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-					<d2l-tab id="earth" text="Earth &amp; Planetary Sciences" slot="tabs" selected></d2l-tab>
-					<d2l-tab-panel labelled-by="earth" slot="panels">Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
-					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="Earth &amp; Planetary Sciences" selected>Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
+					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
@@ -111,10 +93,8 @@ describe('d2l-tabs', () => {
 		it('action slot', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs>
-					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
 					<d2l-button slot="ext">Search</d2l-button>
 				</d2l-tabs>
 			`, { viewport });
@@ -124,10 +104,8 @@ describe('d2l-tabs', () => {
 		it('no padding', async() => {
 			const elem = await fixture(html`
 				<d2l-tabs>
-					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="all" slot="panels" no-padding style="background-color: orange;">Tab content for All</d2l-tab-panel>
-					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+					<d2l-tab-panel text="All" no-padding style="background-color: orange;">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 			await expect(elem).to.be.golden();
@@ -139,26 +117,18 @@ describe('d2l-tabs', () => {
 
 		const nextFixture = html`
 			<d2l-tabs>
-				<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
-				<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-				<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
-				<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-				<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-				<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
-				<d2l-tab id="geology" text="Geology" slot="tabs"></d2l-tab>
-				<d2l-tab-panel labelled-by="geology" slot="panels">Tab content for Geology</d2l-tab-panel>
+				<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+				<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+				<d2l-tab-panel text="Geology">Tab content for Geology</d2l-tab-panel>
 			</d2l-tabs>
 		`;
 		const previousFixture = html`
 			<d2l-tabs>
-				<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
-				<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-				<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-				<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-				<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-				<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
-				<d2l-tab id="geology" text="Geology" slot="tabs" selected></d2l-tab>
-				<d2l-tab-panel labelled-by="geology" slot="panels">Tab content for Geology</d2l-tab-panel>
+				<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+				<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+				<d2l-tab-panel text="Geology" selected>Tab content for Geology</d2l-tab-panel>
 			</d2l-tabs>
 		`;
 
@@ -193,12 +163,9 @@ describe('d2l-tabs', () => {
 				it('action slot', async() => {
 					const elem = await fixture(html`
 						<d2l-tabs>
-							<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-							<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-							<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-							<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-							<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-							<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+							<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+							<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+							<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 							<d2l-button slot="ext">Search</d2l-button>
 						</d2l-tabs>
 					`, { viewport, rtl });
@@ -228,12 +195,9 @@ describe('d2l-tabs', () => {
 		beforeEach(async() => {
 			elem = await fixture(html`
 				<d2l-tabs max-to-show="2">
-					<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-					<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
-					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 				</d2l-tabs>
 			`, { viewport });
 		});
@@ -258,12 +222,9 @@ describe('d2l-tabs', () => {
 
 		const keyboardFixture = html`
 			<d2l-tabs>
-				<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
-				<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-				<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
-				<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-				<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-				<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+				<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+				<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 			</d2l-tabs>
 		`;
 
@@ -295,10 +256,8 @@ describe('d2l-tabs', () => {
 			it(`selects on ${key}`, async() => {
 				const elem = await fixture(html`
 					<d2l-tabs>
-						<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
-						<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-						<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-						<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
 					</d2l-tabs>
 				`, { viewport });
 				await sendKeysElem(elem, 'press', `ArrowRight+${key}`);


### PR DESCRIPTION
[Jira task](https://desire2learn.atlassian.net/browse/GAUD-7483)

I'll try to split this out into other PRs. This just shows it all together.

===

This is the initial work to hook up a `d2l-tab` and `d2l-tab-panel`. They are connected via `labelled-by` on `d2l-tab-panel` corresponding to the `id` on `d2l-tab`.

I implemented it based us replacing existing `d2l-tab-panel` usages with the `d2l-tab` / `d2l-tab-panel` pair, which would then allow for the removal of the code now marked "legacy" in tabs.js.

To be done separately:
- skeleton behaviour
- tab change event listener (e.g., text changes, need to recalculate)
- add/remove tab animations and workflow
- accessibility behaviour (implementing/testing the `aria-controls` and `aria-labelledby` behaviour)
- panel and tab slot change - any error handling if no matching tab/panel found
- demo for a custom tab that uses `TabMixin`