### PR TITLE
feat: Tabs: Minor tweaks to tab and tab-panel

### DIFF
--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -92,25 +92,22 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 
 	render() {
 		return html`
-			<div class="d2l-skeletize">
-				${this.renderContent()}
-			</div>
+			${this.renderContent()}
 			<div class="d2l-tab-selected-indicator d2l-skeletize-container"></div>
 		`;
 	}
 
 	update(changedProperties) {
 		super.update(changedProperties);
-		changedProperties.forEach((oldVal, prop) => {
-			if (prop === 'selected') {
-				this.ariaSelected = this.selected;
-				if (this.selected === 'true') {
-					this.dispatchEvent(new CustomEvent(
-						'd2l-tab-selected', { bubbles: true, composed: true }
-					));
-				}
+
+		if (changedProperties.has('selected')) {
+			this.ariaSelected = this.selected;
+			if (this.selected) {
+				this.dispatchEvent(new CustomEvent(
+					'd2l-tab-selected', { bubbles: true, composed: true }
+				));
 			}
-		});
+		}
 	}
 
 	renderContent() {

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -9,7 +9,7 @@ export const TabPanelMixin = superclass => class extends superclass {
 			 * Id of the tab that labels this panel
 			 * @type {string}
 			 */
-			labelledBy: { type: String },
+			labelledBy: { type: String, attribute: 'labelled-by' },
 			/**
 			 * Opt out of default padding/whitespace around the panel
 			 * @type {boolean}
@@ -21,12 +21,12 @@ export const TabPanelMixin = superclass => class extends superclass {
 			// eslint-disable-next-line lit/no-native-attributes
 			role: { type: String, reflect: true },
 			/**
-			 * Use to select the tab
+			 * Use to select the tab. Do not set if using the d2l-tab/d2l-tab-panel implementation.
 			 * @type {boolean}
 			 */
 			selected: { type: Boolean, reflect: true },
 			/**
-			 * ACCESSIBILITY: REQUIRED: The text used for the tab, as well as labelling the panel
+			 * ACCESSIBILITY: The text used for the tab, as well as labelling the panel. Required if not using d2l-tab/d2l-tab-panel implementation.
 			 * @type {string}
 			 */
 			text: { type: String }
@@ -65,13 +65,14 @@ export const TabPanelMixin = superclass => class extends superclass {
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
-		changedProperties.forEach((oldVal, prop) => {
+		changedProperties.forEach((_, prop) => {
 			if (prop === 'labelledBy') {
 				this.setAttribute('aria-labelledby', this.labelledBy);
 			} else if (prop === 'selected') {
-				if (this.selected) {
+				// assuming if this.text that we are using the old workflow
+				if (this.selected && this.text) {
 					requestAnimationFrame(() => {
-						/** Dispatched when a tab is selected */
+						/** Dispatched when a tab is selected if NOT using the d2l-tab/d2l-tab-panel implementation. */
 						this.dispatchEvent(new CustomEvent(
 							'd2l-tab-panel-selected', { bubbles: true, composed: true }
 						));

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -65,14 +65,13 @@ export const TabPanelMixin = superclass => class extends superclass {
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
-		changedProperties.forEach((_, prop) => {
+		changedProperties.forEach((oldVal, prop) => {
 			if (prop === 'labelledBy') {
 				this.setAttribute('aria-labelledby', this.labelledBy);
 			} else if (prop === 'selected') {
-				// assuming if this.text that we are using the old workflow
-				if (this.selected && this.text) {
+				if (this.selected) {
 					requestAnimationFrame(() => {
-						/** Dispatched when a tab is selected if NOT using the d2l-tab/d2l-tab-panel implementation. */
+						/** Dispatched when a tab is selected */
 						this.dispatchEvent(new CustomEvent(
 							'd2l-tab-panel-selected', { bubbles: true, composed: true }
 						));

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -5,6 +5,16 @@ import { TabMixin } from './tab-mixin.js';
 
 class Tab extends TabMixin(LitElement) {
 
+	static get properties() {
+		return {
+			/**
+			 * ACCESSIBILITY: REQUIRED: The text used for the tab, as well as labelling the panel.
+			 * @type {string}
+			 */
+			text: { type: String }
+		};
+	}
+
 	static get styles() {
 		const styles = [ css`
 			.d2l-tab-text {
@@ -30,13 +40,12 @@ class Tab extends TabMixin(LitElement) {
 
 	renderContent() {
 		const contentClasses = {
-			'd2l-tab-handler': true,
 			'd2l-tab-text': true,
 		};
 
 		return html`
 			<div class="${classMap(contentClasses)}">
-				<slot></slot>
+				${this.text}
 			</div>
 		`;
 	}


### PR DESCRIPTION
Part of [this Jira task](https://desire2learn.atlassian.net/browse/GAUD-7483)

Does the following:
- Add labelled-by attribute to tab panel
- Update tab-panel docs
- Add `text` property to `d2l-tab` (default implementation of the `d2l-tab` / `d2l-tab-panel` method)

No impact is expected as `d2l-tab` is not in use.