### PR TITLE
GAUD-7584: collapsible panel borders when inline status changes

### DIFF
--- a/components/collapsible-panel/collapsible-panel-group.js
+++ b/components/collapsible-panel/collapsible-panel-group.js
@@ -50,7 +50,7 @@ class CollapsiblePanelGroup extends SkeletonGroupMixin(LitElement) {
 			?.querySelector('slot')
 			?.assignedNodes({ flatten: true })
 			.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName === 'D2L-COLLAPSIBLE-PANEL');
-		if (panels?.length) return;
+		if (!panels?.length) return;
 
 		const isInline = panels[0].type === 'inline';
 		this._spaced = !isInline;

--- a/components/collapsible-panel/collapsible-panel-group.js
+++ b/components/collapsible-panel/collapsible-panel-group.js
@@ -9,6 +9,12 @@ import { SubscriberRegistryController } from '../../controllers/subscriber/subsc
  */
 class CollapsiblePanelGroup extends SkeletonGroupMixin(LitElement) {
 
+	static get properties() {
+		return {
+			_spaced: { state: true }
+		};
+	}
+
 	static get styles() {
 		return css`
 			:host ::slotted(*) {
@@ -28,11 +34,12 @@ class CollapsiblePanelGroup extends SkeletonGroupMixin(LitElement) {
 	constructor() {
 		super();
 		this._panels = new SubscriberRegistryController(this, 'collapsible-panel-group');
+		this._spaced = true;
 	}
 
 	render() {
 		const classes = {
-			spaced: this._panels?.[0]?.type !== 'inline',
+			spaced: this._spaced,
 		};
 
 		return html`<slot class="${classMap(classes)}"></slot>`;
@@ -46,6 +53,7 @@ class CollapsiblePanelGroup extends SkeletonGroupMixin(LitElement) {
 		if (!panels || panels.length === 0) return;
 
 		const isInline = panels[0].type === 'inline';
+		this._spaced = !isInline;
 		for (let i = 0; i < panels.length; i++) {
 			if (i < panels.length - 1) {
 				panels[i]._noBottomBorder = isInline;

--- a/components/collapsible-panel/collapsible-panel-group.js
+++ b/components/collapsible-panel/collapsible-panel-group.js
@@ -54,13 +54,7 @@ class CollapsiblePanelGroup extends SkeletonGroupMixin(LitElement) {
 
 		const isInline = panels[0].type === 'inline';
 		this._spaced = !isInline;
-		for (let i = 0; i < panels.length; i++) {
-			if (i < panels.length - 1) {
-				panels[i]._noBottomBorder = isInline;
-			} else {
-				panels[i]._noBottomBorder = false;
-			}
-		}
+		panels.forEach((p, idx) => p._isLastPanelInGroup = idx === panels.length - 1);
 	}
 }
 

--- a/components/collapsible-panel/collapsible-panel-group.js
+++ b/components/collapsible-panel/collapsible-panel-group.js
@@ -50,7 +50,7 @@ class CollapsiblePanelGroup extends SkeletonGroupMixin(LitElement) {
 			?.querySelector('slot')
 			?.assignedNodes({ flatten: true })
 			.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.tagName === 'D2L-COLLAPSIBLE-PANEL');
-		if (!panels || panels.length === 0) return;
+		if (panels?.length) return;
 
 		const isInline = panels[0].type === 'inline';
 		this._spaced = !isInline;

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -87,7 +87,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			_focused: { state: true },
 			_hasBefore: { state: true },
 			_hasSummary: { state: true },
-			_noBottomBorder: { state: true },
+			_isLastPanelInGroup: { state: true },
 			_scrolled: { state: true },
 		};
 	}
@@ -330,7 +330,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			}
 		});
 		this._hasSummary = false;
-		this._noBottomBorder = false;
+		this._isLastPanelInGroup = false;
 		this._scrolled = false;
 	}
 
@@ -350,7 +350,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			'has-summary': this._hasSummary,
 			'has-before': this._hasBefore,
 			'scrolled': this._scrolled,
-			'no-bottom-border': this._noBottomBorder,
+			'no-bottom-border': this.type === 'inline' && !this._isLastPanelInGroup,
 		};
 
 		return html`

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -4,6 +4,7 @@ import '../expand-collapse/expand-collapse-content.js';
 import { css, html, LitElement } from 'lit';
 import { heading1Styles, heading2Styles, heading3Styles, heading4Styles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { EventSubscriberController } from '../../controllers/subscriber/subscriberControllers.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
@@ -321,6 +322,13 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 		this.type = 'default';
 		this.noSticky = false;
 		this._focused = false;
+		this._group = undefined;
+		this._groupSubscription = new EventSubscriberController(this, 'collapsible-panel-group', {
+			onSubscribe: (registry) => {
+				this._group = registry;
+				this._group._updatePanelAttributes();
+			}
+		});
 		this._hasSummary = false;
 		this._noBottomBorder = false;
 		this._scrolled = false;
@@ -377,6 +385,10 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 
 		if (changedProperties.has('noSticky')) {
 			this._stickyObserverUpdate();
+		}
+
+		if (changedProperties.has('type')) {
+			this._group?._updatePanelAttributes();
 		}
 	}
 

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -330,7 +330,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			}
 		});
 		this._hasSummary = false;
-		this._isLastPanelInGroup = false;
+		this._isLastPanelInGroup = true;
 		this._scrolled = false;
 	}
 

--- a/components/collapsible-panel/test/collapsible-panel-group.test.js
+++ b/components/collapsible-panel/test/collapsible-panel-group.test.js
@@ -1,0 +1,41 @@
+import '../collapsible-panel.js';
+import '../collapsible-panel-group.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
+
+describe('d2l-collapsible-panel-group', () => {
+
+	it('should construct', () => {
+		runConstructor('d2l-collapsible-panel-group');
+	});
+
+	it('should set bottom borders on inline panels', async() => {
+		const elem = await fixture(html`
+			<d2l-collapsible-panel-group>
+				<d2l-collapsible-panel panel-title="Panel Title 1" type="inline"></d2l-collapsible-panel>
+				<d2l-collapsible-panel panel-title="Panel Title 2" type="inline"></d2l-collapsible-panel>
+				<d2l-collapsible-panel panel-title="Panel Title 3" type="inline"></d2l-collapsible-panel>
+			</d2l-collapsible-panel-group>
+		`);
+		const panels = elem.querySelectorAll('d2l-collapsible-panel');
+		expect(panels[0]._noBottomBorder).to.be.true;
+		expect(panels[1]._noBottomBorder).to.be.true;
+		expect(panels[2]._noBottomBorder).to.be.false;
+	});
+
+	it('should set bottom borders on delayed inline panels', async() => {
+		const elem = await fixture(html`
+			<d2l-collapsible-panel-group>
+				<d2l-collapsible-panel panel-title="Panel Title 1"></d2l-collapsible-panel>
+				<d2l-collapsible-panel panel-title="Panel Title 2"></d2l-collapsible-panel>
+				<d2l-collapsible-panel panel-title="Panel Title 3"></d2l-collapsible-panel>
+			</d2l-collapsible-panel-group>
+		`);
+		const panels = elem.querySelectorAll('d2l-collapsible-panel');
+		panels[0].setAttribute('type', 'inline');
+		await elem.updateComplete;
+		expect(panels[0]._noBottomBorder).to.be.true;
+		expect(panels[1]._noBottomBorder).to.be.true;
+		expect(panels[2]._noBottomBorder).to.be.false;
+	});
+
+});

--- a/components/collapsible-panel/test/collapsible-panel-group.test.js
+++ b/components/collapsible-panel/test/collapsible-panel-group.test.js
@@ -8,7 +8,7 @@ describe('d2l-collapsible-panel-group', () => {
 		runConstructor('d2l-collapsible-panel-group');
 	});
 
-	it('should set bottom borders on inline panels', async() => {
+	it('should set position on inline panels', async() => {
 		const elem = await fixture(html`
 			<d2l-collapsible-panel-group>
 				<d2l-collapsible-panel panel-title="Panel Title 1" type="inline"></d2l-collapsible-panel>
@@ -17,12 +17,12 @@ describe('d2l-collapsible-panel-group', () => {
 			</d2l-collapsible-panel-group>
 		`);
 		const panels = elem.querySelectorAll('d2l-collapsible-panel');
-		expect(panels[0]._noBottomBorder).to.be.true;
-		expect(panels[1]._noBottomBorder).to.be.true;
-		expect(panels[2]._noBottomBorder).to.be.false;
+		expect(panels[0]._isLastPanelInGroup).to.be.false;
+		expect(panels[1]._isLastPanelInGroup).to.be.false;
+		expect(panels[2]._isLastPanelInGroup).to.be.true;
 	});
 
-	it('should set bottom borders on delayed inline panels', async() => {
+	it('should set position on delayed inline panels', async() => {
 		const elem = await fixture(html`
 			<d2l-collapsible-panel-group>
 				<d2l-collapsible-panel panel-title="Panel Title 1"></d2l-collapsible-panel>
@@ -33,9 +33,9 @@ describe('d2l-collapsible-panel-group', () => {
 		const panels = elem.querySelectorAll('d2l-collapsible-panel');
 		panels[0].setAttribute('type', 'inline');
 		await elem.updateComplete;
-		expect(panels[0]._noBottomBorder).to.be.true;
-		expect(panels[1]._noBottomBorder).to.be.true;
-		expect(panels[2]._noBottomBorder).to.be.false;
+		expect(panels[0]._isLastPanelInGroup).to.be.false;
+		expect(panels[1]._isLastPanelInGroup).to.be.false;
+		expect(panels[2]._isLastPanelInGroup).to.be.true;
 	});
 
 });

--- a/components/collapsible-panel/test/collapsible-panel.test.js
+++ b/components/collapsible-panel/test/collapsible-panel.test.js
@@ -1,6 +1,5 @@
 import '../collapsible-panel.js';
 import '../collapsible-panel-summary-item.js';
-import '../collapsible-panel-group.js';
 import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-collapsible-panel', () => {
@@ -8,7 +7,6 @@ describe('d2l-collapsible-panel', () => {
 	it('should construct', () => {
 		runConstructor('d2l-collapsible-panel');
 		runConstructor('d2l-collapsible-panel-summary-item');
-		runConstructor('d2l-collapsible-panel-group');
 	});
 
 	describe('panel label', () => {


### PR DESCRIPTION
When collapsible panels are arranged in a group, and they're of type "inline", then one of the borders between the items is "collapsed" (i.e. hidden), except for the last item.

<img width="429" alt="Screenshot 2025-03-14 at 10 12 55 AM" src="https://github.com/user-attachments/assets/aa4973a5-cfd7-4940-bb2c-8ed3bf95188d" />

This is currently accomplished with a `slotchange` event on the group which then iterates over the items and based on the type of the first item, sets a reactive state property on each one to potentially hide some borders.

When using these in the LMS however, because things can be slower there I noticed that often (always) the `slotchange` event fired _before_ the panels had even initialized their properties, so the borders were never hidden. Another issue is that if the type changed to `inline` (or from `inline`) later, the `slotchange` event wouldn't fire and the borders would be incorrect.

This change updates the group & panels to use the subscriber controller. That way, whenever a panel's `type` changes it can notify the group to recalculate.