### PR TITLE
feat: Tabs: Add initial functionality for supporting d2l-tab/d2l-tab-panel

### DIFF
--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -11,6 +11,7 @@
 			import '../../dropdown/dropdown-menu.js';
 			import '../../menu/menu.js';
 			import '../../menu/menu-item.js';
+			import '../tab.js';
 			import '../tabs.js';
 			import '../tab-panel.js';
 		</script>
@@ -35,35 +36,17 @@
 			</d2l-demo-snippet>
 
 			<h2>Tabs (paired d2l-tab with d2l-panel)</h2>
+			<div>This format is still a WIP. Please do not use yet.</div>
 
 			<d2l-demo-snippet>
-				<div>This format is not yet functional. Please do not use yet.</div>
 				<template>
 					<d2l-tabs>
 						<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
 						<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
 						<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-						<d2l-tab id="earth" text="Earth &amp; Planetary Sciences" slot="tabs"></d2l-tab>
-						<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
-						<d2l-tab id="math" text="Math" slot="tabs"></d2l-tab>
 						<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
 						<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
 						<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
-						<d2l-tab-panel labelled-by="earth" slot="panels">Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
-						<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for physics</d2l-tab-panel>
-						<d2l-tab-panel labelled-by="math" slot="panels">Tab content for math</d2l-tab-panel>
-						<d2l-dropdown-button-subtle slot="ext" text="Explore Topics">
-							<d2l-dropdown-menu>
-								<d2l-menu label="Astronomy">
-									<d2l-menu-item text="Introduction"></d2l-menu-item>
-									<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
-									<d2l-menu-item text="The Solar System"></d2l-menu-item>
-									<d2l-menu-item text="Stars &amp; Galaxies"></d2l-menu-item>
-									<d2l-menu-item text="The Night Sky"></d2l-menu-item>
-									<d2l-menu-item text="The Universe"></d2l-menu-item>
-								</d2l-menu>
-							</d2l-dropdown-menu>
-						</d2l-dropdown-button-subtle>
 					</d2l-tabs>
 				</template>
 			</d2l-demo-snippet>

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -13,8 +13,7 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		return {
 			selected: { type: Boolean, reflect: true },
 			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
-			tabIndex: { type: Number, reflect: true, attribute: 'tabindex' }
+			role: { type: String, reflect: true }
 		};
 	}
 
@@ -67,7 +66,6 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		super();
 		this.role = 'tab';
 		this.selected = false;
-		this.tabIndex = -1;
 	}
 
 	connectedCallback() {

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -12,6 +12,9 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	static get properties() {
 		return {
 			selected: { type: Boolean, reflect: true },
+			// eslint-disable-next-line lit/no-native-attributes
+			role: { type: String, reflect: true },
+			tabIndex: { type: Number, reflect: true, attribute: 'tabindex' }
 		};
 	}
 
@@ -62,7 +65,6 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 
 	constructor() {
 		super();
-		this.ariaSelected = false;
 		this.role = 'tab';
 		this.selected = false;
 		this.tabIndex = -1;

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -752,6 +752,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 				if (tab.selected) {
 					tab.selected = false;
 					const panel = this._getPanel(tab.id);
+					// panel may not exist if it's being removed
 					if (panel) panel.selected = false;
 				}
 				if (tab.tabIndex === 0) tab.tabIndex = -1;

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -747,12 +747,16 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 		await this.updateComplete;
 
 		selectedPanel.selected = true;
-		const prevSelectTab = this._tabs.find(tab => (tab.id !== selectedTab.id && tab.selected));
-		if (prevSelectTab) {
-			prevSelectTab.selected = false;
-			const prevSelectPanel = this._getPanel(prevSelectTab.id);
-			if (prevSelectPanel) prevSelectPanel.selected = false;
-		}
+		this._tabs.forEach((tab) => {
+			if (tab.id !== selectedTab.id) {
+				if (tab.selected) {
+					tab.selected = false;
+					const panel = this._getPanel(tab.id);
+					if (panel) panel.selected = false;
+				}
+				if (tab.tabIndex === 0) tab.tabIndex = -1;
+			}
+		});
 
 		this.requestUpdate();
 	}

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -627,7 +627,10 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 		this._resetFocusables();
 	}
 
+	// remove after d2l-tab/d2l-tab-panel backport
 	_handlePanelSelected(e) {
+		if (!this._defaultSlotBehavior) return;
+
 		const tabInfo = this._getTabInfo(e.target.id);
 		// event could be from nested tabs
 		if (!tabInfo) return;

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -22,7 +22,6 @@ const scrollButtonWidth = 56;
  * A component for tabbed content. It supports the "d2l-tab-panel" component for the content, renders tabs responsively, and provides virtual scrolling for large tab lists.
  * @slot - Contains the tab panels (e.g., "d2l-tab-panel" components)
  * @slot ext - Additional content (e.g., a button) positioned at right
- * @fires d2l-tabs-initialized - Dispatched when the component is initialized
  */
 class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))) {
 
@@ -502,14 +501,9 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 		if (this._defaultSlotBehavior) return this._getPanelDefaultSlotBehavior(id);
 
 		if (!this.shadowRoot) return;
-		// use simple selector for slot (Edge)
-		const slot = this.shadowRoot.querySelector('.d2l-panels-container').querySelector('slot[name="panels"]');
+		const slot = this.shadowRoot.querySelector('slot[name="panels"]');
 		const panels = this._getPanels(slot);
-		for (let i = 0; i < panels.length; i++) {
-			if (panels[i].labelledBy === id) {
-				return panels[i];
-			}
-		}
+		return panels.find(panel => panel.labelledBy === id);
 	}
 
 	// remove after d2l-tab/d2l-tab-panel backport
@@ -527,8 +521,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 
 	_getPanels(slot) {
 		if (!slot) return;
-		return slot.assignedNodes({ flatten: true })
-			.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.role === 'tabpanel');
+		return slot.assignedElements({ flatten: true }).filter((node) => node.role === 'tabpanel');
 	}
 
 	// remove after d2l-tab/d2l-tab-panel backport
@@ -616,10 +609,6 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 				return this._updateScrollPosition(selectedTabInfo);
 			});
 		}
-
-		this.dispatchEvent(new CustomEvent(
-			'd2l-tabs-initialized', { bubbles: true, composed: true }
-		));
 
 	}
 
@@ -795,8 +784,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 	async _handleTabsSlotChange(e) {
 		this._defaultSlotBehavior = false;
 
-		this._tabs = e.target.assignedNodes({ flatten: true })
-			.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.role === 'tab');
+		this._tabs = e.target.assignedElements({ flatten: true }).filter((node) => node.role === 'tab');
 
 		// handle case where there are less than two tabs initially
 		this._updateTabListVisibility(this._tabs);
@@ -823,10 +811,6 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			const selectedPanel = this._getPanel(selectedTab.id);
 			if (selectedPanel) selectedPanel.selected = true;
 		}
-
-		this.dispatchEvent(new CustomEvent(
-			'd2l-tabs-initialized', { bubbles: true, composed: true }
-		));
 	}
 
 	_isPositionInLeftScrollArea(position) {

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -206,7 +206,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 		this._maxWidth = null;
 		this._scrollCollapsed = false;
 		this._state = 'shown';
-		this._tabInfos = [];
+		this._tabInfos = []; // remove after d2l-tab/d2l-tab-panel backport
 		this._translationValue = 0;
 	}
 
@@ -531,6 +531,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.role === 'tabpanel');
 	}
 
+	// remove after d2l-tab/d2l-tab-panel backport
 	_getTabInfo(id) {
 		return this._tabInfos.find((t) => t.id === id);
 	}
@@ -740,8 +741,6 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			this._handleTabSelectedDefaultSlotBehavior(e);
 			return;
 		}
-
-		e.stopPropagation();
 
 		const selectedTab = e.target;
 		const selectedPanel = this._getPanel(e.target.id);

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -1,8 +1,9 @@
+import '../tab.js';
 import '../tabs.js';
 import '../tab-panel.js';
 import { fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
-const normalFixture = html`
+const defaultFixture = html`
 	<div>
 		<d2l-tabs>
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
@@ -10,6 +11,19 @@ const normalFixture = html`
 			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 		</d2l-tabs>
 	</div>
+`;
+
+const normalFixture = html`
+<div>
+	<d2l-tabs>
+		<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+		<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+		<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+		<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+		<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+		<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+	</d2l-tabs>
+</div>
 `;
 
 describe('d2l-tabs', () => {
@@ -24,22 +38,36 @@ describe('d2l-tabs', () => {
 			runConstructor('d2l-tab-panel');
 		});
 
+		it('should construct tab', () => {
+			runConstructor('d2l-tab');
+		});
+
 	});
 
 	describe('events', () => {
 
+		// remove after d2l-tab/d2l-tab-panel backport
 		it('dispatches d2l-tab-panel-selected', async() => {
-			const el = await fixture(normalFixture);
+			const el = await fixture(defaultFixture);
 			const panel = el.querySelectorAll('d2l-tab-panel')[1];
 			setTimeout(() => panel.selected = true);
 			await oneEvent(panel, 'd2l-tab-panel-selected');
 		});
 
+		// remove after d2l-tab/d2l-tab-panel backport
 		it('dispatches d2l-tab-panel-text-changed', async() => {
-			const el = await fixture(normalFixture);
+			const el = await fixture(defaultFixture);
 			const panel = el.querySelector('d2l-tab-panel');
 			setTimeout(() => panel.setAttribute('text', 'new text'));
 			await oneEvent(panel, 'd2l-tab-panel-text-changed');
+		});
+
+		it('dispatches d2l-tab-selected', async() => {
+			const el = await fixture(normalFixture);
+			const tab = el.querySelectorAll('d2l-tab')[1];
+			setTimeout(() => tab.selected = true);
+			const tabs = el.querySelector('d2l-tabs');
+			await oneEvent(tabs, 'd2l-tab-selected');
 		});
 
 	});

--- a/components/tabs/test/tabs.vdiff.js
+++ b/components/tabs/test/tabs.vdiff.js
@@ -124,7 +124,7 @@ const ellipsisFixture = {
 	`
 };
 
-const actionSlotFixture = {
+const actionSlotBasicFixture = {
 	default: html`
 		<d2l-tabs>
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
@@ -138,6 +138,28 @@ const actionSlotFixture = {
 			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
 			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
 			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+			<d2l-button slot="ext">Search</d2l-button>
+		</d2l-tabs>
+	`
+};
+
+const actionSlotOverflowFixture = {
+	default: html`
+		<d2l-tabs>
+			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+			<d2l-button slot="ext">Search</d2l-button>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs>
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 			<d2l-button slot="ext">Search</d2l-button>
 		</d2l-tabs>
 	`
@@ -230,7 +252,7 @@ describe('d2l-tabs', () => {
 		});
 
 		it('action slot', async() => {
-			const elem = await fixture(actionSlotFixture[useFixture], { viewport });
+			const elem = await fixture(actionSlotBasicFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
@@ -317,7 +339,7 @@ describe('d2l-tabs', () => {
 				});
 
 				it('action slot', async() => {
-					const elem = await fixture(actionSlotFixture[useFixture], { viewport, rtl });
+					const elem = await fixture(actionSlotOverflowFixture[useFixture], { viewport, rtl });
 					await expect(elem).to.be.golden();
 				});
 

--- a/components/tabs/test/tabs.vdiff.js
+++ b/components/tabs/test/tabs.vdiff.js
@@ -1,113 +1,241 @@
 import '../../button/button.js';
+import '../tab.js';
 import '../tabs.js';
 import '../tab-panel.js';
 import { clickElem, expect, fixture, focusElem, html, sendKeysElem } from '@brightspace-ui/testing';
 
-const noPanelSelectedFixture = html`
-	<d2l-tabs>
-		<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-		<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-		<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-	</d2l-tabs>
-`;
-const panelSelectedFixture = html`
-	<d2l-tabs>
-		<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-		<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
-		<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-	</d2l-tabs>
-`;
+const noPanelSelectedFixture = {
+	default: html`
+		<d2l-tabs>
+			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs>
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`
+};
+
+const panelSelectedFixture = {
+	default: html`
+		<d2l-tabs>
+			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+			<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs>
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels" selected>Tab content for Biology</d2l-tab-panel>
+			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`
+};
+
+const oneTabFixture = {
+	default: html`
+		<d2l-tabs>
+			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs>
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+		</d2l-tabs>
+	`
+};
+
+const skeletonFixture = {
+	default: html`
+		<d2l-tabs skeleton>
+			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+			<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
+			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs skeleton>
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+			<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for Physics</d2l-tab-panel>
+			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`
+};
+
+const skeletonNoTextFixture = {
+	default: html`
+		<d2l-tabs skeleton>
+			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+			<d2l-tab-panel>Tab content for Biology</d2l-tab-panel>
+			<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
+			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs skeleton>
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+			<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for Physics</d2l-tab-panel>
+			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`
+};
+
+const ellipsisFixture = {
+	default: html`
+		<d2l-tabs>
+			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+			<d2l-tab-panel text="Earth &amp; Planetary Sciences" selected>Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
+			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs>
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+			<d2l-tab id="earth" text="Earth &amp; Planetary Sciences" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="earth" slot="panels" selected>Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
+			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`
+};
+
+const actionSlotFixture = {
+	default: html`
+		<d2l-tabs>
+			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+			<d2l-button slot="ext">Search</d2l-button>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs>
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+			<d2l-button slot="ext">Search</d2l-button>
+		</d2l-tabs>
+	`
+};
+
+const noPaddingFixture = {
+	default: html`
+		<d2l-tabs>
+			<d2l-tab-panel text="All" no-padding style="background-color: orange;">Tab content for All</d2l-tab-panel>
+			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs>
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels" no-padding style="background-color: orange;">Tab content for All</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+		</d2l-tabs>
+	`
+};
+
+const maxToShowFixture = {
+	default: html`
+		<d2l-tabs max-to-show="2">
+			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
+			<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`,
+	paired: html`
+		<d2l-tabs max-to-show="2">
+			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels" selected>Tab content for Biology</d2l-tab-panel>
+			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+		</d2l-tabs>
+	`
+};
 
 const viewport = { width: 376 };
+const useFixture = 'default';
 
 describe('d2l-tabs', () => {
 
 	describe('basic', () => {
 
 		it('no panel selected', async() => {
-			const elem = await fixture(noPanelSelectedFixture, { viewport });
+			const elem = await fixture(noPanelSelectedFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
 		it('panel selected', async() => {
-			const elem = await fixture(panelSelectedFixture, { viewport });
+			const elem = await fixture(panelSelectedFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
 		it('one tab', async() => {
-			const elem = await fixture(html`
-				<d2l-tabs>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-				</d2l-tabs>
-			`, { viewport });
+			const elem = await fixture(oneTabFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
 		it('skeleton', async() => {
-			const elem = await fixture(html`
-				<d2l-tabs skeleton>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-					<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
-					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-				</d2l-tabs>
-			`, { viewport });
+			const elem = await fixture(skeletonFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
 		it('skeleton no text', async() => {
-			const elem = await fixture(html`
-				<d2l-tabs skeleton>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel>Tab content for Biology</d2l-tab-panel>
-					<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
-					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-				</d2l-tabs>
-			`, { viewport });
+			const elem = await fixture(skeletonNoTextFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
 		it('ellipsis', async() => {
-			const elem = await fixture(html`
-				<d2l-tabs>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Earth &amp; Planetary Sciences" selected>Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
-					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-				</d2l-tabs>
-			`, { viewport });
+			const elem = await fixture(ellipsisFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
 		it('non-selected tab focus', async() => {
-			const elem = await fixture(noPanelSelectedFixture, { viewport });
+			const elem = await fixture(noPanelSelectedFixture[useFixture], { viewport });
 			await sendKeysElem(elem, 'press', 'ArrowRight');
 			await expect(elem).to.be.golden();
 		});
 
 		it('selected tab focus', async() => {
-			const elem = await fixture(panelSelectedFixture, { viewport });
+			const elem = await fixture(panelSelectedFixture[useFixture], { viewport });
 			await focusElem(elem);
 			await expect(elem).to.be.golden();
 		});
 
 		it('action slot', async() => {
-			const elem = await fixture(html`
-				<d2l-tabs>
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-					<d2l-button slot="ext">Search</d2l-button>
-				</d2l-tabs>
-			`, { viewport });
+			const elem = await fixture(actionSlotFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
 		it('no padding', async() => {
-			const elem = await fixture(html`
-				<d2l-tabs>
-					<d2l-tab-panel text="All" no-padding style="background-color: orange;">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-				</d2l-tabs>
-			`, { viewport });
+			const elem = await fixture(noPaddingFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
@@ -115,22 +243,50 @@ describe('d2l-tabs', () => {
 
 	describe('overflow', () => {
 
-		const nextFixture = html`
-			<d2l-tabs>
-				<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
-				<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
-				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-				<d2l-tab-panel text="Geology">Tab content for Geology</d2l-tab-panel>
-			</d2l-tabs>
-		`;
-		const previousFixture = html`
-			<d2l-tabs>
-				<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
-				<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-				<d2l-tab-panel text="Geology" selected>Tab content for Geology</d2l-tab-panel>
-			</d2l-tabs>
-		`;
+		const nextFixture = {
+			default: html`
+				<d2l-tabs>
+					<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab-panel text="Geology">Tab content for Geology</d2l-tab-panel>
+				</d2l-tabs>
+			`,
+			paired: html`
+				<d2l-tabs>
+					<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="biology" slot="panels" selected>Tab content for Biology</d2l-tab-panel>
+					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab id="geology" text="Geology" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="geology" slot="panels">Tab content for Geology</d2l-tab-panel>
+				</d2l-tabs>
+			`
+		};
+		const previousFixture = {
+			default: html`
+				<d2l-tabs>
+					<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab-panel text="Geology" selected>Tab content for Geology</d2l-tab-panel>
+				</d2l-tabs>
+			`,
+			paired: html`
+				<d2l-tabs>
+					<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+					<d2l-tab id="geology" text="Geology" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="geology" slot="panels" selected>Tab content for Geology</d2l-tab-panel>
+				</d2l-tabs>
+			`
+		};
 
 		['ltr', 'rtl'].forEach((dir) => {
 
@@ -139,47 +295,40 @@ describe('d2l-tabs', () => {
 			describe(dir, () => {
 
 				it('scroll next', async() => {
-					const elem = await fixture(nextFixture, { viewport, rtl });
+					const elem = await fixture(nextFixture[useFixture], { viewport, rtl });
 					await expect(elem).to.be.golden();
 				});
 
 				it('scrolls next on click', async() => {
-					const elem = await fixture(nextFixture, { viewport, rtl });
+					const elem = await fixture(nextFixture[useFixture], { viewport, rtl });
 					await clickElem(elem.shadowRoot.querySelector('.d2l-tabs-scroll-next-container button'));
 					await expect(elem).to.be.golden();
 				});
 
 				it('scroll previous', async() => {
-					const elem = await fixture(previousFixture, { viewport, rtl });
+					const elem = await fixture(previousFixture[useFixture], { viewport, rtl });
 					await expect(elem).to.be.golden();
 				});
 
 				it('scrolls previous on click', async() => {
-					const elem = await fixture(previousFixture, { viewport, rtl });
+					const elem = await fixture(previousFixture[useFixture], { viewport, rtl });
 					await clickElem(elem.shadowRoot.querySelector('.d2l-tabs-scroll-previous-container button'));
 					await expect(elem).to.be.golden();
 				});
 
 				it('action slot', async() => {
-					const elem = await fixture(html`
-						<d2l-tabs>
-							<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-							<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-							<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-							<d2l-button slot="ext">Search</d2l-button>
-						</d2l-tabs>
-					`, { viewport, rtl });
+					const elem = await fixture(actionSlotFixture[useFixture], { viewport, rtl });
 					await expect(elem).to.be.golden();
 				});
 
 				it('focus next', async() => {
-					const elem = await fixture(nextFixture, { viewport, rtl });
+					const elem = await fixture(nextFixture[useFixture], { viewport, rtl });
 					await focusElem(elem.shadowRoot.querySelector('.d2l-tabs-scroll-next-container button'));
 					await expect(elem).to.be.golden();
 				});
 
 				it('focus previous', async() => {
-					const elem = await fixture(previousFixture, { viewport, rtl });
+					const elem = await fixture(previousFixture[useFixture], { viewport, rtl });
 					await focusElem(elem.shadowRoot.querySelector('.d2l-tabs-scroll-previous-container button'));
 					await expect(elem).to.be.golden();
 				});
@@ -193,13 +342,7 @@ describe('d2l-tabs', () => {
 
 		let elem;
 		beforeEach(async() => {
-			elem = await fixture(html`
-				<d2l-tabs max-to-show="2">
-					<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-					<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
-					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-				</d2l-tabs>
-			`, { viewport });
+			elem = await fixture(maxToShowFixture[useFixture], { viewport });
 		});
 
 		it('initial', async() => {
@@ -220,46 +363,69 @@ describe('d2l-tabs', () => {
 
 	describe('keyboard', () => {
 
-		const keyboardFixture = html`
-			<d2l-tabs>
-				<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
-				<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
-				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-			</d2l-tabs>
-		`;
+		const keyboardFixture = {
+			default: html`
+				<d2l-tabs>
+					<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+					<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+					<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+				</d2l-tabs>
+			`,
+			paired: html`
+				<d2l-tabs>
+					<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="biology" slot="panels" selected>Tab content for Biology</d2l-tab-panel>
+					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+				</d2l-tabs>
+			`
+		};
 
 		it('focuses next on right arrow', async() => {
-			const elem = await fixture(keyboardFixture, { viewport });
+			const elem = await fixture(keyboardFixture[useFixture], { viewport });
 			await sendKeysElem(elem, 'press', 'ArrowRight');
 			await expect(elem).to.be.golden();
 		});
 
 		it('focuses previous on left arrow', async() => {
-			const elem = await fixture(keyboardFixture, { viewport });
+			const elem = await fixture(keyboardFixture[useFixture], { viewport });
 			await sendKeysElem(elem, 'press', 'ArrowLeft');
 			await expect(elem).to.be.golden();
 		});
 
 		it('focuses first on right arrow from last', async() => {
-			const elem = await fixture(keyboardFixture, { viewport });
+			const elem = await fixture(keyboardFixture[useFixture], { viewport });
 			await sendKeysElem(elem, 'press', 'ArrowRight+ArrowRight');
 			await expect(elem).to.be.golden();
 		});
 
 		it('focuses last on left arrow from first', async() => {
-			const elem = await fixture(keyboardFixture, { viewport });
+			const elem = await fixture(keyboardFixture[useFixture], { viewport });
 			await sendKeysElem(elem, 'press', 'ArrowLeft+ArrowLeft');
 			await expect(elem).to.be.golden();
 		});
 
 		['Space', 'Enter'].forEach((key) => {
-			it(`selects on ${key}`, async() => {
-				const elem = await fixture(html`
+			const keyboardSelectionFixture = {
+				default: html`
 					<d2l-tabs>
 						<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
 						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
 					</d2l-tabs>
-				`, { viewport });
+				`,
+				paired: html`
+					<d2l-tabs>
+						<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+						<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+					</d2l-tabs>
+				`
+			};
+			it(`selects on ${key}`, async() => {
+				const elem = await fixture(keyboardSelectionFixture[useFixture], { viewport });
 				await sendKeysElem(elem, 'press', `ArrowRight+${key}`);
 				await expect(elem).to.be.golden();
 			});

--- a/components/tabs/test/tabs.vdiff.js
+++ b/components/tabs/test/tabs.vdiff.js
@@ -36,8 +36,8 @@ const panelSelectedFixture = {
 		<d2l-tabs>
 			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
 			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="biology" slot="panels" selected>Tab content for Biology</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
 			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
 			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 		</d2l-tabs>
@@ -116,8 +116,8 @@ const ellipsisFixture = {
 		<d2l-tabs>
 			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
 			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-			<d2l-tab id="earth" text="Earth &amp; Planetary Sciences" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="earth" slot="panels" selected>Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
+			<d2l-tab id="earth" text="Earth &amp; Planetary Sciences" slot="tabs" selected></d2l-tab>
+			<d2l-tab-panel labelled-by="earth" slot="panels">Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
 			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
 			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 		</d2l-tabs>
@@ -194,8 +194,8 @@ const maxToShowFixture = {
 		<d2l-tabs max-to-show="2">
 			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
 			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="biology" slot="panels" selected>Tab content for Biology</d2l-tab-panel>
+			<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
 			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
 			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 		</d2l-tabs>
@@ -278,8 +278,8 @@ describe('d2l-tabs', () => {
 				<d2l-tabs>
 					<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
 					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="biology" slot="panels" selected>Tab content for Biology</d2l-tab-panel>
+					<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
 					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
 					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 					<d2l-tab id="geology" text="Geology" slot="tabs"></d2l-tab>
@@ -304,8 +304,8 @@ describe('d2l-tabs', () => {
 					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
 					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
 					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
-					<d2l-tab id="geology" text="Geology" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="geology" slot="panels" selected>Tab content for Geology</d2l-tab-panel>
+					<d2l-tab id="geology" text="Geology" slot="tabs" selected></d2l-tab>
+					<d2l-tab-panel labelled-by="geology" slot="panels">Tab content for Geology</d2l-tab-panel>
 				</d2l-tabs>
 			`
 		};
@@ -397,8 +397,8 @@ describe('d2l-tabs', () => {
 				<d2l-tabs>
 					<d2l-tab id="all" text="All Courses" slot="tabs"></d2l-tab>
 					<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-					<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-					<d2l-tab-panel labelled-by="biology" slot="panels" selected>Tab content for Biology</d2l-tab-panel>
+					<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+					<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
 					<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
 					<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 				</d2l-tabs>


### PR DESCRIPTION
Part of [this Jira task](https://desire2learn.atlassian.net/browse/GAUD-7483)

This adds the slots for `d2l-tab` and `d2l-tab-panel` and handles them in a very basic way. All that is supported is the basic pairing of the tab and panel, as well as clicking on a tab to change.

Note that the vdiffs didn't actually change, I just created a way to more easily test both scenarios locally.