### PR TITLE
feat: Tabs: New Structure: Add aria-label to the tablist and aria-controls to the tab

### DIFF
--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -40,12 +40,12 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-tabs>
+					<d2l-tabs text="Courses">
 						<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
 						<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
 						<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-						<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-						<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="all" slot="panels" id="all-panel">Tab content for All</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="biology" slot="panels" id="biology-panel">Tab content for Biology</d2l-tab-panel>
 						<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 					</d2l-tabs>
 				</template>

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -8,6 +8,8 @@ import { ArrowKeysMixin } from '../../mixins/arrow-keys/arrow-keys-mixin.js';
 import { bodyCompactStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { getUniqueId } from '../../helpers/uniqueId.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { repeat } from 'lit/directives/repeat.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
@@ -32,6 +34,11 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			 * @type {number}
 			 */
 			maxToShow: { type: Number, attribute: 'max-to-show' },
+			/**
+			 * REQUIRED: ACCESSIBILITY: Label for the tablist
+			 * @type {string}
+			 */
+			text: { type: String },
 			_allowScrollNext: { type: Boolean },
 			_allowScrollPrevious: { type: Boolean },
 			_defaultSlotBehavior: { state: true },
@@ -305,6 +312,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 						<div class="d2l-tabs-container-list"
 							@d2l-tab-selected="${this._handleTabSelected}"
 							@focusout="${this._handleFocusOut}"
+							aria-label="${ifDefined(this.text)}"
 							role="tablist"
 							style="${styleMap(tabsContainerListStyles)}">
 							${repeat(this._tabInfos, (tabInfo) => tabInfo.id, (tabInfo) => html`
@@ -799,6 +807,14 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 				selectedTab.tabIndex = 0;
 			}
 		}
+
+		this._tabs.forEach((tab) => {
+			const panel = this._getPanel(tab.id);
+			if (!panel) return;
+
+			if (!panel.id) panel.id = getUniqueId();
+			tab.setAttribute('aria-controls', `${panel.id}`);
+		});
 
 		await this.updateComplete;
 

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -806,15 +806,15 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 				selectedTab.selected = true;
 				selectedTab.tabIndex = 0;
 			}
+
+			this._tabs.forEach((tab) => {
+				const panel = this._getPanel(tab.id);
+				if (!panel) return;
+	
+				if (!panel.id) panel.id = getUniqueId();
+				tab.setAttribute('aria-controls', `${panel.id}`);
+			});
 		}
-
-		this._tabs.forEach((tab) => {
-			const panel = this._getPanel(tab.id);
-			if (!panel) return;
-
-			if (!panel.id) panel.id = getUniqueId();
-			tab.setAttribute('aria-controls', `${panel.id}`);
-		});
 
 		await this.updateComplete;
 

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -810,7 +810,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			this._tabs.forEach((tab) => {
 				const panel = this._getPanel(tab.id);
 				if (!panel) return;
-	
+
 				if (!panel.id) panel.id = getUniqueId();
 				tab.setAttribute('aria-controls', `${panel.id}`);
 			});

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -35,7 +35,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			 */
 			maxToShow: { type: Number, attribute: 'max-to-show' },
 			/**
-			 * REQUIRED: ACCESSIBILITY: Label for the tablist
+			 * REQUIRED: ACCESSIBILITY: Accessible text for the tablist
 			 * @type {string}
 			 */
 			text: { type: String },

--- a/components/tabs/test/tabs.axe.js
+++ b/components/tabs/test/tabs.axe.js
@@ -1,10 +1,11 @@
+import '../tab.js';
 import '../tabs.js';
 import '../tab-panel.js';
 import { expect, fixture, html } from '@brightspace-ui/testing';
 
 describe('d2l-tabs', () => {
 
-	it('passes all aXe tests', async() => {
+	it('passes all aXe tests, default structure', async() => {
 		const el = await fixture(html`
 			<d2l-tabs>
 				<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
@@ -12,6 +13,49 @@ describe('d2l-tabs', () => {
 				<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
 			</d2l-tabs>`);
 		await expect(el).to.be.accessible();
+	});
+
+	it('passes all aXe tests', async() => {
+		const el = await fixture(html`
+			<d2l-tabs>
+				<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+				<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+				<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+			</d2l-tabs>`);
+		await expect(el).to.be.accessible();
+	});
+
+	it('adds aria-controls to the tabs', async() => {
+		const el = await fixture(html`
+			<d2l-tabs>
+				<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="all" slot="panels" id="all-panel">Tab content for All</d2l-tab-panel>
+				<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+				<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+			</d2l-tabs>`);
+		expect(el.querySelector('#all').getAttribute('aria-controls')).to.equal('all-panel');
+		expect(el.querySelector('#biology').hasAttribute('aria-controls'));
+
+		const attr = el.querySelector('#biology').getAttribute('aria-controls');
+		expect(typeof attr).to.equal('string');
+	});
+
+	it('adds aria-labelledby to the panels', async() => {
+		const el = await fixture(html`
+			<d2l-tabs>
+				<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="all" slot="panels" id="all-panel">Tab content for All</d2l-tab-panel>
+				<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+				<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+				<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+			</d2l-tabs>`);
+		expect(el.querySelector('#all-panel').getAttribute('aria-labelledby')).to.equal('all');
 	});
 
 });


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7657)

Implements the [W3C Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)

Adds the following which were not yet implemented from the bullet point list near the bottom of the page:
- Adds `aria-controls` to the tabs
- Adds `aria-label` to the `tablist` element. Note that we don't yet anticipate a usecase for a visible label at this point.

The `text` property would be required, but since it hasn't been until this point I have not yet added the required mixin to enforce this. I'll be going through all the usages of tabs, at which point I can add the `text` property as I go.