### PR TITLE
GAUD-7676: switch to CSS logical properties

### DIFF
--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -9,14 +9,13 @@ import { getFocusPseudoClass } from '../../helpers/focus.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { ThemeMixin } from '../../mixins/theme/theme-mixin.js';
 
 /**
  * A button component that can be used just like the native button for instances where only an icon is displayed.
  * @slot icon - Optional slot for a custom icon
  */
-class ButtonIcon extends PropertyRequiredMixin(ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(RtlMixin(LitElement))))) {
+class ButtonIcon extends PropertyRequiredMixin(ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -103,11 +102,7 @@ class ButtonIcon extends PropertyRequiredMixin(ThemeMixin(ButtonMixin(VisibleOnA
 				}
 
 				:host([h-align="text"]) button {
-					left: var(--d2l-button-icon-h-align);
-				}
-				:host([dir="rtl"][h-align="text"]) button {
-					left: 0;
-					right: var(--d2l-button-icon-h-align);
+					inset-inline-start: var(--d2l-button-icon-h-align);
 				}
 
 				/* Firefox includes a hidden border which messes up button dimensions */

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -13,7 +13,6 @@ import '../menu/menu-item-link.js';
 import { css, html, LitElement } from 'lit';
 import { OVERFLOW_CLASS, OVERFLOW_MINI_CLASS, OverflowGroupMixin } from './overflow-group-mixin.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 const OPENER_STYLE = {
 	DEFAULT: 'default',
@@ -58,7 +57,7 @@ function createMenuItemSeparator() {
  * @attr {'default'|'icon'} [opener-type="default"] - Set the opener type to 'icon' for a `...` menu icon instead of `More actions` text
  * @attr {boolean} auto-show - Use predefined classes on slot elements to set min and max buttons to show
 */
-class OverflowGroup extends OverflowGroupMixin(RtlMixin(LitElement)) {
+class OverflowGroup extends OverflowGroupMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -87,15 +86,7 @@ class OverflowGroup extends OverflowGroupMixin(RtlMixin(LitElement)) {
 			::slotted(span),
 			::slotted(d2l-dropdown:not(.d2l-overflow-dropdown)),
 			::slotted(d2l-dropdown-button) {
-				margin-right: 0.6rem;
-			}
-			:host([dir="rtl"]) ::slotted(d2l-button),
-			:host([dir="rtl"]) ::slotted(d2l-link),
-			:host([dir="rtl"]) ::slotted(span),
-			:host([dir="rtl"]) ::slotted(d2l-dropdown:not(.d2l-overflow-dropdown)),
-			:host([dir="rtl"]) ::slotted(d2l-dropdown-button) {
-				margin-left: 0.6rem;
-				margin-right: 0;
+				margin-inline-end: 0.6rem;
 			}
 			::slotted(d2l-button-subtle),
 			::slotted(d2l-button-icon),
@@ -104,17 +95,7 @@ class OverflowGroup extends OverflowGroupMixin(RtlMixin(LitElement)) {
 			::slotted(d2l-dropdown-context-menu),
 			::slotted(d2l-selection-action),
 			::slotted(d2l-selection-action-dropdown) {
-				margin-right: 0.2rem;
-			}
-			:host([dir="rtl"]) ::slotted(d2l-button-subtle),
-			:host([dir="rtl"]) ::slotted(d2l-button-icon),
-			:host([dir="rtl"]) ::slotted(d2l-dropdown-button-subtle),
-			:host([dir="rtl"]) ::slotted(d2l-dropdown-more),
-			:host([dir="rtl"]) ::slotted(d2l-dropdown-context-menu),
-			:host([dir="rtl"]) ::slotted(d2l-selection-action),
-			:host([dir="rtl"]) ::slotted(d2l-selection-action-dropdown) {
-				margin-left: 0.2rem;
-				margin-right: 0;
+				margin-inline-end: 0.2rem;
 			}
 		`];
 	}

--- a/components/selection/selection-controls.js
+++ b/components/selection/selection-controls.js
@@ -8,7 +8,6 @@ import { formatNumber } from '@brightspace-ui/intl/lib/number.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { PageableSubscriberMixin } from '../paging/pageable-subscriber-mixin.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { SelectionObserverMixin } from './selection-observer-mixin.js';
 
 /**
@@ -16,7 +15,7 @@ import { SelectionObserverMixin } from './selection-observer-mixin.js';
  * @slot - Responsive container using `d2l-overflow-group` for `d2l-selection-action` elements
  * @fires d2l-selection-observer-subscribe - Internal event
  */
-export class SelectionControls extends PageableSubscriberMixin(SelectionObserverMixin(RtlMixin(LocalizeCoreElement(LitElement)))) {
+export class SelectionControls extends PageableSubscriberMixin(SelectionObserverMixin(LocalizeCoreElement(LitElement))) {
 
 	static get properties() {
 		return {
@@ -95,27 +94,16 @@ export class SelectionControls extends PageableSubscriberMixin(SelectionObserver
 				flex: none;
 			}
 			d2l-selection-select-all + d2l-selection-summary {
-				margin-left: 0.9rem;
-			}
-			:host([dir="rtl"]) d2l-selection-select-all + d2l-selection-summary {
-				margin-left: 0;
-				margin-right: 0.9rem;
+				margin-inline-start: 0.9rem;
 			}
 			d2l-selection-select-all-pages {
 				flex: none;
-				margin-left: 0.45rem;
-			}
-			:host([dir="rtl"]) d2l-selection-select-all-pages {
-				margin-left: 0;
-				margin-right: 0.45rem;
+				margin-inline-start: 0.45rem;
 			}
 			.d2l-selection-controls-actions {
 				--d2l-overflow-group-justify-content: flex-end;
 				flex: auto;
-				text-align: right;
-			}
-			:host([dir="rtl"]) .d2l-selection-controls-actions {
-				text-align: left;
+				text-align: end;
 			}
 			.d2l-sticky-edge {
 				left: 0;


### PR DESCRIPTION
I'm going to be making some fixes in these components and in order to simplify those changes it made sense to switch them to use CSS logical properties instead of the `RtlMixin`. Hopefully no vdiffs here.