### PR TITLE
WIP - Focus empty state

### DIFF
--- a/components/empty-state/empty-state-simple.js
+++ b/components/empty-state/empty-state-simple.js
@@ -4,12 +4,14 @@ import { html, LitElement } from 'lit';
 import { bodyCompactStyles } from '../typography/styles.js';
 import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
+import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
+import { getFirstFocusableDescendant } from '../../helpers/focus.js';
 
 /**
  * The `d2l-empty-state-simple` component is an empty state component that displays a description. An empty state action component can be placed inside of the default slot to add an optional action.
  * @slot - Slot for empty state actions
  */
-class EmptyStateSimple extends PropertyRequiredMixin(RtlMixin(LitElement)) {
+class EmptyStateSimple extends FocusMixin(PropertyRequiredMixin(RtlMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -25,13 +27,23 @@ class EmptyStateSimple extends PropertyRequiredMixin(RtlMixin(LitElement)) {
 		return [bodyCompactStyles, emptyStateStyles, emptyStateSimpleStyles];
 	}
 
+	static get focusElementSelector() {
+		return 'p.d2l-empty-state-description';
+	}
+
 	render() {
 		return html`
 			<div class="empty-state-container">
-				<p class="d2l-body-compact d2l-empty-state-description">${this.description}</p>
+				<p class="d2l-body-compact d2l-empty-state-description" tabindex="-1">${this.description}</p>
 				<slot class="action-slot"></slot>
 			</div>
 		`;
+	}
+
+	_getFocusTarget() {
+		const slotElement = this.shadowRoot.querySelector('slot.action-slot');
+		const focusTarget = getFirstFocusableDescendant(slotElement);
+		return focusTarget ?? super._getFocusTarget();
 	}
 
 }

--- a/mixins/focus/focus-mixin.js
+++ b/mixins/focus/focus-mixin.js
@@ -20,24 +20,27 @@ export const FocusMixin = dedupeMixin(superclass => class extends superclass {
 	}
 
 	focus() {
-
-		const selector = this.constructor.focusElementSelector;
-		if (!selector) {
-			throw new Error(`FocusMixin: no static focusElementSelector provided for "${this.tagName}"`);
-		}
-
 		if (!this.hasUpdated) {
 			this._focusOnFirstRender = true;
 			return;
 		}
 
-		const elem = this.shadowRoot.querySelector(selector);
-		if (!elem) {
-			throw new Error(`FocusMixin: selector "${selector}" yielded no element for "${this.tagName}"`);
+		const focusTarget = this._getFocusTarget();
+		if (!focusTarget) {
+			throw new Error(`FocusMixin: No focus target found for "${this.tagName}"`);
 		}
 
-		elem.focus();
+		focusTarget.focus();
+	}
 
+	_getFocusTarget() {
+		const selector = this.constructor.focusElementSelector;
+		if (!selector) {
+			throw new Error(`FocusMixin: no static focusElementSelector provided for "${this.tagName}"`);
+		}
+
+		const elem = this.shadowRoot.querySelector(selector);
+		return elem;
 	}
 
 });


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/LURV-5075

## Description

When modifying lists the focus needs to be managed when the last item is removed. This PR allows `d2l-empty-state` to be focused. 

This draft is currently a PoC and doesn't include the illustrated empty state. Also full disclosure I haven't tested this yet.