### PR TITLE
GAUD-7682: add ability for empty states to focus

### DIFF
--- a/components/empty-state/empty-state-action-button.js
+++ b/components/empty-state/empty-state-action-button.js
@@ -1,6 +1,7 @@
 import '../button/button.js';
 import '../button/button-subtle.js';
 import { css, html, LitElement, nothing } from 'lit';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 
@@ -9,7 +10,7 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  * @fires d2l-empty-state-action - Dispatched when the action button is clicked
  * @fires d2l-empty-state-illustrated-check - Internal event
  */
-class EmptyStateActionButton extends PropertyRequiredMixin(LitElement) {
+class EmptyStateActionButton extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -38,6 +39,10 @@ class EmptyStateActionButton extends PropertyRequiredMixin(LitElement) {
 	constructor() {
 		super();
 		this._illustrated = false;
+	}
+
+	static get focusElementSelector() {
+		return '.d2l-empty-state-action';
 	}
 
 	connectedCallback() {

--- a/components/empty-state/empty-state-action-link.js
+++ b/components/empty-state/empty-state-action-link.js
@@ -1,12 +1,13 @@
 import { html, LitElement, nothing } from 'lit';
 import { bodyCompactStyles } from '../typography/styles.js';
+import { FocusMixin } from '../../mixins/focus-mixin.js';
 import { linkStyles } from '../link/link.js';
 import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 
 /**
  * `d2l-empty-state-action-link` is an empty state action component that can be placed inside of the default slot of `empty-state-simple` or `empty-state-illustrated` to add a link action to the component.
  */
-class EmptyStateActionLink extends PropertyRequiredMixin(LitElement) {
+class EmptyStateActionLink extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -25,6 +26,10 @@ class EmptyStateActionLink extends PropertyRequiredMixin(LitElement) {
 
 	static get styles() {
 		return [bodyCompactStyles, linkStyles];
+	}
+
+	static get focusElementSelector() {
+		return '.d2l-link';
 	}
 
 	render() {

--- a/components/empty-state/empty-state-illustrated.js
+++ b/components/empty-state/empty-state-illustrated.js
@@ -2,9 +2,9 @@ import { emptyStateIllustratedStyles, emptyStateStyles } from './empty-state-sty
 import { html, LitElement, nothing } from 'lit';
 import { bodyCompactStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { EmptyStateMixin } from './empty-state-mixin.js';
 import { LoadingCompleteMixin } from '../../mixins/loading-complete/loading-complete-mixin.js';
 import { loadSvg } from '../../generated/empty-state/presetIllustrationLoader.js';
-import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { runAsync } from '../../directives/run-async/run-async.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -17,7 +17,7 @@ const illustrationAspectRatio = 500 / 330;
  * @slot - Slot for empty state actions
  * @slot illustration - Slot for custom SVG content if `illustration-name` property is not set
  */
-class EmptyStateIllustrated extends LoadingCompleteMixin(PropertyRequiredMixin(LitElement)) {
+class EmptyStateIllustrated extends LoadingCompleteMixin(EmptyStateMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -74,7 +74,7 @@ class EmptyStateIllustrated extends LoadingCompleteMixin(PropertyRequiredMixin(L
 		return html`
 			${this.#renderIllustration()}
 			<p class="${classMap(titleClass)}">${this.titleText}</p>
-			<p class="d2l-body-compact d2l-empty-state-description">${this.description}</p>
+			<p class="d2l-body-compact d2l-empty-state-description" tabindex="-1">${this.description}</p>
 			<slot class="action-slot"></slot>
 		`;
 	}

--- a/components/empty-state/empty-state-mixin.js
+++ b/components/empty-state/empty-state-mixin.js
@@ -1,0 +1,22 @@
+import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
+
+export const EmptyStateMixin = superclass => class extends PropertyRequiredMixin(superclass) {
+
+	focus() {
+		if (!this.hasUpdated) {
+			return;
+		}
+		const action = this.shadowRoot?.querySelector('.action-slot').assignedElements().find(
+			el => el.tagName === 'D2L-EMPTY-STATE-ACTION-BUTTON' || el.tagName === 'D2L-EMPTY-STATE-ACTION-LINK'
+		);
+		if (action !== undefined) {
+			action.focus();
+			return;
+		}
+		const title = this.shadowRoot?.querySelector('.d2l-empty-state-description');
+		if (title !== null) {
+			title.focus();
+		}
+	}
+
+};

--- a/components/empty-state/empty-state-simple.js
+++ b/components/empty-state/empty-state-simple.js
@@ -2,14 +2,13 @@ import '../button/button-subtle.js';
 import { emptyStateSimpleStyles, emptyStateStyles } from './empty-state-styles.js';
 import { html, LitElement } from 'lit';
 import { bodyCompactStyles } from '../typography/styles.js';
-import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
+import { EmptyStateMixin } from './empty-state-mixin.js';
 
 /**
  * The `d2l-empty-state-simple` component is an empty state component that displays a description. An empty state action component can be placed inside of the default slot to add an optional action.
  * @slot - Slot for empty state actions
  */
-class EmptyStateSimple extends PropertyRequiredMixin(RtlMixin(LitElement)) {
+class EmptyStateSimple extends EmptyStateMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -28,7 +27,7 @@ class EmptyStateSimple extends PropertyRequiredMixin(RtlMixin(LitElement)) {
 	render() {
 		return html`
 			<div class="empty-state-container">
-				<p class="d2l-body-compact d2l-empty-state-description">${this.description}</p>
+				<p class="d2l-body-compact d2l-empty-state-description" tabindex="-1">${this.description}</p>
 				<slot class="action-slot"></slot>
 			</div>
 		`;

--- a/components/empty-state/empty-state-styles.js
+++ b/components/empty-state/empty-state-styles.js
@@ -1,5 +1,6 @@
 import '../colors/colors.js';
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
+import { getFocusPseudoClass } from '../../helpers/focus.js';
 
 export const emptyStateStyles = css`
 
@@ -18,6 +19,12 @@ export const emptyStateStyles = css`
 	.action-slot::slotted(d2l-empty-state-action-button:first-of-type),
 	.action-slot::slotted(d2l-empty-state-action-link:first-of-type) {
 		display: inline;
+	}
+
+	.d2l-empty-state-description:${unsafeCSS(getFocusPseudoClass())} {
+		border-radius: 0.3rem;
+		outline: 2px solid var(--d2l-color-celestine);
+		outline-offset: 3px;
 	}
 
 `;

--- a/components/empty-state/test/empty-state-illustrated.test.js
+++ b/components/empty-state/test/empty-state-illustrated.test.js
@@ -1,8 +1,39 @@
 import '../empty-state-illustrated.js';
 import '../empty-state-action-button.js';
 import '../empty-state-action-link.js';
-import { fixture, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
+import { expect, fixture, focusElem, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
+import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { html } from 'lit';
+
+const noActionFixture = html`
+	<d2l-empty-state-illustrated
+		illustration-name="fish-hook"
+		title-text="No Learning Paths Yet"
+		description="Get started by clicking below to create your first learning path."></d2l-empty-state-illustrated>
+`;
+
+const actionButtonFixture = html`
+	<d2l-empty-state-illustrated
+		illustration-name="tumbleweed"
+		title-text="No Learning Paths Yet"
+		description="Get started by clicking below to create your first learning path.">
+		<d2l-empty-state-action-button
+			text="Create Learning Paths">
+		</d2l-empty-state-action-button>
+	</d2l-empty-state-illustrated>
+`;
+
+const actionLinkFixture = html`
+	<d2l-empty-state-illustrated
+		illustration-name="tumbleweed"
+		title-text="No Learning Paths Yet"
+		description="Get started by clicking below to create your first learning path.">
+		<d2l-empty-state-action-link
+			text="Create Learning Paths"
+			href="#">
+		</d2l-empty-state-action-link>
+	</d2l-empty-state-illustrated>
+`;
 
 describe('d2l-empty-state-illustrated', () => {
 
@@ -11,16 +42,7 @@ describe('d2l-empty-state-illustrated', () => {
 	});
 
 	it('dispatches d2l-empty-state-action when action is clicked when using the default subtle button', async() => {
-		const el = await fixture(html`
-			<d2l-empty-state-illustrated
-				illustration-name="tumbleweed"
-				title-text="No Learning Paths Yet"
-				description="Get started by clicking below to create your first learning path.">
-				<d2l-empty-state-action-button
-					text="Create Learning Paths">
-				</d2l-empty-state-action-button>
-			</d2l-empty-state-illustrated>
-		`);
+		const el = await fixture(actionButtonFixture);
 		const button = el.querySelector('d2l-empty-state-action-button');
 		setTimeout(() => button.shadowRoot.querySelector('d2l-button-subtle').click());
 		await oneEvent(button, 'd2l-empty-state-action');
@@ -48,20 +70,43 @@ describe('d2l-empty-state-illustrated', () => {
 	});
 
 	it('dispatches click event when action link is clicked', async() => {
-		const el = await fixture(html`
-			<d2l-empty-state-illustrated
-				illustration-name="tumbleweed"
-				title-text="No Learning Paths Yet"
-				description="Get started by clicking below to create your first learning path.">
-				<d2l-empty-state-action-link
-					text="Create Learning Paths"
-					href="#">
-				</d2l-empty-state-action-link>
-			</d2l-empty-state-illustrated>
-		`);
+		const el = await fixture(actionLinkFixture);
 		const link = el.querySelector('d2l-empty-state-action-link');
 		setTimeout(() => link.shadowRoot.querySelector('a').click());
 		await oneEvent(link, 'click');
+	});
+
+	describe('focus', () => {
+
+		it('should focus on description when no action is present', async() => {
+			const el = await fixture(noActionFixture);
+			const description = el.shadowRoot.querySelector('.d2l-empty-state-description');
+			await focusElem(el);
+			const areEqual = getComposedActiveElement() === description;
+			expect(areEqual).to.be.true;
+		});
+
+		it('should focus on action button', async() => {
+			const el = await fixture(actionButtonFixture);
+			const button = el
+				.querySelector('d2l-empty-state-action-button')
+				.shadowRoot.querySelector('d2l-button-subtle')
+				.shadowRoot.querySelector('button');
+			await focusElem(el);
+			const areEqual = getComposedActiveElement() === button;
+			expect(areEqual).to.be.true;
+		});
+
+		it('should focus on action link', async() => {
+			const el = await fixture(actionLinkFixture);
+			const link = el
+				.querySelector('d2l-empty-state-action-link')
+				.shadowRoot.querySelector('a');
+			await focusElem(el);
+			const areEqual = getComposedActiveElement() === link;
+			expect(areEqual).to.be.true;
+		});
+
 	});
 
 });

--- a/components/empty-state/test/empty-state-simple.test.js
+++ b/components/empty-state/test/empty-state-simple.test.js
@@ -1,8 +1,32 @@
 import '../empty-state-action-button.js';
 import '../empty-state-action-link.js';
 import '../empty-state-simple.js';
-import { fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, focusElem, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { html } from 'lit';
+
+const noActionFixture = html`
+	<d2l-empty-state-simple description="There are no assignments to display."></d2l-empty-state-simple>
+`;
+
+const actionButtonFixture = html`
+	<d2l-empty-state-simple
+		description="There are no assignments to display.">
+		<d2l-empty-state-action-button
+			text="Create New Assignment">
+		</d2l-empty-state-action-button>
+	</d2l-empty-state-simple>
+`;
+
+const actionLinkFixture = html`
+	<d2l-empty-state-simple
+		description="There are no assignments to display.">
+		<d2l-empty-state-action-link
+			text="Create New Assignment"
+			href="#">
+		</d2l-empty-state-action-link>
+	</d2l-empty-state-simple>
+`;
 
 describe('d2l-empty-state-simple', () => {
 
@@ -19,32 +43,50 @@ describe('d2l-empty-state-simple', () => {
 	});
 
 	it('dispatches d2l-empty-state-action when action is clicked', async() => {
-		const el = await fixture(html`
-			<d2l-empty-state-simple
-				description="There are no assignments to display.">
-				<d2l-empty-state-action-button
-					text="Create New Assignment">
-				</d2l-empty-state-action-button>
-			</d2l-empty-state-simple>
-		`);
+		const el = await fixture(actionButtonFixture);
 		const button = el.querySelector('d2l-empty-state-action-button');
-		setTimeout(() => button.shadowRoot.querySelector('d2l-button-subtle').click());
+		clickElem(button.shadowRoot.querySelector('d2l-button-subtle'));
 		await oneEvent(button, 'd2l-empty-state-action');
 	});
 
 	it('dispatches click event when action link is clicked', async() => {
-		const el = await fixture(html`
-			<d2l-empty-state-simple
-				description="There are no assignments to display.">
-				<d2l-empty-state-action-link
-					text="Create New Assignment"
-					href="#">
-				</d2l-empty-state-action-link>
-			</d2l-empty-state-simple>
-		`);
+		const el = await fixture(actionLinkFixture);
 		const link = el.querySelector('d2l-empty-state-action-link');
-		setTimeout(() => link.shadowRoot.querySelector('a').click());
+		clickElem(link.shadowRoot.querySelector('a'));
 		await oneEvent(link, 'click');
+	});
+
+	describe('focus', () => {
+
+		it('should focus on description when no action is present', async() => {
+			const el = await fixture(noActionFixture);
+			const description = el.shadowRoot.querySelector('.d2l-empty-state-description');
+			await focusElem(el);
+			const areEqual = getComposedActiveElement() === description;
+			expect(areEqual).to.be.true;
+		});
+
+		it('should focus on action button', async() => {
+			const el = await fixture(actionButtonFixture);
+			const button = el
+				.querySelector('d2l-empty-state-action-button')
+				.shadowRoot.querySelector('d2l-button-subtle')
+				.shadowRoot.querySelector('button');
+			await focusElem(el);
+			const areEqual = getComposedActiveElement() === button;
+			expect(areEqual).to.be.true;
+		});
+
+		it('should focus on action link', async() => {
+			const el = await fixture(actionLinkFixture);
+			const link = el
+				.querySelector('d2l-empty-state-action-link')
+				.shadowRoot.querySelector('a');
+			await focusElem(el);
+			const areEqual = getComposedActiveElement() === link;
+			expect(areEqual).to.be.true;
+		});
+
 	});
 
 });


### PR DESCRIPTION
Thanks @KaiPrince for raising this.

When managing focus (especially when a list becomes empty for example), sometimes it's required to place focus on an empty state.

This fix makes both the simple and illustrated empty states focusable. Internally, they'll focus on the first action and fall back to the description text.