### PR TITLE
Remove translateY from d2l-card.

### DIFF
--- a/components/card/card.js
+++ b/components/card/card.js
@@ -221,19 +221,7 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 			}
 			@media (prefers-reduced-motion: no-preference) {
 				:host {
-					transition: transform 300ms ease-out 50ms, box-shadow 0.2s;
-				}
-
-				:host(:hover),
-				:host([subtle]:hover),
-				:host([_active]:hover),
-				:host([subtle][_active]:hover) {
-					transform: translateY(-4px);
-				}
-
-				:host(:not([href])),
-				:host([subtle]:not([href])) {
-					transform: none;
+					transition: box-shadow 0.2s;
 				}
 			}
 		`];


### PR DESCRIPTION
[GAUD-7690](https://desire2learn.atlassian.net/browse/GAUD-7690)

This PR removes `d2l-card`'s hover vertical translation (-4px) because:

* The `transform` creates a containing block that interferes with `fixed` position dropdown calculations, and
* We prefer not to have it for aesthetic reasons

[GAUD-7690]: https://desire2learn.atlassian.net/browse/GAUD-7690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ