### PR TITLE
Fix PopoverMixin auto-close handler to not close the popover if focusing on opener

### DIFF
--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -954,8 +954,7 @@ export const PopoverMixin = superclass => class extends superclass {
 			}
 
 			const activeElement = getComposedActiveElement();
-			if (isComposedAncestor(this, activeElement)
-				|| activeElement === this._opener) {
+			if (isComposedAncestor(this, activeElement) || isComposedAncestor(this._opener, activeElement)) {
 				return;
 			}
 


### PR DESCRIPTION
[GAUD-6564](https://desire2learn.atlassian.net/browse/GAUD-6564)

This PR fixes an issue where the dropdown would close if focus is moved to the opener, or would close and re-open if the user clicked the opener while the popover is open. This change makes the logic identical to the previous (non-popover) implementation which addresses this defective behaviour and maintains compatibility with the various dropdown openers.

For ref, the original impl: https://github.com/BrightspaceUI/core/blob/main/components/dropdown/dropdown-content-mixin.js#L573

[GAUD-6564]: https://desire2learn.atlassian.net/browse/GAUD-6564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ