### PR TITLE
fix: apply a border on buttons in WHCM

### DIFF
--- a/components/button/button-styles.js
+++ b/components/button/button-styles.js
@@ -25,4 +25,9 @@ export const buttonStyles = css`
 		outline: 2px solid var(--d2l-button-focus-color, var(--d2l-color-celestine));
 		outline-offset: var(--d2l-button-focus-offset, 2px);
 	}
+	@media (prefers-contrast: more) {
+		button {
+			border: 2px solid transparent;
+		}
+	}
 `;

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -41,7 +41,7 @@ class Button extends ButtonMixin(LitElement) {
 
 				button {
 					font-family: inherit;
-					padding: 0.55rem 1.5rem;
+					padding: 0 1.5rem;
 					width: 100%;
 				}
 


### PR DESCRIPTION
[GAUD-7681](https://desire2learn.atlassian.net/browse/GAUD-7681)

If buttons hide their borders -- like we do with ours -- then WHCM doesn't know to apply a border around them like it should. That results in this, where buttons just look like normal text:

![Screenshot 2025-03-28 at 10 14 07 AM](https://github.com/user-attachments/assets/b0bccbba-985a-4659-ab86-36897f5f4a15)

Because adding a border can impact the height and width of buttons, we decided to only apply this change when we detect that a high-contrast mode is being used.

Result:
![Screenshot 2025-03-28 at 2 25 52 PM](https://github.com/user-attachments/assets/4966d1b5-ff09-4993-be71-81d0bb352172)

Note: I'll be fixing the fact that `<d2l-button-icon>`'s icon is grey with a separate fix.

Not expecting any vdiffs. 🤞 


[GAUD-7681]: https://desire2learn.atlassian.net/browse/GAUD-7681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ