### PR TITLE
Delay dispatching d2l-dropdown-open to fix Firefox scroll issue

### DIFF
--- a/components/dropdown/dropdown-popover-mixin.js
+++ b/components/dropdown/dropdown-popover-mixin.js
@@ -347,8 +347,10 @@ export const DropdownPopoverMixin = superclass => class extends LocalizeCoreElem
 			this.#contentElement.scrollTop ??= 0;
 		}
 
-		/** Dispatched when the dropdown is opened */
-		this.dispatchEvent(new CustomEvent('d2l-dropdown-open', { bubbles: true, composed: true }));
+		setTimeout(() => {
+			/** Dispatched when the dropdown is opened */
+			this.dispatchEvent(new CustomEvent('d2l-dropdown-open', { bubbles: true, composed: true }));
+		});
 	}
 
 	#handlePopoverPosition() {

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -336,8 +336,10 @@ export const PopoverMixin = superclass => class extends superclass {
 
 		this.#addRepositionHandlers();
 
-		/** @ignore */
-		this.dispatchEvent(new CustomEvent('d2l-popover-open', { bubbles: true, composed: true }));
+		setTimeout(() => {
+			/** @ignore */
+			this.dispatchEvent(new CustomEvent('d2l-popover-open', { bubbles: true, composed: true }));
+		});
 
 	}
 

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -336,10 +336,8 @@ export const PopoverMixin = superclass => class extends superclass {
 
 		this.#addRepositionHandlers();
 
-		setTimeout(() => {
-			/** @ignore */
-			this.dispatchEvent(new CustomEvent('d2l-popover-open', { bubbles: true, composed: true }));
-		});
+		/** @ignore */
+		this.dispatchEvent(new CustomEvent('d2l-popover-open', { bubbles: true, composed: true }));
 
 	}
 


### PR DESCRIPTION
[GAUD-6564](https://desire2learn.atlassian.net/browse/GAUD-6564)

This PR fixes and issue when using `PopoverMixin` for `d2l-dropdown-menu` content would be scrolled when opening with [spacebar] in Firefox. This event was delayed in the original implementation ([here](https://github.com/BrightspaceUI/core/blob/main/components/dropdown/dropdown-content-mixin.js#L639)), so this change maintains compatibility/timing for that event, which can be important for `d2l-dropdown-menu` and potentially other consumers.

[GAUD-6564]: https://desire2learn.atlassian.net/browse/GAUD-6564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ