### PR TITLE
SHIELD-10734 - Convert none elements in MathML sub/superscripts to mrow so they properly render

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -61,6 +61,16 @@ class HtmlBlockMathRenderer {
 			elm.style.height = '0.5rem';
 		});
 
+		// WIRIS outputs bad syntax for empty sub/superscripts, but changing these on write
+		// can be risky. Instead, change them on render to minimize potential damage if this
+		// impacts legitimate usages.
+		if (context.replaceNoneSubSuperScripts) {
+			elem.querySelectorAll('math mmultiscripts > none').forEach(elm => {
+				const mrow = document.createElementNS('http://www.w3.org/1998/Math/MathML', 'mrow');
+				elm.replaceWith(mrow);
+			});
+		}
+
 		// If we're using deferred rendering, we need to create a document structure
 		// within the element so MathJax can appropriately process math.
 		if (!options.noDeferredRendering) elem.innerHTML = `<mjx-doc><mjx-head></mjx-head><mjx-body>${elem.innerHTML}</mjx-body></mjx-doc>`;


### PR DESCRIPTION
When adding equations with super/subscripts, WIRIS uses a `<none>` element to indicate skipping a particular row, e.g.
```
<math>
  <mmultiscripts>
    <mi>x</mi>
    <mprescripts />
    <none></none>
    <mi>a</mi>
  </mmultiscripts>
</math>
```
Based on the MathML Core standard, I don't think this is actually correct, and I believe this should be represented as an empty `mrow` element instead. This PR works around that on render within the html-block rendering code while we wait for a fix to (hopefully) come from WIRIS.

I believe the more correct place to do this work would be on save, however I worry about the blast radius if this selector ends up catching unintended usages. I don't think it should, but at the very least I think I would like to do this on render _at least for now_, and we can explore pulling it out and adding it on save if this soaks for a while without drawing Support tickets.