### PR TITLE
feat: Add `timezone-hidden` attribute

### DIFF
--- a/components/inputs/demo/input-time.html
+++ b/components/inputs/demo/input-time.html
@@ -40,6 +40,13 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Hidden Timezone</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-input-time label="Start Time" timezone-hidden></d2l-input-time>
+				</template>
+			</d2l-demo-snippet>
+
 			<h2>Custom Interval</h2>
 			<d2l-demo-snippet>
 				<template>

--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -137,6 +137,7 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 | `labelled-by` | String | HTML id of an element in the same shadow root which acts as the input's label |
 | `opened` | Boolean | Indicates if the dropdown is open |
 | `required` | Boolean | Indicates that a value is required |
+| `timezone-hidden` | Boolean | Hides the timezone inside the selection dropdown. Should only be used when the input uses a different timezone than the document's settings |
 | `time-interval` | String, default: `thirty` | Number of minutes between times shown in dropdown. Valid values include `five`, `ten`, `fifteen`, `twenty`, `thirty`, and `sixty`. |
 | `value` | String, default `''` | Value of the input. This should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's timezone](#timezone) (if applicable). |
 
@@ -276,7 +277,7 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 
 ## Accessibility
 
-The date and time components generally follow the W3C's best practice recommendations for a [Date picker dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). For details on the accessibility of the calendar within the date input components, see [Calendar Accessibility](../calendar#accessibility). 
+The date and time components generally follow the W3C's best practice recommendations for a [Date picker dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/). For details on the accessibility of the calendar within the date input components, see [Calendar Accessibility](../calendar#accessibility).
 
 A few notable accessibility-related features of these components are:
 

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -3,7 +3,7 @@ import '../dropdown/dropdown-menu.js';
 import '../menu/menu.js';
 import '../menu/menu-item-radio.js';
 
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { formatDateInISOTime, getDateFromISOTime, getToday } from '../../helpers/dateTime.js';
 import { formatTime, parseTime } from '@brightspace-ui/intl/lib/dateTime.js';
 import { bodySmallStyles } from '../typography/styles.js';
@@ -165,6 +165,11 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 			 */
 			timeInterval: { type: String, attribute: 'time-interval' },
 			/**
+			 * Hides the timezone inside the selection dropdown. Should only be used when the input uses a different timezone than the document's settings
+			 * @type {Boolean}
+			 */
+			timezoneHidden: { type: Boolean, attribute: 'timezone-hidden' },
+			/**
 			 * Value of the input
 			 * @type {string}
 			 */
@@ -226,6 +231,7 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 		this.opened = false;
 		this.required = false;
 		this.timeInterval = 'thirty';
+		this.timezoneHidden = false;
 		this._dropdownFirstOpened = false;
 		this._dropdownId = getUniqueId();
 		this._hiddenContentWidth = '6rem';
@@ -371,7 +377,9 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 						root-view>
 						${menuItems}
 					</d2l-menu>
-					<div class="d2l-input-time-timezone d2l-body-small" id="${dropdownIdTimezone}" slot="footer">${this._timezone}</div>
+					${!this.timezoneHidden ? html`
+						<div class="d2l-input-time-timezone d2l-body-small" id="${dropdownIdTimezone}" slot="footer">${this._timezone}</div>
+					` : nothing}
 				</d2l-dropdown-menu>
 			</d2l-dropdown>
 			${this._renderInlineHelp(this._inlineHelpId)}

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -8,6 +8,7 @@ const fixtureWithValue = '<d2l-input-time value="11:22:33" label="label text"></
 const hourLongIntervals = '<d2l-input-time label="label text" time-interval="sixty"></d2l-input-time>';
 const hourLongIntervalsEnforced = '<d2l-input-time label="label text" time-interval="sixty" enforce-time-intervals></d2l-input-time>';
 const labelHiddenFixture = '<d2l-input-time label="label text" label-hidden time-interval="sixty"></d2l-input-time>';
+const tzHiddenFixture = '<d2l-input-time label="label text" timezone-hidden time-interval="sixty"></d2l-input-time>';
 
 function dispatchEvent(elem, eventType, composed) {
 	const e = new Event(
@@ -61,6 +62,19 @@ describe('d2l-input-time', () => {
 		it('should create offscreen label when label-hidden', async() => {
 			const elem = await fixture(labelHiddenFixture);
 			expect(elem.shadowRoot.querySelector('.d2l-offscreen').innerText).to.equal('label text');
+		});
+	});
+
+	describe('hiding timezone', () => {
+
+		it('should display timezone by default', async() => {
+			const elem = await fixture(basicFixture);
+			expect(elem.shadowRoot.querySelector('.d2l-input-time-timezone')).to.not.be.null;
+		});
+
+		it('should hide timezone when timezon-hidden', async() => {
+			const elem = await fixture(tzHiddenFixture);
+			expect(elem.shadowRoot.querySelector('.d2l-input-time-timezone')).to.be.null;
 		});
 	});
 


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-7697)

Adding the option to hide the time zone on the dropdown selection when the input's time zone does not match the one set by the document.