### PR TITLE
Fix dropdown reposition flicker that results from voa hide transform

### DIFF
--- a/mixins/visible-on-ancestor/visible-on-ancestor-mixin.js
+++ b/mixins/visible-on-ancestor/visible-on-ancestor-mixin.js
@@ -5,14 +5,17 @@ const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 export const visibleOnAncestorStyles = css`
 
-	:host([__voa-state="hidden"]),
-	:host([__voa-state="hiding"]) {
+	:host([__voa-state="hidden"]) {
 		opacity: 0 !important;
 		transform: translateY(-10px) !important;
 	}
-	:host([__voa-state="showing"]),
-	:host([__voa-state="hiding"]) {
+	:host([__voa-state="showing"]) {
 		transition: transform 200ms ease-out, opacity 200ms ease-out !important;
+	}
+	:host([__voa-state="hiding"]) {
+		opacity: 0 !important;
+		transform: none !important;
+		transition: opacity 200ms ease-out !important;
 	}
 
 	:host([__voa-state="hidden"][animation-type="opacity"]),
@@ -30,12 +33,7 @@ export const visibleOnAncestorStyles = css`
 		:host([__voa-state="hidden"]),
 		:host([__voa-state="hiding"]) {
 			opacity: 1 !important;
-			transform: translateY(0) !important;
-		}
-		:host([__voa-state="hidden"][d2l-visible-on-ancestor-no-hover-hide]),
-		:host([__voa-state="hiding"][d2l-visible-on-ancestor-no-hover-hide]) {
-			opacity: 0 !important;
-			transform: translateY(-10px) !important;
+			transform: none !important;
 		}
 	}
 


### PR DESCRIPTION
[GAUD-7690](https://desire2learn.atlassian.net/browse/GAUD-7690)

This PR fixes a dropdown flicker due to the VOA hide `transform` that is applied when a user dismisses the VOA dropdown via soft-close. The VOA `transform` would create a containing block during the animation, resulting in the browser briefly repositioning the dropdown within that new containing block.

Discussed with Jeff and we agreed to remove the `transform` translation when hiding the VOA items. We're keeping the translation when showing VOA items since dropdowns cannot be open during that animation. We're also keeping the `opacity` animation while hiding VOA items since it does not create a containing block. This keeps the code relatively simple and still provides a nice animated experience.

Other options considered:
* Delaying the VOA animation until the dropdown animation is complete. We don't really want the animations to run in series. We don't want the total elapsed time for dismissing the VOA item to run that long.
* Animating `top` instead. This would require forcing the `position` on the VOA item, potentially overriding consumer properties. This doesn't seem like a safe change. Also, in testing, animating `top` was not as buttery smooth as `transform`.
* Somehow updating dropdown to not reposition itself if it detects that it's opener has been updated to define a containing block.

[GAUD-7690]: https://desire2learn.atlassian.net/browse/GAUD-7690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ