### PR TITLE
[spike] List: Support toc-style single-selection mode

### DIFF
--- a/components/list/demo/list-nested.html
+++ b/components/list/demo/list-nested.html
@@ -14,6 +14,7 @@
 			import '../list-item-content.js';
 			import './list-item-custom.js';
 			import '../list-item.js';
+			import '../list-item-menu-item.js';
 			import '../list-controls.js';
 			import '../list.js';
 			import '../../menu/menu.js';
@@ -21,6 +22,7 @@
 			import '../../paging/pager-load-more.js';
 			import '../../selection/selection-action.js';
 			import '../../switch/switch.js';
+			import '../../tooltip/tooltip-help.js';
 
 			import './demo-list-nested-iterations-helper.js';
 		</script>
@@ -28,7 +30,66 @@
 	<body unresolved>
 
 		<d2l-demo-page page-title="d2l-list (nested)">
+			<d2l-demo-snippet>
+				<template>
+					<d2l-list grid menu style="width: 334px;">
+						<d2l-list-item-menu-item key="L1-1" label="Label for L1-1" color="#006fbf">
+							<d2l-list-item-content>
+								<div>Earth Sciences (L1)</div>
+								<div slot="supporting-info">This course will teach the basics of earth sciences.</div>
+								<div slot="secondary"><d2l-tooltip-help text="Due: Jan 30, 2023">Available: Jan 11, 2023</d2l-tooltip-help></div>
+							</d2l-list-item-content>
+							<d2l-list slot="nested" menu>
+								<d2l-list-item-menu-item key="L2-1" label="Label for L2-1" color="#29a6ff" >
+									<d2l-list-item-content>
+										<div>Introductory Earth Sciences (L2)</div>
+									</d2l-list-item-content>
+									<d2l-list slot="nested" menu>
+										<d2l-list-item-menu-item key="L3-1" label="Label for L3-1" color="#e8f8ff">
+											<d2l-list-item-content>
+												<div>Glaciation (L3)</div>
+												<div slot="secondary" style="padding: 5px;"><d2l-tooltip-help text="Due: Jan 28, 2023">Available: Jan 11, 2023</d2l-tooltip-help></div>
+											</d2l-list-item-content>
 
+									<d2l-list slot="nested" menu>
+										<d2l-list-item-menu-item key="L4-1" label="Label for L4-1" color="#e8f8ff">
+											<d2l-list-item-content>
+												<div>Glaciation (L4)</div>
+												<div slot="secondary" style="padding: 5px;"><d2l-tooltip-help text="Due: Jan 28, 2023">Available: Jan 11, 2023</d2l-tooltip-help></div>
+											</d2l-list-item-content>
+										</d2l-list-item-menu-item>
+									</d2l-list>
+										</d2l-list-item-menu-item>
+									</d2l-list>
+								</d2l-list-item-menu-item>
+							</d2l-list>
+						</d2l-list-item-menu-item>
+						<d2l-list-item-menu-item key="L1-2" label="Label for L1-2" color="#006fbf">
+							<d2l-list-item-content>
+								<div>Earth Sciences 2.0 (L1)</div>
+								<div slot="supporting-info">This course will teach the expertise of earth sciences.</div>
+								<div slot="secondary"><d2l-tooltip-help text="Due: Jan 30, 2023">Available: Jan 11, 2023</d2l-tooltip-help></div>
+							</d2l-list-item-content>
+
+							<d2l-list slot="nested" menu>
+								<d2l-list-item-menu-item key="L1-2-2" label="Label for L1-2-2" color="#e8f8ff">
+									<d2l-list-item-content>
+										<div>Glaciation (L5)</div>
+										<div slot="secondary" style="padding: 5px;"><d2l-tooltip-help text="Due: Jan 28, 2023">Available: Jan 11, 2023</d2l-tooltip-help></div>
+									</d2l-list-item-content>
+								</d2l-list-item-menu-item>
+							</d2l-list>
+						</d2l-list-item-menu-item>
+					</d2l-list>
+				</template>
+				<script type="module">
+					requestAnimationFrame(() => {
+						document.addEventListener('d2l-list-item-menu-item-click', (e) => {
+							console.log('d2l-list-item-menu-item: click event');
+						});
+					});
+				</script>
+			</d2l-demo-snippet>
 
 			<d2l-demo-snippet>
 				<template>

--- a/components/list/list-item-menu-item-mixin.js
+++ b/components/list/list-item-menu-item-mixin.js
@@ -1,0 +1,154 @@
+import '../colors/colors.js';
+import { css, html } from 'lit';
+import { getUniqueId } from '../../helpers/uniqueId.js';
+import { ListItemMixin } from './list-item-mixin.js';
+import { EventSubscriberController } from '../../controllers/subscriber/subscriberControllers.js';
+
+const interactiveElements = {
+	// 'a' only if an href is present
+	'button': true,
+	'input': true,
+	'select': true,
+	'textarea': true,
+	'd2l-tooltip-help': true,
+	'd2l-button': true
+};
+
+const interactiveRoles = {
+	'button': true,
+	'checkbox': true,
+	'combobox': true,
+	'link': true,
+	'listbox': true,
+	'menuitem': true,
+	'menuitemcheckbox': true,
+	'menuitemradio': true,
+	'option': true,
+	'radio': true,
+	'slider': true,
+	'spinbutton': true,
+	'switch': true,
+	'tab:': true,
+	'textbox': true,
+	'treeitem': true
+};
+
+function getIsInteractiveChildClicked(e, linkElem) {
+	const composedPath = e.composedPath();
+	for (let i = 0; i < composedPath.length; i++) {
+		const elem = composedPath[i];
+		if (!elem.getAttribute) continue;
+
+		if (elem === linkElem) {
+			return false;
+		}
+
+		const nodeName = elem.nodeName.toLowerCase();
+		if (interactiveElements[nodeName] || (nodeName === 'a' && elem.hasAttribute('href'))) {
+			return true;
+		}
+
+		const role = (elem.getAttribute('role') || '');
+		if (interactiveRoles[role]) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export const ListItemMenuItemMixin = superclass => class extends ListItemMixin(superclass) {
+
+	static get properties() {
+		return {
+			/**
+			 * possible values: page, location
+			 */
+			current: { type: String, reflect: true },
+			menuItemDisabled: { type: Boolean, reflect: true, attribute: 'menu-item-disabled' },
+		};
+	}
+
+	static get styles() {
+
+		const styles = [ css`
+			:host([menu-item-disabled]) [slot="content-action"] {
+				pointer-events: none;
+			}
+			[slot="outside-control-container"] {
+				margin: 0 -12px;
+			}
+			a {
+				background-color: transparent;
+				border: none;
+				cursor: pointer;
+				display: block;
+				height: 100%;
+				outline: none;
+				width: 100%;
+			}
+			:host(:not([menu-item-disabled])) [slot="control-action"],
+			:host(:not([menu-item-disabled])) [slot="outside-control-action"] {
+				grid-column-end: control-end;
+			}
+			.d2l-list-item-content ::slotted(*) {
+				width: 100%;
+			}
+		` ];
+
+		super.styles && styles.unshift(super.styles);
+		return styles;
+	}
+
+	constructor() {
+		super();
+		this.current = undefined;
+		this.menuItemDisabled = false;
+		this._primaryActionId = getUniqueId();
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+
+		this.addEventListener('d2l-list-item-menu-item-set-current', async(e) => {
+			if (e.target === this) return;
+			this.current = 'location';
+		});
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (changedProperties.has('current')) this.ariaCurrent = this.current;
+		if (this.current === 'location') this.ariaCurrent = 'location';
+	}
+
+	dispatchResetEvent() {
+		this.dispatchEvent(new CustomEvent('d2l-list-item-menu-item-set-current', { bubbles: true }));
+	}
+
+	_handleMenuItemClick(e) {
+		if (getIsInteractiveChildClicked(e, this.shadowRoot.querySelector(`#${this._primaryActionId}`))) {
+			e.preventDefault();
+		} else {
+			this.current = 'page';
+			/** Dispatched when the item's primary link action is clicked */
+			this.dispatchEvent(new CustomEvent('d2l-list-item-menu-item-click', { bubbles: true }));
+		}
+	}
+
+	_handleMenuItemKeyDown(e) {
+		if (e.keyCode !== 32) return;
+		// handle the space key
+		e.preventDefault();
+		e.stopPropagation();
+		e.target.click();
+	}
+
+	_renderPrimaryAction(labelledBy, content) {
+		return html`<a aria-labelledby="${labelledBy}"
+			@click="${this._handleMenuItemClick}"
+			id="${this._primaryActionId}"
+			tabindex="0"
+			@keydown="${this._handleMenuItemKeyDown}">${content}</a>`;
+	}
+
+};

--- a/components/list/list-item-menu-item.js
+++ b/components/list/list-item-menu-item.js
@@ -1,0 +1,19 @@
+import { ListItemMenuItemMixin } from './list-item-menu-item-mixin.js';
+import { LitElement } from 'lit';
+
+/**
+ * A component for a "listitem" child within a list. It provides semantics, basic layout, breakpoints for responsiveness, a link for navigation, and selection.
+ * @slot - Default content placed inside of the component
+ * @slot illustration - Image associated with the list item located at the left of the item
+ * @slot actions - Actions (e.g., button icons) associated with the listen item located at the right of the item
+ * @slot nested - Nested d2l-list element
+ */
+class ListItemMenuItem extends ListItemMenuItemMixin(LitElement) {
+
+	render() {
+		return this._renderListItem();
+	}
+
+}
+
+customElements.define('d2l-list-item-menu-item', ListItemMenuItem);

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -92,7 +92,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			_highlight: { type: Boolean, reflect: true },
 			_highlighting: { type: Boolean, reflect: true },
 			_showAddButton: { type: Boolean, attribute: '_show-add-button', reflect: true },
-			_siblingHasColor: { state: true },
+			_siblingHasColor: { state: true }
 		};
 	}
 
@@ -336,6 +336,13 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			:host([_hovering-primary-action]) [slot="outside-control-container"],
 			:host([_hovering-selection]) [slot="outside-control-container"] {
 				box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+			}
+			:host([current="page"]) [slot="outside-control-container"] {
+				margin-block: 1px;
+				outline: 3px solid var(--d2l-button-focus-color, var(--d2l-color-celestine));
+			}
+			:host([current="page"]) [slot="control-container"]::after {
+				border-color: transparent;
 			}
 			:host(:not([selection-disabled]):not([skeleton])[selected]) [slot="outside-control-container"] {
 				background-color: #f3fbff;
@@ -679,7 +686,19 @@ export const ListItemMixin = superclass => class extends composeMixins(
 		};
 
 		const alignNested = ((this.draggable && this.selectable) || (this.expandable && this.selectable && this.color)) ? 'control' : undefined;
-		const primaryAction = ((!this.noPrimaryAction && this._renderPrimaryAction) ? this._renderPrimaryAction(this._contentId) : null);
+
+		const contentAreaContent = html`
+			<div slot="content"
+				class="d2l-list-item-content"
+				id="${this._contentId}"
+				@mouseenter="${this._onMouseEnter}"
+				@mouseleave="${this._onMouseLeave}">
+				<slot name="illustration" class="d2l-list-item-illustration">${illustration}</slot>
+				<slot>${content}</slot>
+			</div>
+		`;
+
+		const primaryAction = ((!this.noPrimaryAction && this._renderPrimaryAction) ? this._renderPrimaryAction(this._contentId, contentAreaContent) : null);
 		let tooltipForId = null;
 		if (this._showAddButton) {
 			tooltipForId = this._addButtonTopId;
@@ -741,15 +760,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 					@mouseenter="${this._onMouseEnterPrimaryAction}"
 					@mouseleave="${this._onMouseLeavePrimaryAction}">
 						${primaryAction}
-				</div>` : nothing}
-				<div slot="content"
-					class="d2l-list-item-content"
-					id="${this._contentId}"
-					@mouseenter="${this._onMouseEnter}"
-					@mouseleave="${this._onMouseLeave}">
-					<slot name="illustration" class="d2l-list-item-illustration">${illustration}</slot>
-					<slot>${content}</slot>
-				</div>
+				</div>` : contentAreaContent}
 				<div slot="actions"
 					@mouseenter="${this._onMouseEnter}"
 					@mouseleave="${this._onMouseLeave}"

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -164,6 +164,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 		this.addEventListener('d2l-list-item-nested-change', (e) => this._handleListItemNestedChange(e));
 		this.addEventListener('d2l-list-item-property-change', (e) => this._handleListItemPropertyChange(e));
 		this.addEventListener('d2l-list-item-add-button-click', (e) => this._handleListItemAddButtonClick(e));
+		this.addEventListener('d2l-list-item-menu-item-click', (e) => this._handleListItemMenuItemClick(e));
 		ro.observe(this);
 	}
 
@@ -340,6 +341,20 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 		const listSlot = this.shadowRoot.querySelector('slot:not([name])');
 		const focusable = (e.shiftKey ? getPreviousFocusable(listSlot) : getNextFocusable(listSlot, false, true, true));
 		if (focusable) focusable.focus();
+	}
+
+	_handleListItemMenuItemClick(e) {
+		if (this.slot === 'nested') return;
+
+		const items = this.querySelectorAll('d2l-list-item-menu-item');
+		items.forEach((item) => {
+			if (item === e.target) return;
+
+			item.current = undefined;
+		});
+
+		e.target.dispatchResetEvent();
+	
 	}
 
 	_handleListItemAddButtonClick(e) {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7497)

Context:
We are looking to support using `d2l-list` as the side nav for Lessons. A current limitation is that list selection isn't necessarily built for a table of contents.

Research Notes:
- The spike code here is based off of the [w3c menu structure](https://www.w3.org/WAI/tutorials/menus/structure/)
- Note that this uses lists at its core whereas our d2l-list is an application. When in grid mode the list items have a role of `rowgroup`
- w3c recommends marking up the outside of the list with a `nav`. I did not do that here. I'm not sure how much we want to overall modify our current list role structure so I stayed more in scope of the individual items
- `aria-current`: they recommend using `aria-current="page"` to indicate the current page if we are not removing the link when a page is selected
    - They don't specifically call out `aria-current="location"` but examples I saw showed usage of that on the parents of the currently selected page

Related design questions:
- w3c suggests ~disabling~ removing the anchor from the currently selected page in the menu. Are we planning on doing that? It's not what currently happens in lessons so I'd imaging at the start we'd be keeping things generally the same. 
    - Not going to do this since we're following the `aria-current` pattern
- should this be a link or button internally? w3c is using a link which I thinks seems somewhat correct since it's a navigation but I believe we wouldn't be providing an href and instead triggering an event that lessons would then handle. 
    - button

Notes:
- Adds `d2l-list-item-menu-item` (name TBD) and corresponding mixin to support this