### PR TITLE
Clean up unsupported --d2l-dropdown-vertical-offset property

### DIFF
--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -351,7 +351,6 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 				if (isNaN(newVerticalOffset)) {
 					newVerticalOffset = defaultVerticalOffset;
 				}
-				this.style.setProperty('--d2l-dropdown-verticaloffset', `${newVerticalOffset}px`);
 				this._verticalOffset = newVerticalOffset;
 			}
 		});

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -385,13 +385,13 @@ describe('d2l-dropdown', () => {
 		it('vertical offset should update if set without px', async() => {
 			content.setAttribute('vertical-offset', 100);
 			await nextFrame();
-			expect(content.style.getPropertyValue('--d2l-dropdown-verticaloffset')).to.equal('100px');
+			expect(content._verticalOffset).to.equal(100);
 		});
 
 		it('vertical offset should update if set with px', async() => {
 			content.setAttribute('vertical-offset', '50px');
 			await nextFrame();
-			expect(content.style.getPropertyValue('--d2l-dropdown-verticaloffset')).to.equal('50px');
+			expect(content._verticalOffset).to.equal(50);
 		});
 
 		it('vertical offset should default to 16 if removed', async() => {
@@ -399,13 +399,13 @@ describe('d2l-dropdown', () => {
 			await nextFrame();
 			content.removeAttribute('vertical-offset');
 			await nextFrame();
-			expect(content.style.getPropertyValue('--d2l-dropdown-verticaloffset')).to.equal('16px');
+			expect(content._verticalOffset).to.equal(16);
 		});
 
 		it('vertical offset should default to 16 if set to an invalid number', async() => {
 			content.setAttribute('vertical-offset', 'thisisnotasize');
 			await nextFrame();
-			expect(content.style.getPropertyValue('--d2l-dropdown-verticaloffset')).to.equal('16px');
+			expect(content._verticalOffset).to.equal(16);
 		});
 
 	});


### PR DESCRIPTION
[GAUD-6658](https://desire2learn.atlassian.net/browse/GAUD-6658)

This `--d2l-dropdown-verticaloffset` property is no longer supported since we switched to fixed positioning. Consumers are expected to use the `vertical-offset` attribute/property if they need a custom offset.

[GAUD-6658]: https://desire2learn.atlassian.net/browse/GAUD-6658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ