### PR TITLE
Remove previous Safari fix that causes mobile dropdown content to become unscrollable

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -53,7 +53,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			_isFullHeight: { state: true },
 			_left: { state: true },
 			_margin: { state: true },
-			_mobileDropdownShowing: { state: true },
 			_nestedShowing: { state: true },
 			_overflowBottom: { state: true },
 			_overflowTop: { state: true },
@@ -73,7 +72,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._autoSize = true;
 		this._dialogId = getUniqueId();
 		this._fullscreenWithin = 0;
-		this._handleDropdownOpenClose = this._handleDropdownOpenClose.bind(this);
 		this._handleMvcDialogOpen = this._handleMvcDialogOpen.bind(this);
 		this._inIframe = false;
 		this._isDialogMixin = true;
@@ -81,7 +79,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		this._height = 0;
 		this._left = 0;
 		this._margin = { top: defaultMargin.top, right: defaultMargin.right, bottom: defaultMargin.bottom, left: defaultMargin.left };
-		this._mobileDropdownShowing = false;
 		this._nestedShowing = false;
 		this._overflowBottom = false;
 		this._overflowTop = false;
@@ -158,8 +155,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	_addHandlers() {
 		window.addEventListener('resize', this._updateSize);
 		this.addEventListener('touchstart', this._handleTouchStart);
-		this.addEventListener('d2l-dropdown-open', this._handleDropdownOpenClose, { capture: true });
-		this.addEventListener('d2l-dropdown-close', this._handleDropdownOpenClose, { capture: true });
 		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-dialog-content').addEventListener('scroll', this._updateOverflow);
 	}
 
@@ -350,10 +345,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 		e.stopPropagation();
 	}
 
-	_handleDropdownOpenClose(e) {
-		this._mobileDropdownShowing = e.composedPath()[0]._useMobileStyling;
-	}
-
 	_handleFocusTrapEnter(e) {
 		// ignore focus trap events when the target is another element
 		// to prevent infinite focus loops
@@ -476,8 +467,6 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	_removeHandlers() {
 		window.removeEventListener('resize', this._updateSize);
 		this.removeEventListener('touchstart', this._handleTouchStart);
-		this.removeEventListener('d2l-dropdown-open', this._handleDropdownOpenClose, { capture: true });
-		this.removeEventListener('d2l-dropdown-close', this._handleDropdownOpenClose, { capture: true });
 		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-dialog-content').removeEventListener('scroll', this._updateOverflow);
 	}
 
@@ -506,8 +495,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			'd2l-dialog-outer-nested-showing': !this._useNative && this._nestedShowing,
 			'd2l-dialog-outer-scroll': this._scroll,
 			'd2l-dialog-fullscreen-mobile': info.fullscreenMobile,
-			'd2l-dialog-fullscreen-within': this._fullscreenWithin !== 0,
-			'd2l-dialog-dropdown-mobile': this._mobileDropdownShowing
+			'd2l-dialog-fullscreen-within': this._fullscreenWithin !== 0
 		};
 
 		return html`${this._useNative ?

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -151,10 +151,6 @@ export const dialogStyles = css`
 		overflow: auto;
 	}
 
-	.d2l-dialog-dropdown-mobile .d2l-dialog-content {
-		overflow: hidden; /* workaround to fix clipping of nested fixed position elements with overlowing content in Safari bug: https://bugs.webkit.org/show_bug.cgi?id=160953 */
-	}
-
 	.d2l-dialog-footer {
 		box-sizing: border-box;
 		flex: none;


### PR DESCRIPTION
[GAUD-7745](https://desire2learn.atlassian.net/browse/GAUD-7745)

This PR fixes an issue where mobile dialog content would become unscrollable after dismissing a nested mobile dropdown. This issue can be observed in our demo pages, but more importantly, the My Courses widget. It removes the code that was added in [this PR](https://github.com/BrightspaceUI/core/pull/4234) to address a Safari clipping issue - I have confirmed that this is no longer an issue for us.

This broken scroll behaviour was the result of our fix setting `overflow: hidden` on the dialog content while the mobile dropdown was open, but never actually removing it when the dropdown is dismissed.

[GAUD-7745]: https://desire2learn.atlassian.net/browse/GAUD-7745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ