### PR TITLE
fix: require label on fieldset

### DIFF
--- a/components/inputs/input-fieldset.js
+++ b/components/inputs/input-fieldset.js
@@ -5,14 +5,14 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { InputInlineHelpMixin } from './input-inline-help.js';
 import { inputLabelStyles } from './input-label-styles.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
+import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 /**
  * A component wrapper to be used when a page contains multiple inputs which are related (for example to form an address) to wrap those related inputs.
  * @slot - Related input components
  */
-class InputFieldset extends InputInlineHelpMixin(SkeletonMixin(RtlMixin(LitElement))) {
+class InputFieldset extends PropertyRequiredMixin(InputInlineHelpMixin(SkeletonMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -20,7 +20,7 @@ class InputFieldset extends InputInlineHelpMixin(SkeletonMixin(RtlMixin(LitEleme
 			 * REQUIRED: Label for the fieldset
 			 * @type {string}
 			 */
-			label: { type: String },
+			label: { type: String, required: true },
 			/**
 			 * Hides the label visually
 			 * @type {boolean}

--- a/components/inputs/test/input-fieldset.test.js
+++ b/components/inputs/test/input-fieldset.test.js
@@ -1,5 +1,6 @@
 import '../input-fieldset.js';
-import { runConstructor } from '@brightspace-ui/testing';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
+import { createMessage } from '../../../mixins/property-required/property-required-mixin.js';
 
 describe('d2l-input-fieldset', () => {
 
@@ -9,6 +10,19 @@ describe('d2l-input-fieldset', () => {
 			runConstructor('d2l-input-fieldset');
 		});
 
+	});
+
+	describe('validation', () => {
+		it('should throw when label is missing', async() => {
+			const elem = await fixture(html`<d2l-input-fieldset></d2l-input-fieldset>`);
+			expect(() => elem.flushRequiredPropertyErrors())
+				.to.throw(TypeError, createMessage(elem, 'label'));
+		});
+
+		it('should not throw when label is provided', async() => {
+			const elem = await fixture(html`<d2l-input-fieldset label="fieldset"></d2l-input-fieldset>`);
+			expect(() => elem.flushRequiredPropertyErrors()).to.not.throw();
+		});
 	});
 
 });


### PR DESCRIPTION
[GAUD-7757](https://desire2learn.atlassian.net/browse/GAUD-7757)

While investigating how to solve spacing between fields/inputs, I noticed some places using `<d2l-input-fieldset>` but not providing a label. This is going to result in an empty `<legend>` and really defeats the purpose of using it in the first place.

Separately I'm going to go through the places that weren't using this correctly and fix them.

[GAUD-7757]: https://desire2learn.atlassian.net/browse/GAUD-7757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ