### PR TITLE
Update menu-items to avoid some inefficient updates

### DIFF
--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -108,7 +108,7 @@ export const MenuItemMixin = superclass => class extends superclass {
 				case 'lines':
 					if (!(changedProperties.get('lines') === undefined && this.lines === defaultLines)) {
 						this.style.setProperty('--d2l-menu-item-lines', this.lines);
-					} 
+					}
 					break;
 			}
 		});

--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -106,7 +106,9 @@ export const MenuItemMixin = superclass => class extends superclass {
 					this._ariaDisabled = this.disabled ? 'true' : 'false';
 					break;
 				case 'lines':
-					if (!(changedProperties.get('lines') === undefined && this.lines === defaultLines)) this.style.setProperty('--d2l-menu-item-lines', this.lines);
+					if (!(changedProperties.get('lines') === undefined && this.lines === defaultLines)) {
+						this.style.setProperty('--d2l-menu-item-lines', this.lines);
+					} 
 					break;
 			}
 		});

--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -91,23 +91,25 @@ export const MenuItemMixin = superclass => class extends superclass {
 
 	updated(changedProperties) {
 		super.updated(changedProperties);
-
-		changedProperties.forEach((oldValue, propName) => {
-			if (propName === 'hidden') {
-				this._onHidden();
-			} else if (propName === 'disabled') {
-				this._ariaDisabled = this.disabled ? 'true' : 'false';
-			} else if (propName === 'text' || propName === 'description') {
-				this._ariaLabel = this.description || this.text;
-			}
-		});
+		if (changedProperties.has('hidden')) this._onHidden();
 	}
 
 	willUpdate(changedProperties) {
 		super.willUpdate(changedProperties);
-		if (changedProperties.has('lines') && !(changedProperties.get('lines') === undefined && this.lines === defaultLines)) {
-			this.style.setProperty('--d2l-menu-item-lines', this.lines);
-		}
+		changedProperties.forEach((oldValue, propName) => {
+			switch (propName) {
+				case 'text':
+				case 'description':
+					this._ariaLabel = this.description || this.text;
+					break;
+				case 'disabled':
+					this._ariaDisabled = this.disabled ? 'true' : 'false';
+					break;
+				case 'lines':
+					if (!(changedProperties.get('lines') === undefined && this.lines === defaultLines)) this.style.setProperty('--d2l-menu-item-lines', this.lines);
+					break;
+			}
+		});
 	}
 
 	__action() {

--- a/components/menu/menu-item-return.js
+++ b/components/menu/menu-item-return.js
@@ -39,9 +39,9 @@ class MenuItemReturn extends RtlMixin(LocalizeCoreElement(MenuItemMixin(LitEleme
 		];
 	}
 
-	firstUpdated() {
-		super.firstUpdated();
-		this.setAttribute('aria-label', this.localize('components.menu-item-return.return'));
+	constructor() {
+		super();
+		this.text = null;
 	}
 
 	render() {
@@ -51,14 +51,15 @@ class MenuItemReturn extends RtlMixin(LocalizeCoreElement(MenuItemMixin(LitEleme
 		`;
 	}
 
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		changedProperties.forEach((oldValue, propName) => {
-			if (propName === 'text') {
+	willUpdate(changedProperties) {
+		super.willUpdate(changedProperties);	
+		if (changedProperties.has('text')) {
+			if (this.text) {
 				this.setAttribute('aria-label', this.localize('components.menu-item-return.returnCurrentlyShowing', 'menuTitle', this.text));
+			} else {
+				this.setAttribute('aria-label', this.localize('components.menu-item-return.return'));
 			}
-		});
+		}
 	}
 
 }

--- a/components/menu/menu-item-return.js
+++ b/components/menu/menu-item-return.js
@@ -52,7 +52,7 @@ class MenuItemReturn extends RtlMixin(LocalizeCoreElement(MenuItemMixin(LitEleme
 	}
 
 	willUpdate(changedProperties) {
-		super.willUpdate(changedProperties);	
+		super.willUpdate(changedProperties);
 		if (changedProperties.has('text')) {
 			if (this.text) {
 				this.setAttribute('aria-label', this.localize('components.menu-item-return.returnCurrentlyShowing', 'menuTitle', this.text));


### PR DESCRIPTION
[GAUD-7763](https://desire2learn.atlassian.net/browse/GAUD-7763)

This PR eliminates most of the menu-item warnings by moving several updates to `willUpdate`:

> Element d2l-menu-item scheduled an update (generally because a property was set) after an update completed, causing a new update to be scheduled. This is inefficient and should be avoided unless the next update can only be scheduled as a side effect of the previous update. See https://lit.dev/msg/change-in-update for more information.

There is still one instance of this warning that arises with nested menus, which I think is unavoidable (at least without more significant changes) because the parent menu-item `slot` needs to be rendered before it can determine if there are child-views.

[GAUD-7763]: https://desire2learn.atlassian.net/browse/GAUD-7763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ