### PR TITLE
Tabs: New Structure: Run vdiff tests in CI on new paired structure

### DIFF
--- a/components/tabs/test/tabs.vdiff.js
+++ b/components/tabs/test/tabs.vdiff.js
@@ -5,7 +5,7 @@ import '../tab-panel.js';
 import { clickElem, expect, fixture, focusElem, html, sendKeysElem } from '@brightspace-ui/testing';
 
 const noPanelSelectedFixture = {
-	default: html`
+	deprecated: html`
 		<d2l-tabs>
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
@@ -25,7 +25,7 @@ const noPanelSelectedFixture = {
 };
 
 const panelSelectedFixture = {
-	default: html`
+	deprecated: html`
 		<d2l-tabs>
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 			<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
@@ -45,7 +45,7 @@ const panelSelectedFixture = {
 };
 
 const oneTabFixture = {
-	default: html`
+	deprecated: html`
 		<d2l-tabs>
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 		</d2l-tabs>
@@ -54,29 +54,6 @@ const oneTabFixture = {
 		<d2l-tabs>
 			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
 			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-		</d2l-tabs>
-	`
-};
-
-const skeletonFixture = {
-	default: html`
-		<d2l-tabs skeleton>
-			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
-			<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
-			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-		</d2l-tabs>
-	`,
-	paired: html`
-		<d2l-tabs skeleton>
-			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-			<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-			<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for Physics</d2l-tab-panel>
-			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 		</d2l-tabs>
 	`
 };
@@ -91,29 +68,6 @@ const skeletonSetOnEachTabFixture = {
 			<d2l-tab id="physics" text="Physics" slot="tabs" skeleton></d2l-tab>
 			<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for Physics</d2l-tab-panel>
 			<d2l-tab id="chemistry" text="Chemistry" slot="tabs" skeleton></d2l-tab>
-			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
-		</d2l-tabs>
-	`
-};
-
-const skeletonNoTextFixture = {
-	default: html`
-		<d2l-tabs skeleton>
-			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
-			<d2l-tab-panel>Tab content for Biology</d2l-tab-panel>
-			<d2l-tab-panel text="Physics">Tab content for Physics</d2l-tab-panel>
-			<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
-		</d2l-tabs>
-	`,
-	paired: html`
-		<d2l-tabs skeleton>
-			<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-			<d2l-tab id="biology" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
-			<d2l-tab id="physics" text="Physics" slot="tabs"></d2l-tab>
-			<d2l-tab-panel labelled-by="physics" slot="panels">Tab content for Physics</d2l-tab-panel>
-			<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
 			<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
 		</d2l-tabs>
 	`
@@ -135,7 +89,7 @@ const skeletonSetOnEachTabNoTextFixture = {
 };
 
 const ellipsisFixture = {
-	default: html`
+	deprecated: html`
 		<d2l-tabs>
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 			<d2l-tab-panel text="Earth &amp; Planetary Sciences" selected>Tab content for Earth &amp; Planetary Sciences</d2l-tab-panel>
@@ -155,7 +109,7 @@ const ellipsisFixture = {
 };
 
 const actionSlotBasicFixture = {
-	default: html`
+	deprecated: html`
 		<d2l-tabs>
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
@@ -174,7 +128,7 @@ const actionSlotBasicFixture = {
 };
 
 const actionSlotOverflowFixture = {
-	default: html`
+	deprecated: html`
 		<d2l-tabs>
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
@@ -196,7 +150,7 @@ const actionSlotOverflowFixture = {
 };
 
 const noPaddingFixture = {
-	default: html`
+	deprecated: html`
 		<d2l-tabs>
 			<d2l-tab-panel text="All" no-padding style="background-color: orange;">Tab content for All</d2l-tab-panel>
 			<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
@@ -213,7 +167,7 @@ const noPaddingFixture = {
 };
 
 const maxToShowFixture = {
-	default: html`
+	deprecated: html`
 		<d2l-tabs max-to-show="2">
 			<d2l-tab-panel text="All">Tab content for All</d2l-tab-panel>
 			<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
@@ -233,7 +187,7 @@ const maxToShowFixture = {
 };
 
 const viewport = { width: 376 };
-const useFixture = 'default';
+const useFixture = 'paired';
 
 describe('d2l-tabs', () => {
 
@@ -255,23 +209,11 @@ describe('d2l-tabs', () => {
 		});
 
 		it('skeleton', async() => {
-			const elem = await fixture(skeletonFixture[useFixture], { viewport });
-			await expect(elem).to.be.golden();
-		});
-
-		it('skeleton no text', async() => {
-			const elem = await fixture(skeletonNoTextFixture[useFixture], { viewport });
-			await expect(elem).to.be.golden();
-		});
-
-		it('skeleton set on tab', async() => {
-			if (useFixture === 'default') return;
 			const elem = await fixture(skeletonSetOnEachTabFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
 
-		it('skeleton set on tab no text', async() => {
-			if (useFixture === 'default') return;
+		it('skeleton no text', async() => {
 			const elem = await fixture(skeletonSetOnEachTabNoTextFixture[useFixture], { viewport });
 			await expect(elem).to.be.golden();
 		});
@@ -308,7 +250,7 @@ describe('d2l-tabs', () => {
 	describe('overflow', () => {
 
 		const nextFixture = {
-			default: html`
+			deprecated: html`
 				<d2l-tabs>
 					<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
 					<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
@@ -330,7 +272,7 @@ describe('d2l-tabs', () => {
 			`
 		};
 		const previousFixture = {
-			default: html`
+			deprecated: html`
 				<d2l-tabs>
 					<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
 					<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
@@ -428,7 +370,7 @@ describe('d2l-tabs', () => {
 	describe('keyboard', () => {
 
 		const keyboardFixture = {
-			default: html`
+			deprecated: html`
 				<d2l-tabs>
 					<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
 					<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
@@ -473,7 +415,7 @@ describe('d2l-tabs', () => {
 
 		['Space', 'Enter'].forEach((key) => {
 			const keyboardSelectionFixture = {
-				default: html`
+				deprecated: html`
 					<d2l-tabs>
 						<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
 						<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
@@ -497,4 +439,101 @@ describe('d2l-tabs', () => {
 
 	});
 
+	describe('deprecated structure', () => {
+
+		describe('basic', () => {
+			it('no panel selected', async() => {
+				const elem = await fixture(noPanelSelectedFixture['deprecated'], { viewport });
+				await expect(elem).to.be.golden();
+			});
+
+			it('panel selected', async() => {
+				const elem = await fixture(panelSelectedFixture['deprecated'], { viewport });
+				await expect(elem).to.be.golden();
+			});
+
+			it('one tab', async() => {
+				const elem = await fixture(oneTabFixture['deprecated'], { viewport });
+				await expect(elem).to.be.golden();
+			});
+		});
+
+		describe('overflow', () => {
+			const nextFixture = {
+				deprecated: html`
+					<d2l-tabs>
+						<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+						<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+						<d2l-tab-panel text="Geology">Tab content for Geology</d2l-tab-panel>
+					</d2l-tabs>
+				`
+			};
+
+			['ltr', 'rtl'].forEach((dir) => {
+
+				const rtl = dir === 'rtl';
+
+				describe(dir, () => {
+
+					it('scroll next', async() => {
+						const elem = await fixture(nextFixture['deprecated'], { viewport, rtl });
+						await expect(elem).to.be.golden();
+					});
+
+					it('scrolls next on click', async() => {
+						const elem = await fixture(nextFixture['deprecated'], { viewport, rtl });
+						await clickElem(elem.shadowRoot.querySelector('.d2l-tabs-scroll-next-container button'));
+						await expect(elem).to.be.golden();
+					});
+
+					it('action slot', async() => {
+						const elem = await fixture(actionSlotOverflowFixture['deprecated'], { viewport, rtl });
+						await expect(elem).to.be.golden();
+					});
+
+					it('focus next', async() => {
+						const elem = await fixture(nextFixture['deprecated'], { viewport, rtl });
+						await focusElem(elem.shadowRoot.querySelector('.d2l-tabs-scroll-next-container button'));
+						await expect(elem).to.be.golden();
+					});
+				});
+			});
+		});
+
+		describe('keyboard', () => {
+
+			const keyboardFixture = {
+				deprecated: html`
+					<d2l-tabs>
+						<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+						<d2l-tab-panel text="Biology" selected>Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel text="Chemistry">Tab content for Chemistry</d2l-tab-panel>
+					</d2l-tabs>
+				`
+			};
+
+			it('focuses next on right arrow', async() => {
+				const elem = await fixture(keyboardFixture['deprecated'], { viewport });
+				await sendKeysElem(elem, 'press', 'ArrowRight');
+				await expect(elem).to.be.golden();
+			});
+
+			['Space', 'Enter'].forEach((key) => {
+				const keyboardSelectionFixture = {
+					deprecated: html`
+						<d2l-tabs>
+							<d2l-tab-panel text="All Courses">Tab content for All</d2l-tab-panel>
+							<d2l-tab-panel text="Biology">Tab content for Biology</d2l-tab-panel>
+						</d2l-tabs>
+					`
+				};
+				it(`selects on ${key}`, async() => {
+					const elem = await fixture(keyboardSelectionFixture['deprecated'], { viewport });
+					await sendKeysElem(elem, 'press', `ArrowRight+${key}`);
+					await expect(elem).to.be.golden();
+				});
+			});
+		});
+	});
 });


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7486)

Does the following:
- Flips the tabs vdiff tests to run using the paired structure instead of the old structure
- Adds some of the vdiff tests to run on the old structure (note that this will be removed post-backport of new structure into existing tabs usages)