### PR TITLE
Add no-content-scroll property to DialogMixin

### DIFF
--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -15,6 +15,7 @@
 			import '../../filter/filter.js';
 			import '../../filter/filter-dimension-set.js';
 			import '../../filter/filter-dimension-set-value.js';
+			import '../../inputs/input-checkbox.js';
 			import '../../list/demo/demo-list.js';
 			import '../dialog.js';
 			import './dialog-async-content.js';
@@ -291,6 +292,38 @@
 					<script>
 						document.querySelector('#openScrollFocus').addEventListener('click', () => {
 							document.querySelector('#dialogScrollFocus').opened = true;
+						});
+					</script>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Dialog (no content scrolling)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-button id="openNoScrollDialog">Show Dialog</d2l-button>
+					<d2l-dialog id="noScrollDialog" title-text="Dialog Title">
+						<d2l-input-checkbox id="noScroll">Show extra paragraphs</d2l-input-checkbox>
+						<div>
+							<p>Deadlights jack lad schooner scallywag dance the hempen jig carouser broadside cable strike colors. Bring a spring upon her cable holystone blow the man down spanker</p>
+							<p id="p2" style="display: none;">Shiver me timbers to go on account lookout wherry doubloon chase. Belay yo-ho-ho keelhaul squiffy black spot yardarm spyglass sheet transom heave to.</p>
+							<p id="p3" style="display: none;">Trysail Sail ho Corsair red ensign hulk smartly boom jib rum gangway. Case shot Shiver me timbers gangplank crack Jennys tea cup ballast Blimey lee snow crow's nest rutters. Fluke jib scourge of the seven seas boatswain schooner gaff booty Jack Tar transom spirits.</p>
+						</div>
+						<d2l-button slot="footer" primary data-dialog-action="ok">Click Me!</d2l-button>
+						<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+					</d2l-dialog>
+					<script>
+						document.querySelector('#noScroll').addEventListener('change', async(e) => {
+							const dialog = document.querySelector('#noScrollDialog');
+							dialog.noContentScroll = true;
+							const display = e.target.checked ? 'block' : 'none';
+							dialog.querySelector('#p2').style.display = display;
+							dialog.querySelector('#p3').style.display = display;
+							await dialog.resize();
+							dialog.noContentScroll = false;
+						});
+						document.querySelector('#openNoScrollDialog').addEventListener('click', () => {
+							document.querySelector('#noScrollDialog').opened = true;
 						});
 					</script>
 				</template>

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -41,7 +41,10 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			 * Whether or not the dialog is open
 			 */
 			opened: { type: Boolean, reflect: true },
-
+			/**
+			 * Opt out of dialog content scrolling
+			 */
+			noContentScroll: { type: Boolean, attribute: 'no-content-scroll', reflect: true },
 			/**
 			 * The optional title for the dialog
 			 */
@@ -68,6 +71,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 	constructor() {
 		super();
 		this.focusableContentElemPresent = false;
+		this.noContentScroll = false;
 		this.opened = false;
 		this._autoSize = true;
 		this._dialogId = getUniqueId();

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -42,7 +42,7 @@ export const DialogMixin = superclass => class extends RtlMixin(superclass) {
 			 */
 			opened: { type: Boolean, reflect: true },
 			/**
-			 * Opt out of dialog content scrolling
+			 * ADVANCED: Opt out of dialog content scrolling
 			 */
 			noContentScroll: { type: Boolean, attribute: 'no-content-scroll', reflect: true },
 			/**

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -147,7 +147,7 @@ export const dialogStyles = css`
 		height: 100%;
 	}
 
-	.d2l-dialog-outer-scroll .d2l-dialog-content {
+	:host(:not([no-content-scroll])) .d2l-dialog-outer-scroll .d2l-dialog-content {
 		overflow: auto;
 	}
 


### PR DESCRIPTION
[GAUD-7784](https://desire2learn.atlassian.net/browse/GAUD-7784)

This PR adds the `no-content-scroll` property/attribute to `DialogMixin` to give consumers the ability to turn off the content scrollbar. The primary motivation is to avoid potential scrollbar flickering while they are changing dialog contents and resizing. 

As shown in the demo, they apply `no-content-scroll`, make their changes, call the dialog's `resize()` method, and then remove `no-content-scroll`.

In testing, the scrollbar flickering is not consistent. It happens maybe 10-25% of the time.

[GAUD-7784]: https://desire2learn.atlassian.net/browse/GAUD-7784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ