### PR TITLE
Fix d2l-input-date-time validation (JavaScript error)

### DIFF
--- a/components/form/demo/form-demo.js
+++ b/components/form/demo/form-demo.js
@@ -1,6 +1,7 @@
 
 import '../../button/button.js';
 import '../../button/floating-buttons.js';
+import '../../inputs/input-date-time-range.js';
 import '../../inputs/input-percent.js';
 import '../../inputs/input-text.js';
 import '../../inputs/input-textarea.js';
@@ -49,6 +50,9 @@ class FormNestedDemo extends LitElement {
 						</div>
 						<div class="d2l-form-demo-container">
 							<d2l-input-percent label="Awesome" name="grade"></d2l-input-percent>
+						</div>
+						<div class="d2l-form-demo-container">
+							<d2l-input-date-time-range label="Date Range"></d2l-input-date-time-range>
 						</div>
 						<fieldset class="d2l-form-demo-container">
 							<legend>Choose your favorite monster</legend>

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -308,7 +308,12 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 		if (!this.shadowRoot) return;
 		const dateInput = this.shadowRoot.querySelector('d2l-input-date');
 		const timeInput = this.shadowRoot.querySelector('d2l-input-time');
-		const errors = await Promise.all([dateInput.validate(), timeInput.validate(), super.validate()]);
+
+		const errors = await Promise.all([
+			dateInput.validate(), 
+			timeInput ? timeInput.validate() : Promise.resolve([]), 
+			super.validate()
+		]);
 		return [...errors[0], ...errors[1], ...errors[2]];
 	}
 

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -310,8 +310,8 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 		const timeInput = this.shadowRoot.querySelector('d2l-input-time');
 
 		const errors = await Promise.all([
-			dateInput.validate(), 
-			timeInput ? timeInput.validate() : Promise.resolve([]), 
+			dateInput.validate(),
+			timeInput ? timeInput.validate() : Promise.resolve([]),
 			super.validate()
 		]);
 		return [...errors[0], ...errors[1], ...errors[2]];

--- a/components/inputs/test/input-date-time.test.js
+++ b/components/inputs/test/input-date-time.test.js
@@ -4,6 +4,7 @@ import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import sinon from 'sinon';
 
 const basicFixture = '<d2l-input-date-time label="label text"></d2l-input-date-time>';
+const requiredFixture = '<d2l-input-date-time label="label text" required></d2l-input-date-time>';
 const valueFixture = '<d2l-input-date-time label="label text" value="2019-03-02T05:00:00.000Z"></d2l-input-date-time>';
 const minMaxFixture = '<d2l-input-date-time label="label text" min-value="2018-08-27T03:30:00Z" max-value="2018-09-30T17:30:00Z"></d2l-input-date-time>';
 const minMaxLocalizedFixture = '<d2l-input-date-time label="label text" localized min-value="2018-08-27T03:30:00" max-value="2018-09-30T17:30:00"></d2l-input-date-time>';
@@ -149,6 +150,29 @@ describe('d2l-input-date-time', () => {
 				expect(elem.invalid).to.be.true;
 				expect(elem.validationError).to.equal(`Date must be before or on ${expectedEnd}`);
 			});
+
+			it('should return no errors when not required', async() => {
+				const elem = await fixture(basicFixture);
+				const errors = await elem.validate();
+				expect(errors.length).to.equal(0);
+			});
+
+			it('should return no errors when required and a value is provided', async() => {
+				const elem = await fixture(requiredFixture);
+				const inputElem = getChildElem(elem, 'd2l-input-date');
+				inputElem.value = '2018-02-02';
+				setTimeout(() => dispatchEvent(inputElem, 'change'));
+				await oneEvent(elem, 'change');
+				const errors = await elem.validate();
+				expect(errors.length).to.equal(0);
+			});
+
+			it('should return 1 error when required and no value is provided', async() => {
+				const elem = await fixture(requiredFixture);
+				const errors = await elem.validate();
+				expect(errors.length).to.equal(1);
+			});
+
 		});
 	});
 


### PR DESCRIPTION
[GAUD-7790](https://desire2learn.atlassian.net/browse/GAUD-7790)

This PR fixes a JavaScript error that would happen in `d2l-date-time`'s `validate()` method when validating a `form`. The root cause of this error is that the `d2l-input-time` is `null` if the user has not selected a date, resulting in a JavaScript error when trying to call `validate()` on it. This error would occur regardless of whether the input is required.

[GAUD-7790]: https://desire2learn.atlassian.net/browse/GAUD-7790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ