### PR TITLE
feat: Tabs: New Structure: Add before and after slots to d2l-tab

### DIFF
--- a/components/tabs/README.md
+++ b/components/tabs/README.md
@@ -91,6 +91,7 @@ An element that displays the corresponding tab panel when selected.
 <!-- docs: demo code properties name:d2l-tab sandboxTitle:'Tab' display:block -->
 ```html
 <script type="module">
+  import '@brightspace-ui/core/components/count-badge/count-badge.js';
   import '@brightspace-ui/core/components/tabs/tab.js';
   import '@brightspace-ui/core/components/tabs/tabs.js';
   import '@brightspace-ui/core/components/tabs/tab-panel.js';
@@ -99,7 +100,9 @@ An element that displays the corresponding tab panel when selected.
 <d2l-tabs text="Courses">
   <d2l-tab id="all" text="All" slot="tabs" selected></d2l-tab>
   <d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
-  <d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+  <d2l-tab id="biology" text="Biology" slot="tabs">
+    <d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+  </d2l-tab>
   <d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
   <d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
   <d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>

--- a/components/tabs/README.md
+++ b/components/tabs/README.md
@@ -122,6 +122,13 @@ An element that displays the corresponding tab panel when selected.
 | `text` | String, required | The text used for the tab and for labelling the corresponding panel |
 | `selected` | Boolean | Use to select the tab |
 
+### Slots
+
+| Slot | Description |
+|--|--|
+| `before` | Slot for content to be displayed before the tab text |
+| `after` | Slot for content to be displayed after the tab text |
+
 ### Events
 - `d2l-tab-content-change`: Dispatched when the text attribute is changed. Triggers virtual scrolling calculations in parent `d2l-tabs`.
 - `d2l-tab-selected`: Dispatched when a tab is selected
@@ -144,6 +151,8 @@ Promise.resolve(tabs.hideTab((tab))).then(() => {
 ### Custom Tabs
 
 The `TabMixin` can be used to create custom tabs. It is IMPORTANT to call the `dispatchContentChangeEvent` function in `TabMixin` when content changes in the consumer in order to properly trigger calculations. Ensure that there is only one element in any custom tab to focus on, else the focus and keyboard navigation behaviors become confusing for users. Note that the parent `d2l-tabs` element handles `tabindex` focus management, and so consumers should not be rendering focusable elements within custom tabs.
+
+Before creating a custom tab, ensure that the case is not covered by using a standard `d2l-tab` with content in the `before` and/or `after` slot(s). 
 
 <!-- docs: demo code sandboxTitle:'TabMixin' display:block-->
 ```html

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -55,6 +55,36 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Tabs (with before and after slot content)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-tabs text="Courses">
+						<d2l-tab id="beforelong" text="Long Panel Text That Will Also Have Slot Content" slot="tabs">
+							<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+						</d2l-tab>
+						<d2l-tab id="afterlong" text="Long Panel Text That Will Also Have Slot Content" slot="tabs">
+							<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+						</d2l-tab>
+						<d2l-tab id="beforeshort" text="Biology" slot="tabs">
+							<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+						</d2l-tab>
+						<d2l-tab id="aftershort" text="Biology" slot="tabs">
+							<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+						</d2l-tab>
+						<d2l-tab id="beforeafter" text="Biology" slot="tabs">
+							<d2l-count-badge number="5" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+							<d2l-count-badge number="10" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+						</d2l-tab>
+						<d2l-tab-panel labelled-by="beforelong" slot="panels">Tab content for All</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="afterlong" slot="panels">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="beforeshort" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="aftershort" slot="panels">Tab content for Physics</d2l-tab-panel>
+						<d2l-tab-panel labelled-by="beforeafter" slot="panels">Tab content for Trig</d2l-tab-panel>
+					</d2l-tabs>
+				</template>
+			</d2l-demo-snippet>
+
 			<h2>Tabs (with custom tab)</h2>
 
 			<d2l-demo-snippet>

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -4,8 +4,10 @@ import { getFocusPseudoClass } from '../../helpers/focus.js';
 import { TabMixin } from './tab-mixin.js';
 
 /**
- * @attr id - REQUIRED: Unique identifier for the tab
+ * @attr {string} id - REQUIRED: Unique identifier for the tab
  * @fires d2l-tab-content-change - Dispatched when the text attribute is changed. Triggers virtual scrolling calculations in parent d2l-tabs.
+ * @slot before - Slot for content to be displayed before the tab text
+ * @slot after - Slot for content to be displayed after the tab text
  */
 class Tab extends TabMixin(LitElement) {
 
@@ -21,18 +23,18 @@ class Tab extends TabMixin(LitElement) {
 
 	static get styles() {
 		const styles = [ css`
-			.d2l-tab-text {
+			.d2l-tab-inner-content {
 				overflow: hidden;
 				padding: 0.1rem;
 				text-overflow: ellipsis;
 				white-space: nowrap;
 			}
-			:host(:${unsafeCSS(getFocusPseudoClass())}) .d2l-tab-text {
+			:host(:${unsafeCSS(getFocusPseudoClass())}) .d2l-tab-inner-content {
 				border-radius: 0.3rem;
 				color: var(--d2l-color-celestine);
 				outline: 2px solid var(--d2l-color-celestine);
 			}
-			.d2l-tab-text-skeletize-override {
+			.d2l-tab-inner-content-skeletize-override {
 				min-width: 50px;
 			}
 			:host([skeleton]) .d2l-tab-content.d2l-skeletize::before {
@@ -55,12 +57,16 @@ class Tab extends TabMixin(LitElement) {
 	renderContent() {
 		const overrideSkeletonText = this.skeleton && (!this.text || this.text.length === 0);
 		const contentClasses = {
-			'd2l-tab-text': true,
-			'd2l-tab-text-skeletize-override': overrideSkeletonText
+			'd2l-tab-inner-content': true,
+			'd2l-tab-inner-content-skeletize-override': overrideSkeletonText
 		};
 
 		return html`
-			<div class="${classMap(contentClasses)}">${overrideSkeletonText ? html`&nbsp;` : this.text}</div>
+			<div class="${classMap(contentClasses)}">
+				<slot name="before"></slot>
+				<span>${overrideSkeletonText ? html`&nbsp;` : this.text}</span>
+				<slot name="after"></slot>
+			</div>
 		`;
 	}
 }

--- a/components/tabs/test/tabs.vdiff.js
+++ b/components/tabs/test/tabs.vdiff.js
@@ -1,4 +1,5 @@
 import '../../button/button.js';
+import '../../count-badge/count-badge.js';
 import '../tab.js';
 import '../tabs.js';
 import '../tab-panel.js';
@@ -437,6 +438,101 @@ describe('d2l-tabs', () => {
 			});
 		});
 
+	});
+
+	describe('slots', () => {
+		if (useFixture === 'default') return;
+
+		const slotsFixture = html`
+			<d2l-tabs>
+				<d2l-tab id="beforelong" text="Long Panel Text That Will Also Have Slot Content" slot="tabs">
+					<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab id="beforeafter" text="All" slot="tabs">
+					<d2l-count-badge number="5" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+					<d2l-count-badge number="10" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab id="afterlong" text="Long Panel Text That Will Also Have Slot Content" slot="tabs">
+					<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab id="beforeshort" text="All" slot="tabs">
+					<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab id="aftershort" text="All" slot="tabs">
+					<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab-panel labelled-by="beforelong" slot="panels">Tab content for All</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="afterlong" slot="panels">Tab content for Biology</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="beforeshort" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="aftershort" slot="panels">Tab content for Physics</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="beforeafter" slot="panels">Tab content for Trig</d2l-tab-panel>
+			</d2l-tabs>
+		`;
+		const slotsSkeletonFixture = html`
+			<d2l-tabs skeleton>
+				<d2l-tab id="beforelong" text="Long Panel Text That Will Also Have Slot Content" slot="tabs" skeleton>
+					<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab id="beforeafter" text="All" slot="tabs" skeleton>
+					<d2l-count-badge number="5" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+					<d2l-count-badge number="10" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab id="afterlong" text="Long Panel Text That Will Also Have Slot Content" slot="tabs" skeleton>
+					<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab id="beforeshort" text="All" slot="tabs" skeleton>
+					<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab id="aftershort" text="All" slot="tabs" skeleton>
+					<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab-panel labelled-by="beforelong" slot="panels">Tab content for All</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="afterlong" slot="panels">Tab content for Biology</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="beforeshort" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="aftershort" slot="panels">Tab content for Physics</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="beforeafter" slot="panels">Tab content for Trig</d2l-tab-panel>
+			</d2l-tabs>
+		`;
+		const slotsSkeletonNoTextFixture = html`
+			<d2l-tabs skeleton>
+				<d2l-tab id="beforelong" text="Long Panel Text That Will Also Have Slot Content" slot="tabs" skeleton>
+					<d2l-count-badge number="100" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab id="beforeafter" slot="tabs" skeleton>
+					<d2l-count-badge number="5" size="small" text="100 new notifications" type="notification" slot="before"></d2l-count-badge>
+					<d2l-count-badge number="10" size="small" text="100 new notifications" type="notification" slot="after"></d2l-count-badge>
+				</d2l-tab>
+				<d2l-tab-panel labelled-by="beforelong" slot="panels">Tab content for All</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="beforeafter" slot="panels">Tab content for Trig</d2l-tab-panel>
+			</d2l-tabs>
+		`;
+
+		it('default', async() => {
+			const elem = await fixture(slotsFixture);
+			await expect(elem).to.be.golden();
+		});
+
+		it('focus', async() => {
+			const elem = await fixture(slotsFixture);
+			await focusElem(elem);
+			await expect(elem).to.be.golden();
+		});
+
+		it('focus both slots', async() => {
+			const elem = await fixture(slotsFixture);
+			await sendKeysElem(elem, 'press', 'ArrowRight');
+			await expect(elem).to.be.golden();
+		});
+
+		it('skeleton', async() => {
+			const elem = await fixture(slotsSkeletonFixture);
+			await expect(elem).to.be.golden();
+		});
+
+		it('skeleton no text', async() => {
+			const elem = await fixture(slotsSkeletonNoTextFixture);
+			await expect(elem).to.be.golden();
+		});
 	});
 
 	describe('deprecated structure', () => {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7659)

Adds `before` and `after` slots to the `d2l-tab` component.