### PR TITLE
fix: prevent change events within supporting slot from propagating

### DIFF
--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -238,7 +238,7 @@ class InputCheckbox extends InputInlineHelpMixin(FocusMixin(SkeletonMixin(LitEle
 			${this._renderInlineHelp(this.#inlineHelpId)}
 			${offscreenContainer}
 			${disabledTooltip}
-			<div class="${classMap(supportingClasses)}"><slot name="supporting" @slotchange="${this.#handleSupportingSlotChange}"></slot></div>
+			<div class="${classMap(supportingClasses)}" @change="${this.#handleSupportingChange}"><slot name="supporting" @slotchange="${this.#handleSupportingSlotChange}"></slot></div>
 		`;
 	}
 
@@ -274,6 +274,10 @@ class InputCheckbox extends InputInlineHelpMixin(FocusMixin(SkeletonMixin(LitEle
 
 	#handleMouseLeave() {
 		this._isHovered = false;
+	}
+
+	#handleSupportingChange(e) {
+		e.stopPropagation();
 	}
 
 	#handleSupportingSlotChange(e) {

--- a/components/inputs/test/input-checkbox.test.js
+++ b/components/inputs/test/input-checkbox.test.js
@@ -44,21 +44,31 @@ describe('d2l-input-checkbox', () => {
 
 	describe('events', () => {
 
-		let elem;
-		beforeEach(async() => {
-			elem = await fixture(uncheckedFixture);
-		});
-
 		it('should fire "change" event when input element is clicked', async() => {
-			setTimeout(() => getInput(elem).click());
+			const elem = await fixture(uncheckedFixture);
+			clickElem(getInput(elem));
 			const { target } = await oneEvent(elem, 'change');
 			expect(target).to.equal(elem);
 		});
 
 		it('should reflect that a previously unchecked input is now checked', async() => {
-			setTimeout(() => getInput(elem).click());
+			const elem = await fixture(uncheckedFixture);
+			clickElem(getInput(elem));
 			const { target } = await oneEvent(elem, 'change');
 			expect(target.checked).to.equal(true);
+		});
+
+		it('should prevent "change" events inside supporting slot from propagating', async() => {
+			const elem = await fixture(html`
+				<d2l-input-checkbox aria-label="label">
+					<d2l-input-checkbox aria-label="nested" slot="supporting"></d2l-input-checkbox>
+				</d2l-input-checkbox>
+			`);
+			const nestedElem = elem.querySelector('[aria-label="nested"]');
+			let eventFired = false;
+			elem.addEventListener('change', () => eventFired = true);
+			await clickElem(getInput(nestedElem));
+			expect(eventFired).to.be.false;
 		});
 
 	});


### PR DESCRIPTION
[GAUD-7778](https://desire2learn.atlassian.net/browse/GAUD-7778)

With the introduction of the new `supporting` slot for checkbox inputs, there are some use cases where they're nesting other checkboxes or inputs inside that slot. When those components fire their own `change` events, it propagates up and appears to originate from the checkbox itself. That often causes consumers to flip the state of the checkbox, which isn't what we want!

[GAUD-7778]: https://desire2learn.atlassian.net/browse/GAUD-7778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ