### PR TITLE
Remove RtlMixin usage that is not needed anymore.

### DIFF
--- a/components/offscreen/offscreen.js
+++ b/components/offscreen/offscreen.js
@@ -1,5 +1,4 @@
 import { css, html, LitElement } from 'lit';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * A private helper declarations that should not be used by general consumers
@@ -25,7 +24,7 @@ export const offscreenStyles = css`
  * A component for positioning content offscreen to only be visible to screen readers.
  * @slot - Default content placed inside of the component
  */
-class Offscreen extends RtlMixin(LitElement) {
+class Offscreen extends LitElement {
 	static get styles() {
 		return css`
 			:host {

--- a/components/overflow-group/overflow-group-mixin.js
+++ b/components/overflow-group/overflow-group-mixin.js
@@ -1,8 +1,6 @@
 import { css, html, nothing } from 'lit';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
-import { offscreenStyles } from '../offscreen/offscreen.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 export const OVERFLOW_CLASS = 'd2l-overflow-container';
@@ -25,7 +23,7 @@ async function filterAsync(arr, callback) {
 	return results.filter(i => i !== fail);
 }
 
-export const OverflowGroupMixin = superclass => class extends LocalizeCoreElement(RtlMixin(superclass)) {
+export const OverflowGroupMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
 	static get properties() {
 		return {
@@ -68,7 +66,7 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 	}
 
 	static get styles() {
-		return [offscreenStyles, css`
+		return css`
 			:host {
 				display: block;
 			}
@@ -82,7 +80,7 @@ export const OverflowGroupMixin = superclass => class extends LocalizeCoreElemen
 			.d2l-overflow-group-container ::slotted([data-is-chomped]) {
 				display: none !important;
 			}
-		`];
+		`;
 	}
 
 	constructor() {


### PR DESCRIPTION
[GAUD-7802](https://desire2learn.atlassian.net/browse/GAUD-7802)

* The `d2l-offscreen` component extends `RtlMixin` but it doesn't need to (since https://github.com/BrightspaceUI/core/pull/4192)
* The `OverflowGroupMixin` includes the `offscreenStyles` (i.e. `d2l-offscreen` CSS class) but it doesn't use them
* The `OverflowGroupMixin` extends `RtlMixin` when it doesn't need to

[GAUD-7802]: https://desire2learn.atlassian.net/browse/GAUD-7802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ