### PR TITLE
Update list grid mode to use row and gridcell roles.

### DIFF
--- a/components/filter/test/filter.axe.js
+++ b/components/filter/test/filter.axe.js
@@ -53,7 +53,7 @@ describe('d2l-filter', () => {
 
 			elem.opened = true;
 			await oneEvent(dropdown, 'd2l-dropdown-open');
-			await expect(elem).to.be.accessible({ ignoredRules: ['aria-roles', 'aria-required-children', 'aria-required-parent'] }); // d2l-list's grid mode does not apply the grid roles because of lack of iOS support
+			await expect(elem).to.be.accessible({ ignoredRules: ['aria-required-parent'] }); // d2l-list's grid mode does not apply the grid roles because of lack of iOS support
 		});
 	});
 
@@ -67,7 +67,7 @@ describe('d2l-filter', () => {
 		await oneEvent(dropdown, 'd2l-dropdown-open');
 		menuItem.click();
 		await oneEvent(menu, 'd2l-hierarchical-view-show-complete');
-		await expect(elem).to.be.accessible({ ignoredRules: ['aria-roles', 'aria-required-children', 'aria-required-parent'] }); // d2l-list's grid mode does not apply the grid roles because of lack of iOS support
+		await expect(elem).to.be.accessible({ ignoredRules: ['aria-required-parent'] }); // d2l-list's grid mode does not apply the grid roles because of lack of iOS support
 	});
 
 });

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -214,7 +214,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 	connectedCallback() {
 		super.connectedCallback();
-		this.role = this.gridActive ? 'gridrow' : undefined;
+		this.role = this.gridActive ? 'gridcell' : undefined;
 	}
 
 	firstUpdated() {
@@ -265,7 +265,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 	_focusFirstRow() {
 		const list = findComposedAncestor(this, (node) => node.tagName === 'D2L-LIST');
-		const row = list.firstElementChild.shadowRoot.querySelector('[role="gridrow"]');
+		const row = list.firstElementChild.shadowRoot.querySelector('[role="gridcell"]');
 		if (this.dir === 'rtl') {
 			row._focusLastCell();
 		} else {
@@ -288,7 +288,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 	_focusLastRow() {
 		const list = findComposedAncestor(this, (node) => node.tagName === 'D2L-LIST');
-		const row = list.lastElementChild.shadowRoot.querySelector('[role="gridrow"]');
+		const row = list.lastElementChild.shadowRoot.querySelector('[role="gridcell"]');
 		if (this.dir === 'rtl') {
 			row._focusFirstCell();
 		} else {
@@ -320,7 +320,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 	_focusNextRow(focusInfo, previous = false, num = 1) {
 
-		const curListItem = findComposedAncestor(this, node => node.role === 'rowgroup');
+		const curListItem = findComposedAncestor(this, node => node.role === 'row');
 		let listItem = curListItem;
 
 		while (num > 0) {
@@ -331,7 +331,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 		}
 
 		if (!listItem) return;
-		const listItemRow = listItem.shadowRoot.querySelector('[role="gridrow"]');
+		const listItemRow = listItem.shadowRoot.querySelector('[role="gridcell"]');
 		const focusedCellItem = listItemRow._focusCellItem(focusInfo);
 
 		if (!focusedCellItem) {
@@ -339,7 +339,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			if (!listItem._tryFocus()) {
 				// ultimate fallback to generic method for getting next/previous focusable
 				const nextFocusable = previous ? getPreviousFocusable(listItem) : getNextFocusable(listItem);
-				const nextListItem = findComposedAncestor(nextFocusable, (node) => node.role === 'rowgroup' || node.role === 'listitem');
+				const nextListItem = findComposedAncestor(nextFocusable, (node) => node.role === 'row' || node.role === 'listitem');
 				if (nextListItem && this._isContainedInSameRootList(curListItem, nextListItem)) {
 					nextFocusable.focus();
 				}
@@ -363,7 +363,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 		// check for nested list first; this check needs to account for standard list-items as well as custom
 		const nestedList = listItem.querySelector('[slot="nested"]') || listItem.shadowRoot.querySelector('d2l-list');
 		if (nestedList && (!listItem.expandable || (listItem.expandable && listItem.expanded))) {
-			const nestedListItem = [...nestedList.children].find(node => node.role === 'rowgroup');
+			const nestedListItem = [...nestedList.children].find(node => node.role === 'row');
 			if (nestedListItem) return nestedListItem;
 		}
 
@@ -372,7 +372,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			// check for sibling list-item
 			let nextElement = listItem.nextElementSibling;
 			while (nextElement) {
-				if (nextElement.role === 'rowgroup') return nextElement;
+				if (nextElement.role === 'row') return nextElement;
 				nextElement = nextElement.nextElementSibling;
 			}
 
@@ -380,7 +380,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 			const list = findComposedAncestor(listItem, node => node.tagName === 'D2L-LIST');
 			if (list.slot !== 'nested' && !(list.parentNode.tagName === 'SLOT' && list.parentNode.name === 'nested')) return;
 
-			const parentListItem = findComposedAncestor(list, node => node.role === 'rowgroup');
+			const parentListItem = findComposedAncestor(list, node => node.role === 'row');
 			return getNextListItem(parentListItem);
 
 		};
@@ -396,14 +396,14 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 		// try to get the previous list-item in the current list sub-tree including nested
 		while (previousElement) {
-			if (previousElement.role === 'rowgroup') {
+			if (previousElement.role === 'row') {
 
 				let nestedList;
 				do {
 					// this check needs to account for standard list-items as well as custom
 					nestedList = previousElement.querySelector('[slot="nested"]') || previousElement.shadowRoot.querySelector('d2l-list');
 					if (nestedList) {
-						const nestedListItems = [...nestedList.children].filter(node => node.role === 'rowgroup');
+						const nestedListItems = [...nestedList.children].filter(node => node.role === 'row');
 						if (nestedListItems.length) {
 							previousElement = nestedListItems[nestedListItems.length - 1];
 						} else {
@@ -421,7 +421,7 @@ class ListItemGenericLayout extends RtlMixin(LitElement) {
 
 		// this check needs to account for standard list-items as well as custom
 		if (list.slot === 'nested' || (list.parentNode.tagName === 'SLOT' && list.parentNode.name === 'nested')) {
-			const parentListItem = findComposedAncestor(list, node => node.role === 'rowgroup');
+			const parentListItem = findComposedAncestor(list, node => node.role === 'row');
 			return parentListItem;
 		}
 

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -460,7 +460,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 
 	connectedCallback() {
 		super.connectedCallback();
-		if (this.role === 'rowgroup') {
+		if (this.role === 'row') {
 			addTabListener();
 		}
 		if (!this.selectable && !this.expandable) {
@@ -599,12 +599,12 @@ export const ListItemMixin = superclass => class extends composeMixins(
 
 	_isListItem(node) {
 		if (!node) node = this;
-		return node.role === 'rowgroup' || node.role === 'listitem';
+		return node.role === 'row' || node.role === 'listitem';
 	}
 
 	_onFocusIn() {
 		this._focusing = true;
-		if (this.role !== 'rowgroup' || !tabPressed || hasDisplayedKeyboardTooltip) return;
+		if (this.role !== 'row' || !tabPressed || hasDisplayedKeyboardTooltip) return;
 		this._displayKeyboardTooltip = true;
 		hasDisplayedKeyboardTooltip = true;
 	}
@@ -696,7 +696,7 @@ export const ListItemMixin = superclass => class extends composeMixins(
 				@focusout="${this._onFocusOut}"
 				class="${classMap(classes)}"
 				data-separators="${ifDefined(this._separators)}"
-				?grid-active="${this.role === 'rowgroup'}"
+				?grid-active="${this.role === 'row'}"
 				?no-primary-action="${this.noPrimaryAction}">
 				${this._showAddButton && this.first ? html`
 				<div slot="add-top">

--- a/components/list/list-item-role-mixin.js
+++ b/components/list/list-item-role-mixin.js
@@ -27,7 +27,7 @@ export const ListItemRoleMixin = superclass => class extends superclass {
 
 		const separators = parent.getAttribute('separators');
 
-		this.role = parent.hasAttribute('grid') ? 'rowgroup' : 'listitem';
+		this.role = parent.hasAttribute('grid') ? 'row' : 'listitem';
 		this._nested = (parent.slot === 'nested');
 		this._separators = separators || undefined;
 		this._extendSeparators = parent.hasAttribute('extend-separators');

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -205,7 +205,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 	}
 
 	render() {
-		const role = !this.grid ? 'list' : 'application';
+		const role = !this.grid ? 'list' : 'application'; // not using grid role due to Safari+VO: https://bugs.webkit.org/show_bug.cgi?id=291591
 		const ariaLabel = this.slot !== 'nested' ? this.label : undefined;
 		return html`
 			<slot name="controls"></slot>
@@ -235,7 +235,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 		if (!slot) slot = this.shadowRoot.querySelector('slot:not([name])');
 		if (!slot) return [];
 		return slot.assignedNodes({ flatten: true }).filter((node) => {
-			return node.nodeType === Node.ELEMENT_NODE && (node.role === 'rowgroup' || node.role === 'listitem');
+			return node.nodeType === Node.ELEMENT_NODE && (node.role === 'row' || node.role === 'listitem');
 		});
 	}
 

--- a/components/list/test/list-item-role-mixin.test.js
+++ b/components/list/test/list-item-role-mixin.test.js
@@ -16,7 +16,7 @@ describe('ListItemRoleMixin', () => {
 
 	it('changes role to rowgroup when list parent has grid enabled', async() => {
 		const el = await fixture(`<d2l-list grid><${tag}></${tag}></d2l-list>`);
-		expect(el.querySelector(tag).role).to.equal('rowgroup');
+		expect(el.querySelector(tag).role).to.equal('row');
 	});
 
 	it('changes role to listitem when list parent has grid disabled', async() => {

--- a/components/list/test/list.axe.js
+++ b/components/list/test/list.axe.js
@@ -5,32 +5,39 @@ import '../list-item-button.js';
 import '../../selection/selection-action.js';
 import { expect, fixture, html } from '@brightspace-ui/testing';
 
-const normalFixture = html`
-	<d2l-list>
-		<d2l-list-controls slot="controls">
-			<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
-			<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
-		</d2l-list-controls>
-		<d2l-list-item>
-			<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
-			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>
-		</d2l-list-item>
-		<d2l-list-item href="http://www.d2l.com">
-			<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
-			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>
-		</d2l-list-item>
-		<d2l-list-item-button>
-			<div class="d2l-list-item-text d2l-body-compact">Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
-			<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.1</div>
-		</d2l-list-item-button>
-	</d2l-list>
-`;
+const getListTemplate = options => {
+	return html`
+		<d2l-list ?grid="${options.grid}">
+			<d2l-list-controls slot="controls">
+				<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+				<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+			</d2l-list-controls>
+			<d2l-list-item>
+				<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
+				<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>
+			</d2l-list-item>
+			<d2l-list-item href="http://www.d2l.com">
+				<div class="d2l-list-item-text d2l-body-compact">Identify categories of physical activities</div>
+				<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation A1.2</div>
+			</d2l-list-item>
+			<d2l-list-item-button>
+				<div class="d2l-list-item-text d2l-body-compact">Apply a decision-making process to assess risks and make safe decisions in a variety of situations</div>
+				<div class="d2l-list-item-text-secondary d2l-body-small">Specific Expectation B2.1</div>
+			</d2l-list-item-button>
+		</d2l-list>
+	`;
+};
 
 describe('d2l-list', () => {
 
-	it('should pass all aXe tests', async() => {
-		const elem = await fixture(normalFixture);
+	it('should pass all aXe tests in list mode', async() => {
+		const elem = await fixture(getListTemplate({ grid: false }));
 		await expect(elem).to.be.accessible();
+	});
+
+	it('should pass all aXe tests in grid mode', async() => {
+		const elem = await fixture(getListTemplate({ grid: true }));
+		await expect(elem).to.be.accessible({ ignoredRules: ['aria-required-parent'] }); // d2l-list's grid mode does not apply the grid role because Safari does not properly handle cases where the roles (grid, row, gridcell) are distributed across DOM scopes
 	});
 
 });


### PR DESCRIPTION
[GAUD-7712](https://desire2learn.atlassian.net/browse/GAUD-7712)

This PR updates the list components to use the correct `row` and `gridcell` roles as per Aria guidelines. It does not update to use the `grid` role (we're still using `role="application"`) due to Safari+VO ignoring the grid content (See [Webkit Issue](https://bugs.webkit.org/show_bug.cgi?id=291591)), which can be reproduce in the Lit Playground [here](https://lit.dev/playground/#project=W3sibmFtZSI6ImdyaWQtY29tcG9uZW50cy5qcyIsImNvbnRlbnQiOiJpbXBvcnQge2h0bWwsIGNzcywgTGl0RWxlbWVudH0gZnJvbSAnbGl0JztcblxuY2xhc3MgVGVzdEdyaWQxIGV4dGVuZHMgTGl0RWxlbWVudCB7XG5cdHJlbmRlcigpIHtcblx0XHRyZXR1cm4gaHRtbGBcblx0XHRcdDxkaXYgcm9sZT1cImdyaWRcIj5cblx0XHRcdFx0PHNsb3Q-PC9zbG90PlxuXHRcdFx0PC9kaXY-XG5cdFx0YDtcblx0fVxufVxuY3VzdG9tRWxlbWVudHMuZGVmaW5lKCd0ZXN0LWdyaWQtMScsIFRlc3RHcmlkMSk7XG5cbmNsYXNzIFRlc3RHcmlkMiBleHRlbmRzIExpdEVsZW1lbnQge1xuXHRyZW5kZXIoKSB7XG5cdFx0cmV0dXJuIGh0bWxgXG5cdFx0XHQ8ZGl2PlxuXHRcdFx0XHQ8c2xvdD48L3Nsb3Q-XG5cdFx0XHQ8L2Rpdj5cblx0XHRgO1xuXHR9XG59XG5jdXN0b21FbGVtZW50cy5kZWZpbmUoJ3Rlc3QtZ3JpZC0yJywgVGVzdEdyaWQyKTsifSx7Im5hbWUiOiJpbmRleC5odG1sIiwiY29udGVudCI6IjwhRE9DVFlQRSBodG1sPlxuPGhlYWQ-XG4gIDxzY3JpcHQgdHlwZT1cIm1vZHVsZVwiIHNyYz1cIi4vZ3JpZC1jb21wb25lbnRzLmpzXCI-PC9zY3JpcHQ-XG48L2hlYWQ-XG48Ym9keT5cbiAgICBUaGlzIGRvZXMgbm90IHdvcmsgaW4gU2FmYXJpK1ZPOlxuXHQ8dGVzdC1ncmlkLTE-IDwhLS0gZ3JpZCByb2xlIHJlbmRlcmVkIGluIHNoYWRvd0RPTSAtLT5cblx0XHQ8ZGl2IHJvbGU9XCJyb3dcIj5cblx0XHRcdDxkaXYgcm9sZT1cImdyaWRjZWxsXCI-PGEgaHJlZj1cImh0dHBzOi8vZm9vLmNvbVwiPmFwcGxlczwvYT48L2Rpdj5cblx0XHQ8L2Rpdj5cdFx0XHRcdFxuXHQ8L3Rlc3QtZ3JpZC0xPlxuICAgIDxicj5cbiAgICBUaGlzIGRvZXMgd29yayBpbiBTYWZhcmkrVk86XG4gICAgPHRlc3QtZ3JpZC0yIHJvbGU9XCJncmlkXCI-XG5cdFx0PGRpdiByb2xlPVwicm93XCI-XG5cdFx0XHQ8ZGl2IHJvbGU9XCJncmlkY2VsbFwiPjxhIGhyZWY9XCJodHRwczovL2Zvby5jb21cIj5iYW5hbmFzPC9hPjwvZGl2PlxuXHRcdDwvZGl2Plx0XHRcdFx0XG5cdDwvdGVzdC1ncmlkLTI-XG48L2JvZHk-XG4ifSx7Im5hbWUiOiJwYWNrYWdlLmpzb24iLCJjb250ZW50Ijoie1xuICBcImRlcGVuZGVuY2llc1wiOiB7XG4gICAgXCJsaXRcIjogXCJeMy4wLjBcIixcbiAgICBcIkBsaXQvcmVhY3RpdmUtZWxlbWVudFwiOiBcIl4yLjAuMFwiLFxuICAgIFwibGl0LWVsZW1lbnRcIjogXCJeNC4wLjBcIixcbiAgICBcImxpdC1odG1sXCI6IFwiXjMuMC4wXCJcbiAgfVxufSIsImhpZGRlbiI6dHJ1ZX1d).

While this does not fully address the aXe errors, it gets us closer to properly rendering these roles. Once Webkit is fixed for grid roles across DOM scopes, we should only need to change `role="application"` -> `role="grid"`. All other browsers currently support this case.

[GAUD-7712]: https://desire2learn.atlassian.net/browse/GAUD-7712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ