### PR TITLE
SPIKE: experiment with radio inputs

### DIFF
--- a/components/inputs/demo/input-radio.html
+++ b/components/inputs/demo/input-radio.html
@@ -6,6 +6,8 @@
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
 		<script type="module">
 			import '../../demo/demo-page.js';
+			import '../input-radio.js';
+			import '../input-radio-group.js';
 			import '../input-radio-spacer.js';
 			import './input-radio-label-test.js';
 			import './input-radio-label-simple-test.js';
@@ -15,6 +17,14 @@
 	</head>
 	<body unresolved>
 		<d2l-demo-page page-title="d2l-input-radio">
+
+			<d2l-demo-snippet>
+				<d2l-input-radio-group label="Bread">
+					<d2l-input-radio label="Whole wheat" checked></d2l-input-radio>
+					<d2l-input-radio label="White"></d2l-input-radio>
+					<d2l-input-radio label="Gluten free"></d2l-input-radio>
+				</d2l-input-radio-group>
+			</d2l-demo-snippet>
 
 			<h2>Simple radio group with labels</h2>
 			<d2l-demo-snippet>

--- a/components/inputs/input-radio-group.js
+++ b/components/inputs/input-radio-group.js
@@ -1,0 +1,75 @@
+import { css, html, LitElement } from 'lit';
+import { getUniqueId } from '../../helpers/uniqueId.js';
+import { inputLabelStyles } from './input-label-styles.js';
+import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
+
+class InputRadioGroup extends PropertyRequiredMixin(LitElement) {
+
+	static get properties() {
+		return {
+			/**
+			 * REQUIRED: Label for the input
+			 * @type {string}
+			 */
+			label: { required: true, type: String },
+			/**
+			 * Hides the label visually
+			 * @type {boolean}
+			 */
+			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean }
+		};
+	}
+
+	static get styles() {
+		return [inputLabelStyles, css`
+			div[role="radiogroup"] {
+				display: flex;
+				flex-direction: column;
+				gap: 0.6rem;
+			}
+		`];
+	}
+
+	constructor() {
+		super();
+		this.labelHidden = false;
+	}
+
+	render() {
+		// TODO: handle required validation
+		// TODO: handle being in a form
+		return html`
+			<span class="d2l-input-label" ?hidden="${this.labelHidden}" id="${this.#labelId}">${this.label}</span>
+			<div aria-labelledby="${this.#labelId}" @click="${this.#handleClick}" @keydown="${this.#handleKeyDown}" role="radiogroup">	
+				<slot></slot>
+			</div>
+		`;
+	}
+
+	#labelId = getUniqueId();
+
+	#getRadios() {
+		return this.shadowRoot
+			.querySelector('slot')
+			.assignedElements()
+			.filter(el => el.tagName === 'D2L-INPUT-RADIO');
+	}
+
+	#handleClick(e) {
+		if (e.target.tagName !== 'D2L-INPUT-RADIO') return;
+		const radios = this.#getRadios();
+		radios.forEach(el => {
+			el.checked = (el === e.target);
+			// TODO: possibly dispatch a change event here
+		});
+		e.preventDefault();
+	}
+
+	#handleKeyDown(e) {
+		if (e.target.tagName !== 'D2L-INPUT-RADIO') return;
+		// TODO: handle space and arrow keys
+		e.preventDefault();
+	}
+
+}
+customElements.define('d2l-input-radio-group', InputRadioGroup);

--- a/components/inputs/input-radio.js
+++ b/components/inputs/input-radio.js
@@ -1,0 +1,62 @@
+import { css, html, LitElement } from 'lit';
+import { getUniqueId } from '../../helpers/uniqueId.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
+import { radioStyles } from './input-radio-styles.js';
+
+class InputRadio extends PropertyRequiredMixin(LitElement) {
+
+	static get properties() {
+		// TODO: handle name & value
+		return {
+			checked: { type: Boolean, reflect: true },
+			disabled: { type: Boolean, reflect: true },
+			/**
+			 * REQUIRED: Label for the input
+			 * @type {string}
+			 */
+			label: { required: true, type: String },
+			/**
+			 * Hides the label visually
+			 * @type {boolean}
+			 */
+			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean }
+		};
+	}
+
+	static get styles() {
+		return [radioStyles, css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`];
+	}
+
+	constructor() {
+		super();
+		this.checked = false;
+		this.disabled = false;
+	}
+
+	render() {
+		return html`
+			<span class="d2l-input-radio-label">
+				<span
+					aria-checked="${this.checked}"
+					aria-labelledby="${this.#labelId}"
+					class="d2l-input-radio"
+					?disabled="${this.disabled}"
+					role="radio"
+					tabindex="${ifDefined(this.checked ? '0' : undefined)}"></span>
+				<span id="${this.#labelId}" ?hidden="${this.labelHidden}">${this.label}</span>
+			</span>
+		`;
+	}
+
+	#labelId = getUniqueId();
+
+}
+customElements.define('d2l-input-radio', InputRadio);


### PR DESCRIPTION
Because radios within the same group can't span shadow roots, we currently don't have a `<d2l-input-radio>` component. Instead, developers need to style native radios. That works for the most part, but has a few disadvantages:

- It's difficult to properly put space between a group of radio inputs
- Because there's no concept of a group, a separate label or fieldset needs to be constructed, leading to more room for divergence
- Change event listeners need to be installed on each radio, instead of a single listener for the group
- Generally developers are used to using our `<d2l-input-*>` components with `label`/`label-hidden` and radios (and selects) are a weird exception.

I tried experimenting with a `<d2l-input-radio>` that rendered a native radio but with no shadow root. This did allow sibling `<d2l-input-radio>`s to act as a group, but meant that `<style>` leaked out into the parent scope and was repeated over and over for each radio. I also tried adding a `<d2l-input-radio-group>` also had no shadow root, but it had a similar issue.

In the end, the PoC shown here uses ARIA to apply `radiogroup` and `radio` roles to `<d2l-input-radio-group>` and `<d2l-input-radio>` custom elements. And in my testing with various AT combinations, it works really well! I didn't notice any issues.

Curious what others think and whether we feel like it's worth taking this across the line?