### PR TITLE
Move toast's alert role to d2l-alert for improved announcement ux.

### DIFF
--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -232,13 +232,14 @@ class AlertToast extends LitElement {
 			'd2l-alert-toast-container-lowest': !this._totalSiblingHeightBelow,
 			'vdiff-target': true
 		};
+
 		return html`
 			<div
 				class="${classMap(containerClasses)}"
 				data-state="${this._state}"
 				style="${styleMap(containerStyles)}"
 				@transitionend=${this._onTransitionEnd}>
-				<d2l-alert
+				<d2l-alert role="${ this._state !== states.CLOSED ? 'alert' : '' }"
 					@blur=${this._onBlur}
 					button-text="${ifDefined(this.buttonText)}"
 					@d2l-alert-button-press=${this._handleButtonPress}
@@ -392,7 +393,6 @@ class AlertToast extends LitElement {
 		this._totalSiblingHeightBelow = 0;
 		this._numAlertsBelow = 0;
 		this._closeClicked = false;
-		this.removeAttribute('role');
 	}
 
 	_onTransitionEnd() {
@@ -420,13 +420,11 @@ class AlertToast extends LitElement {
 					this._state = states.OPEN;
 				}
 			}
-			this.setAttribute('role', 'alert');
 		} else {
 			if (!this._innerContainer) return;
 
 			if (activeReduceMotion || this._state === states.PREOPENING) {
 				cancelAnimationFrame(this._preopenFrame);
-				this.removeAttribute('role');
 			} else if (this._state === states.OPENING || this._state === states.OPEN || this._state === states.SLIDING) {
 				this._state = states.CLOSING;
 			}

--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -239,7 +239,7 @@ class AlertToast extends LitElement {
 				data-state="${this._state}"
 				style="${styleMap(containerStyles)}"
 				@transitionend=${this._onTransitionEnd}>
-				<d2l-alert role="${ this._state !== states.CLOSED ? 'alert' : '' }"
+				<d2l-alert
 					@blur=${this._onBlur}
 					button-text="${ifDefined(this.buttonText)}"
 					@d2l-alert-button-press=${this._handleButtonPress}
@@ -249,6 +249,7 @@ class AlertToast extends LitElement {
 					?hidden="${this._state === states.CLOSED}"
 					@mouseenter=${this._onMouseEnter}
 					@mouseleave=${this._onMouseLeave}
+					role="${ifDefined(this._state !== states.CLOSED ? 'alert' : undefined)}"
 					subtext="${ifDefined(this.subtext)}"
 					type="${ifDefined(this.type)}">
 					<slot></slot>

--- a/components/alert/test/alert-toast.axe.js
+++ b/components/alert/test/alert-toast.axe.js
@@ -25,7 +25,7 @@ describe('d2l-alert-toast', () => {
 
 	it('should have status alert when open', async() => {
 		const el = await fixture(html`<d2l-alert-toast open>message</d2l-alert-toast>`);
-		expect(el.getAttribute('role')).to.equal('alert');
+		expect(el.shadowRoot.querySelector('d2l-alert').getAttribute('role')).to.equal('alert');
 	});
 
 });


### PR DESCRIPTION
[GAUD-7279](https://desire2learn.atlassian.net/browse/GAUD-7279)

This PR moves the `role="alert"` from the host element `d2l-alert-toast` to the internal `d2l-alert`.

I tried lots of other options, some improved one browser but completely broke another browser. Overall this is an improvement, albeit still not perfect. The use of `role="alert"` is apparently extremely finicky, as described in Margaree's Jira comments.

These are my test results, with reduced motion preference both on/off.

Announcement before:
```
chrome+vo - not announced

safari+vo - not announced

firefox+vo - 1x text; 2x close

chrome+nvda - 3x text; 5x close

edge+nvda - 3x text; 5x close

firefox+nvda - 1x text; 1x close
```

Announcement after:
```
chrome+vo - 1x text; 1x close (improved)

safari+vo - 1x text; 2x close (improved)

firefox+vo - 1x text; 2x close (no change)

chrome+nvda - 2x text; 3x close (improved)

edge+nvda - 2x text; 3x close (improved)

firefox+nvda - 1x text; 1x close (no change)
```

[GAUD-7279]: https://desire2learn.atlassian.net/browse/GAUD-7279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ