### PR TITLE
Remove RtlMixin from icon components.

### DIFF
--- a/components/icons/icon-custom.js
+++ b/components/icons/icon-custom.js
@@ -1,9 +1,8 @@
 import { css, html, LitElement } from 'lit';
 import { fixSvg } from './fix-svg.js';
 import { iconStyles } from './icon-styles.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
-class IconCustom extends RtlMixin(LitElement) {
+class IconCustom extends LitElement {
 
 	static get properties() {
 		return {

--- a/components/icons/icon-styles.js
+++ b/components/icons/icon-styles.js
@@ -28,10 +28,9 @@ export const iconStyles = css`
 		pointer-events: none;
 		width: 100%;
 	}
-	:host([dir="rtl"]) svg[mirror-in-rtl],
-	:host([dir="rtl"]) ::slotted(svg[mirror-in-rtl]) {
-		-webkit-transform: scale(-1, 1);
-		transform: scale(-1, 1);
+	svg[mirror-in-rtl],
+	::slotted(svg[mirror-in-rtl]) {
+		transform: var(--d2l-mirror-transform, ${document.dir === 'rtl' ? css`scale(-1, 1)` : css`none`}); /* stylelint-disable-line @stylistic/string-quotes, @stylistic/function-whitespace-after */
 		transform-origin: center;
 	}
 `;

--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -4,11 +4,10 @@ import { fixSvg } from './fix-svg.js';
 import { guard } from 'lit/directives/guard.js';
 import { iconStyles } from './icon-styles.js';
 import { loadSvg } from '../../generated/icons/presetIconLoader.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import { until } from 'lit/directives/until.js';
 
-class Icon extends RtlMixin(LitElement) {
+class Icon extends LitElement {
 
 	static get properties() {
 		return {

--- a/components/typography/typography.js
+++ b/components/typography/typography.js
@@ -7,10 +7,12 @@ if (!document.head.querySelector('#d2l-typography-font-face')) {
 	style.textContent = `
 		* {
 			--d2l-document-direction: ltr;
+			--d2l-mirror-transform: none;
 		}
 
 		html[dir="rtl"] * {
 			--d2l-document-direction: rtl;
+			--d2l-mirror-transform: scale(-1, 1);
 		}
 
 		${fontFacesCss}


### PR DESCRIPTION
[GAUD-7814](https://desire2learn.atlassian.net/browse/GAUD-7814)

This PR eliminates the usage of `RtlMixin` from `d2l-icon` and `d2l-icon-custom`.