### PR TITLE
GAUD-7819: remove unnecessary uses of typography import

### DIFF
--- a/components/collapsible-panel/test/collapsible-panel.vdiff.js
+++ b/components/collapsible-panel/test/collapsible-panel.vdiff.js
@@ -1,7 +1,6 @@
 import '../../button/button-icon.js';
 import '../../link/link.js';
 import '../../status-indicator/status-indicator.js';
-import '../../typography/typography.js';
 import '../collapsible-panel.js';
 import '../collapsible-panel-summary-item.js';
 import { expect, fixture, focusElem, html, nextFrame, oneEvent } from '@brightspace-ui/testing';

--- a/components/tooltip/test/tooltip-help.vdiff.js
+++ b/components/tooltip/test/tooltip-help.vdiff.js
@@ -1,4 +1,3 @@
-import '../../typography/typography.js';
 import '../tooltip-help.js';
 import { clickElem, expect, fixture, focusElem, hoverElem, html, oneEvent } from '@brightspace-ui/testing';
 


### PR DESCRIPTION
Typography styles are included automatically in vdiff pages (via a copy unfortunately), so these are unnecessary.