### PR TITLE
GAUD-7836 - Update width docs for dialog-fullscreen

### DIFF
--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -39,7 +39,7 @@ class DialogFullscreen extends PropertyRequiredMixin(LocalizeCoreElement(AsyncCo
 			 */
 			titleText: { type: String, attribute: 'title-text', required: true },
 			/**
-			 * The preferred width (unit-less) for the dialog. Maximum 1170.
+			 * The preferred width (unit-less) for the dialog. Minimum 1170 (anything smaller will have no effect).
 			 */
 			width: { type: Number },
 			_autoSize: { state: true }, /* DE52039 This is only redefined here to suppress a lit-analyzer linting issue */


### PR DESCRIPTION
Not tied to the wording here at all, suggest away!

This property is not on the dialog README - see my question in our team slack thread on whether we care about this or not.