### PR TITLE
fix: List item: Dispatch click event from ListItemLinkMixin and ListItemButtonMixin to maintain previous functionality in consumers

### DIFF
--- a/components/list/list-item-button-mixin.js
+++ b/components/list/list-item-button-mixin.js
@@ -80,6 +80,9 @@ export const ListItemButtonMixin = superclass => class extends ListItemMixin(sup
 
 			// Dispatches click event from the list item to maintain existing functionality in consumers that listen for the click event
 			const listItemClickEvent = new e.constructor(e.type, e);
+			listItemClickEvent.preventDefault = () => {
+				e.preventDefault();
+			};
 			/** @ignore */
 			this.dispatchEvent(listItemClickEvent);
 		}

--- a/components/list/list-item-button-mixin.js
+++ b/components/list/list-item-button-mixin.js
@@ -74,8 +74,14 @@ export const ListItemButtonMixin = superclass => class extends ListItemMixin(sup
 		if (this._getDescendantClicked(e)) {
 			e.preventDefault();
 		} else {
+			e.stopPropagation();
 			/** Dispatched when the item's primary button action is clicked */
 			this.dispatchEvent(new CustomEvent('d2l-list-item-button-click', { bubbles: true }));
+
+			// Dispatches click event from the list item to maintain existing functionality in consumers that listen for the click event
+			const listItemClickEvent = new e.constructor(e.type, e);
+			/** @ignore */
+			this.dispatchEvent(listItemClickEvent);
 		}
 	}
 

--- a/components/list/list-item-link-mixin.js
+++ b/components/list/list-item-link-mixin.js
@@ -60,8 +60,14 @@ export const ListItemLinkMixin = superclass => class extends ListItemMixin(super
 		if (this._getDescendantClicked(e)) {
 			e.preventDefault();
 		} else {
+			e.stopPropagation();
 			/** Dispatched when the item's primary link action is clicked */
 			this.dispatchEvent(new CustomEvent('d2l-list-item-link-click', { bubbles: true }));
+
+			// Dispatches click event from the list item to maintain existing functionality in consumers that listen for the click event
+			const listItemClickEvent = new e.constructor(e.type, e);
+			/** @ignore */
+			this.dispatchEvent(listItemClickEvent);
 		}
 	}
 

--- a/components/list/list-item-link-mixin.js
+++ b/components/list/list-item-link-mixin.js
@@ -66,6 +66,9 @@ export const ListItemLinkMixin = superclass => class extends ListItemMixin(super
 
 			// Dispatches click event from the list item to maintain existing functionality in consumers that listen for the click event
 			const listItemClickEvent = new e.constructor(e.type, e);
+			listItemClickEvent.preventDefault = () => {
+				e.preventDefault();
+			};
 			/** @ignore */
 			this.dispatchEvent(listItemClickEvent);
 		}

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -584,7 +584,6 @@ describe('d2l-list-item', () => {
 					<div>Item 1</div>
 					<div slot="secondary"><d2l-button>Button</d2l-button></div>
 				</d2l-list-item>`);
-			
 			setTimeout(() => el.querySelector('d2l-button').click());
 			await oneEvent(el.querySelector('d2l-button'), 'click');
 		});
@@ -606,7 +605,6 @@ describe('d2l-list-item', () => {
 					<div>Item 1</div>
 					<div slot="secondary"><d2l-button>Button</d2l-button></div>
 				</d2l-list-item>`);
-			
 			setTimeout(() => el.querySelector('d2l-button').click());
 			const e = await oneEvent(el, 'click');
 			expect(e.target).to.equal(el.querySelector('d2l-button'));
@@ -644,7 +642,6 @@ describe('d2l-list-item-button', () => {
 					<div>Item 1</div>
 					<div slot="secondary"><d2l-button>Button</d2l-button></div>
 				</d2l-list-item-button>`);
-			
 			setTimeout(() => el.querySelector('d2l-button').click());
 			const e = await oneEvent(el, 'click');
 			expect(e.target).to.equal(el.querySelector('d2l-button'));
@@ -694,7 +691,6 @@ describe('d2l-list-item-button', () => {
 					<div>Item 1</div>
 					<div slot="secondary"><d2l-button>Button</d2l-button></div>
 				</d2l-list-item-button>`);
-			
 			setTimeout(() => el.querySelector('d2l-button').click());
 			await oneEvent(el.querySelector('d2l-button'), 'click');
 		});

--- a/components/list/test/list.test.js
+++ b/components/list/test/list.test.js
@@ -577,6 +577,40 @@ describe('d2l-list-item', () => {
 			await clickElem(el.querySelector('d2l-button'));
 			expect(dispatched).to.equal(false);
 		});
+
+		it('dispatches element\'s click event when interactive content clicked', async() => {
+			const el = await fixture(html`
+				<d2l-list-item action-href="javascript:void(0)" label="item">
+					<div>Item 1</div>
+					<div slot="secondary"><d2l-button>Button</d2l-button></div>
+				</d2l-list-item>`);
+			
+			setTimeout(() => el.querySelector('d2l-button').click());
+			await oneEvent(el.querySelector('d2l-button'), 'click');
+		});
+
+		it('dispatches click event with correct target when clicked', async() => {
+			const el = await fixture(html`
+				<d2l-list-item action-href="javascript:void(0)" label="item">
+					<div>Item 1</div>
+					<div slot="secondary"><d2l-button>Button</d2l-button></div>
+				</d2l-list-item>`);
+			clickElem(el.shadowRoot.querySelector('div'));
+			const e = await oneEvent(el, 'click');
+			expect(e.target).to.equal(el);
+		});
+
+		it('dispatches click event with correct target when interactive content clicked', async() => {
+			const el = await fixture(html`
+				<d2l-list-item action-href="javascript:void(0)" label="item">
+					<div>Item 1</div>
+					<div slot="secondary"><d2l-button>Button</d2l-button></div>
+				</d2l-list-item>`);
+			
+			setTimeout(() => el.querySelector('d2l-button').click());
+			const e = await oneEvent(el, 'click');
+			expect(e.target).to.equal(el.querySelector('d2l-button'));
+		});
 	});
 
 });
@@ -592,6 +626,29 @@ describe('d2l-list-item-button', () => {
 	});
 
 	describe('events', () => {
+
+		it('dispatches click event with correct target when clicked', async() => {
+			const el = await fixture(html`
+				<d2l-list-item-button label="item">
+					<div>Item 1</div>
+					<div slot="secondary"><d2l-button>Button</d2l-button></div>
+				</d2l-list-item-button>`);
+			clickElem(el.shadowRoot.querySelector('div'));
+			const e = await oneEvent(el, 'click');
+			expect(e.target).to.equal(el);
+		});
+
+		it('dispatches click event with correct target when interactive content clicked', async() => {
+			const el = await fixture(html`
+				<d2l-list-item-button label="item">
+					<div>Item 1</div>
+					<div slot="secondary"><d2l-button>Button</d2l-button></div>
+				</d2l-list-item-button>`);
+			
+			setTimeout(() => el.querySelector('d2l-button').click());
+			const e = await oneEvent(el, 'click');
+			expect(e.target).to.equal(el.querySelector('d2l-button'));
+		});
 
 		it('dispatches d2l-list-item-button-click event when clicked', async() => {
 			const el = await fixture(html`<d2l-list-item-button label="item"></d2l-list-item-button>`);
@@ -629,6 +686,17 @@ describe('d2l-list-item-button', () => {
 			el.addEventListener('d2l-list-item-button-click', () => dispatched = true);
 			await clickElem(el.querySelector('d2l-button'));
 			expect(dispatched).to.equal(false);
+		});
+
+		it('dispatches element\'s click event when interactive content clicked', async() => {
+			const el = await fixture(html`
+				<d2l-list-item-button label="item">
+					<div>Item 1</div>
+					<div slot="secondary"><d2l-button>Button</d2l-button></div>
+				</d2l-list-item-button>`);
+			
+			setTimeout(() => el.querySelector('d2l-button').click());
+			await oneEvent(el.querySelector('d2l-button'), 'click');
 		});
 
 		it('dispatches d2l-list-item-add-button-click event when first add button clicked', async() => {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7846)

**Problem**:
Recent work to list items ([here](https://github.com/BrightspaceUI/core/pull/5520)) impacted the `click` event such that it is now dispatched from the content rather than the list-item. This is because of the removal of `pointer-events: none` on the content. The event target is now the content being clicked rather than the list item (e.g., `d2l-list-item`) and so any consumer relying on getting the top-level list item as the click event target would no longer work as expected.

Consumers should be listening for `d2l-list-item-button-click` and `d2l-list-item-link-click` but that pattern is not always being followed.

**Solution Summary**:
When the click was on the list item (not an interactive element with in it):
1. Stops propagation, so that the event with the "incorrect" target does not get picked up by the listener
2. Duplicates the event so that the consumer can get any info they might need from it (e.g., `clientX`)
3. Dispatches the duplicate event but from the list item

Let me know thoughts on this. There are potentially risks I'm missing here. It definitely feels hacky, so let me know if you have an alternative idea.

I've been manually testing this and it seems to work. If this seems like a good direction I'll add some unit tests as well.