### PR TITLE
Add pseudoLocalization

### DIFF
--- a/mixins/localize/localize-mixin.js
+++ b/mixins/localize/localize-mixin.js
@@ -8,6 +8,9 @@ export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinB
 	constructor() {
 		super();
 		super.constructor.setLocalizeMarkup(localizeMarkup);
+		if (super.constructor.documentLocaleSettings.pseudoLocalization?.isAvailable) {
+			this.localize = (...args) => super.constructor.pseudoLocalize((...args) => super.localize(...args), ...args);
+		}
 	}
 
 	connectedCallback() {

--- a/mixins/localize/localize-mixin.js
+++ b/mixins/localize/localize-mixin.js
@@ -8,7 +8,7 @@ export const _LocalizeMixinBase = dedupeMixin(superclass => class LocalizeMixinB
 	constructor() {
 		super();
 		super.constructor.setLocalizeMarkup(localizeMarkup);
-		if (super.constructor.documentLocaleSettings.pseudoLocalization?.isAvailable) {
+		if (super.constructor.documentLocaleSettings.pseudoLocalization?.textFormat) {
 			this.localize = (...args) => super.constructor.pseudoLocalize((...args) => super.localize(...args), ...args);
 		}
 	}

--- a/mixins/localize/test/localize-mixin.test.js
+++ b/mixins/localize/test/localize-mixin.test.js
@@ -12,7 +12,6 @@ const pseudoLocalizationOn = () => {
 	const dlsChange = new Promise(r => resolve = r);
 	documentLocaleSettings.addChangeListener(resolve);
 	document.documentElement.dataset.pseudoLocalization = JSON.stringify({
-		isAvailable: true,
 		textFormat: '{0} | {1}',
 	});
 	return dlsChange;
@@ -291,7 +290,7 @@ describe('LocalizeMixin', () => {
 	afterEach(() => documentLocaleSettings.reset());
 
 	[true, false].forEach(pseudoLocalization => {
-		it(`should share resources between instances, pseudoLocalization ${pseudoLocalization ? 'on' : 'off'}`, async () => {
+		it(`should share resources between instances, pseudoLocalization ${pseudoLocalization ? 'on' : 'off'}`, async() => {
 			pseudoLocalization && await pseudoLocalizationOn();
 			const elemStatic = await fixture(`<${staticTag}></${staticTag}>`);
 			const elemStatic2 = await fixture(`<${staticTag}></${staticTag}>`);

--- a/mixins/localize/test/localize-mixin.test.js
+++ b/mixins/localize/test/localize-mixin.test.js
@@ -279,11 +279,20 @@ describe('LocalizeMixin', () => {
 
 	afterEach(() => documentLocaleSettings.reset());
 
+	it('should share resources between instances', async() => {
+		const elemStatic = await fixture(`<${staticTag}></${staticTag}>`);
+		const elemStatic2 = await fixture(`<${staticTag}></${staticTag}>`);
+		const elemAsync = await fixture(`<${asyncTag}></${asyncTag}>`);
+		const elemDifferent = await fixture(`<${multiMixinTagConsolidated}></${multiMixinTagConsolidated}>`);
+		expect(elemStatic.localize.resources).to.equal(elemStatic2.localize.resources);
+		expect(elemStatic.localize.resources).to.equal(elemAsync.localize.resources);
+		expect(elemStatic.localize.resources).to.not.equal(elemDifferent.localize.resources);
+	});
+
 	['static', 'async'].forEach((type) => {
 
-		const f = (type === 'static') ? `<${staticTag}></${staticTag}>` :
-			`<${asyncTag}></${asyncTag}>`;
 		const tagName = (type === 'static') ? staticTag : asyncTag;
+		const f = `<${tagName}></${tagName}>`;
 
 		describe(`localize (${type})`, () => {
 
@@ -459,6 +468,18 @@ describe('LocalizeMixin', () => {
 			expect(elem).lightDom.to.equal(t.expect);
 		}));
 
+	});
+
+	describe('pseudoLocalize', () => {
+		it('should replace {0} and {1} with formatted message and message name', async() => {
+			document.documentElement.dataset.pseudoLocalization = JSON.stringify({
+				isAvailable: true,
+				textFormat: '{0} | {1}',
+			});
+			const elem = await fixture(`<${synchronousTag}></${synchronousTag}>`);
+			expect(elem.localize('sync')).to.equal('Synchronous Content | sync');
+			document.documentElement.dataset.pseudoLocalization = null;
+		});
 	});
 
 	describe('browser language settings in mixin', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@brightspace-ui/intl": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.25.1.tgz",
-      "integrity": "sha512-ZuVBQZUe+wy2rbKqMjFBsCMMOelV5nYRFOINC0uL9Yz+bzLkWIqk5mnxD7iFS6SokiFU/sL/9g7Z3v+wS8eMBQ==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.26.0.tgz",
+      "integrity": "sha512-9Bxul6woLpDntX93lE+mNqfR8u6s/P+CGqpOY5zoJqOqAQvfx6JKjjXYK1mkjkmjx90voDDdh7B9lwpcSUsV6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "intl-messageformat": "^10"


### PR DESCRIPTION
[GAUD-7785](https://desire2learn.atlassian.net/browse/GAUD-7785): Make pseudo-l10n work in our Internationalization (i18n) methods

Because component instances need to share resources, we need to set up `pseudoLocalization` slightly differently from the base class in `intl`.

Depends on [@brightspaceui/intl](https://github.com/BrightspaceUI/intl/pull/248)

[GAUD-7785]: https://desire2learn.atlassian.net/browse/GAUD-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ