### PR TITLE
SHIELD-11083 - Fix html-block demo samples

### DIFF
--- a/components/html-block/README.md
+++ b/components/html-block/README.md
@@ -56,23 +56,23 @@ Examples are provided to display how user-authored math can be embedded within y
   import '@brightspace-ui/core/tools/mathjax-test-context.js';
 </script>
 <d2l-html-block html="
-  <math xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;>
-    <msqrt>
-      <mn>3</mn>
-      <mi>x</mi>
-      <mo>&#x2212;</mo>
-      <mn>1</mn>
-    </msqrt>
-    <mo>+</mo>
-    <mo stretchy=&quot;false&quot;>(</mo>
-    <mn>1</mn>
-    <mo>+</mo>
-    <mi>x</mi>
-    <msup>
-      <mo stretchy=&quot;false&quot;>)</mo>
-      <mn>2</mn>
-    </msup>
-  </math>">
+  &lt;math xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;>
+    &lt;msqrt&gt;
+      &lt;mn&gt;3&lt;/mn&gt;
+      &lt;mi&gt;x&lt;/mi&gt;
+      &lt;mo&gt;&#x2212;&lt;/mo&gt;
+      &lt;mn&gt;1&lt;/mn&gt;
+    &lt;/msqrt&gt;
+    &lt;mo&gt;+&lt;/mo&gt;
+    &lt;mo stretchy=&quot;false&quot;&gt;(&lt;/mo&gt;
+    &lt;mn&gt;1&lt;/mn&gt;
+    &lt;mo&gt;+&lt;/mo&gt;
+    &lt;mi&gt;x&lt;/mi&gt;
+    &lt;msup&gt;
+      &lt;mo stretchy=&quot;false&quot;>)&lt;/mo&gt;
+      &lt;mn&gt;2&lt;/mn&gt;
+    &lt;/msup&gt;
+  &lt;/math&gt;">
 </d2l-html-block>
 ```
 

--- a/components/html-block/demo/html-block-code.html
+++ b/components/html-block/demo/html-block-code.html
@@ -25,21 +25,21 @@
 
 		<h2 class="d2l-heading-3">Block Samples</h2>
 
-		<d2l-html-block>
-<pre class="d2l-code d2l-code-dark"><code class="language-javascript">function helloGrumpy(name) {
+		<d2l-html-block html="
+&lt;pre class=&quot;d2l-code d2l-code-dark&quot;&gt;&lt;code class=&quot;language-javascript&quot;&gt;function helloGrumpy(name) {
 	console.log(`Hi there ${name}.`);
 }
-helloGrumpy('Wizard');</code></pre>
-<br>
-<pre class="d2l-code d2l-code-dark"><code class="language-javascript line-numbers">function helloGrumpy(name) {
+helloGrumpy('Wizard');&lt;/code&gt;&lt;/pre&gt;
+&lt;br&gt;
+&lt;pre class=&quot;d2l-code d2l-code-dark&quot;&gt;&lt;code class=&quot;language-javascript line-numbers&quot;&gt;function helloGrumpy(name) {
 	console.log(`Hi there ${name}. Here's some really long text to test overflowing the bounding container.`);
 }
-helloGrumpy('Wizard');</code></pre>
+helloGrumpy('Wizard');&lt;/code&gt;&lt;/pre&gt;">
 		</d2l-html-block>
 
 		<h2 class="d2l-heading-3">Inline Samples</h2>
 
-		<d2l-html-block html="The best type of donuts are he kind you assign in code, for example: &lt;code class=&quot;d2l-code d2l-code-dark language-javascript&quot;&gt;const jelly = 'donuts';lgt;/code&gt;. The next best type of thing you can assign in code is stuff you can ferment. &lt;code class=&quot;d2l-code d2l-code-dark language-javascript&quot;&gt;let beer = hopsAndWater.map(ingredients => ferment(ingredients));&lt;/code&gt;"></d2l-html-block>
+		<d2l-html-block html="The best type of donuts are he kind you assign in code, for example: &lt;code class=&quot;d2l-code d2l-code-dark language-javascript&quot;&gt;const jelly = 'donuts';&lt;/code&gt;. The next best type of thing you can assign in code is stuff you can ferment. &lt;code class=&quot;d2l-code d2l-code-dark language-javascript&quot;&gt;let beer = hopsAndWater.map(ingredients => ferment(ingredients));&lt;/code&gt;"></d2l-html-block>
 
 	</body>
 </html>


### PR DESCRIPTION
Just fixing up a couple places where the html-block demo had mangled output. In one case this was due to a bad configuration, and in the others it was due to malformed encoding of various kinds.