### PR TITLE
fix: Add method to return year and month as object

### DIFF
--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -32,7 +32,7 @@ Note: All `*-value` properties should be in ISO 8601 calendar date format (`YYYY
 
 ### Methods
 
-- `getShownYearAndMonth()`: returns an object containing the year and month in view.
+- `getShownValue()`: returns the date representing the year and month in view as an ISO 8601 calendar date format (`YYYY-MM-DD`).
 
 ## Accessibility
 

--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -32,7 +32,7 @@ Note: All `*-value` properties should be in ISO 8601 calendar date format (`YYYY
 
 ### Methods
 
-- `getShownValue()`: returns the date representing the year and month in view as an ISO 8601 calendar date format (`YYYY-MM-DD`).
+- `getShownYearAndMonth()`: returns an object containing the year and month in view.
 
 ## Accessibility
 

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -633,10 +633,6 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		}
 	}
 
-	getShownValue() {
-		return new Date(this._shownYear, this._shownMonth).toISOString();
-	}
-
 	getShownYearAndMonth() {
 		return { year: this._shownYear, month: this._shownMonth };
 	}

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -637,6 +637,10 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		return new Date(this._shownYear, this._shownMonth).toISOString();
 	}
 
+	getShownYearAndMonth() {
+		return { year: this._shownYear, month: this._shownMonth };
+	}
+
 	async reset(allowDisabled) {
 		const date = this._getInitialFocusDate();
 		await this._updateFocusDate(date, false, allowDisabled);

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -633,6 +633,10 @@ class Calendar extends LocalizeCoreElement(RtlMixin(LitElement)) {
 		}
 	}
 
+	getShownValue() {
+		return new Date(this._shownYear, this._shownMonth).toISOString();
+	}
+
 	getShownYearAndMonth() {
 		return { year: this._shownYear, month: this._shownMonth };
 	}

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -362,23 +362,6 @@ describe('d2l-calendar', () => {
 			});
 		});
 
-		describe('getShownValue', () => {
-
-			it('gets the date of the year and month in view', async() => {
-				const calendar = await fixture(normalFixture);
-				expect(new Date(calendar.getShownValue())).to.deep.equal(new Date(2015, 8, 1));
-			});
-
-			it('gets the new date of the year and month in view after the view changes', async() => {
-				const calendar = await fixture(normalFixture);
-				const el = calendar.shadowRoot.querySelectorAll('d2l-button-icon')[0];
-				clickElem(el);
-				await oneEvent(calendar, 'd2l-calendar-view-change');
-				expect(new Date(calendar.getShownValue())).to.deep.equal(new Date(2015, 7, 1));
-			});
-
-		});
-
 		describe('getShownYearAndMonth', () => {
 			it('gets the date of the year and month in view', async() => {
 				const calendar = await fixture(normalFixture);

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -362,6 +362,23 @@ describe('d2l-calendar', () => {
 			});
 		});
 
+		describe('getShownValue', () => {
+
+			it('gets the date of the year and month in view', async() => {
+				const calendar = await fixture(normalFixture);
+				expect(new Date(calendar.getShownValue())).to.deep.equal(new Date(2015, 8, 1));
+			});
+
+			it('gets the new date of the year and month in view after the view changes', async() => {
+				const calendar = await fixture(normalFixture);
+				const el = calendar.shadowRoot.querySelectorAll('d2l-button-icon')[0];
+				clickElem(el);
+				await oneEvent(calendar, 'd2l-calendar-view-change');
+				expect(new Date(calendar.getShownValue())).to.deep.equal(new Date(2015, 7, 1));
+			});
+
+		});
+
 		describe('getShownYearAndMonth', () => {
 			it('gets the date of the year and month in view', async() => {
 				const calendar = await fixture(normalFixture);

--- a/components/calendar/test/calendar.test.js
+++ b/components/calendar/test/calendar.test.js
@@ -379,6 +379,21 @@ describe('d2l-calendar', () => {
 
 		});
 
+		describe('getShownYearAndMonth', () => {
+			it('gets the date of the year and month in view', async() => {
+				const calendar = await fixture(normalFixture);
+				expect(calendar.getShownYearAndMonth()).to.deep.equal({ year: 2015, month: 8 });
+			});
+
+			it('gets the new date of the year and month in view after the view changes', async() => {
+				const calendar = await fixture(normalFixture);
+				const el = calendar.shadowRoot.querySelectorAll('d2l-button-icon')[0];
+				clickElem(el);
+				await oneEvent(calendar, 'd2l-calendar-view-change');
+				expect(calendar.getShownYearAndMonth()).to.deep.equal({ year: 2015, month: 7 });
+			});
+		});
+
 		describe('getDatesInMonthArray', () => {
 			it('returns expected array for Feb 2020 (days from prev month, no days from next month', () => {
 				const dates = [[


### PR DESCRIPTION
SHIELD-11093

This method returns the shown year and month as an object instead of converting it to an ISO date string.

Converting the date to UTC was problematic for timezones with a positive offset from UTC, resulting in code thinking that the month being shown was off by a month.