### PR TITLE
GAUD-7848 - Stop invalid tooltip from appearing when the input-text becomes disabled

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -492,7 +492,7 @@ class InputText extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(La
 		}
 
 		let tooltip = nothing;
-		if (!this.skeleton) {
+		if (!this.skeleton && !this.disabled) {
 			if (this.validationError && !this.noValidate && !this.hideInvalidTooltip) {
 				// this tooltip is using "announced" since we don't want aria-describedby wire-up - VoiceOver ignores our message when the input is invalid
 				tooltip = html`<d2l-tooltip state="error" announced align="start" class="vdiff-target">${this.validationError} <span class="d2l-offscreen">${this.description}</span></d2l-tooltip>`;


### PR DESCRIPTION
The issue raised was for `d2l-input-number`, but that uses `d2l-input-text` under the hood. The invalid tooltip will no longer appear on hover if the input is disabled after it becomes invalid.

I tried adding a test for this, but it was pretty slow because I needed to wait long enough to confirm the tooltip does or does not show and I wasn't confident it wouldn't flake.