### PR TITLE
Fix possible tooltip JavaScript error when force-show is used.

### DIFF
--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -564,6 +564,8 @@ class Tooltip extends RtlMixin(LitElement) {
 
 		// Compute the size of the spaces above, below, left and right and find which space to fit the tooltip in
 		const content = this._getContent();
+		if (content === null) return;
+
 		const spaces = this._computeAvailableSpaces(targetRect, spaceAround);
 		const space = await this._fitContentToSpace(content, spaces);
 


### PR DESCRIPTION
[GAUD-7903](https://desire2learn.atlassian.net/browse/GAUD-7903)

It is possible (at least from the demo) for the content to still be null when trying to initially update the position when `force-show` is used. 

[GAUD-7903]: https://desire2learn.atlassian.net/browse/GAUD-7903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ