### PR TITLE
Add option to hide script element from formatted demo-snippet.

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -192,7 +192,13 @@ class DemoSnippet extends LitElement {
 		text = text.replace(/^[\t]*<template>[\n]*/, '').replace(/[\n]*[\t]*<\/template>$/, '');
 
 		// fix script whitespace (for some reason brower keeps <script> indent but not the rest)
-		let lines = text.replace(/\t/g, '  ').replace(/<\/script>/g, '\n</script>').replace(/<script>/g, '<script>\n').replace(/<script type="module">/g, '<script type="module">\n').split('\n');
+		let lines = text
+			.replace(/\t/g, '  ')
+			.replace(/<\/script>/g, '\n</script>')
+			.replace(/<script>/g, '<script>\n')
+			.replace(/<script type="module">/g, '<script type="module">\n')
+			.replace(/<script data-demo-hide(.+?)<\/script>/gis, '')
+			.split('\n');
 		let scriptIndent = 0;
 		lines = lines.map((l) => {
 			if (l.indexOf('<script') > -1) {


### PR DESCRIPTION

Sometimes it is desirable to place `script` elements inside the demo-snippet `template` so that the elements will be rendered in time to query them for event wire-up, etc. (rather than placing them elsewhere in the document including precarious `setTimeout` or `rAF` timing). But sometimes we don't necessarily want to show all the demo snippet script. 

This PR adds a `data-demo-hide` option that will exclude the `script` from the formatted code-view output.

For example:
```html
<d2l-demo-snippet>
    <template>
        <d2l-dessert>Donuts</d2l-dessert>
        <script data-demo-hide> <!-- this script will run but won't be shown in snippet -->
            (demo => {
                ...
            })(document.currentScript.parentNode);
        </script>
        <script> <!-- this script will run but will be shown in snippet -->
            (demo => {
                ...
            })(document.currentScript.parentNode);
        </script>
    </template>
</d2l-demo-snippet>
```
