### PR TITLE
fix: collapsible panel chevron grey in WHCM

### DIFF
--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -253,9 +253,10 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			d2l-icon-custom svg {
 				position: absolute;
 				transform-origin: 0.4rem;
+				color: var(--d2l-color-tungsten);
 			}
 			:host([expanded]) d2l-icon-custom svg {
-				fill: var(--d2l-color-tungsten);
+				fill: currentColor;
 				transform: rotate(90deg);
 			}
 			@media (prefers-reduced-motion: no-preference) {
@@ -309,6 +310,12 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			}
 			.d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-summary {
 				display: none;
+			}
+
+			@media (prefers-contrast: more) {
+				d2l-icon-custom svg {
+					color: inherit;
+				}
 			}
 		`];
 	}
@@ -461,7 +468,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 					</div>
 					<d2l-icon-custom size="tier1" class="d2l-skeletize" aria-hidden="true">
 						<svg xmlns="http://www.w3.org/2000/svg" width="10" height="18" fill="none" viewBox="0 0 10 18">
-							<path stroke="var(--d2l-color-tungsten)" stroke-linejoin="round" stroke-width="2" d="m9 9-8 8V1l8 8Z"/>
+							<path stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="m9 9-8 8V1l8 8Z"/>
 						</svg>
 					</d2l-icon-custom>
 				</div>

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -251,9 +251,9 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 				transform-origin: center;
 			}
 			d2l-icon-custom svg {
+				color: var(--d2l-color-tungsten);
 				position: absolute;
 				transform-origin: 0.4rem;
-				color: var(--d2l-color-tungsten);
 			}
 			:host([expanded]) d2l-icon-custom svg {
 				fill: currentColor;

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -251,7 +251,6 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 				transform-origin: center;
 			}
 			d2l-icon-custom svg {
-				color: var(--d2l-color-tungsten);
 				position: absolute;
 				transform-origin: 0.4rem;
 			}
@@ -310,12 +309,6 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			}
 			.d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-summary {
 				display: none;
-			}
-
-			@media (prefers-contrast: more) {
-				d2l-icon-custom svg {
-					color: inherit;
-				}
 			}
 		`];
 	}


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-7700)

Use inherited color for chevron on WHCM. 
Before:
![image](https://github.com/user-attachments/assets/f5b6367e-246d-47a2-9a07-383505d85cd6)

Fix:
![image](https://github.com/user-attachments/assets/eb6a5400-1494-4248-95b3-11f7cabb185d)
