### PR TITLE
fix: Dialog/dropdown: Handle issue where clicking dropdown causes it to close in a dialog

### DIFF
--- a/components/dialog/demo/dialog-fullscreen.html
+++ b/components/dialog/demo/dialog-fullscreen.html
@@ -268,6 +268,35 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Simple dialog with longer loading content</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-button>Show Dialog</d2l-button>
+					<d2l-dialog-fullscreen title-text="Fullscreen Title">
+					</d2l-dialog-fullscreen>
+					<d2l-dropdown style="display: none;" id="thing">
+						<button class="d2l-dropdown-opener">Open!</button>
+						<d2l-dropdown-content>
+							<a href=" " style="display: block;">A Link</a>
+							Some content... Click me!
+						</d2l-dropdown-content>
+					</d2l-dropdown>
+
+					<script>
+						(demo => {
+							demo.querySelector('d2l-button').addEventListener('click', () => {
+								demo.querySelector('d2l-dialog-fullscreen').opened = true;
+								setTimeout(() => {
+									demo.querySelector('d2l-dropdown').style.display = 'block';
+									demo.querySelector('d2l-dialog-fullscreen').appendChild(demo.querySelector('d2l-dropdown'));
+								}, 1000);
+							});
+						})(document.currentScript.parentNode);
+					</script>
+				</template>
+			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 	</body>
 </html>

--- a/components/dialog/demo/dialog-fullscreen.html
+++ b/components/dialog/demo/dialog-fullscreen.html
@@ -275,7 +275,7 @@
 					<d2l-button>Show Dialog</d2l-button>
 					<d2l-dialog-fullscreen title-text="Fullscreen Title">
 					</d2l-dialog-fullscreen>
-					<d2l-dropdown style="display: none;" id="thing">
+					<d2l-dropdown style="display: none;">
 						<button class="d2l-dropdown-opener">Open!</button>
 						<d2l-dropdown-content>
 							<a href=" " style="display: block;">A Link</a>

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -254,7 +254,7 @@ class DialogFullscreen extends PropertyRequiredMixin(LocalizeCoreElement(AsyncCo
 
 		const content = html`
 			${loading}
-			<div style=${styleMap(slotStyles)}><slot></slot></div>
+			<div style=${styleMap(slotStyles)}><slot @slotchange="${this._handleSlotChange}"></slot></div>
 		`;
 
 		const contentTabIndex = !this.focusableContentElemPresent ? '0' : undefined;
@@ -310,6 +310,12 @@ class DialogFullscreen extends PropertyRequiredMixin(LocalizeCoreElement(AsyncCo
 	_handleResize() {
 		this._icon = mediaQueryList.matches ? 'tier1:close-small' : 'tier1:close-large-thick';
 		this._headerStyle = mediaQueryList.matches ? 'd2l-heading-3' : 'd2l-heading-2';
+	}
+
+	_handleSlotChange() {
+		requestAnimationFrame(() => {
+			this._checkForFocusableContentElem();
+		});
 	}
 
 }

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -167,7 +167,7 @@ class Dialog extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMix
 
 		const content = html`
 			${loading}
-			<div id="${ifDefined(this._textId)}" style=${styleMap(slotStyles)}><slot></slot></div>
+			<div id="${ifDefined(this._textId)}" style=${styleMap(slotStyles)}><slot @slotchange="${this._handleSlotChange}"></slot></div>
 		`;
 
 		const contentTabIndex = !this.focusableContentElemPresent ? '0' : undefined;
@@ -226,6 +226,12 @@ class Dialog extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMix
 	_handleResize() {
 		this._autoSize = !mediaQueryList.matches;
 		this.resize();
+	}
+
+	_handleSlotChange() {
+		requestAnimationFrame(() => {
+			this._checkForFocusableContentElem();
+		});
 	}
 
 }

--- a/components/dialog/test/dialog-fullscreen.test.js
+++ b/components/dialog/test/dialog-fullscreen.test.js
@@ -1,5 +1,7 @@
 import '../dialog-fullscreen.js';
-import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
+import '../../dropdown/dropdown.js';
+import '../../dropdown/dropdown-content.js';
+import { aTimeout, clickElem, expect, fixture, html, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
 import { createMessage } from '../../../mixins/property-required/property-required-mixin.js';
 
 describe('d2l-dialog-fullscreen', () => {
@@ -20,6 +22,60 @@ describe('d2l-dialog-fullscreen', () => {
 				.to.throw(TypeError, createMessage(el, 'title-text'));
 		});
 
+	});
+
+	describe('behavior', () => {
+
+		it('should not close a dropdown when it is within a dialog where the content is displayed late', async() => {
+			const el = await fixture(html`
+					<d2l-dialog-fullscreen opened>
+						<d2l-dropdown style="display: none;">
+							<button class="d2l-dropdown-opener">Open!</button>
+							<d2l-dropdown-content>
+								<a href=" " style="display: block;">A Link</a>
+								<div>Some content... Click me!</div>
+							</d2l-dropdown-content>
+						</d2l-dropdown>
+					</d2l-dialog-fullscreen>
+			`);
+			await aTimeout(100);
+			const dropdown = el.querySelector('d2l-dropdown');
+			dropdown.style.display = 'block';
+
+			const content = el.querySelector('d2l-dropdown-content');
+			content.setAttribute('opened', true);
+			await oneEvent(content, 'd2l-dropdown-open');
+
+			let dispatched = false;
+			content.addEventListener('d2l-dropdown-close', () => dispatched = true);
+
+			const div = content.querySelector('div');
+			clickElem(div);
+			await aTimeout(100);
+			expect(dispatched).to.be.false;
+		});
+
+		it('sets focusableContentElemPresent to true when there is a focusable element in the dialog added late', async() => {
+			const el = await fixture(html`
+				<div>
+					<d2l-dialog-fullscreen opened>
+					</d2l-dialog-fullscreen>
+					<d2l-dropdown>
+						<button class="d2l-dropdown-opener">Open!</button>
+						<d2l-dropdown-content>
+							<a href=" " style="display: block;">A Link</a>
+							<div>Some content... Click me!</div>
+						</d2l-dropdown-content>
+					</d2l-dropdown>
+				</div>
+			`);
+
+			const dialog = el.querySelector('d2l-dialog-fullscreen');
+			expect(dialog.focusableContentElemPresent).to.be.false;
+			await aTimeout(300);
+			dialog.appendChild(el.querySelector('d2l-dropdown'));
+			await waitUntil(() => dialog.focusableContentElemPresent, 'focusableContentElemPresent never became true');
+		});
 	});
 
 });

--- a/components/dialog/test/dialog.test.js
+++ b/components/dialog/test/dialog.test.js
@@ -1,5 +1,7 @@
 import '../dialog.js';
-import { expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import '../../dropdown/dropdown.js';
+import '../../dropdown/dropdown-content.js';
+import { aTimeout, clickElem, expect, fixture, oneEvent, runConstructor, waitUntil } from '@brightspace-ui/testing';
 import { createMessage } from '../../../mixins/property-required/property-required-mixin.js';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { html } from 'lit';
@@ -76,6 +78,57 @@ describe('d2l-dialog', () => {
 			await oneEvent(el, 'd2l-dialog-open');
 			const paragraph = el.querySelector('p');
 			expect(getComposedActiveElement()).to.not.equal(paragraph);
+		});
+
+		it('should not close a dropdown when it is within a dialog where the content is displayed late', async() => {
+			const el = await fixture(html`
+					<d2l-dialog opened>
+						<d2l-dropdown style="display: none;">
+							<button class="d2l-dropdown-opener">Open!</button>
+							<d2l-dropdown-content>
+								<a href=" " style="display: block;">A Link</a>
+								<div>Some content... Click me!</div>
+							</d2l-dropdown-content>
+						</d2l-dropdown>
+					</d2l-dialog>
+			`);
+			await aTimeout(300);
+			const dropdown = el.querySelector('d2l-dropdown');
+			dropdown.style.display = 'block';
+
+			const content = el.querySelector('d2l-dropdown-content');
+			content.setAttribute('opened', true);
+			await oneEvent(content, 'd2l-dropdown-open');
+
+			let dispatched = false;
+			content.addEventListener('d2l-dropdown-close', () => dispatched = true);
+
+			const div = content.querySelector('div');
+			clickElem(div);
+			await aTimeout(100);
+			expect(dispatched).to.be.false;
+		});
+
+		it('sets focusableContentElemPresent to true when there is a focusable element in the dialog added late', async() => {
+			const el = await fixture(html`
+				<div>
+					<d2l-dialog opened>
+					</d2l-dialog>
+					<d2l-dropdown>
+						<button class="d2l-dropdown-opener">Open!</button>
+						<d2l-dropdown-content>
+							<a href=" " style="display: block;">A Link</a>
+							<div>Some content... Click me!</div>
+						</d2l-dropdown-content>
+					</d2l-dropdown>
+				</div>
+			`);
+
+			const dialog = el.querySelector('d2l-dialog');
+			expect(dialog.focusableContentElemPresent).to.be.false;
+			await aTimeout(300);
+			dialog.appendChild(el.querySelector('d2l-dropdown'));
+			await waitUntil(() => dialog.focusableContentElemPresent, 'focusableContentElemPresent never became true');
 		});
 
 	});

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -569,7 +569,8 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 			const activeElement = getComposedActiveElement();
 
 			if (isComposedAncestor(this, activeElement)
-				|| isComposedAncestor(this.__getOpener(), activeElement)) {
+				|| isComposedAncestor(this.__getOpener(), activeElement)
+				|| isComposedAncestor(activeElement, this)) {
 				return;
 			}
 			this.close();

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -573,7 +573,7 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 				return;
 			}
 			this.close();
-		}, 0);
+		}, 10);
 	}
 
 	__onClose(e) {

--- a/components/dropdown/test/dropdown-openers.vdiff.js
+++ b/components/dropdown/test/dropdown-openers.vdiff.js
@@ -47,6 +47,7 @@ describe('dropdown-openers', () => {
 		await nextFrame();
 		await sendKeys('press', 'Tab');
 		await sendKeys('press', 'Tab');
+		await oneEvent(elem, 'd2l-dropdown-close');
 		await expect(elem).to.be.golden();
 	});
 


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7161)

**TODO:**
- [x] Tests
- [x] Add simplified example

**Problem:**
When a dialog consists of asynchronous content where the first focusable item is a dropdown, clicking the dropdown can often cause it to close.

**Issues at play:**
1. When something has focus in the dropdown and then the dropdown is clicked elsewhere, the `blur` event is triggered, triggering the [__onAutoCloseFocus](https://github.com/BrightspaceUI/core/blob/main/components/dropdown/dropdown-content-mixin.js#L557) method. There seems to be a bit of a race condition here between the blur and the clicked item in the filter receiving focus. A timeout increase was added here to handle this piece.
2. When the dialog content eventually loads, [focusableContentElemPresent](https://github.com/BrightspaceUI/core/blob/main/components/dialog/dialog-mixin.js#L39) needs to get set to `true`, else the dialog content is considered to be the active element [here](https://github.com/BrightspaceUI/core/blob/main/components/dropdown/dropdown-content-mixin.js#L560) if something non-focusable is clicked on in the dropdown (the timeout fixes things if something focusable is clicked in the dropdown, but not if something non-focusable is clicked; that's what the remainder of the changes are for).

The changes I've made here fix things for several cases but not all, so curious for others' thoughts.

**Why was this seemingly fixed if a different dropdown got opened?**
When the other dropdown menu was opened, hierarchical mixin was running [__removeAncestorTabIndicies](https://github.com/BrightspaceUI/core/blob/main/components/hierarchical-view/hierarchical-view-mixin.js#L545) which was turning the `tab-index=0` on the dialog content into `data-d2l-hierarchical-view-tabindex`. This seems weird. I didn't handle that here but it should probably have a separate ticket.