### PR TITLE
fix: Menu: Move tabindex around to correspond with focus

### DIFF
--- a/components/menu/demo/menu.html
+++ b/components/menu/demo/menu.html
@@ -17,6 +17,42 @@
 	<body unresolved>
 
 		<d2l-demo-page page-title="d2l-menu">
+			<h2>Basic Menu (demo of focus bug)</h2>
+			<d2l-demo-snippet>
+				<template>
+					<div role="menu">
+						<div role="menuitem" tabindex="0">
+							<span>Menu Item 1</span>
+						</div>
+						<div role="menuitem" tabindex="-1">
+							<span>Menu Item 2</span>
+						</div>
+						<div role="menuitem" tabindex="-1">
+							<span>Menu Item 3</span>
+						</div>
+					</div>
+				<script>
+					const menu = document.querySelector('div[role="menu"]');
+					const menuItems = menu.querySelectorAll('div[role="menuitem"]');
+
+					menuItems.forEach(item => {
+						item.addEventListener('keydown', (e) => {
+							if (e.keyCode === 40 || e.keyCode === 38) {
+								// prevent scrolling when up/down arrows pressed
+								e.preventDefault();
+								e.stopPropagation();
+								if (e.keyCode === 40) {
+									if (item.nextSibling) item.nextElementSibling.focus();
+								} else if (e.keyCode === 38) {
+									if (item.previousSibling) item.previousSibling.focus();
+								}
+								return;
+							}
+						});
+					});
+				</script>
+				</template>
+			</d2l-demo-snippet>
 
 			<h2>Menu</h2>
 

--- a/components/menu/demo/menu.html
+++ b/components/menu/demo/menu.html
@@ -23,11 +23,9 @@
 					<div role="menu">
 						<div role="menuitem" tabindex="0">
 							<span>Menu Item 1</span>
-						</div>
-						<div role="menuitem" tabindex="-1">
+						</div><div role="menuitem" tabindex="-1">
 							<span>Menu Item 2</span>
-						</div>
-						<div role="menuitem" tabindex="-1">
+						</div><div role="menuitem" tabindex="-1">
 							<span>Menu Item 3</span>
 						</div>
 					</div>
@@ -42,7 +40,7 @@
 								e.preventDefault();
 								e.stopPropagation();
 								if (e.keyCode === 40) {
-									if (item.nextSibling) item.nextElementSibling.focus();
+									if (item.nextSibling) item.nextSibling.focus();
 								} else if (e.keyCode === 38) {
 									if (item.previousSibling) item.previousSibling.focus();
 								}

--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -166,6 +166,7 @@ export const MenuItemMixin = superclass => class extends superclass {
 			return;
 		}
 		this.focus();
+		this.setAttribute('tabindex', '0');
 	}
 
 	__onKeyDown(e) {

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -176,46 +176,33 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 
 	_focusFirst() {
 		const item = this._tryGetNextFocusable();
-		if (item) {
-			item.setAttribute('tabindex', '0');
-			item.focus();
-		}
+		if (item) this._focusItem(item);
+	}
+
+	_focusItem(item) {
+		item.setAttribute('tabindex', '0');
+		item.focus();
 	}
 
 	_focusLast() {
 		const item = this._tryGetPreviousFocusable();
-		if (item) {
-			item.setAttribute('tabindex', '0');
-			item.focus();
-		}
+		if (item) this._focusItem(item);
 	}
 
 	_focusNext(item) {
 		item = this._tryGetNextFocusable(item);
-
-		if (item) {
-			item.setAttribute('tabindex', '0');
-			item.focus();
-		} else {
-			this._focusFirst();
-		}
+		item ? this._focusItem(item) : this._focusFirst();
 	}
 
 	_focusPrevious(item) {
 		item = this._tryGetPreviousFocusable(item);
-
-		if (item) {
-			item.setAttribute('tabindex', '0');
-			item.focus();
-		} else {
-			this._focusLast();
-		}
+		item ? this._focusItem(item) : this._focusLast();
 	}
 
 	_focusSelected() {
 		const selected = this.querySelector('[selected]');
 		if (selected) {
-			selected.focus();
+			this._focusItem(selected);
 		} else {
 			this._focusFirst();
 		}
@@ -280,7 +267,8 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 	}
 
 	_onFocusOut(e) {
-		if (e.target.role !== 'menuitem' || e.target.hasAttribute('first')) return;
+		e.stopPropagation();
+		if (e.target.role !== 'menuitem' || e.target.hasAttribute('first') || e.target.hasChildView) return;
 		e.target.setAttribute('tabindex', '-1');
 	}
 
@@ -345,7 +333,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 		while (itemIndex !== targetItemIndex) {
 			const item = focusableItems[itemIndex];
 			if (startsWith(item, searchChar)) {
-				item.focus();
+				this._focusItem(item);
 				return;
 			}
 			itemIndex = getNextOrFirstIndex(itemIndex);

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -268,7 +268,8 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 
 	_onFocusOut(e) {
 		e.stopPropagation();
-		if (e.target.role !== 'menuitem' || e.target.hasAttribute('first') || e.target.hasChildView) return;
+		const isMenuItem = e.target.role === 'menuitem' || e.target.role === 'menuitemcheckbox' || e.target.role === 'menuitemradio';
+		if (!isMenuItem || e.target.hasAttribute('first') || e.target.hasChildView) return;
 		e.target.setAttribute('tabindex', '-1');
 	}
 

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -102,6 +102,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 		this.addEventListener('d2l-menu-item-visibility-change', this._onMenuItemsChanged);
 		this.addEventListener('keydown', this._onKeyDown);
 		this.addEventListener('keypress', this._onKeyPress);
+		this.addEventListener('focusout', this._onFocusOut);
 
 		this._labelChanged();
 
@@ -175,22 +176,40 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 
 	_focusFirst() {
 		const item = this._tryGetNextFocusable();
-		if (item) item.focus();
+		if (item) {
+			item.setAttribute('tabindex', '0');
+			item.focus();
+		}
 	}
 
 	_focusLast() {
 		const item = this._tryGetPreviousFocusable();
-		if (item) item.focus();
+		if (item) {
+			item.setAttribute('tabindex', '0');
+			item.focus();
+		}
 	}
 
 	_focusNext(item) {
 		item = this._tryGetNextFocusable(item);
-		item ? item.focus() : this._focusFirst();
+
+		if (item) {
+			item.setAttribute('tabindex', '0');
+			item.focus();
+		} else {
+			this._focusFirst();
+		}
 	}
 
 	_focusPrevious(item) {
 		item = this._tryGetPreviousFocusable(item);
-		item ? item.focus() : this._focusLast();
+
+		if (item) {
+			item.setAttribute('tabindex', '0');
+			item.focus();
+		} else {
+			this._focusLast();
+		}
 	}
 
 	_focusSelected() {
@@ -258,6 +277,11 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 		this.setAttribute('aria-label', this.label);
 		const returnItem = this._getMenuItemReturn();
 		if (returnItem) returnItem.setAttribute('text', this.label);
+	}
+
+	_onFocusOut(e) {
+		if (e.target.role !== 'menuitem' || e.target.hasAttribute('first')) return;
+		e.target.setAttribute('tabindex', '-1');
 	}
 
 	_onKeyDown(e) {

--- a/components/menu/test/menu.test.js
+++ b/components/menu/test/menu.test.js
@@ -81,41 +81,58 @@ describe('d2l-menu', () => {
 
 		it('moves focus to next focusable item when down arrow is pressed', async() => {
 			await sendKeysElem(elem.querySelector('#c1'), 'press', 'ArrowDown');
+			expect(elem.querySelector('#a1').getAttribute('tabindex')).to.equal('0');
+			expect(elem.querySelector('#c1').getAttribute('tabindex')).to.equal('-1');
+			expect(elem.querySelector('#d1').getAttribute('tabindex')).to.equal('0');
 			expect(document.activeElement).to.equal(elem.querySelector('#d1'));
 		});
 
 		it('moves focus to previous focusable item when up arrow is pressed', async() => {
 			await sendKeysElem(elem.querySelector('#d1'), 'press', 'ArrowUp');
+			expect(elem.querySelector('#d1').getAttribute('tabindex')).to.equal('-1');
+			expect(elem.querySelector('#c1').getAttribute('tabindex')).to.equal('0');
 			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
 		});
 
 		it('moves focus to first focusable item when down arrow is pressed on last focusable item', async() => {
 			await sendKeysElem(elem.querySelector('#d1'), 'press', 'ArrowDown');
+			expect(elem.querySelector('#d1').getAttribute('tabindex')).to.equal('-1');
+			expect(elem.querySelector('#a1').getAttribute('tabindex')).to.equal('0');
 			expect(document.activeElement).to.equal(elem.querySelector('#a1'));
 		});
 
 		it('moves focus to last focusable item when up arrow is pressed on first focusable item', async() => {
 			await sendKeysElem(elem.querySelector('#a1'), 'press', 'ArrowUp');
+			expect(elem.querySelector('#a1').getAttribute('tabindex')).to.equal('0'); // first item
+			expect(elem.querySelector('#d1').getAttribute('tabindex')).to.equal('0');
 			expect(document.activeElement).to.equal(elem.querySelector('#d1'));
 		});
 
 		it('sets focus to disabled menu items', async() => {
 			await sendKeysElem(elem.querySelector('#a1'), 'press', 'ArrowDown');
+			expect(elem.querySelector('#a1').getAttribute('tabindex')).to.equal('0'); // first item
+			expect(elem.querySelector('#b1').getAttribute('tabindex')).to.equal('0');
 			expect(document.activeElement).to.equal(elem.querySelector('#b1'));
 		});
 
 		it('sets focus to next item that starts with character pressed', async() => {
 			await sendKeysElem(elem.querySelector('#a1'), 'press', 'c');
+			expect(elem.querySelector('#a1').getAttribute('tabindex')).to.equal('0'); // first item
+			expect(elem.querySelector('#c1').getAttribute('tabindex')).to.equal('0');
 			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
 		});
 
 		it('sets focus to next item that starts with uppercase character pressed', async() => {
 			await sendKeysElem(elem.querySelector('#a1'), 'press', 'C');
+			expect(elem.querySelector('#a1').getAttribute('tabindex')).to.equal('0'); // first item
+			expect(elem.querySelector('#c1').getAttribute('tabindex')).to.equal('0');
 			expect(document.activeElement).to.equal(elem.querySelector('#c1'));
 		});
 
 		it('sets focus by rolling over to beginning of menu when searching if necessary', async() => {
 			await sendKeysElem(elem.querySelector('#c1'), 'press', 'b');
+			expect(elem.querySelector('#c1').getAttribute('tabindex')).to.equal('-1');
+			expect(elem.querySelector('#b1').getAttribute('tabindex')).to.equal('0');
 			expect(document.activeElement).to.equal(elem.querySelector('#b1'));
 		});
 
@@ -130,6 +147,7 @@ describe('d2l-menu', () => {
 			`);
 			await nextFrame();
 			await focusElem(elem);
+			expect(elem.querySelector('#r3').getAttribute('tabindex')).to.equal('0');
 			await expect(document.activeElement).to.equal(elem.querySelector('#r3'));
 		});
 
@@ -171,6 +189,22 @@ describe('d2l-menu', () => {
 				return (document.activeElement.tagName === 'D2L-MENU-ITEM-RETURN') ||
 					(document.activeElement === nestedMenu);
 			}, 'Focus on return');
+			expect(elem.querySelector('#a1').getAttribute('tabindex')).to.equal('0');
+			expect(elem.querySelector('#b1').hasAttribute('tabindex')).to.be.false;
+			const returnItem = elem.querySelector('#nestedMenu')._getMenuItemReturn();
+			expect(returnItem.getAttribute('tabindex')).to.equal('0');
+		});
+
+		it('moves focus to next focusable item when down arrow is pressed', async() => {
+			setTimeout(() => clickElem(elem.querySelector('#b1')));
+			await oneEvent(elem, 'd2l-hierarchical-view-show-complete');
+
+			const returnItem = elem.querySelector('#nestedMenu')._getMenuItemReturn();
+			await sendKeysElem(returnItem, 'press', 'ArrowDown');
+
+			expect(returnItem.getAttribute('tabindex')).to.equal('0');
+			expect(elem.querySelector('#a2').getAttribute('tabindex')).to.equal('0');
+			expect(document.activeElement).to.equal(elem.querySelector('#a2'));
 		});
 
 		it('shows nested menu when right arrow is pressed on opener', async() => {
@@ -185,6 +219,9 @@ describe('d2l-menu', () => {
 			setTimeout(() => sendKeysElem(elem.querySelector('#b2'), 'press', 'ArrowLeft'));
 			await oneEvent(elem, 'd2l-hierarchical-view-hide-complete');
 			expect(elem.isActive()).to.be.true;
+
+			expect(elem.querySelector('#a1').getAttribute('tabindex')).to.equal('0');
+			expect(elem.querySelector('#b1').getAttribute('tabindex')).to.equal('0');
 		});
 
 		it('hides nested menu when escape is pressed in nested menu', async() => {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7938)

**Problem:**
In Chrome or Safari on the menu demo page:
1. Tab into a menu
2. Arrow key down to a non-first item
3. Press tab; note that focus goes to the first item of the list

**Expected Behaviour:**
Pressing tab would go to the next focusable item in the document.

**Solution Notes:**
This bug is strange. It seems that there can be a browser expectation that when an item is receiving keyboard focus it should also have a tabindex of 0. I noticed a w3c pattern that follow this solution behaviour.