### PR TITLE
fix: Dropdown: Do not auto close if active element is __previousFocusableAncestor when in a custom element

### DIFF
--- a/components/dialog/demo/dialog.html
+++ b/components/dialog/demo/dialog.html
@@ -329,6 +329,36 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Simple dialog with longer loading content</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-button>Show Dialog</d2l-button>
+					<d2l-dialog title-text="Fullscreen Title">
+					</d2l-dialog>
+					<d2l-dropdown style="display: none; padding: 30px;">
+						<button class="d2l-dropdown-opener">Open!</button>
+						<d2l-dropdown-content>
+							<a href=" " style="display: block;">A Link</a>
+							Some content... Click me!
+						</d2l-dropdown-content>
+					</d2l-dropdown>
+
+					<script>
+						(demo => {
+							demo.querySelector('d2l-button').addEventListener('click', () => {
+								demo.querySelector('d2l-dialog').opened = true;
+								setTimeout(() => {
+									demo.querySelector('d2l-dropdown').style.display = 'block';
+									demo.querySelector('d2l-dialog').appendChild(demo.querySelector('d2l-dropdown'));
+									demo.querySelector('d2l-dialog').resize();
+								}, 1000);
+							});
+						})(document.currentScript.parentNode);
+					</script>
+				</template>
+			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 	</body>
 </html>

--- a/components/dropdown/dropdown-content-mixin.js
+++ b/components/dropdown/dropdown-content-mixin.js
@@ -569,7 +569,8 @@ export const DropdownContentMixin = superclass => class extends LocalizeCoreElem
 			const activeElement = getComposedActiveElement();
 
 			if (isComposedAncestor(this, activeElement)
-				|| isComposedAncestor(this.__getOpener(), activeElement)) {
+				|| isComposedAncestor(this.__getOpener(), activeElement)
+				|| activeElement === this.__previousFocusableAncestor) {
 				return;
 			}
 			this.close();

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -1,6 +1,7 @@
 import '../dropdown.js';
 import '../dropdown-content.js';
-import { aTimeout, expect, fixture, focusElem, html, nextFrame, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { aTimeout, clickElem, defineCE, expect, fixture, focusElem, html, nextFrame, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { css, LitElement } from 'lit';
 
 const normalFixture = html`
 	<div>
@@ -68,6 +69,33 @@ const dropdownD2LButtonOpener = html`
 		</div>
 	</div>
 `;
+
+const wrappedDropdown = defineCE(
+	class extends LitElement {
+		static get styles() {
+			return css`
+				:host { display: inline-block; }
+			`;
+		}
+		render() {
+			return html`
+				<div>
+					<div id="optionallyFocusable" tabindex="0">
+						<d2l-dropdown>
+							<button class="another-class d2l-dropdown-opener"></button>
+							<d2l-dropdown-content opened>
+								<p id="non_focusable_inside">a</p>
+								<a id="focusable_inside" href="http://www.desire2learn.com">b</a>
+							</d2l-dropdown-content>
+						</d2l-dropdown>
+						<p id="non_focusable_outside">c</p>
+						<button id="focusable_outside">out here</button>
+					</div>
+				</div>
+			`;
+		}
+	}
+);
 
 describe('d2l-dropdown', () => {
 
@@ -319,6 +347,12 @@ describe('d2l-dropdown', () => {
 			await focusElem(focusableAncestor);
 			await aTimeout(100);
 			expect(content.opened).to.be.true;
+		});
+
+		it('should not close when activeElement becomes focusable ancestor when in a custom element', async() => {
+			const elem = await fixture(`<${wrappedDropdown}></${wrappedDropdown}>`);
+			await clickElem(elem.shadowRoot.querySelector('#non_focusable_inside'));
+			expect(elem.shadowRoot.querySelector('d2l-dropdown-content').opened).to.be.true;
 		});
 
 		[


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7161)

See https://github.com/BrightspaceUI/core/pull/5659 for additional context.

**Problem:**
When clicking on dropdown content in a non-focusable location when the dropdown is in something like a dialog (e.g., custom element) where the dialog content has `tabindex="0"`, the dropdown would then auto close.

**Expected Behaviour:**
That the dropdown will not auto-close if clicked in it at all.

**Solution Notes:**
There is a check for `document.activeElement === this.__previousFocusableAncestor` but that doesn't work in this case since `document.activeElement` returns the `d2l-dialog` whereas `this.__previousFocusableAncestor` returns the dialog content. I added a check for if the composed active element is `__previousFocusableAncestor`.