### PR TITLE
List item nav > Add more complex example

### DIFF
--- a/components/list/demo/demo-list-nav.js
+++ b/components/list/demo/demo-list-nav.js
@@ -1,0 +1,162 @@
+import '../../icons/icon.js';
+import '../list-item-content.js';
+import '../list-item-nav-button.js';
+import '../list.js';
+import '../../tooltip/tooltip-help.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { listDemos } from './list-demo-scenarios.js';
+import { moveLocations } from '../list-item-drag-drop-mixin.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+class ListDemoNav extends LitElement {
+
+	static get properties() {
+		return {
+			_currentItem: { state: true }
+		};
+	}
+
+	static get styles() {
+		return [
+			css`
+				:host {
+					display: block;
+					max-width: 400px;
+				}
+				d2l-icon {
+					margin-right: 0.7rem;
+				}
+				d2l-tooltip-help {
+					padding: 5px;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+		this._currentItem = null;
+	}
+
+	render() {
+		return html`
+			<div @d2l-list-items-move="${this._handleListItemsMove}">
+				<d2l-list 
+					grid 
+					drag-multiple
+					@d2l-list-item-button-click="${this._handleItemClick}">
+					${repeat(this.#list, (item) => item.key, (item) => this._renderItem(item))}
+				</d2l-list>
+			</div>
+		`;
+	}
+
+	#list = listDemos.nav;
+
+	_handleItemClick(e) {
+		if (!e.target.expandable) {
+			this._currentItem = e.target;
+			return;
+		}
+
+		if (this._currentItem !== e.target) {
+			e.target.expanded = true;
+			this._currentItem = e.target;
+		} else {
+			e.target.expanded = !e.target.expanded;
+		}
+	}
+
+	async _handleListItemsMove(e) {
+
+		const sourceListItems = e.detail.sourceItems;
+		const target = e.detail.target;
+
+		// helper that gets the array containing item data, the item data, and the index within the array
+		const getItemInfo = (items, key) => {
+			for (let i = 0; i < items.length; i++) {
+				if (items[i].key === key) {
+					return { owner: items, item: items[i], index: i };
+				}
+				if (items[i].items && items[i].items.length > 0) {
+					const tempItemData = getItemInfo(items[i].items, key);
+					if (tempItemData) return tempItemData;
+				}
+			}
+		};
+
+		const dataToMove = [];
+
+		// remove data elements from original locations
+		sourceListItems.forEach(sourceListItem => {
+			const info = getItemInfo(this.#list, sourceListItem.key);
+			if (info?.owner) {
+				info.owner.splice(info.index, 1);
+			}
+			if (info?.item) {
+				dataToMove.push(info.item);
+			}
+		});
+
+		// append data elements to new location
+		const targetInfo = getItemInfo(this.#list, target.item.key);
+		let targetItems;
+		let targetIndex;
+		if (target.location === moveLocations.nest) {
+			if (!targetInfo.item.items) targetInfo.item.items = [];
+			targetItems = targetInfo.item.items;
+			targetIndex = targetItems.length;
+		} else {
+			targetItems = targetInfo?.owner;
+			if (!targetItems) return;
+			if (target.location === moveLocations.above) targetIndex = targetInfo.index;
+			else if (target.location === moveLocations.below) targetIndex = targetInfo.index + 1;
+		}
+		for (let i = dataToMove.length - 1; i >= 0; i--) {
+			targetItems.splice(targetIndex, 0, dataToMove[i]);
+		}
+
+		this.requestUpdate();
+		await this.updateComplete;
+
+		if (e.detail.keyboardActive) {
+			setTimeout(() => {
+				if (!this.shadowRoot) return;
+				const newItem = this.shadowRoot.querySelector('d2l-list').getListItemByKey(sourceListItems[0].key);
+				newItem.activateDragHandle();
+			});
+		}
+	}
+
+	_renderItem(item) {
+		const hasSubList = item.items && item.items.length > 0;
+		return html`
+			<d2l-list-item-nav-button
+				key="${ifDefined(item.key)}"
+				draggable
+				drag-handle-text="${item.primaryText}"
+				color="${ifDefined(item.color)}"
+				?expandable="${hasSubList}"
+				?expanded="${hasSubList}"
+				drop-nested
+				label="${item.primaryText}">
+				<d2l-list-item-content>
+					<div>${item.hasIcon ? html`<d2l-icon icon="tier2:file-document"></d2l-icon>` : nothing}${item.primaryText}</div>
+					${item.tooltipOpenerText && item.tooltipText
+							? html`<div slot="secondary"><d2l-tooltip-help text="${item.tooltipOpenerText}">${item.tooltipText}</d2l-tooltip-help></div>`
+							: nothing
+					}
+				</d2l-list-item-content>
+				${hasSubList ? html`
+					<d2l-list slot="nested">
+						${repeat(item.items, (subItem) => subItem.key, (subItem) => this._renderItem(subItem))}
+					</d2l-list>`
+						: nothing
+				}
+			</d2l-list-item-nav-button>
+		`;
+	}
+}
+
+customElements.define('d2l-demo-list-nav', ListDemoNav);

--- a/components/list/demo/list-demo-scenarios.js
+++ b/components/list/demo/list-demo-scenarios.js
@@ -317,5 +317,56 @@ export const listDemos = {
 		primaryText: 'Applied Wetland Science',
 		dropNested: true,
 		items: []
-	}]
+	}],
+	nav: [{
+		key: '1',
+		primaryText: 'Introductory Earth Sciences',
+		dropNested: true,
+		color: '#006fbf',
+		items: [{
+			key: '1-1',
+			primaryText: 'Glaciation',
+			dropNested: true,
+			items: [],
+			color: '#29a6ff',
+			tooltipText: 'Starts: 2023-09-01, Ends: 2023-12-01',
+			tooltipOpenerText: 'Due: 2023-10-10',
+			hasIcon: true
+		}, {
+			key: '1-2',
+			primaryText: 'Weathering',
+			dropNested: true,
+			items: [],
+			color: '#29a6ff',
+			tooltipText: 'Starts: 2023-10-01, Ends: 2023-12-01',
+			tooltipOpenerText: 'Due: 2023-11-10',
+			hasIcon: true
+		}, {
+			key: '1-3',
+			primaryText: 'Volcanism',
+			dropNested: true,
+			items: [],
+			color: '#29a6ff',
+			hasIcon: true
+		}]
+	}, {
+		key: '2',
+		primaryText: 'Applied Wetland Science',
+		color: '#cd2026',
+		items: [{
+			key: '2-1',
+			primaryText: 'Carbon & Nitrogen Cycling',
+			dropNested: true,
+			items: [],
+			color: '#ff575a',
+			hasIcon: true
+		}, {
+			key: '2-2',
+			primaryText: 'Wetland Engineering',
+			dropNested: true,
+			items: [],
+			color: '#ff575a',
+			hasIcon: true
+		}]
+	}],
 };

--- a/components/list/demo/list-nested.html
+++ b/components/list/demo/list-nested.html
@@ -25,6 +25,7 @@
 			import '../../switch/switch.js';
 			import '../../tooltip/tooltip-help.js';
 
+			import './demo-list-nav.js';
 			import './demo-list-nested-iterations-helper.js';
 		</script>
 	</head>
@@ -226,36 +227,36 @@
 				</template>
 			</d2l-demo-snippet>
 
-			<h2>Side nav item</h2>
+			<h2>Side nav list (simple)</h2>
 
 			<d2l-demo-snippet>
 				<template>
 					<d2l-list grid style="width: 334px;">
-						<d2l-list-item-nav-button key="L1-1" label="Welcome!" color="#006fbf" expandable expanded draggable>
+						<d2l-list-item-nav-button key="L1-1" label="Welcome!" color="#006fbf" expandable expanded>
 							<d2l-list-item-content>
 								<div>Welcome!</div>
 							</d2l-list-item-content>
 							<d2l-list slot="nested" grid>
-								<d2l-list-item-nav-button key="L2-1" label="Syallabus Confirmation" draggable>
+								<d2l-list-item-nav-button key="L2-1" label="Syallabus Confirmation">
 									<d2l-list-item-content>
 										<div><d2l-icon style="margin-right: 0.7rem;" icon="tier2:file-document"></d2l-icon>Syallabus Confirmation</div>
-										<div slot="secondary"><d2l-tooltip-help text="Due: May 2, 2023 at 2 pm">Due: May 2, 2023</d2l-tooltip-help></div>
+										<div slot="secondary"><d2l-tooltip-help text="Due: May 2, 2023 at 2 pm" style="padding: 5px;">Start: May 1, 2023 at 12:01 AM</d2l-tooltip-help></div>
 									</d2l-list-item-content>
 								</d2l-list-item-nav-button>
 							</d2l-list>
 						</d2l-list-item-nav-button>
-						<d2l-list-item-nav-button key="L2-2" label="Unit 1: Poetry" color="#29a6ff" expandable expanded draggable>
+						<d2l-list-item-nav-button key="L2-2" label="Unit 1: Poetry" color="#29a6ff" expandable expanded>
 							<d2l-list-item-content>
 								<div>Unit 1: Fiction</div>
-								<div slot="secondary"><d2l-tooltip-help text="Starts: May 2, 2023 at 2 pm">Starts: May 2, 2023</d2l-tooltip-help></div>
+								<div slot="secondary"><d2l-tooltip-help text="Due: May 2, 2023 at 5 pm" style="padding: 5px;">Starts: May 1, 2023 at 12:01 AM</d2l-tooltip-help></div>
 							</d2l-list-item-content>
 							<d2l-list slot="nested" grid>
-								<d2l-list-item-nav-button key="L3-2" label="Fiction" draggable>
+								<d2l-list-item-nav-button key="L3-2" label="Fiction">
 									<d2l-list-item-content>
 										<div><d2l-icon style="margin-right: 0.7rem;" icon="tier2:file-document"></d2l-icon>Fiction</div>
 									</d2l-list-item-content>
 								</d2l-list-item-nav-button>
-								<d2l-list-item-nav-button key="L3-2" label="Ten rules for writing fiction" draggable>
+								<d2l-list-item-nav-button key="L3-2" label="Ten rules for writing fiction">
 									<d2l-list-item-content>
 										<div><d2l-icon style="margin-right: 0.7rem;" icon="tier2:file-document"></d2l-icon>Ten rules for writing fiction</div>
 									</d2l-list-item-content>
@@ -284,6 +285,14 @@
 						})(document.currentScript.parentNode);
 					</script>
 				</template>
+			</d2l-demo-snippet>
+
+			<h2>Side nav list (more complex with drag & drop)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-demo-list-nav></d2l-demo-list-nav>
+					</template>
 			</d2l-demo-snippet>
 
 			<h2>All Iterations</h2>


### PR DESCRIPTION
Part of [this Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7928)

Does the following:
- Improves on existing demos based on Mark's feedback (padding around tooltip-help, improve tooltip-help content)
- Adds a more complex demo that implements nested drag & drop (and removes draggable from the simple demo since it isn't actually working)