### PR TITLE
fix: date-time-range-to: debounce resizeobserver callback calls

### DIFF
--- a/components/filter/test/filter.vdiff.js
+++ b/components/filter/test/filter.vdiff.js
@@ -168,16 +168,17 @@ describe('filter', () => {
 				{ name: 'dates', template: createSingleDimDate() },
 				{ name: 'dates-long', template: createSingleDimDateCustom({ long: true }) },
 				{ name: 'dates-custom-selected', template: createSingleDimDateCustom({ customSelected: true }) },
-				{ name: 'dates-custom-selected-start-value', template: createSingleDimDateCustom({ customSelected: true, startValue: '2018-02-12T05:00:00.000Z' }) },
+				{ name: 'dates-custom-selected-start-value', template: createSingleDimDateCustom({ customSelected: true, startValue: '2018-02-12T05:00:00.000Z' }), waitForBlockDisplay: true },
 				{ name: 'dates-custom-selected-start-value-date', template: createSingleDimDateCustom({ customSelected: true, startValue: '2018-02-12T05:00:00.000Z', type: 'date' }) },
 				{ name: 'dates-custom-selected-same-start-end-date', template: createSingleDimDateCustom({ customSelected: true, startValue: '2018-02-12T05:00:00.000Z', endValue: '2018-02-13T04:59:59.000Z', type: 'date' }) },
 				{ name: 'dates-long-custom-selected', template: createSingleDimDateCustom({ long: true, longCustomSelected: true }) },
-			].forEach(({ name, template }) => {
+			].forEach(({ name, template, waitForBlockDisplay }) => {
 				it(`${rtl ? 'rtl-' : ''}${name}`, async() => {
 					const elem = await fixture(template, { rtl, viewport: { height: 1500 } });
 					elem.opened = true;
 					await oneEvent(elem, 'd2l-filter-dimension-first-open');
 					await nextFrame();
+					if (waitForBlockDisplay) await waitUntil(() => elem.shadowRoot.querySelector('d2l-input-date-time-range').shadowRoot.querySelector('d2l-input-date-time-range-to')._blockDisplay, 'component never changed layout');
 					await expect(elem).to.be.golden();
 				});
 

--- a/components/inputs/input-date-time-range-to.js
+++ b/components/inputs/input-date-time-range-to.js
@@ -172,9 +172,9 @@ class InputDateTimeRangeTo extends SkeletonMixin(LocalizeCoreElement(LitElement)
 		const leftElem = this.shadowRoot.querySelector('.d2l-input-date-time-range-start-container');
 		let leftElemHeight = 0;
 
-		this._leftElemResizeObserver = this._leftElemResizeObserver || new ResizeObserver(debounce(() => {
+		this._leftElemResizeObserver = this._leftElemResizeObserver || new ResizeObserver(() => {
 			leftElemHeight = Math.ceil(parseFloat(getComputedStyle(leftElem).getPropertyValue('height')));
-		}, 5));
+		});
 		this._leftElemResizeObserver.disconnect();
 		this._leftElemResizeObserver.observe(leftElem);
 

--- a/components/inputs/input-date-time-range-to.js
+++ b/components/inputs/input-date-time-range-to.js
@@ -11,8 +11,7 @@ function debounce(func, delay) {
 	let timer = 0;
 	return function() {
 		clearTimeout(timer);
-		// eslint-disable-next-line no-invalid-this
-		timer = setTimeout(() => func.apply(this), delay);
+		timer = setTimeout(func, delay);
 	};
 }
 
@@ -184,7 +183,7 @@ class InputDateTimeRangeTo extends SkeletonMixin(LocalizeCoreElement(LitElement)
 			const height = Math.ceil(parseFloat(getComputedStyle(container).getPropertyValue('height')));
 			if (height >= (leftElemHeight * 2)) this._blockDisplay = true; // switch to _blockDisplay styles if content has wrapped (needed for "to" to occupy its own line)
 			else this._blockDisplay = false;
-		}, 5));
+		}, 5).bind(this));
 		this._parentElemResizeObserver.disconnect();
 		this._parentElemResizeObserver.observe(this._parentNode);
 	}

--- a/components/inputs/input-date-time-range-to.js
+++ b/components/inputs/input-date-time-range-to.js
@@ -7,6 +7,15 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
+function debounce(func, delay) {
+	let timer = 0;
+	return function() {
+		clearTimeout(timer);
+		// eslint-disable-next-line no-invalid-this
+		timer = setTimeout(() => func.apply(this), delay);
+	};
+}
+
 class InputDateTimeRangeTo extends SkeletonMixin(LocalizeCoreElement(LitElement)) {
 
 	static get properties() {
@@ -163,19 +172,19 @@ class InputDateTimeRangeTo extends SkeletonMixin(LocalizeCoreElement(LitElement)
 		const leftElem = this.shadowRoot.querySelector('.d2l-input-date-time-range-start-container');
 		let leftElemHeight = 0;
 
-		this._leftElemResizeObserver = this._leftElemResizeObserver || new ResizeObserver(() => {
+		this._leftElemResizeObserver = this._leftElemResizeObserver || new ResizeObserver(debounce(() => {
 			leftElemHeight = Math.ceil(parseFloat(getComputedStyle(leftElem).getPropertyValue('height')));
-		});
+		}, 5));
 		this._leftElemResizeObserver.disconnect();
 		this._leftElemResizeObserver.observe(leftElem);
 
-		this._parentElemResizeObserver = this._parentElemResizeObserver || new ResizeObserver(async() => {
+		this._parentElemResizeObserver = this._parentElemResizeObserver || new ResizeObserver(debounce(async() => {
 			this._blockDisplay = false;
 			await this.updateComplete;
 			const height = Math.ceil(parseFloat(getComputedStyle(container).getPropertyValue('height')));
 			if (height >= (leftElemHeight * 2)) this._blockDisplay = true; // switch to _blockDisplay styles if content has wrapped (needed for "to" to occupy its own line)
 			else this._blockDisplay = false;
-		});
+		}, 5));
 		this._parentElemResizeObserver.disconnect();
 		this._parentElemResizeObserver.observe(this._parentNode);
 	}

--- a/components/inputs/test/input-date-time-range.vdiff.js
+++ b/components/inputs/test/input-date-time-range.vdiff.js
@@ -1,5 +1,5 @@
 import '../input-date-time-range.js';
-import { defineCE, expect, fixture, focusElem, html, nextFrame, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
+import { defineCE, expect, fixture, focusElem, html, nextFrame, oneEvent, sendKeysElem, waitUntil } from '@brightspace-ui/testing';
 import { LitElement, nothing } from 'lit';
 import { reset, useFakeTimers } from 'sinon';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -293,6 +293,7 @@ describe('d2l-input-date-time-range', () => {
 						actualElem = elem.querySelector('d2l-input-date-time-range');
 						await changeInnerInputDateTime(elem, startDateSelector, startDate);
 						await changeInnerInputDateTime(elem, endDateSelector, endDate, true);
+						await waitUntil(() => actualElem.shadowRoot.querySelector('d2l-input-date-time-range-to')._blockDisplay, 'component never changed layout');
 					});
 
 					it('basic', async() => {
@@ -327,6 +328,7 @@ describe('d2l-input-date-time-range', () => {
 						actualElem = elem.querySelector('d2l-input-date-time-range');
 						await changeInnerInputTextDate(elem, startDateSelector, startDate, true);
 						await changeInnerInputTextDate(elem, endDateSelector, endDate, true);
+						await waitUntil(() => actualElem.shadowRoot.querySelector('d2l-input-date-time-range-to')._blockDisplay, 'component never changed layout');
 					});
 
 					it('basic', async() => {
@@ -381,6 +383,7 @@ describe('d2l-input-date-time-range', () => {
 						actualElem = elem.querySelector('d2l-input-date-time-range');
 						await changeInnerInputTextDate(elem, changeStartDateFirst ? startDateSelector : endDateSelector, changeStartDateFirst ? startDate : endDate, true);
 						await changeInnerInputTextDate(elem, changeStartDateFirst ? endDateSelector : startDateSelector, changeStartDateFirst ? endDate : startDate, true);
+						await waitUntil(() => actualElem.shadowRoot.querySelector('d2l-input-date-time-range-to')._blockDisplay, 'component never changed layout');
 					});
 
 					it('focus start', async() => {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7959)

**Problem:**
cds-session-management-ui was experiencing ResizeObserver undelivered notification errors. We generally can ignore this error, but I thought I'd try to get rid of it.

**Solution Notes:**
This debounces the ResizeObserver parent change callback in date-time-range-to. I did find that was only necessary to do this to one of the resizeobservers to get rid of the error in cds-session-management-ui, and also it went away if the timeout was 0. Having it 5 seems to not be perceptible visually, while also reducing the number of calls by about a third.

Let me know any thoughts or if my logic is totally flawed here.