### PR TITLE
fix: Collapsible-panel: Fix focus-visible with NVDA

### DIFF
--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -368,7 +368,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 	render() {
 		const classes = {
 			'd2l-collapsible-panel': true,
-			'focused': this._focused && !this._clicked,
+			'focused': this._focused,
 			'has-summary': this._hasSummary,
 			'has-before': this._hasBefore,
 			'scrolled': this._scrolled,
@@ -455,7 +455,7 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 
 	_onBlur() {
 		setTimeout(() => {
-			// don't blur if the button still ends up in focus
+			// don't remove focus if the button still ends up in focus
 			if (getComposedActiveElement() === this.shadowRoot.querySelector('button')) return;
 			this._focused = false;
 		}, 10);

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -6,6 +6,7 @@ import { heading1Styles, heading2Styles, heading3Styles, heading4Styles } from '
 import { classMap } from 'lit/directives/class-map.js';
 import { EventSubscriberController } from '../../controllers/subscriber/subscriberControllers.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
+import { getComposedActiveElement } from '../../helpers/focus.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { isComposedAncestor } from '../../helpers/dom.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
@@ -26,6 +27,21 @@ const normalizeHeadingLevel = (number) => {
 };
 
 const defaultHeading = 3;
+
+let tabPressed = false;
+let tabListenerAdded = false;
+function addTabListener() {
+	if (tabListenerAdded) return;
+	tabListenerAdded = true;
+	document.addEventListener('keydown', e => {
+		if (e.keyCode !== 9) return;
+		tabPressed = true;
+	});
+	document.addEventListener('keyup', e => {
+		if (e.keyCode !== 9) return;
+		tabPressed = false;
+	});
+}
 
 /**
  * A container with a title that can be expanded/collapsed to show/hide content.
@@ -85,7 +101,6 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 			 * @type {boolean}
 			 */
 			noSticky: { attribute: 'no-sticky', type: Boolean },
-			_clicked: { state: true },
 			_focused: { state: true },
 			_hasBefore: { state: true },
 			_hasSummary: { state: true },
@@ -323,7 +338,6 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 		this.paddingType = 'default';
 		this.type = 'default';
 		this.noSticky = false;
-		this._clicked = false;
 		this._focused = false;
 		this._group = undefined;
 		this._groupSubscription = new EventSubscriberController(this, 'collapsible-panel-group', {
@@ -339,6 +353,11 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 
 	static get focusElementSelector() {
 		return '.d2l-collapsible-panel-opener';
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		addTabListener();
 	}
 
 	disconnectedCallback() {
@@ -425,7 +444,6 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 	}
 
 	_handlePanelClick(e) {
-		this._clicked = e.detail && e.detail > 0; // detect if click event is from a mouse
 		const content = this.shadowRoot.querySelector('.d2l-collapsible-panel-content');
 		if (e.target !== content && !isComposedAncestor(content, e.target)) this._toggleExpand();
 	}
@@ -436,11 +454,15 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(RtlMixin(LitElement))) {
 	}
 
 	_onBlur() {
-		this._focused = false;
-		this._clicked = false;
+		setTimeout(() => {
+			// don't blur if the button still ends up in focus
+			if (getComposedActiveElement() === this.shadowRoot.querySelector('button')) return;
+			this._focused = false;
+		}, 10);
 	}
 
 	_onFocus() {
+		if (!tabPressed) return;
 		this._focused = true;
 	}
 

--- a/components/collapsible-panel/test/collapsible-panel.test.js
+++ b/components/collapsible-panel/test/collapsible-panel.test.js
@@ -1,6 +1,6 @@
 import '../collapsible-panel.js';
 import '../collapsible-panel-summary-item.js';
-import { clickElem, expect, fixture, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, html, oneEvent, runConstructor, sendKeys } from '@brightspace-ui/testing';
 
 describe('d2l-collapsible-panel', () => {
 
@@ -149,8 +149,23 @@ describe('d2l-collapsible-panel', () => {
 			expect(panel.classList.contains(focusedClass)).to.be.false;
 		});
 
+		it('tabbing into header should trigger focused class', async() => {
+			await sendKeys('press', 'Tab');
+			expect(panel.classList.contains(focusedClass)).to.be.true;
+		});
+
+		it('tabbing into header then clicking should not remove focused class', async() => {
+			await sendKeys('press', 'Tab');
+			expect(panel.classList.contains(focusedClass)).to.be.true;
+			const header = elem.shadowRoot.querySelector('.d2l-collapsible-panel-header');
+			clickElem(header);
+			await oneEvent(elem, 'd2l-collapsible-panel-expand');
+			expect(panel.classList.contains(focusedClass)).to.be.true;
+		});
+
 		it('selecting heading with keypress should trigger focused class and expand', async() => {
-			sendKeysElem(elem.shadowRoot.querySelector('button'), 'press', 'Enter');
+			sendKeys('press', 'Tab');
+			sendKeys('press', 'Enter');
 			await oneEvent(elem, 'd2l-collapsible-panel-expand');
 			expect(panel.classList.contains(focusedClass)).to.be.true;
 		});

--- a/components/collapsible-panel/test/collapsible-panel.vdiff.js
+++ b/components/collapsible-panel/test/collapsible-panel.vdiff.js
@@ -89,6 +89,7 @@ function createCustomWithSummary() {
 
 async function focusPanel(elem) {
 	await focusElem(elem.querySelector('d2l-collapsible-panel'));
+	elem.querySelector('d2l-collapsible-panel')._focused = true;
 }
 
 async function scrollTo(elem, y) {


### PR DESCRIPTION
New strategy for [this Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7882)

**Problem:**
NVDA and JAWS treat enter on a button as a click. With the new focus implementation, `this._clicked` was being set to `true` and so the `focused` class wasn't being added.

**Solution notes:**
This adds a tab event listener, as used in other places like tag-list. When focus occurs, it checks for if it was a tab focus and then adds the `focused` class. It also keeps `focused` if the button blurs due to a click on the header.