### PR TITLE
fix: properly display input borders in WHCM

### DIFF
--- a/components/inputs/input-select-styles.js
+++ b/components/inputs/input-select-styles.js
@@ -73,7 +73,7 @@ export const selectStyles = css`
 			color: FieldText;
 			forced-color-adjust: none;
 			height: 2rem;
-			outline: 1px solid FieldText;
+			outline: 1px solid ButtonBorder;
 			padding-inline: 0.6rem 16px;
 		}
 
@@ -81,6 +81,10 @@ export const selectStyles = css`
 		.d2l-input-select:not([disabled]):hover {
 			box-shadow: none;
 			outline: 2px solid Highlight;
+		}
+
+		.d2l-input-select:disabled {
+			outline: 1px solid GrayText;
 		}
 
 		.d2l-input-select[aria-invalid="true"] {

--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -1,5 +1,8 @@
 import '../colors/colors.js';
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
+import { getFocusPseudoClass } from '../../helpers/focus.js';
+
+const focusClass = unsafeCSS(getFocusPseudoClass());
 
 export const inputStyles = css`
 	.d2l-input {
@@ -26,7 +29,7 @@ export const inputStyles = css`
 	}
 	.d2l-input,
 	.d2l-input:hover:disabled,
-	.d2l-input:focus:disabled,
+	.d2l-input:${focusClass}:disabled,
 	[aria-invalid="true"].d2l-input:disabled {
 		border-color: var(--d2l-input-border-color, var(--d2l-color-galena));
 		border-width: 1px;
@@ -44,7 +47,7 @@ export const inputStyles = css`
 		font-weight: 400;
 	}
 	.d2l-input:hover,
-	.d2l-input:focus,
+	.d2l-input:${focusClass},
 	.d2l-input-focus {
 		border-color: var(--d2l-color-celestine);
 		border-width: 2px;
@@ -72,45 +75,48 @@ export const inputStyles = css`
 	}
 	textarea.d2l-input,
 	textarea.d2l-input:hover:disabled,
-	textarea.d2l-input:focus:disabled,
+	textarea.d2l-input:${focusClass}:disabled,
 	textarea[aria-invalid="true"].d2l-input:disabled {
-		padding-bottom: 0.5rem;
-		padding-top: 0.5rem;
+		padding-block: 0.5rem;
 	}
 	textarea.d2l-input:hover,
-	textarea.d2l-input:focus {
+	textarea.d2l-input:${focusClass} {
 		padding: var(--d2l-input-padding-focus, calc(0.75rem - 1px));
-		padding-bottom: calc(0.5rem - 1px);
-		padding-top: calc(0.5rem - 1px);
+		padding-block: calc(0.5rem - 1px);
 	}
 	textarea.d2l-input[aria-invalid="true"] {
 		background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDE4IDE4Ij4KICA8cGF0aCBmaWxsPSIjY2QyMDI2IiBkPSJNMTcuNzkgMTUuMTFsLTctMTRhMiAyIDAgMCAwLTMuNTggMGwtNyAxNGExLjk3NSAxLjk3NSAwIDAgMCAuMDkgMS45NEEyIDIgMCAwIDAgMiAxOGgxNGExLjk5NCAxLjk5NCAwIDAgMCAxLjctLjk1IDEuOTY3IDEuOTY3IDAgMCAwIC4wOS0xLjk0ek05IDE2YTEuNSAxLjUgMCAxIDEgMS41LTEuNUExLjUgMS41IDAgMCAxIDkgMTZ6bS45OC00LjgwNmExIDEgMCAwIDEtMS45NiAwbC0uOTktNUExIDEgMCAwIDEgOC4wMSA1aDEuOTgzYTEgMSAwIDAgMSAuOTggMS4xOTR6Ii8+Cjwvc3ZnPgo=");
 		background-position: top 12px right 18px;
 		background-repeat: no-repeat;
 		background-size: 0.8rem 0.8rem;
-		padding-right: calc(18px + 0.8rem);
+		padding-inline-end: calc(18px + 0.8rem);
 	}
 	textarea.d2l-input[aria-invalid="true"]:hover,
-	textarea.d2l-input[aria-invalid="true"]:focus {
+	textarea.d2l-input[aria-invalid="true"]:${focusClass} {
 		background-position: top calc(12px - 1px) right calc(18px - 1px);
-		padding-right: calc(18px + 0.8rem - 1px);
+		padding-inline-end: calc(18px + 0.8rem - 1px);
 	}
 	:host([dir="rtl"]) textarea.d2l-input[aria-invalid="true"] {
 		background-position: top 12px left 18px;
-		padding: var(--d2l-input-padding, 0.75rem);
-		padding-bottom: 0.5rem;
-		padding-left: calc(18px + 0.8rem);
-		padding-top: 0.5rem;
 	}
-	:host([dir="rtl"]) textarea.d2l-input[aria-invalid="true"]:focus,
+	:host([dir="rtl"]) textarea.d2l-input[aria-invalid="true"]:${focusClass},
 	:host([dir="rtl"]) textarea.d2l-input[aria-invalid="true"]:hover {
 		background-position: top calc(12px - 1px) left calc(18px - 1px);
-		padding: var(--d2l-input-padding-focus, calc(0.75rem - 1px));
-		padding-bottom: calc(0.5rem - 1px);
-		padding-left: calc(18px + 0.8rem - 1px);
-		padding-top: calc(0.5rem - 1px);
 	}
 	textarea[aria-invalid="true"].d2l-input:disabled {
 		background-image: none;
+	}
+
+	@media (prefers-contrast: more) {
+		[aria-invalid="true"].d2l-input {
+			background-color: Field;
+			border-color: var(--d2l-color-cinnabar);
+			box-shadow: none;
+			color: FieldText;
+			forced-color-adjust: none;
+		}
+		.d2l-input-focus {
+			border-color: Highlight;
+		}
 	}
 `;


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-8025)

Properly applying border styles on inputs.

Before:
- Invalid:
![image](https://github.com/user-attachments/assets/ff458ee6-af4b-41bb-8835-765570c91322)
- `d2l-input-focus`:
![image](https://github.com/user-attachments/assets/c50aadb8-2f24-4727-824d-284d67177af6)

Now:
- Invalid: 
![image](https://github.com/user-attachments/assets/6acdc6f5-835e-485e-8f2c-4e5ec11d84be)
- `d2l-input-focus`:
![image](https://github.com/user-attachments/assets/0ed9beff-42d4-45d0-b95c-292f4e3af496)

Also, reverted input select styles to use `ButtonBorder` and `GrayText`(when disabled) system colors which are the expected ones.