### PR TITLE
Fix Thai font in sass file

### DIFF
--- a/components/typography/typography.scss
+++ b/components/typography/typography.scss
@@ -33,7 +33,7 @@
 	& :lang(th),
 	&:lang(tha),
 	& :lang(tha) {
-		font-family: "Hiragino Kaku Gothic Pro", "Meiyro", sans-serif;
+		font-family: "Noto Sans Thai", system-ui, Tahoma;
 	}
 
 	&:lang(zh),


### PR DESCRIPTION
[GAUD-7274](https://desire2learn.atlassian.net/browse/GAUD-7274): Support Thai fonts

In #5690 I did a copy-paste whoopsie-doodle and made Thai use the Japanese font in the sass file.



[GAUD-7274]: https://desire2learn.atlassian.net/browse/GAUD-7274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ