### PR TITLE
fix: require that menu be provided a label and menu-item be provided text

### DIFF
--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -1,6 +1,8 @@
+import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
+
 const defaultLines = 2;
 
-export const MenuItemMixin = superclass => class extends superclass {
+export const MenuItemMixin = superclass => class extends PropertyRequiredMixin(superclass) {
 
 	static get properties() {
 		return {
@@ -45,7 +47,7 @@ export const MenuItemMixin = superclass => class extends superclass {
 			 * REQUIRED: Text displayed by the menu item
 			 * @type {string}
 			 */
-			text: { type: String },
+			text: { type: String, required: true },
 			/**
 			 * ACCESSIBILITY: A description of the menu item that will be used by screen readers for additional context
 			 * @type {string}

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -3,6 +3,7 @@ import '../icons/icon.js';
 import './menu-item-return.js';
 import { css, html, LitElement } from 'lit';
 import { HierarchicalViewMixin } from '../hierarchical-view/hierarchical-view-mixin.js';
+import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { ThemeMixin } from '../../mixins/theme/theme-mixin.js';
 
 const keyCodes = {
@@ -20,7 +21,7 @@ const keyCodes = {
  * @slot - Menu items
  * @fires d2l-menu-resize - Dispatched when size of menu changes (e.g., when nested menu of a different size is opened)
  */
-class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
+class Menu extends PropertyRequiredMixin(ThemeMixin(HierarchicalViewMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -32,7 +33,7 @@ class Menu extends ThemeMixin(HierarchicalViewMixin(LitElement)) {
 			 * ACCESSIBILITY: Acts as the primary label for the menu (REQUIRED for root menu)
 			 * @type {string}
 			 */
-			label: { type: String },
+			label: { type: String, required: true },
 			/**
 			 * @ignore
 			 */

--- a/components/menu/test/menu-item-checkbox.test.js
+++ b/components/menu/test/menu-item-checkbox.test.js
@@ -14,7 +14,7 @@ describe('d2l-menu-item-checkbox', () => {
 	describe('accessibility', () => {
 
 		it('has role="menuitemcheckbox"', async() => {
-			const elem = await fixture(html`<d2l-menu-item-checkbox></d2l-menu-item-checkbox>`);
+			const elem = await fixture(html`<d2l-menu-item-checkbox text="cb"></d2l-menu-item-checkbox>`);
 			expect(elem.getAttribute('role')).to.equal('menuitemcheckbox');
 		});
 
@@ -31,13 +31,13 @@ describe('d2l-menu-item-checkbox', () => {
 	describe('events', () => {
 
 		it('should set selected=true when "d2l-menu-item-select" event occurs', async() => {
-			const elem = await fixture(html`<d2l-menu-item-checkbox></d2l-menu-item-checkbox>`);
+			const elem = await fixture(html`<d2l-menu-item-checkbox text="cb"></d2l-menu-item-checkbox>`);
 			dispatchItemSelectEvent(elem);
 			expect(elem.selected).to.be.true;
 		});
 
 		it('dispatches "d2l-menu-item-change" event when selected by calling __onSelect()', async() => {
-			const elem = await fixture(html`<d2l-menu-item-checkbox value="1"></d2l-menu-item-checkbox>`);
+			const elem = await fixture(html`<d2l-menu-item-checkbox value="1" text="cb"></d2l-menu-item-checkbox>`);
 			setTimeout(() => dispatchItemSelectEvent(elem));
 			const { detail } = await oneEvent(elem, 'd2l-menu-item-change');
 			expect(detail.value).to.equal('1');

--- a/components/menu/test/menu-item-mixin.test.js
+++ b/components/menu/test/menu-item-mixin.test.js
@@ -1,76 +1,80 @@
-import { defineCE, expect, fixture, oneEvent } from '@brightspace-ui/testing';
+import { clickElem, defineCE, expect, fixture, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
+import { createMessage } from '../../../mixins/property-required/property-required-mixin.js';
 import { LitElement } from 'lit';
 import { MenuItemMixin } from '../menu-item-mixin.js';
 
 const tag = defineCE(
-	class extends MenuItemMixin(LitElement) {}
+	class extends MenuItemMixin(LitElement) {
+		render() { return this.text; }
+	}
 );
-
-function dispatchKeyEvent(elem, key) {
-	const eventObj = document.createEvent('Events');
-	eventObj.initEvent('keydown', true, true);
-	eventObj.keyCode = key;
-	elem.dispatchEvent(eventObj);
-}
 
 describe('MenuItemMixin', () => {
 
-	let elem;
-	beforeEach(async() => {
-		elem = await fixture(`<${tag} id="my-menu-item"></${tag}>`);
-	});
-
 	describe('accessibility', () => {
-
-		it('has role="menuitem"', () => {
+		it('has role="menuitem"', async() => {
+			const elem = await fixture(`<${tag} text="my menu item"></${tag}>`);
 			expect(elem.getAttribute('role')).to.equal('menuitem');
 		});
 
 		it('adds aria-disabled to disabled menu item', async() => {
-			const disabledElem = await fixture(`<${tag} id="my-menu-item-disabled" disabled></${tag}>`);
-			expect(disabledElem.getAttribute('aria-disabled')).to.equal('true');
+			const elem = await fixture(`<${tag} text="my menu item" disabled></${tag}>`);
+			expect(elem.getAttribute('aria-disabled')).to.equal('true');
 		});
 
 		it('adds aria-label to menu items', async() => {
-			const elem = await fixture(`<${tag} id="my-menu-item" text="menu-item"></${tag}>`);
-			expect(elem.getAttribute('aria-label')).to.equal('menu-item');
+			const elem = await fixture(`<${tag} text="my menu item"></${tag}>`);
+			expect(elem.getAttribute('aria-label')).to.equal('my menu item');
 		});
 
 		it('overrides aria-label with description text', async() => {
-			const elem = await fixture(`<${tag} id="my-menu-item" text="menu-item" description="description-text"></${tag}>`);
+			const elem = await fixture(`<${tag} text="my menu item" description="description-text"></${tag}>`);
 			expect(elem.getAttribute('aria-label')).to.equal('description-text');
 		});
 	});
 
 	describe('events', () => {
-
 		it('dispatches "d2l-menu-item-select" event when item clicked', async() => {
-			setTimeout(() => elem.click());
+			const elem = await fixture(`<${tag} text="my menu item"></${tag}>`);
+			clickElem(elem);
 			const { target } = await oneEvent(elem, 'd2l-menu-item-select');
-			expect(target.id).to.equal('my-menu-item');
+			expect(target).to.equal(elem);
 		});
 
 		it('dispatches "d2l-menu-item-select" event when enter key pressed on item', async() => {
-			setTimeout(() => dispatchKeyEvent(elem, 13));
+			const elem = await fixture(`<${tag} text="my menu item"></${tag}>`);
+			sendKeysElem(elem, 'press', 'Enter');
 			const { target } = await oneEvent(elem, 'd2l-menu-item-select');
-			expect(target.id).to.equal('my-menu-item');
+			expect(target).to.equal(elem);
 		});
 
 		it('dispatches "d2l-menu-item-select" event when space key pressed on item', async() => {
-			setTimeout(() => dispatchKeyEvent(elem, 32));
+			const elem = await fixture(`<${tag} text="my menu item"></${tag}>`);
+			sendKeysElem(elem, 'press', 'Space');
 			const { target } = await oneEvent(elem, 'd2l-menu-item-select');
-			expect(target.id).to.equal('my-menu-item');
+			expect(target).to.equal(elem);
 		});
 
 		it('does not dispatch select event for disabled item', async() => {
-			elem.disabled = true;
-			await elem.updateComplete;
+			const elem = await fixture(`<${tag} text="disabled menu item" disabled></${tag}>`);
 			let dispatched = false;
 			elem.addEventListener('d2l-menu-item-select', () => dispatched = true);
-			elem.click();
+			await clickElem(elem);
 			expect(dispatched).to.be.false;
 		});
+	});
 
+	describe('validation', () => {
+		it('should throw when text is missing', async() => {
+			const elem = await fixture(`<${tag}></${tag}>`);
+			expect(() => elem.flushRequiredPropertyErrors())
+				.to.throw(TypeError, createMessage(elem, 'text'));
+		});
+
+		it('should not throw when text is provided', async() => {
+			const elem = await fixture(`<${tag} text="my menu item"></${tag}>`);
+			expect(() => elem.flushRequiredPropertyErrors()).to.not.throw();
+		});
 	});
 
 });

--- a/components/menu/test/menu-item-radio.test.js
+++ b/components/menu/test/menu-item-radio.test.js
@@ -14,7 +14,7 @@ describe('d2l-menu-item-radio', () => {
 	describe('accessibility', () => {
 
 		it('has role="menuitemradio"', async() => {
-			const elem = await fixture(html`<d2l-menu-item-radio></d2l-menu-item-radio>`);
+			const elem = await fixture(html`<d2l-menu-item-radio text="rdo"></d2l-menu-item-radio>`);
 			expect(elem.getAttribute('role')).to.equal('menuitemradio');
 		});
 
@@ -31,7 +31,7 @@ describe('d2l-menu-item-radio', () => {
 	describe('events', () => {
 
 		it('should set selected=true when "d2l-menu-item-select" event occurs', async() => {
-			const elem = await fixture(html`<d2l-menu-item-radio></d2l-menu-item-radio>`);
+			const elem = await fixture(html`<d2l-menu-item-radio text="rdo"></d2l-menu-item-radio>`);
 			dispatchItemSelectEvent(elem);
 			expect(elem.selected).to.be.true;
 		});
@@ -39,12 +39,12 @@ describe('d2l-menu-item-radio', () => {
 		it('deselects other radio options in the menu when selected', async() => {
 			const elem = await fixture(html`
 				<div>
-					<d2l-menu-item-radio id="item1" value="1" selected></d2l-menu-item-radio>
-					<d2l-menu-item-radio id="item2" value="2"></d2l-menu-item-radio>
+					<d2l-menu-item-radio text="item1" value="1" selected></d2l-menu-item-radio>
+					<d2l-menu-item-radio text="item2" value="2"></d2l-menu-item-radio>
 				</div>
 			`);
-			const item1 = elem.querySelector('#item1');
-			const item2 = elem.querySelector('#item2');
+			const item1 = elem.querySelector('[text="item1"]');
+			const item2 = elem.querySelector('[text="item2"]');
 			expect(item1.selected).to.be.true;
 			expect(item2.selected).to.be.false;
 			dispatchItemSelectEvent(item2);
@@ -53,7 +53,7 @@ describe('d2l-menu-item-radio', () => {
 		});
 
 		it('dispatches "d2l-menu-item-change" event when selected by calling __onSelect()', async() => {
-			const elem = await fixture(html`<d2l-menu-item-radio value="1"></d2l-menu-item-radio>`);
+			const elem = await fixture(html`<d2l-menu-item-radio text="rdo" value="1"></d2l-menu-item-radio>`);
 			setTimeout(() => dispatchItemSelectEvent(elem));
 			const { detail } = await oneEvent(elem, 'd2l-menu-item-change');
 			expect(detail.value).to.equal('1');

--- a/components/menu/test/menu.axe.js
+++ b/components/menu/test/menu.axe.js
@@ -7,8 +7,8 @@ describe('d2l-menu', () => {
 	it('should pass all aXe tests', async() => {
 		const elem = await fixture(html`
 			<d2l-menu label="menu label">
-				<d2l-menu-item>label 1</d2l-menu-item>
-				<d2l-menu-item>label 2</d2l-menu-item>
+				<d2l-menu-item text="label 1"></d2l-menu-item>
+				<d2l-menu-item text="label 2"></d2l-menu-item>
 			</d2l-menu>
 		`);
 		await expect(elem).to.be.accessible();

--- a/components/menu/test/menu.test.js
+++ b/components/menu/test/menu.test.js
@@ -3,6 +3,7 @@ import '../menu-item.js';
 import '../menu-item-radio.js';
 import './custom-slots.js';
 import { clickElem, defineCE, expect, fixture, focusElem, html, nextFrame, oneEvent, runConstructor, sendKeysElem, waitUntil } from '@brightspace-ui/testing';
+import { createMessage } from '../../../mixins/property-required/property-required-mixin.js';
 import { LitElement } from 'lit';
 import { MenuItemMixin } from '../menu-item-mixin.js';
 
@@ -14,8 +15,8 @@ describe('d2l-menu', () => {
 		beforeEach(async() => {
 			elem = await fixture(html`
 				<d2l-menu label="menu label">
-					<d2l-menu-item></d2l-menu-item>
-					<d2l-menu-item></d2l-menu-item>
+					<d2l-menu-item text="item 1"></d2l-menu-item>
+					<d2l-menu-item text="item 2"></d2l-menu-item>
 				</d2l-menu>
 			`);
 		});
@@ -159,14 +160,14 @@ describe('d2l-menu', () => {
 		beforeEach(async() => {
 			elem = await fixture(html`
 				<d2l-menu id="menu">
-					<d2l-menu-item id="a1"></d2l-menu-item>
+					<d2l-menu-item id="a1" text="a1"></d2l-menu-item>
 					<d2l-menu-item id="b1" text="b">
 						<d2l-menu id="nestedMenu">
-							<d2l-menu-item id="a2"></d2l-menu-item>
-							<d2l-menu-item id="b2"></d2l-menu-item>
+							<d2l-menu-item id="a2" text="a2"></d2l-menu-item>
+							<d2l-menu-item id="b2" text="b2"></d2l-menu-item>
 						</d2l-menu>
 					</d2l-menu-item>
-					<d2l-menu-item id="c1"></d2l-menu-item>
+					<d2l-menu-item id="c1" text="c1"></d2l-menu-item>
 				</d2l-menu>
 			`);
 			nestedMenu = elem.querySelector('#nestedMenu');
@@ -307,6 +308,32 @@ describe('d2l-menu', () => {
 		const items = await elem._getMenuItems();
 		expect(items.length).to.equal(2);
 
+	});
+
+	describe('validation', () => {
+		it('should throw when label is missing', async() => {
+			const elem = await fixture(html`<d2l-menu></d2l-menu>`);
+			expect(() => elem.flushRequiredPropertyErrors())
+				.to.throw(TypeError, createMessage(elem, 'label'));
+		});
+
+		it('should not throw when label is provided', async() => {
+			const elem = await fixture(html`<d2l-menu label="options"></d2l-menu>`);
+			expect(() => elem.flushRequiredPropertyErrors()).to.not.throw();
+		});
+
+		it('should not throw when label is provided as a nested menu', async() => {
+			const elem = await fixture(html`
+				<d2l-menu label="options">
+					<d2l-menu-item text="option 1">
+						<d2l-menu>
+							<d2l-menu-item text="option 1A"></d2l-menu-item>
+						</d2l-menu>
+					</d2l-menu-item>
+				</d2l-menu>
+			`);
+			expect(() => elem.flushRequiredPropertyErrors()).to.not.throw();
+		});
 	});
 
 });


### PR DESCRIPTION
GAUD-8044

This throws errors if `<d2l-menu>` isn't provided a `label`, although nested menus get their label automatically from the parent `<d2l-menu-item>` so they are exempt. Similarly, `<d2l-menu-item>` now requires that `text` be set.