### PR TITLE
feat: tab: only allow one element of specific elems per slot

### DIFF
--- a/components/tabs/README.md
+++ b/components/tabs/README.md
@@ -129,8 +129,8 @@ An element that displays the corresponding tab panel when selected.
 
 | Slot | Description |
 |--|--|
-| `before` | Slot for content to be displayed before the tab text |
-| `after` | Slot for content to be displayed after the tab text |
+| `before` | Slot for content to be displayed before the tab text. Supports `d2l-icon`, `d2l-icon-custom`, and `d2l-count-badge`. Only the *first* item assigned to this slot will be shown. |
+| `after` | Slot for content to be displayed after the tab text. Supports `d2l-icon`, `d2l-icon-custom`, and `d2l-count-badge`. Only the *first* item assigned to this slot will be shown. |
 
 ### Events
 - `d2l-tab-content-change`: Dispatched when the text attribute is changed. Triggers virtual scrolling calculations in parent `d2l-tabs`.

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -3,11 +3,26 @@ import { classMap } from 'lit/directives/class-map.js';
 import { getFocusPseudoClass } from '../../helpers/focus.js';
 import { TabMixin } from './tab-mixin.js';
 
+function handleSlotChange(e) {
+	const slot = e.target;
+	if (!slot || !slot.assignedElements || slot.assignedElements().length === 0) return;
+	const elems = slot.assignedElements({ flatten: true }).filter((node) => (getComputedStyle(node).display !== 'none' || node.hasAttribute('data-hide')));
+	if (!elems) return;
+
+	for (let i = 0; i < elems.length; i++) {
+		if (i === 0) {
+			elems[i].removeAttribute('data-hide');
+		} else {
+			elems[i].setAttribute('data-hide', 'data-hide');
+		}
+	}
+}
+
 /**
  * @attr {string} id - REQUIRED: Unique identifier for the tab
  * @fires d2l-tab-content-change - Dispatched when the text attribute is changed. Triggers virtual scrolling calculations in parent d2l-tabs.
- * @slot before - Slot for content to be displayed before the tab text
- * @slot after - Slot for content to be displayed after the tab text
+ * @slot before - Slot for content to be displayed before the tab text. Supports `d2l-icon`, `d2l-icon-custom`, and `d2l-count-badge`. Only the *first* item assigned to this slot will be shown.
+ * @slot after - Slot for content to be displayed after the tab text. Supports `d2l-icon`, `d2l-icon-custom`, and `d2l-count-badge`. Only the *first* item assigned to this slot will be shown.
  */
 class Tab extends TabMixin(LitElement) {
 
@@ -59,6 +74,13 @@ class Tab extends TabMixin(LitElement) {
 			:host([skeleton]) .d2l-tab-content.d2l-skeletize::before {
 				inset-block: 0.15rem;
 			}
+			::slotted([slot="before"]:not(d2l-icon):not(d2l-count-badge):not(d2l-icon-custom)),
+			::slotted([slot="after"]:not(d2l-icon):not(d2l-count-badge):not(d2l-icon-custom)) {
+				display: none;
+			}
+			::slotted([data-hide]) {
+				display: none;
+			}
 		`];
 
 		super.styles && styles.unshift(super.styles);
@@ -82,9 +104,9 @@ class Tab extends TabMixin(LitElement) {
 
 		return html`
 			<div class="d2l-tab-text-inner-content">
-				<slot name="before"></slot>
+				<slot name="before" @slotchange="${handleSlotChange}"></slot>
 				<span class="${classMap(contentClasses)}">${overrideSkeletonText ? html`&nbsp;` : this.text}</span>
-				<slot name="after"></slot>
+				<slot name="after" @slotchange="${handleSlotChange}"></slot>
 			</div>
 		`;
 	}

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -213,4 +213,97 @@ describe('d2l-tabs', () => {
 			consoleSpy.restore();
 		});
 	});
+
+	describe('handleSlotChange', () => {
+		it('should set data-hide as expected when simple', async() => {
+			const elem = await fixture(html`
+				<d2l-tab id="all" text="All" slot="tabs">
+					<d2l-icon icon="tier1:checkmark" slot="before"></d2l-icon>
+					<d2l-count-badge icon="tier1:checkmark" slot="after"></d2l-count-badge>
+				</d2l-tab>
+			`);
+			expect(elem.querySelector('d2l-icon').hasAttribute('data-hide')).to.be.false;
+			expect(elem.querySelector('d2l-count-badge').hasAttribute('data-hide')).to.be.false;
+		});
+
+		it('should set data-hide as expected when out of order', async() => {
+			const elem = await fixture(html`
+				<d2l-tab id="all" text="All" slot="tabs">
+					<d2l-count-badge icon="tier1:checkmark" slot="after"></d2l-count-badge>
+					<d2l-icon-custom icon="tier1:checkmark" slot="before"></d2l-icon-custom>
+				</d2l-tab>
+			`);
+			expect(elem.querySelector('d2l-count-badge').hasAttribute('data-hide')).to.be.false;
+			expect(elem.querySelector('d2l-icon-custom').hasAttribute('data-hide')).to.be.false;
+		});
+
+		it('should set data-hide as expected when multiple', async() => {
+			const elem = await fixture(html`
+				<d2l-tab id="all" text="All" slot="tabs">
+					<d2l-icon id="item1" icon="tier1:checkmark" slot="before"></d2l-icon>
+					<d2l-count-badge id="item2" icon="tier1:checkmark" slot="before"></d2l-count-badge>
+					<d2l-icon id="item3" icon="tier1:checkmark" slot="after"></d2l-icon>
+					<d2l-count-badge id="item4" icon="tier1:checkmark" slot="after"></d2l-count-badge>
+				</d2l-tab>
+			`);
+			expect(elem.querySelector('#item1').hasAttribute('data-hide')).to.be.false;
+			expect(elem.querySelector('#item2').hasAttribute('data-hide')).to.be.true;
+			expect(elem.querySelector('#item3').hasAttribute('data-hide')).to.be.false;
+			expect(elem.querySelector('#item4').hasAttribute('data-hide')).to.be.true;
+		});
+
+		it('should remove data-hide when needed', async() => {
+			const elem = await fixture(html`
+				<d2l-tab id="all" text="All" slot="tabs">
+					<d2l-icon id="item1" icon="tier1:checkmark" slot="before"></d2l-icon>
+					<d2l-count-badge id="item2" icon="tier1:checkmark" slot="before"></d2l-count-badge>
+					<d2l-icon id="item3" icon="tier1:checkmark" slot="after"></d2l-icon>
+					<d2l-count-badge id="item4" icon="tier1:checkmark" slot="after"></d2l-count-badge>
+				</d2l-tab>
+			`);
+			const afterVisible = elem.querySelector('#item3');
+			afterVisible.remove();
+			await elem.updateComplete;
+			expect(elem.querySelector('#item1').hasAttribute('data-hide')).to.be.false;
+			expect(elem.querySelector('#item2').hasAttribute('data-hide')).to.be.true;
+			expect(elem.querySelector('#item4').hasAttribute('data-hide')).to.be.false;
+		});
+
+		it('should add data-hide when needed', async() => {
+			const elem = await fixture(html`
+				<d2l-tab id="all" text="All" slot="tabs">
+					<d2l-icon id="item1" icon="tier1:checkmark" slot="before"></d2l-icon>
+					<d2l-count-badge id="item2" icon="tier1:checkmark" slot="before"></d2l-count-badge>
+					<d2l-icon id="item3" icon="tier1:checkmark" slot="after"></d2l-icon>
+					<d2l-count-badge id="item4" icon="tier1:checkmark" slot="after"></d2l-count-badge>
+				</d2l-tab>
+			`);
+			const newElem = document.createElement('d2l-icon');
+			newElem.id = 'item5';
+			newElem.slot = 'after';
+			elem.insertBefore(newElem, elem.querySelector('#item3'));
+			await elem.updateComplete;
+			expect(elem.querySelector('#item1').hasAttribute('data-hide')).to.be.false;
+			expect(elem.querySelector('#item2').hasAttribute('data-hide')).to.be.true;
+			expect(elem.querySelector('#item3').hasAttribute('data-hide')).to.be.true;
+			expect(elem.querySelector('#item4').hasAttribute('data-hide')).to.be.true;
+			expect(elem.querySelector('#item5').hasAttribute('data-hide')).to.be.false;
+		});
+
+		it('should not add data-hide to non-applicable elems', async() => {
+			const elem = await fixture(html`
+				<d2l-tab id="all" text="All" slot="tabs">
+					<d2l-button-subtle icon="tier1:checkmark" slot="before"></d2l-button-subtle>
+					<d2l-icon-custom icon="tier1:checkmark" slot="before"></d2l-icon-custom>
+					<d2l-icon icon="tier1:checkmark" slot="before"></d2l-icon>
+					<d2l-count-badge icon="tier1:checkmark" slot="after"></d2l-count-badge>
+				</d2l-tab>
+			`);
+			expect(elem.querySelector('d2l-button-subtle').hasAttribute('data-hide')).to.be.false;
+			expect(getComputedStyle(elem.querySelector('d2l-button-subtle')).display).to.equal('none');
+			expect(elem.querySelector('d2l-icon-custom').hasAttribute('data-hide')).to.be.false;
+			expect(elem.querySelector('d2l-icon').hasAttribute('data-hide')).to.be.true;
+			expect(elem.querySelector('d2l-count-badge').hasAttribute('data-hide')).to.be.false;
+		});
+	});
 });

--- a/components/tabs/test/tabs.vdiff.js
+++ b/components/tabs/test/tabs.vdiff.js
@@ -469,6 +469,41 @@ describe('d2l-tabs', () => {
 				<d2l-tab-panel labelled-by="beforeafter" slot="panels">Tab content for Trig</d2l-tab-panel>
 			</d2l-tabs>
 		`;
+
+		const slotsMultipleFixture = html`
+			<d2l-tabs>
+				<d2l-tab id="beforeMultiple" text="Tab Text 1" slot="tabs">
+					<d2l-icon icon="tier1:gear" slot="before"></d2l-icon>
+					<d2l-icon icon="tier1:alert" slot="before"></d2l-icon>
+				</d2l-tab>
+				<d2l-tab id="afterMultiple" text="Tab Text 2" slot="tabs">
+					<d2l-icon icon="tier1:gear" slot="after"></d2l-icon>
+					<d2l-icon icon="tier1:alert" slot="after"></d2l-icon>
+				</d2l-tab>
+				<d2l-tab id="bothMultiple" text="Tab Text 3" slot="tabs">
+					<d2l-icon icon="tier1:gear" slot="before"></d2l-icon>
+					<d2l-icon icon="tier1:alert" slot="before"></d2l-icon>
+					<d2l-icon icon="tier1:gear" slot="after"></d2l-icon>
+					<d2l-icon icon="tier1:alert" slot="after"></d2l-icon>
+				</d2l-tab>
+				<d2l-tab id="wrongOrderMultiple" text="Tab Text 4" slot="tabs">
+					<d2l-icon icon="tier1:gear" slot="after"></d2l-icon>
+					<d2l-icon icon="tier1:alert" slot="after"></d2l-icon>
+					<d2l-icon icon="tier1:gear" slot="before"></d2l-icon>
+					<d2l-icon icon="tier1:alert" slot="before"></d2l-icon>
+				</d2l-tab>
+				<d2l-tab id="incorrectContent" text="Tab Text 5" slot="tabs">
+					<d2l-button slot="before">Button Text</d2l-button>
+					<d2l-button slot="after">Button Text 2</d2l-button>
+				</d2l-tab>
+				<d2l-tab-panel labelled-by="beforeMultiple" slot="panels">Tab content for Tab</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="afterMultiple" slot="panels">Tab content for Tab</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="bothMultiple" slot="panels">Tab content for Tab</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="wrongOrderMultiple" slot="panels">Tab content for Tab</d2l-tab-panel>
+				<d2l-tab-panel labelled-by="incorrectContent" slot="panels">Tab content for Tab</d2l-tab-panel>
+			</d2l-tabs>
+		`;
+
 		const slotsSkeletonFixture = html`
 			<d2l-tabs skeleton>
 				<d2l-tab id="beforelong" text="Long Panel Text That Will Also Have Slot Content" slot="tabs" skeleton>
@@ -548,6 +583,11 @@ describe('d2l-tabs', () => {
 
 		it('skeleton no text', async() => {
 			const elem = await fixture(slotsSkeletonNoTextFixture);
+			await expect(elem).to.be.golden();
+		});
+
+		it('handles multiples correctly', async() => {
+			const elem = await fixture(slotsMultipleFixture);
 			await expect(elem).to.be.golden();
 		});
 	});


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7856)

This does the following to the `before` and `after` slots in the `d2l-tab` component:
- only allow `d2l-icon`, `d2l-icon-custom` or `d2l-count-badge` within them
- only one item per slot

Another option instead of the slotchange listener would be to have the following in the css:
```
::slotted([slot="before"]:not(:first-child)),
::slotted([slot="after"]:not(:last-child)) {
                display: none;
}
```
This would require that the before slot content comes before the after slot content and also that there isn't invalid content in the before slot first, but it would simplify the code. Let me know thoughts on this.