### PR TITLE
fix: update select styles to not require RtlMixin

### DIFF
--- a/components/inputs/demo/input-select-test.js
+++ b/components/inputs/demo/input-select-test.js
@@ -1,9 +1,8 @@
 import { css, html, LitElement } from 'lit';
-import { RtlMixin } from '../../../mixins/rtl/rtl-mixin.js';
 import { selectStyles } from '../input-select-styles.js';
 import { SkeletonMixin } from '../../../components/skeleton/skeleton-mixin.js';
 
-class TestInputSelect extends SkeletonMixin(RtlMixin(LitElement)) {
+class TestInputSelect extends SkeletonMixin(LitElement) {
 
 	static get properties() {
 		return {

--- a/components/inputs/input-select-styles.js
+++ b/components/inputs/input-select-styles.js
@@ -18,7 +18,7 @@ export const selectStyles = css`
 		background-color: #ffffff;
 		background-image: ${chevron};
 		background-origin: border-box;
-		background-position: center var(--d2l-mirror-end, right) 17px;
+		background-position: center var(--d2l-inline-end, right) 17px;
 		background-repeat: no-repeat;
 		background-size: 11px 7px;
 		border: none;
@@ -49,7 +49,7 @@ export const selectStyles = css`
 	}
 	.d2l-input-select[aria-invalid="true"] {
 		background-image: ${chevron}, ${invalidIcon};
-		background-position: center var(--d2l-mirror-end, right) 17px, center var(--d2l-mirror-end, right) calc(1px + 11px + 17px);
+		background-position: center var(--d2l-inline-end, right) 17px, center var(--d2l-inline-end, right) calc(1px + 11px + 17px);
 		background-repeat: no-repeat, no-repeat;
 		background-size: 11px 7px, 0.8rem 0.8rem;
 	}
@@ -89,7 +89,7 @@ export const selectStyles = css`
 
 		.d2l-input-select[aria-invalid="true"] {
 			background-image: ${invalidIcon};
-			background-position: center var(--d2l-mirror-end, right) calc(1px + 11px + 17px);
+			background-position: center var(--d2l-inline-end, right) calc(1px + 11px + 17px);
 			background-repeat: no-repeat;
 			background-size: 0.8rem 0.8rem;
 		}

--- a/components/inputs/input-select-styles.js
+++ b/components/inputs/input-select-styles.js
@@ -18,7 +18,7 @@ export const selectStyles = css`
 		background-color: #ffffff;
 		background-image: ${chevron};
 		background-origin: border-box;
-		background-position: center right 17px;
+		background-position: center var(--d2l-mirror-end, right) 17px;
 		background-repeat: no-repeat;
 		background-size: 11px 7px;
 		border: none;
@@ -40,9 +40,6 @@ export const selectStyles = css`
 		padding-inline: calc(0.75rem + 1px) calc(2px + 0.8rem + 1px + 11px + 16px + 1px);
 		vertical-align: middle;
 	}
-	:host([dir="rtl"]) .d2l-input-select {
-		background-position: center left 17px;
-	}
 
 	.d2l-input-select:not([disabled]):hover,
 	.d2l-input-select:not([disabled]):${focusClass} {
@@ -52,7 +49,7 @@ export const selectStyles = css`
 	}
 	.d2l-input-select[aria-invalid="true"] {
 		background-image: ${chevron}, ${invalidIcon};
-		background-position: center right 17px, center right calc(1px + 11px + 17px);
+		background-position: center var(--d2l-mirror-end, right) 17px, center var(--d2l-mirror-end, right) calc(1px + 11px + 17px);
 		background-repeat: no-repeat, no-repeat;
 		background-size: 11px 7px, 0.8rem 0.8rem;
 	}
@@ -60,9 +57,6 @@ export const selectStyles = css`
 	.d2l-input-select[aria-invalid="true"]:${focusClass},
 	.d2l-input-select[aria-invalid="true"]:hover {
 		outline-color: var(--d2l-color-cinnabar);
-	}
-	:host([dir="rtl"]) .d2l-input-select[aria-invalid="true"] {
-		background-position: center left 17px, center left calc(1px + 11px + 17px);
 	}
 	.d2l-input-select:disabled {
 		opacity: 0.5;
@@ -95,7 +89,7 @@ export const selectStyles = css`
 
 		.d2l-input-select[aria-invalid="true"] {
 			background-image: ${invalidIcon};
-			background-position: center right calc(1px + 11px + 17px);
+			background-position: center var(--d2l-mirror-end, right) calc(1px + 11px + 17px);
 			background-repeat: no-repeat;
 			background-size: 0.8rem 0.8rem;
 		}
@@ -104,9 +98,6 @@ export const selectStyles = css`
 		.d2l-input-select[aria-invalid="true"]:${focusClass},
 		.d2l-input-select[aria-invalid="true"]:hover {
 			outline-color: var(--d2l-color-cinnabar);
-		}
-		:host([dir="rtl"]) .d2l-input-select[aria-invalid="true"] {
-			background-position: center left calc(1px + 11px + 17px);
 		}
 	}
 `;

--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -506,10 +506,12 @@ export const baseTypographyStyles = css`
 	html {
 		--d2l-document-direction: ltr;
 		--d2l-mirror-transform: none;
+		--d2l-mirror-end: right;
 	}
 	html[dir="rtl"] {
 		--d2l-document-direction: rtl;
 		--d2l-mirror-transform: scale(-1, 1);
+		--d2l-mirror-end: left;
 	}
 
 	.d2l-typography {

--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -506,12 +506,12 @@ export const baseTypographyStyles = css`
 	html {
 		--d2l-document-direction: ltr;
 		--d2l-mirror-transform: none;
-		--d2l-mirror-end: right;
+		--d2l-inline-end: right;
 	}
 	html[dir="rtl"] {
 		--d2l-document-direction: rtl;
 		--d2l-mirror-transform: scale(-1, 1);
-		--d2l-mirror-end: left;
+		--d2l-inline-end: left;
 	}
 
 	.d2l-typography {


### PR DESCRIPTION
GAUD-8056

With the [recent WHCM fixes](https://github.com/BrightspaceUI/core/pull/5653) to `<select>`s , we updated the padding to use CSS logical properties while the background image for the chevron needed to continue to rely on `:host([dir="rtl"])` styles.

That meant that components using `selectStyles` needed to extend `RtlMixin`. This was always true, but by doing things both ways, any places not extending `RtlMixin` would now have the chevron positioned in the wrong spot but the padding in the correct spot.

Requiring consumers to extend `RtlMixin` was always less than ideal, and our docs don't even mention it. So this takes a different approach by leveraging a CSS variable set in our typography styles -- similar to what we've done for other things.

~This will initially fail vdiffs since they don't use our typography styles unfortunately, but instead have a copy. If we're good with this approach, I'll update the testing library accordingly.~