### PR TITLE
fix: sort buttons should set menu label

### DIFF
--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -262,7 +262,11 @@ class Menu extends PropertyRequiredMixin(ThemeMixin(HierarchicalViewMixin(LitEle
 	}
 
 	_labelChanged() {
-		this.setAttribute('aria-label', this.label);
+		if (typeof this.label === 'string' && this.label.trim().length > 0) {
+			this.setAttribute('aria-label', this.label);
+		} else {
+			this.removeAttribute('aria-label');
+		}
 		const returnItem = this._getMenuItemReturn();
 		if (returnItem) returnItem.setAttribute('text', this.label);
 	}

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -54,7 +54,8 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 				type: String
 			},
 			_hasDropdownItems: { state: true },
-			_selectedMenuItemText: { state: true }
+			_selectedMenuItemText: { state: true },
+			_label: { state: true },
 		};
 	}
 
@@ -142,6 +143,7 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 		this._describedById = getUniqueId();
 		this._describedBySortedId = getUniqueId();
 		this._hasDropdownItems = false;
+		this._label = '';
 	}
 
 	static get focusElementSelector() {
@@ -181,13 +183,13 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 				class="${classMap({ 'd2l-dropdown-opener': this._hasDropdownItems })}"
 				title="${ifDefined(buttonTitle)}"
 				type="button">
-				<slot></slot>${iconView}
+				<slot @slotchange="${this.#handleDefaultSlotChange}"></slot>${iconView}
 			</button><span id="${this._describedById}" hidden>${buttonDescription}</span>${sortedView}`;
 		if (this._hasDropdownItems) {
 			return html`<d2l-dropdown>
 					${button}
 					<d2l-dropdown-menu no-pointer align="start" vertical-offset="4">
-						<d2l-menu @d2l-table-col-sort-button-item-change="${this._handleTablColSortButtonItemChange}">
+						<d2l-menu label="${ifDefined(this._label)}" @d2l-table-col-sort-button-item-change="${this._handleTablColSortButtonItemChange}">
 							<slot name="items" @slotchange="${this._handleSlotChange}"></slot>
 						</d2l-menu>
 					</d2l-dropdown-menu>
@@ -217,6 +219,16 @@ export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElemen
 
 	_handleTablColSortButtonItemChange(e) {
 		this._selectedMenuItemText = e.target?.text;
+	}
+
+	#handleDefaultSlotChange(e) {
+		const labels = e.target?.assignedNodes({ flatten: false })
+			.map(node => {
+				if (node.nodeType === Node.TEXT_NODE) return node.textContent;
+				if (node.nodeType === Node.ELEMENT_NODE) return node.innerText;
+			}).filter(text => typeof(text) === 'string' && text.trim().length > 0)
+			.map(text => text.replace(/[\t\n\r]+/g, ' ').trim());
+		this._label = labels.join(' ');
 	}
 
 }

--- a/components/table/test/table-col-sort-button.axe.js
+++ b/components/table/test/table-col-sort-button.axe.js
@@ -1,0 +1,41 @@
+import '../table-col-sort-button.js';
+import '../table-col-sort-button-item.js';
+import { expect, fixture, html } from '@brightspace-ui/testing';
+
+describe('d2l-table-col-sort-button', () => {
+
+	it('single-facet', async() => {
+		const elem = await fixture(html`
+			<d2l-table-col-sort-button>Field Name</d2l-table-col-sort-button>
+		`);
+		await expect(elem).to.be.accessible();
+	});
+
+	it('multi-faceted', async() => {
+		const elem = await fixture(html`
+			<d2l-table-col-sort-button>
+				Items
+				<d2l-table-col-sort-button-item slot="items" text="Item, ascending"></d2l-table-col-sort-button-item>
+				<d2l-table-col-sort-button-item slot="items" text="Item, descending"></d2l-table-col-sort-button-item>
+			</d2l-table-col-sort-button>
+		`);
+		await expect(elem).to.be.accessible();
+	});
+
+	it('should assign default slot text content to menu label', async() => {
+		const elem = await fixture(html`
+			<d2l-table-col-sort-button>
+				Part 1
+				<div>
+					Part 2
+					<span>Part 3</span>
+					Part 4
+				</div>Part 5
+				<d2l-table-col-sort-button-item slot="items" text="Item, ascending"></d2l-table-col-sort-button-item>
+				<d2l-table-col-sort-button-item slot="items" text="Item, descending"></d2l-table-col-sort-button-item>
+			</d2l-table-col-sort-button>
+		`);
+		expect(elem.shadowRoot.querySelector('d2l-menu').getAttribute('label')).to.equal('Part 1 Part 2 Part 3 Part 4 Part 5');
+	});
+
+});


### PR DESCRIPTION
GAUD-8044

After the new requirement for `<d2l-menu>` to have a `label` was added yesterday, it was noticed (most prominently in Classlist) that the multi-faceted sort buttons aren't setting it.

This one was a little more complicated than it could have been since the "label" for the button is defined in its slot, so getting a reasonable text value for that was a bit of work. IMO I think this makes a good argument for not relying on slots for labels like this in the future, although maybe there was a reason for it here.