### PR TITLE
fix: don't stack hidden description lists

### DIFF
--- a/components/description-list/description-list-wrapper.js
+++ b/components/description-list/description-list-wrapper.js
@@ -19,6 +19,9 @@ export const descriptionListStyles = [
 			grid-auto-flow: row;
 			grid-template-columns: minmax(var(--d2l-dl-wrapper-dt-min-width), auto) minmax(var(--d2l-dl-wrapper-dd-min-width), 1fr);
 		}
+		d2l-dl-wrapper > dl[hidden] {
+			display: none;
+		}
 		d2l-dl-wrapper > dl > dt {
 			margin: var(--d2l-dl-wrapper-dt-margin, 0);
 			max-width: var(--d2l-dl-wrapper-dt-max-width);
@@ -107,6 +110,7 @@ class DescriptionListWrapper extends LitElement {
 	_onResize(entries) {
 		if (!entries || entries.length === 0) return;
 		const entry = entries[0];
+		if (entry.contentRect.width === 0) return; // ignore if we're hidden
 
 		requestAnimationFrame(() => this._stacked = entry.contentRect.width < this.breakpoint);
 	}

--- a/components/description-list/test/description-list.test.js
+++ b/components/description-list/test/description-list.test.js
@@ -1,6 +1,6 @@
 import '../description-list-wrapper.js';
 
-import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
+import { expect, fixture, html, nextFrame, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-dl-wrapper', () => {
 
@@ -36,6 +36,19 @@ describe('d2l-dl-wrapper', () => {
 
 			expect(elem.breakpoint).to.equal(300);
 		});
+	});
+
+	it('should not stack if initially hidden', async() => {
+		const elem = await fixture(html`
+			<d2l-dl-wrapper hidden>
+				<dl>
+					<dt>Title</dt>
+					<dd>Details</dd>
+				</dl>
+			</d2l-dl-wrapper>
+		`);
+		await nextFrame();
+		expect(elem._stacked).to.be.false;
 	});
 
 });


### PR DESCRIPTION
[GAUD-7918](https://desire2learn.atlassian.net/browse/GAUD-7918)

The issue here is that description lists that are hidden (which in this case is because they're in a closed dialog) try to calculate their width to determine if they should stack, but because they're hidden they have a width of `0` and stack. Then when the dialog opens and they get displayed, they re-calculate and decide that they don't need to be stacked, causing jitter.

The fix here is to just not automatically stack when hidden.

[GAUD-7918]: https://desire2learn.atlassian.net/browse/GAUD-7918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ