### PR TITLE
feat: `d2l-object-property-list-item-tooltip-help`

### DIFF
--- a/components/object-property-list/demo/object-property-list.html
+++ b/components/object-property-list/demo/object-property-list.html
@@ -10,6 +10,8 @@
 			import '../object-property-list.js';
 			import '../object-property-list-item.js';
 			import '../object-property-list-item-link.js';
+			import '../object-property-list-item-tooltip-help.js';
+			import '../../icons/icon-custom.js';
 			import '../../status-indicator/status-indicator.js';
 		</script>
 	</head>
@@ -37,6 +39,17 @@
 						<d2l-object-property-list-item-link text="Example link" href="https://www.d2l.com/"></d2l-object-property-list-item-link>
 						<d2l-object-property-list-item-link target="_blank" text="Example new tab link" href="https://www.d2l.com/"></d2l-object-property-list-item-link>
 						<d2l-object-property-list-item-link text="Example link with icon" href="https://www.d2l.com/" icon="tier1:alert"></d2l-object-property-list-item-link>
+						<d2l-object-property-list-item-tooltip-help text="Example tooltip">This are extra details</d2l-object-property-list-item-tooltip-help>
+						<d2l-object-property-list-item-tooltip-help text="Example tooltip with icon" icon="tier1:alert">This are extra details</d2l-object-property-list-item-tooltip-help>
+						<d2l-object-property-list-item-tooltip-help text="Example tooltip with custom icon">
+							This are extra details
+							<d2l-icon-custom slot="icon">
+								<svg xmlns="http://www.w3.org/2000/svg" mirror-in-rtl="true">
+									 <path fill="#494c4e" d="M18 12v5a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-5a1 1 0 0 1 2 0v4h14v-4a1 1 0 0 1 2 0z"/>
+									 <path fill="#494c4e" d="M13.85 3.15l-2.99-3A.507.507 0 0 0 10.5 0H5.4A1.417 1.417 0 0 0 4 1.43v11.14A1.417 1.417 0 0 0 5.4 14h7.2a1.417 1.417 0 0 0 1.4-1.43V3.5a.47.47 0 0 0-.15-.35zM7 2h1a1 1 0 0 1 0 2H7a1 1 0 0 1 0-2zm4 10H7a1 1 0 0 1 0-2h4a1 1 0 0 1 0 2zm0-4H7a1 1 0 0 1 0-2h4a1 1 0 0 1 0 2z"/>
+								 </svg>
+							</d2l-icon-custom>
+						</d2l-object-property-list-item-tooltip-help>
 					</d2l-object-property-list>
 				</template>
 			</d2l-demo-snippet>

--- a/components/object-property-list/object-property-list-item-tooltip-help.js
+++ b/components/object-property-list/object-property-list-item-tooltip-help.js
@@ -1,0 +1,53 @@
+import '../tooltip/tooltip-help.js';
+import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { ObjectPropertyListItem } from './object-property-list-item.js';
+
+/**
+ * A single object property, to be used within an object-property-list,
+ * rendered as a help tooltip and with an optional icon.
+ * @slot - Default content placed inside of the tooltip
+ */
+class ObjectPropertyListItemTooltipHelp extends FocusMixin(ObjectPropertyListItem) {
+	static get properties() {
+		return {
+			/**
+			 * Preset icon key (e.g. "tier1:gear")
+			 * @type {string}
+			 */
+			icon: { type: String, reflect: true, },
+			/**
+			 * Allows this component to inherit certain font properties
+			 * @type {boolean}
+			 */
+			inheritFontStyle: { type: Boolean, attribute: 'inherit-font-style' },
+			/**
+			 * ADVANCED: Force the internal tooltip to open in a certain direction. If no position is provided, the tooltip will open in the first position that has enough space for it in the order: bottom, top, right, left.
+			 * @type {'top'|'bottom'|'left'|'right'}
+			 */
+			position: { type: String }
+		};
+	}
+
+	static get focusElementSelector() {
+		return 'd2l-tooltip-help';
+	}
+
+	_renderText() {
+		return html`
+			<d2l-tooltip-help
+				class="d2l-skeletize"
+				icon="${ifDefined(this.icon)}"
+				?inherit-font-style=${this.inheritFontStyle}
+				postion="${this.position}"
+				?skeleton=${this.skeleton}
+				text="${this.text}">
+				<slot></slot>
+				<slot slot="icon" name="icon"></slot>
+			</d2l-tooltip-help>
+		`;
+	}
+}
+
+customElements.define('d2l-object-property-list-item-tooltip-help', ObjectPropertyListItemTooltipHelp);

--- a/components/object-property-list/test/object-property-list.test.js
+++ b/components/object-property-list/test/object-property-list.test.js
@@ -1,11 +1,12 @@
 import '../object-property-list.js';
 import '../object-property-list-item.js';
+import '../object-property-list-item-tooltip-help.js';
 import '../object-property-list-item-link.js';
 import '../../status-indicator/status-indicator.js';
 import { aTimeout, expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 const validateSeparators = (elem, count) => {
-	const items = elem.querySelectorAll('d2l-object-property-list-item:not([hidden]), d2l-object-property-list-item-link:not([hidden])');
+	const items = elem.querySelectorAll('d2l-object-property-list-item:not([hidden]), d2l-object-property-list-item-link:not([hidden]), d2l-object-property-list-item-tooltip-help:not([hidden])');
 	expect(items.length).to.equal(count);
 	items.forEach((item, i) => {
 		const shouldHaveSeparator = i !== items.length - 1;
@@ -82,16 +83,20 @@ describe('d2l-object-property-list', () => {
 					<d2l-status-indicator slot="status" state="default" text="Status"></d2l-status-indicator>
 					<d2l-object-property-list-item text="Example item 1"></d2l-object-property-list-item>
 					<d2l-object-property-list-item text="Example item 2"></d2l-object-property-list-item>
-					<d2l-object-property-list-item text="Example item 3" hidden id="hidden"></d2l-object-property-list-item>
+					<d2l-object-property-list-item text="Example item 3" hidden></d2l-object-property-list-item>
+					<d2l-object-property-list-item-tooltip-help text="Example item 3" hidden></d2l-object-property-list-item>
 				</d2l-object-property-list>
 			`);
 			validateSeparators(elem, 2);
+			const hiddenElems = [...elem.querySelectorAll('[hidden]')];
+			for (const hiddenElem of hiddenElems)
+				hiddenElem.removeAttribute('hidden');
 
-			elem.querySelector('#hidden').removeAttribute('hidden');
 			await elem.updateComplete;
-			validateSeparators(elem, 3);
+			validateSeparators(elem, 4);
 
-			elem.querySelector('#hidden').setAttribute('hidden', '');
+			for (const hiddenElem of hiddenElems)
+				hiddenElem.setAttribute('hidden', '');
 			await elem.updateComplete;
 			validateSeparators(elem, 2);
 		});

--- a/components/object-property-list/test/object-property-list.vdiff.js
+++ b/components/object-property-list/test/object-property-list.vdiff.js
@@ -2,6 +2,8 @@ import '../../status-indicator/status-indicator.js';
 import '../object-property-list.js';
 import '../object-property-list-item.js';
 import '../object-property-list-item-link.js';
+import '../object-property-list-item-tooltip-help.js';
+import '../../icons/icon-custom.js';
 import { expect, fixture, focusElem, html } from '@brightspace-ui/testing';
 import { nothing } from 'lit';
 
@@ -14,6 +16,17 @@ function createObjectPropertyList(opts) {
 			<d2l-object-property-list-item text="Example item with icon" icon="tier1:grade" ?skeleton="${skeleton}"></d2l-object-property-list-item>
 			<d2l-object-property-list-item-link text="Example link" href="https://www.d2l.com/" ?skeleton="${skeleton}"></d2l-object-property-list-item-link>
 			<d2l-object-property-list-item-link text="Example link with icon" href="https://www.d2l.com/" icon="tier1:alert" ?skeleton="${skeleton}"></d2l-object-property-list-item-link>
+			<d2l-object-property-list-item-tooltip-help text="Example tooltip" ?skeleton="${skeleton}">This are extra details</d2l-object-property-list-item-tooltip-help>
+			<d2l-object-property-list-item-tooltip-help text="Example tooltip with icon" icon="tier1:alert" ?skeleton="${skeleton}">This are extra details</d2l-object-property-list-item-tooltip-help>
+			<d2l-object-property-list-item-tooltip-help text="Example tooltip with custom icon" ?skeleton="${skeleton}">
+				This are extra details
+				<d2l-icon-custom slot="icon">
+					<svg xmlns="http://www.w3.org/2000/svg" mirror-in-rtl="true">
+							<path fill="#494c4e" d="M18 12v5a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-5a1 1 0 0 1 2 0v4h14v-4a1 1 0 0 1 2 0z"/>
+							<path fill="#494c4e" d="M13.85 3.15l-2.99-3A.507.507 0 0 0 10.5 0H5.4A1.417 1.417 0 0 0 4 1.43v11.14A1.417 1.417 0 0 0 5.4 14h7.2a1.417 1.417 0 0 0 1.4-1.43V3.5a.47.47 0 0 0-.15-.35zM7 2h1a1 1 0 0 1 0 2H7a1 1 0 0 1 0-2zm4 10H7a1 1 0 0 1 0-2h4a1 1 0 0 1 0 2zm0-4H7a1 1 0 0 1 0-2h4a1 1 0 0 1 0 2z"/>
+						</svg>
+				</d2l-icon-custom>
+			</d2l-object-property-list-item-tooltip-help>
 		</d2l-object-property-list>
 	`;
 }

--- a/components/tooltip/tooltip-help.js
+++ b/components/tooltip/tooltip-help.js
@@ -89,6 +89,9 @@ class TooltipHelp extends SlottedIconMixin(SkeletonMixin(FocusMixin(LitElement))
 			:host([skeleton]) #d2l-tooltip-help-text.d2l-skeletize {
 				text-decoration: none;
 			}
+			:host([skeleton]) slot[name="icon"]::slotted(d2l-icon-custom) {
+				display: none;
+			}
 		`];
 	}
 


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-8021)

Adding a new component `d2l-object-property-list-item-tooltip-help`: 
- It takes the `text` property like the other object property list items.  
- The default slot is used for the tooltip content like `d2l-tooltip-help`
- Support for icons, using an `icon` property an the `icon` slot for custom icons like consumers of `SlottedMixin` 