### PR TITLE
hai-1583 don't set focus element when no href

### DIFF
--- a/components/card/card.js
+++ b/components/card/card.js
@@ -245,7 +245,7 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 	}
 
 	static get focusElementSelector() {
-		return 'a';
+		return this.href ? 'a' : nothing;
 	}
 
 	firstUpdated(changedProperties) {

--- a/mixins/focus/focus-mixin.js
+++ b/mixins/focus/focus-mixin.js
@@ -1,4 +1,5 @@
 import { dedupeMixin } from '@open-wc/dedupe-mixin';
+import { nothing } from 'lit';
 
 export const FocusMixin = dedupeMixin(superclass => class extends superclass {
 
@@ -22,6 +23,12 @@ export const FocusMixin = dedupeMixin(superclass => class extends superclass {
 	focus() {
 
 		const selector = this.constructor.focusElementSelector;
+
+		if (selector === nothing) {
+			super.focus();
+			return;
+		}
+
 		if (!selector) {
 			throw new Error(`FocusMixin: no static focusElementSelector provided for "${this.tagName}"`);
 		}


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/HAI-1583

Since we are using `d2l-card` without specifying an `href`, we need focus to go on the card itself, not the `a` tag.