### PR TITLE
Update d2l-card to conditionally apply focus since it may not render a link

### DIFF
--- a/components/card/card.js
+++ b/components/card/card.js
@@ -4,7 +4,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 /**
@@ -15,7 +14,7 @@ import { styleMap } from 'lit/directives/style-map.js';
  * @slot footer - Slot for footer content, such secondary actions
  * @slot header - Slot for header content, such as course image (no actionable elements)
  */
-class Card extends RtlMixin(LitElement) {
+class Card extends LitElement {
 
 	static get properties() {
 		return {
@@ -141,22 +140,14 @@ class Card extends RtlMixin(LitElement) {
 				padding-bottom: 1.2rem;
 			}
 			.d2l-card-actions {
+				inset-inline-end: 0.6rem;
 				position: absolute;
-				right: 0.6rem;
 				top: 0.6rem;
 				/* this must be higher than footer z-index so dropdowns will be on top */
 				z-index: 3;
 			}
-			:host([dir="rtl"]) .d2l-card-actions {
-				left: 0.6rem;
-				right: auto;
-			}
 			.d2l-card-actions ::slotted(*) {
-				margin-left: 0.3rem;
-			}
-			:host([dir="rtl"]) .d2l-card-actions ::slotted(*) {
-				margin-left: 0;
-				margin-right: 0.3rem;
+				margin-inline-start: 0.3rem;
 			}
 			.d2l-card-badge {
 				line-height: 0;

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -1,7 +1,6 @@
 import '../colors/colors.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
@@ -16,7 +15,7 @@ import { styleMap } from 'lit/directives/style-map.js';
  * @slot footer - Slot for footer content, such secondary actions
  * @slot header - Slot for header content, such as course image (no actionable elements)
  */
-class Card extends FocusMixin(RtlMixin(LitElement)) {
+class Card extends RtlMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -237,15 +236,12 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 		this.subtle = false;
 		this._active = false;
 		this._dropdownActionOpen = false;
+		this._focusOnFirstRender = false;
 		this._footerHidden = true;
 		this._hover = false;
 		this._tooltipShowing = false;
 		this._onBadgeResize = this._onBadgeResize.bind(this);
 		this._onFooterResize = this._onFooterResize.bind(this);
-	}
-
-	static get focusElementSelector() {
-		return 'a';
 	}
 
 	firstUpdated(changedProperties) {
@@ -254,6 +250,11 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 		badgeObserver.observe(this.shadowRoot.querySelector('.d2l-card-badge'));
 		const footerObserver = new ResizeObserver(this._onFooterResize);
 		footerObserver.observe(this.shadowRoot.querySelector('.d2l-card-footer'));
+
+		if (this._focusOnFirstRender) {
+			this._focusOnFirstRender = false;
+			this.focus();
+		}
 	}
 
 	render() {
@@ -306,6 +307,17 @@ class Card extends FocusMixin(RtlMixin(LitElement)) {
 				<div class="${classMap(footerClass)}"><slot name="footer"></slot></div>
 			</div>
 		`;
+	}
+
+	focus() {
+		if (!this.hasUpdated) {
+			this._focusOnFirstRender = true;
+			return;
+		}
+
+		const elem = this.shadowRoot.querySelector('a[href]');
+		if (elem) elem.focus();
+		else super.focus();
 	}
 
 	_onBadgeResize(entries) {


### PR DESCRIPTION
[GAUD-8048](https://desire2learn.atlassian.net/browse/GAUD-8048)

This PR updates `d2l-card` to conditionally apply focus. It removes the use of `FocusMixin` since this focus treatment is special... an anchor may not be rendered depending on whether the consumer has provided an `href`.

Also sneaking in minor change to use CSS logical properties, eliminating the need for `RtlMixin` in `d2l-card`.