### PR TITLE
feat: add `getFocusRingStyles`

### DIFF
--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -64,17 +64,17 @@ class ButtonIcon extends SlottedIconMixin(PropertyRequiredMixin(ThemeMixin(Butto
 				:host([translucent]) {
 					--d2l-button-icon-background-color: rgba(0, 0, 0, 0.5);
 					--d2l-button-icon-background-color-hover: var(--d2l-color-celestine);
-					--d2l-button-focus-color: white;
-					--d2l-button-focus-offset: -4px;
+					--d2l-focus-ring-color: white;
+					--d2l-focus-ring-offset: -4px;
 					--d2l-button-icon-fill-color: white;
 					--d2l-button-icon-fill-color-hover: white;
 				}
 				:host([theme="dark"]) {
 					--d2l-button-icon-background-color: transparent;
 					--d2l-button-icon-background-color-hover: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
-					--d2l-button-focus-color: var(--d2l-color-celestine-plus-1);
 					--d2l-button-icon-fill-color: var(--d2l-color-sylvite);
 					--d2l-button-icon-fill-color-hover: var(--d2l-color-sylvite);
+					--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
 				}
 
 				button {

--- a/components/button/button-move.js
+++ b/components/button/button-move.js
@@ -102,8 +102,8 @@ class ButtonMove extends ThemeMixin(FocusMixin(RtlMixin(LitElement))) {
 				:host([theme="dark"]) {
 					--d2l-button-move-background-color-focus: #000000;
 					--d2l-button-move-icon-background-color-hover: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
-					--d2l-button-focus-color: var(--d2l-color-celestine-plus-1);
 					--d2l-icon-fill-color: var(--d2l-color-sylvite);
+					--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
 				}
 				button {
 					background-color: transparent;

--- a/components/button/button-styles.js
+++ b/components/button/button-styles.js
@@ -1,6 +1,6 @@
 import '../colors/colors.js';
-import { css, unsafeCSS } from 'lit';
-import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { css } from 'lit';
+import { getFocusRingStyles } from '../../helpers/focus.js';
 
 export const buttonStyles = css`
 	button {
@@ -24,10 +24,7 @@ export const buttonStyles = css`
 		white-space: nowrap;
 		width: auto;
 	}
-	button:${unsafeCSS(getFocusPseudoClass())} {
-		outline: 2px solid var(--d2l-button-focus-color, var(--d2l-color-celestine));
-		outline-offset: var(--d2l-button-focus-offset, 2px);
-	}
+	${getFocusRingStyles('button')}
 	@media (prefers-contrast: more) {
 		button {
 			border: 2px solid transparent;

--- a/components/button/test/button-icon.vdiff.js
+++ b/components/button/test/button-icon.vdiff.js
@@ -18,7 +18,7 @@ describe('button-icon', () => {
 		{ category: 'normal', template: html`<d2l-button-icon icon="tier1:gear" text="Icon Button"></d2l-button-icon>` },
 		{ category: 'translucent', template: html`<div style="height: 80px; width: 200px; background: repeating-linear-gradient(45deg, #606dbc, #606dbc 10px, #465298 10px, #465298 20px);"><d2l-button-icon style="margin: 12px;" icon="tier1:gear" text="Icon Button" translucent></d2l-button-icon></div>` },
 		{ category: 'dark', template: html`<div style="height: 80px; width: 200px; background: black;"><d2l-button-icon style="margin: 12px;" icon="tier1:gear" text="Icon Button" theme="dark"></d2l-button-icon></div>` },
-		{ category: 'custom', template: html`<d2l-button-icon icon="tier1:gear" text="Icon Button" style="--d2l-button-icon-min-height: 1.5rem; --d2l-button-icon-min-width: 1.5rem; --d2l-button-icon-border-radius: 4px; --d2l-button-focus-color: #006fbf; --d2l-button-focus-offset: 1px; --d2l-button-icon-fill-color: var(--d2l-color-celestine); --d2l-button-icon-fill-color-hover: var(--d2l-color-celestine-minus-1);"></d2l-button-icon>` },
+		{ category: 'custom', template: html`<d2l-button-icon icon="tier1:gear" text="Icon Button" style="--d2l-button-icon-min-height: 1.5rem; --d2l-button-icon-min-width: 1.5rem; --d2l-button-icon-border-radius: 4px; --d2l-focus-ring-color: #006fbf; --d2l-focus-ring-offset: 1px; --d2l-button-icon-fill-color: var(--d2l-color-celestine); --d2l-button-icon-fill-color-hover: var(--d2l-color-celestine-minus-1);"></d2l-button-icon>` },
 		{ category: 'custom icon', template: customIconTemplate }
 	].forEach(({ category, template }) => {
 

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -1,3 +1,4 @@
+import { getFocusRingStyles } from '../../helpers/focus.js';
 import '../colors/colors.js';
 import { css } from 'lit';
 
@@ -131,12 +132,7 @@ export const dialogStyles = css`
 		overflow: hidden; /* scrollbar is kept hidden while we update the scroll position to avoid scrollbar flash */
 		padding: 0 30px;
 	}
-
-	.d2l-dialog-content:focus-visible {
-		border-radius: 6px;
-		outline: 2px solid var(--d2l-color-celestine);
-		outline-offset: -2px;
-	}
+	${getFocusRingStyles('.d2l-dialog-content', {baseOffset: '-2px', extraStyles: 'border-radius: 6px;'})}
 
 	.d2l-dialog-content > div {
 		position: relative; /* make this the positioned parent for absolute positioned elements like d2l-template-primary-secondary */

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -1,6 +1,6 @@
-import { getFocusRingStyles } from '../../helpers/focus.js';
 import '../colors/colors.js';
 import { css } from 'lit';
+import { getFocusRingStyles } from '../../helpers/focus.js';
 
 export const dialogStyles = css`
 
@@ -132,8 +132,7 @@ export const dialogStyles = css`
 		overflow: hidden; /* scrollbar is kept hidden while we update the scroll position to avoid scrollbar flash */
 		padding: 0 30px;
 	}
-	${getFocusRingStyles('.d2l-dialog-content', {baseOffset: '-2px', extraStyles: 'border-radius: 6px;'})}
-
+	${getFocusRingStyles('.d2l-dialog-content', { baseOffset: '-2px', extraStyles: 'border-radius: 6px;' })}
 	.d2l-dialog-content > div {
 		position: relative; /* make this the positioned parent for absolute positioned elements like d2l-template-primary-secondary */
 	}

--- a/components/empty-state/empty-state-styles.js
+++ b/components/empty-state/empty-state-styles.js
@@ -1,6 +1,6 @@
 import '../colors/colors.js';
-import { css, unsafeCSS } from 'lit';
-import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
+import { css } from 'lit';
+import { getFocusRingStyles } from '../../helpers/focus.js';
 
 export const emptyStateStyles = css`
 
@@ -20,8 +20,10 @@ export const emptyStateStyles = css`
 	.action-slot::slotted(d2l-empty-state-action-link:first-of-type) {
 		display: inline;
 	}
-	${getFocusRingStyles('.d2l-empty-state-description', {baseOffset: '3px', extraStyles: 'border-radius: 0.3rem;'})}
-
+	${getFocusRingStyles(
+		'.d2l-empty-state-description',
+		{ baseOffset: '3px', extraStyles: 'border-radius: 0.3rem;' }
+	)}
 `;
 
 export const emptyStateSimpleStyles = css`

--- a/components/empty-state/empty-state-styles.js
+++ b/components/empty-state/empty-state-styles.js
@@ -1,6 +1,6 @@
 import '../colors/colors.js';
 import { css, unsafeCSS } from 'lit';
-import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
 
 export const emptyStateStyles = css`
 
@@ -20,12 +20,7 @@ export const emptyStateStyles = css`
 	.action-slot::slotted(d2l-empty-state-action-link:first-of-type) {
 		display: inline;
 	}
-
-	.d2l-empty-state-description:${unsafeCSS(getFocusPseudoClass())} {
-		border-radius: 0.3rem;
-		outline: 2px solid var(--d2l-color-celestine);
-		outline-offset: 3px;
-	}
+	${getFocusRingStyles('.d2l-empty-state-description', {baseOffset: '3px', extraStyles: 'border-radius: 0.3rem;'})}
 
 `;
 

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -3,7 +3,7 @@ import { codeStyles, createHtmlBlockRenderer as createCodeRenderer } from '../..
 import { css, html, LitElement, unsafeCSS } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createHtmlBlockRenderer as createMathRenderer } from '../../helpers/mathjax.js';
-import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { getFocusRingStyles } from '../../helpers/focus.js';
 import { LoadingCompleteMixin } from '../../mixins/loading-complete/loading-complete-mixin.js';
 import { renderEmbeds } from '../../helpers/embeds.js';
 import { requestInstance } from '../../mixins/provider/provider-mixin.js';
@@ -108,12 +108,10 @@ export const htmlBlockContentStyles = css`
 		color: var(--d2l-color-celestine-minus-1, #004489);
 		text-decoration: underline;
 	}
-	a:${unsafeCSS(getFocusPseudoClass())} {
-		border-radius: 2px;
-		outline: 2px solid var(--d2l-color-celestine, #006fbf);
-		outline-offset: 1px;
-		text-decoration: underline;
+	a {
+		--d2l-focus-ring-color: var(--d2l-color-celestine, #006fbf);
 	}
+	${getFocusRingStyles('a',{baseOffset: '1px', extraStyles: 'border-radius: 2px; text-decoration: underline;'})}
 	@media print {
 		a,
 		a:visited,

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -1,6 +1,6 @@
 import '../colors/colors.js';
 import { codeStyles, createHtmlBlockRenderer as createCodeRenderer } from '../../helpers/prism.js';
-import { css, html, LitElement, unsafeCSS } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createHtmlBlockRenderer as createMathRenderer } from '../../helpers/mathjax.js';
 import { getFocusRingStyles } from '../../helpers/focus.js';
@@ -111,7 +111,7 @@ export const htmlBlockContentStyles = css`
 	a {
 		--d2l-focus-ring-color: var(--d2l-color-celestine, #006fbf);
 	}
-	${getFocusRingStyles('a',{baseOffset: '1px', extraStyles: 'border-radius: 2px; text-decoration: underline;'})}
+	${getFocusRingStyles('a', { baseOffset: '1px', extraStyles: 'border-radius: 2px; text-decoration: underline;' })}
 	@media print {
 		a,
 		a:visited,

--- a/components/inputs/input-color.js
+++ b/components/inputs/input-color.js
@@ -6,7 +6,7 @@ import { buttonStyles } from '../button/button-styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
-import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { getValidHexColor } from '../../helpers/color.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -226,13 +226,7 @@ class InputColor extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(F
 					outline: none;
 					width: 1.2rem;
 				}
-				.readonly-wrapper:focus {
-					outline: none;
-				}
-				.readonly-wrapper:${unsafeCSS(getFocusPseudoClass())} {
-					outline: 2px solid var(--d2l-color-celestine);
-					outline-offset: 2px;
-				}
+				${getFocusRingStyles('.readonly-wrapper')}
 
 				@media (prefers-contrast: more) {
 					.swatch {

--- a/components/inputs/input-color.js
+++ b/components/inputs/input-color.js
@@ -1,12 +1,12 @@
 import '../dropdown/dropdown.js';
 import '../dropdown/dropdown-content.js';
 import '../tooltip/tooltip.js';
-import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { buttonStyles } from '../button/button-styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
-import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
+import { getFocusRingStyles } from '../../helpers/focus.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { getValidHexColor } from '../../helpers/color.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -227,7 +227,6 @@ class InputColor extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(F
 					width: 1.2rem;
 				}
 				${getFocusRingStyles('.readonly-wrapper')}
-
 				@media (prefers-contrast: more) {
 					.swatch {
 						border: 1px solid FieldText;

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -80,7 +80,7 @@ class InputSearch extends FocusMixin(LocalizeCoreElement(RtlMixin(LitElement))) 
 					--d2l-button-icon-min-height: 1.5rem;
 					--d2l-button-icon-min-width: 1.5rem;
 					--d2l-button-icon-border-radius: 4px;
-					--d2l-button-focus-offset: 1px;
+					--d2l-focus-ring-offset: 1px;
 					margin-left: 0.3rem;
 					margin-right: 0.3rem;
 				}

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -1,6 +1,6 @@
 import '../colors/colors.js';
 import '../icons/icon.js';
-import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { getFocusRingStyles } from '../../helpers/focus.js';
@@ -24,7 +24,7 @@ export const linkStyles = css`
 		color: var(--d2l-color-celestine-minus-1);
 		text-decoration: underline;
 	}
-	${getFocusRingStyles('.d2l-link',{baseOffset: '1px', extraStyles: 'border-radius: 2px; text-decoration: underline;'})}
+	${getFocusRingStyles('.d2l-link', { baseOffset: '1px', extraStyles: 'border-radius: 2px; text-decoration: underline;' })}
 	.d2l-link.d2l-link-main {
 		font-weight: 700;
 	}

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -3,7 +3,7 @@ import '../icons/icon.js';
 import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
-import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { getFocusRingStyles } from '../../helpers/focus.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
@@ -24,12 +24,7 @@ export const linkStyles = css`
 		color: var(--d2l-color-celestine-minus-1);
 		text-decoration: underline;
 	}
-	.d2l-link:${unsafeCSS(getFocusPseudoClass())} {
-		border-radius: 2px;
-		outline: 2px solid var(--d2l-color-celestine);
-		outline-offset: 1px;
-		text-decoration: underline;
-	}
+	${getFocusRingStyles('.d2l-link',{baseOffset: '1px', extraStyles: 'border-radius: 2px; text-decoration: underline;'})}
 	.d2l-link.d2l-link-main {
 		font-weight: 700;
 	}

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -2,7 +2,7 @@ import '../colors/colors.js';
 import { css, html, unsafeCSS } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
-import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
@@ -58,9 +58,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 				padding: 0.1rem;
 				vertical-align: middle;
 			}
-			.d2l-switch-container:${unsafeCSS(getFocusPseudoClass())} {
-				outline: 2px solid var(--d2l-color-celestine);
-			}
+			${getFocusRingStyles('.d2l-switch-container',{baseOffset:'0'})}
 			:host([disabled]) .d2l-switch-container {
 				cursor: default;
 				opacity: 0.5;

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -1,8 +1,8 @@
 import '../colors/colors.js';
-import { css, html, unsafeCSS } from 'lit';
+import { css, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
-import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
+import { getFocusRingStyles } from '../../helpers/focus.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
@@ -58,7 +58,7 @@ export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(super
 				padding: 0.1rem;
 				vertical-align: middle;
 			}
-			${getFocusRingStyles('.d2l-switch-container',{baseOffset:'0'})}
+			${getFocusRingStyles('.d2l-switch-container', { baseOffset:'0' })}
 			:host([disabled]) .d2l-switch-container {
 				cursor: default;
 				opacity: 0.5;

--- a/components/tabs/demo/tab-custom.js
+++ b/components/tabs/demo/tab-custom.js
@@ -1,5 +1,5 @@
 import { css, html, LitElement, unsafeCSS } from 'lit';
-import { getFocusPseudoClass } from '../../../helpers/focus.js';
+import { getFocusPseudoClass, getFocusRingStyles } from '../../../helpers/focus.js';
 import { TabMixin } from '../tab-mixin.js';
 
 class TabCustom extends TabMixin(LitElement) {
@@ -15,11 +15,10 @@ class TabCustom extends TabMixin(LitElement) {
 			:host(:first-child) .d2l-tab-custom-content {
 				margin-inline-start: 0;
 			}
-			:host(:${unsafeCSS(getFocusPseudoClass())}) .d2l-tab-custom-content {
-				border-radius: 0.3rem;
-				color: var(--d2l-color-celestine);
-				outline: 2px solid var(--d2l-color-celestine);
-			}
+			${getFocusRingStyles(
+				`:host(:${getFocusPseudoClass()}) .d2l-tab-custom-content`,
+				{noFocusPseudoClass:true, baseOffset: '0', extraStyles: 'border-radius: 0.3rem;'}
+			)}
 		`];
 
 		super.styles && styles.unshift(super.styles);

--- a/components/tabs/demo/tab-custom.js
+++ b/components/tabs/demo/tab-custom.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement, unsafeCSS } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { getFocusPseudoClass, getFocusRingStyles } from '../../../helpers/focus.js';
 import { TabMixin } from '../tab-mixin.js';
 
@@ -17,7 +17,7 @@ class TabCustom extends TabMixin(LitElement) {
 			}
 			${getFocusRingStyles(
 				`:host(:${getFocusPseudoClass()}) .d2l-tab-custom-content`,
-				{noFocusPseudoClass:true, baseOffset: '0', extraStyles: 'border-radius: 0.3rem;'}
+				{ noFocusPseudoClass:true, baseOffset:'0', extraStyles:'border-radius: 0.3rem;' }
 			)}
 		`];
 

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -1,7 +1,13 @@
 import { css, html, LitElement, unsafeCSS } from 'lit';
-import { classMap } from 'lit/directives/class-map.js';
 import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { TabMixin } from './tab-mixin.js';
+
+const focusRingStyles = getFocusRingStyles(`:host(:${getFocusPseudoClass()}) .d2l-tab-text-inner-content`, {
+	noFocusPseudoClass: true,
+	baseOffset: '0',
+	extraStyles: 'border-radius: 0.3rem; color: var(--d2l-color-celestine);'
+});
 
 /**
  * @attr {string} id - REQUIRED: Unique identifier for the tab
@@ -27,10 +33,7 @@ class Tab extends TabMixin(LitElement) {
 				display: flex;
 				padding: 0.1rem;
 			}
-			${getFocusRingStyles(
-				`:host(:${getFocusPseudoClass()}) .d2l-tab-text-inner-content`,
-				{noFocusPseudoClass:true,baseOffset:'0',extraStyles:'border-radius: 0.3rem; color: var(--d2l-color-celestine);'}
-			)}
+			${focusRingStyles}
 			:host(:${unsafeCSS(getFocusPseudoClass())}) ::slotted(d2l-icon) {
 				color: var(--d2l-color-celestine);
 			}

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -1,6 +1,6 @@
 import { css, html, LitElement, unsafeCSS } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
 import { TabMixin } from './tab-mixin.js';
 
 /**
@@ -27,11 +27,10 @@ class Tab extends TabMixin(LitElement) {
 				display: flex;
 				padding: 0.1rem;
 			}
-			:host(:${unsafeCSS(getFocusPseudoClass())}) .d2l-tab-text-inner-content {
-				border-radius: 0.3rem;
-				color: var(--d2l-color-celestine);
-				outline: 2px solid var(--d2l-color-celestine);
-			}
+			${getFocusRingStyles(
+				`:host(:${getFocusPseudoClass()}) .d2l-tab-text-inner-content`,
+				{noFocusPseudoClass:true,baseOffset:'0',extraStyles:'border-radius: 0.3rem; color: var(--d2l-color-celestine);'}
+			)}
 			:host(:${unsafeCSS(getFocusPseudoClass())}) ::slotted(d2l-icon) {
 				color: var(--d2l-color-celestine);
 			}

--- a/components/tooltip/tooltip-help.js
+++ b/components/tooltip/tooltip-help.js
@@ -1,10 +1,10 @@
 import '../colors/colors.js';
 import '../tooltip/tooltip.js';
-import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { bodySmallStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
-import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
+import { getFocusRingStyles } from '../../helpers/focus.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { SlottedIconMixin } from '../icons/slotted-icon-mixin.js';
@@ -69,10 +69,7 @@ class TooltipHelp extends SlottedIconMixin(SkeletonMixin(FocusMixin(LitElement))
 			#d2l-tooltip-help-text:focus {
 				outline-style: none;
 			}
-			${getFocusRingStyles(
-				'#d2l-tooltip-help-text',
-				{baseOffset: '0.05rem', extraStyles: 'border-radius: 0.05rem; text-underline-offset: 0.1rem;'}
-			)}
+			${getFocusRingStyles('#d2l-tooltip-help-text', { baseOffset: '0.05rem', extraStyles: 'border-radius: 0.05rem; text-underline-offset: 0.1rem;' })}
 			:host([inherit-font-style]) #d2l-tooltip-help-text {
 				color: inherit;
 				font-size: inherit;

--- a/components/tooltip/tooltip-help.js
+++ b/components/tooltip/tooltip-help.js
@@ -4,7 +4,7 @@ import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
 import { bodySmallStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
-import { getFocusPseudoClass } from '../../helpers/focus.js';
+import { getFocusPseudoClass, getFocusRingStyles } from '../../helpers/focus.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { SlottedIconMixin } from '../icons/slotted-icon-mixin.js';
@@ -69,12 +69,10 @@ class TooltipHelp extends SlottedIconMixin(SkeletonMixin(FocusMixin(LitElement))
 			#d2l-tooltip-help-text:focus {
 				outline-style: none;
 			}
-			#d2l-tooltip-help-text:${unsafeCSS(getFocusPseudoClass())} {
-				border-radius: 0.05rem;
-				outline: 2px solid var(--d2l-color-celestine);
-				outline-offset: 0.05rem;
-				text-underline-offset: 0.1rem;
-			}
+			${getFocusRingStyles(
+				'#d2l-tooltip-help-text',
+				{baseOffset: '0.05rem', extraStyles: 'border-radius: 0.05rem; text-underline-offset: 0.1rem;'}
+			)}
 			:host([inherit-font-style]) #d2l-tooltip-help-text {
 				color: inherit;
 				font-size: inherit;

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -1,3 +1,4 @@
+import { css, unsafeCSS } from 'lit';
 import { getComposedChildren, getComposedParent, getNextAncestorSibling, getPreviousAncestorSibling, isVisible } from './dom.js';
 
 const focusableElements = {
@@ -61,6 +62,22 @@ export function getFocusableDescendants(node, options) {
 
 export function getFocusPseudoClass() {
 	return isFocusVisibleSupported() ? 'focus-visible' : 'focus';
+}
+export function getFocusRingStyles(selector, {applyOnHover=false, noFocusPseudoClass=false, baseOffset='2px',extraStyles=''} = {}) {
+	const baseSelector = selector;
+	if (!noFocusPseudoClass) selector += `:${getFocusPseudoClass()}`;
+	if (applyOnHover) selector += `, ${baseSelector}:hover`
+	const cssSelector = unsafeCSS(selector);
+	return css`${cssSelector} {
+		${unsafeCSS(extraStyles)}
+		outline: 2px solid var(--d2l-focus-ring-color, var(--d2l-color-celestine));
+		outline-offset: var(--d2l-focus-ring-offset, ${unsafeCSS(baseOffset)});
+	}
+	@media (prefers-contrast: more) {
+		${cssSelector} {
+			outline-color: var(--d2l-focus-ring-color, Highlight);
+		}
+	}`;
 }
 
 export function getLastFocusableDescendant(node, includeHidden) {

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -63,10 +63,10 @@ export function getFocusableDescendants(node, options) {
 export function getFocusPseudoClass() {
 	return isFocusVisibleSupported() ? 'focus-visible' : 'focus';
 }
-export function getFocusRingStyles(selector, {applyOnHover=false, noFocusPseudoClass=false, baseOffset='2px',extraStyles=''} = {}) {
+export function getFocusRingStyles(selector, { applyOnHover = false, noFocusPseudoClass = false, baseOffset = '2px', extraStyles = '' } = {}) {
 	const baseSelector = selector;
 	if (!noFocusPseudoClass) selector += `:${getFocusPseudoClass()}`;
-	if (applyOnHover) selector += `, ${baseSelector}:hover`
+	if (applyOnHover) selector += `, ${baseSelector}:hover`;
 	const cssSelector = unsafeCSS(selector);
 	return css`${cssSelector} {
 		${unsafeCSS(extraStyles)}

--- a/mixins/interactive/interactive-mixin.js
+++ b/mixins/interactive/interactive-mixin.js
@@ -1,8 +1,8 @@
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
-import { css, html } from 'lit';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
-import { classMap } from 'lit/directives/class-map.js';
 import { getFocusRingStyles, getNextFocusable } from '../../helpers/focus.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { offscreenStyles } from '../../components/offscreen/offscreen.js';
@@ -28,7 +28,7 @@ export const InteractiveMixin = superclass => class extends LocalizeCoreElement(
 	static get styles() {
 		return [offscreenStyles, getFocusRingStyles(
 			'.interactive-focusing-toggle',
-			{noFocusPseudoClass: true, extraStyles: 'border-radius: 6px;'}
+			{ noFocusPseudoClass: true, extraStyles: 'border-radius: 6px;' }
 		)];
 	}
 

--- a/mixins/interactive/interactive-mixin.js
+++ b/mixins/interactive/interactive-mixin.js
@@ -2,7 +2,7 @@ import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { css, html } from 'lit';
 import { findComposedAncestor, isComposedAncestor } from '../../helpers/dom.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { getNextFocusable } from '../../helpers/focus.js';
+import { getFocusRingStyles, getNextFocusable } from '../../helpers/focus.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { offscreenStyles } from '../../components/offscreen/offscreen.js';
@@ -26,13 +26,10 @@ export const InteractiveMixin = superclass => class extends LocalizeCoreElement(
 	}
 
 	static get styles() {
-		return [offscreenStyles, css`
-			.interactive-focusing-toggle {
-				border-radius: 6px;
-				outline: 2px solid var(--d2l-color-celestine);
-				outline-offset: 2px;
-			}
-		`];
+		return [offscreenStyles, getFocusRingStyles(
+			'.interactive-focusing-toggle',
+			{noFocusPseudoClass: true, extraStyles: 'border-radius: 6px;'}
+		)];
 	}
 
 	constructor() {


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-8107)

From the ticket:
A lot of focus rings share the same styles, which are causing issues on WHCM. Centralizing this styles makes these styles easier to maintain and identify snowflakes across daylight.