### PR TITLE
fix: List item draggable: Add margin-inline-end

### DIFF
--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -301,6 +301,9 @@ export const ListItemMixin = superclass => class extends composeMixins(
 			.d2l-list-item-content-extend-separators [slot="outside-control-container"] {
 				margin: 0;
 			}
+			:host([_list-item-new-styles][draggable]) [slot="outside-control-container"] {
+				margin-inline-end: -12px;
+			}
 
 			:host([_has-color-slot]) .d2l-list-item-content-extend-separators [slot="outside-control-container"],
 			:host([dir="rtl"][_has-color-slot]) .d2l-list-item-content-extend-separators [slot="outside-control-container"] {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8081)

**Problem:**
Top juts out past the end of the rounded border on hover for draggable list items.

**Solution notes:**
Non-draggable list items have a -12px right margin that prevents this. This was overridden for draggable items to be 0. I kept the override of 0 for all except the right margin. The left margin is likely 0 so that it lines up nicely with the drag handle.