### PR TITLE
feat: List item: Add docs about using interactive elements within draggable items

### DIFF
--- a/components/list/README.md
+++ b/components/list/README.md
@@ -448,7 +448,7 @@ If an item is draggable, the `drag-handle-text` attribute should be used to prov
 
 #### Draggable lists with interactive content
 
-When a list item contains interactive content and the list item is not interactive in any way other than being `draggable` (i.e., not a link, button, `selectable`, or `expandable`) in order for the interactive content to have mouse events work as expected, one of the following should be done:
+When a list item contains interactive content and the list item is not interactive in any way other than being `draggable` (i.e., not a link, button, `selectable`, or `expandable`), in order for the interactive content to have mouse events work as expected, one of the following should be done:
 - use the `drag-target-handle-only` on the list item; this causes the drag target to be the handle only rather than the entire cell
 - put the interactive content in the `actions` slot
 


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-7817)

Adds docs on how to use interactive elements within list item content in a `draggable` item.

Demos look like this:
<img width="1192" alt="Screenshot 2025-06-17 at 9 30 34 AM" src="https://github.com/user-attachments/assets/ce078e05-763d-4080-b8b5-41da4f96506d" />

and then wrap at smaller widths (min-width for the list is 200px).

Note that I added this as a separate demo in order to keep the previous one just demoing `draggable` in case it gets copy-pasted. Let me know thoughts on this.