### PR TITLE
fix: suppress required text error if not visible

### DIFF
--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -7,6 +7,7 @@ import { ButtonMixin } from './button-mixin.js';
 import { buttonStyles } from './button-styles.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { isVisible } from '../../helpers/dom.js';
 import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { SlottedIconMixin } from '../icons/slotted-icon-mixin.js';
 import { ThemeMixin } from '../../mixins/theme/theme-mixin.js';
@@ -35,7 +36,7 @@ class ButtonIcon extends SlottedIconMixin(PropertyRequiredMixin(ThemeMixin(Butto
 			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true, required: true },
+			text: { type: String, reflect: true, required: { validator: (value, elem) => !!value || !isVisible(elem) } },
 
 			/**
 			 * Indicates to display translucent (e.g., on rich backgrounds)

--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -7,7 +7,6 @@ import { ButtonMixin } from './button-mixin.js';
 import { buttonStyles } from './button-styles.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { isVisible } from '../../helpers/dom.js';
 import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { SlottedIconMixin } from '../icons/slotted-icon-mixin.js';
 import { ThemeMixin } from '../../mixins/theme/theme-mixin.js';
@@ -36,7 +35,7 @@ class ButtonIcon extends SlottedIconMixin(PropertyRequiredMixin(ThemeMixin(Butto
 			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true, required: { validator: (value, elem) => !!value || !isVisible(elem) } },
+			text: { type: String, reflect: true, required: { validator: (value, elem) => !!value || elem.offsetHeight === 0 } },
 
 			/**
 			 * Indicates to display translucent (e.g., on rich backgrounds)

--- a/components/button/test/button-icon.test.js
+++ b/components/button/test/button-icon.test.js
@@ -41,6 +41,12 @@ describe('d2l-button-icon', () => {
 				.to.not.throw();
 		});
 
+		it('does not throw error when no text but not visible', async() => {
+			const el = await fixture(html`<d2l-button-icon icon="tier1:gear" style="display:none"></d2l-button-icon>`);
+			expect(() => el.flushRequiredPropertyErrors())
+				.to.not.throw();
+		});
+
 	});
 
 	describe('events', () => {


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-8212)

Suppress the required `text` property error when the component is not visible.

Polymer elements won't refresh any `text` attribute when localization loads if the component is inside a false `dom-if` block.