### PR TITLE
Fix switch disabled hover state + focus ring

### DIFF
--- a/components/switch/test/switch.vdiff.js
+++ b/components/switch/test/switch.vdiff.js
@@ -16,6 +16,8 @@ describe('d2l-switch', () => {
 			{ name: 'on-focus', template: onFixture, action: async(elem) => await focusElem(elem) },
 			{ name: 'on-hover', template: onFixture, action: async(elem) => await hoverElem(elem.shadowRoot.querySelector('.d2l-switch-inner')) },
 			{ name: 'on-disabled', template: html`<d2l-switch text="Test Text" on disabled></d2l-switch>` },
+			{ name: 'disabled-hover', template: html`<d2l-switch disabled></d2l-switch>`, action: async(elem) => await hoverElem(elem.shadowRoot.querySelector('.d2l-switch-inner')) },
+			{ name: 'focus-sibling', template: html`<span><d2l-switch on></d2l-switch><br><d2l-switch></d2l-switch></span>`, action: async(elem) => await focusElem(elem.children[0].shadowRoot.querySelector('.d2l-switch-container')) },
 			{ name: 'text-hidden', template: html`<d2l-switch text="Test Text" text-position="hidden"></d2l-switch>` },
 			{ name: 'text-start', template: html`<d2l-switch text="Test Text" text-position="start"></d2l-switch>` },
 			{ name: 'text-end', template: html`<d2l-switch text="Test Text" text-position="end"></d2l-switch>` },


### PR DESCRIPTION
[GAUD-8223](https://desire2learn.atlassian.net/browse/GAUD-8223): Disabled switches should have no hover effect

- Removes the hover effect on disabled switches
- Fixes subsequent element borders/box-shadows covering the focus ring

The first vdiff run will be only new tests that should show the existing undesirable behavior. I'll merge those and then push the fixes so the difference is made clear.

[Slack thread](https://d2l.slack.com/archives/C03FC0GDVB7/p1750271660352299)