### PR TITLE
List item drag & drop demos: Show keyboard controls on left/right arrow key

### DIFF
--- a/components/list/demo/demo-list-nav.js
+++ b/components/list/demo/demo-list-nav.js
@@ -123,13 +123,14 @@ class ListDemoNav extends LitElement {
 
 		this.requestUpdate();
 		await this.updateComplete;
+		await this.updateComplete;
 
 		if (e.detail.keyboardActive) {
 			setTimeout(() => {
 				if (!this.shadowRoot) return;
 				const newItem = this.shadowRoot.querySelector('d2l-list').getListItemByKey(sourceListItems[0].key);
 				newItem.activateDragHandle();
-			});
+			}, 10);
 		}
 	}
 

--- a/components/list/demo/demo-list-nested.js
+++ b/components/list/demo/demo-list-nested.js
@@ -134,13 +134,14 @@ class ListDemoNested extends LitElement {
 
 		this.requestUpdate();
 		await this.updateComplete;
+		await this.updateComplete;
 
 		if (e.detail.keyboardActive) {
 			setTimeout(() => {
 				if (!this.shadowRoot) return;
 				const newItem = this.shadowRoot.querySelector('d2l-list').getListItemByKey(sourceListItems[0].key);
 				newItem.activateDragHandle();
-			});
+			}, 10);
 		}
 
 	}


### PR DESCRIPTION
[Jira task](https://desire2learn.atlassian.net/browse/GAUD-8190)

Problem:
On left/right arrow key (to nest an item) the keyboard control handle would disappear after key press.

From what I can tell, this is a demo issue as the demo controls when to show the drag handle in these scenarios, and it looks as though it wasn't waiting long enough to show it (list items weren't totally rendered and ready for the drag handle).