### PR TITLE
SHIELD-11830 - Remove WIRIS sub/superscripts feature flag (defaulting on)

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -64,12 +64,10 @@ class HtmlBlockMathRenderer {
 		// WIRIS outputs bad syntax for empty sub/superscripts, but changing these on write
 		// can be risky. Instead, change them on render to minimize potential damage if this
 		// impacts legitimate usages.
-		if (context.replaceNoneSubSuperScripts) {
-			elem.querySelectorAll('math mmultiscripts > none').forEach(elm => {
-				const mrow = document.createElementNS('http://www.w3.org/1998/Math/MathML', 'mrow');
-				elm.replaceWith(mrow);
-			});
-		}
+		elem.querySelectorAll('math mmultiscripts > none').forEach(elm => {
+			const mrow = document.createElementNS('http://www.w3.org/1998/Math/MathML', 'mrow');
+			elm.replaceWith(mrow);
+		});
 
 		// If we're using deferred rendering, we need to create a document structure
 		// within the element so MathJax can appropriately process math.


### PR DESCRIPTION
Straightforward flag removal here. The flag populating this context parameter is being removed this release and this behaviour is becoming the default.