### PR TITLE
fix: List item drag & drop: Show handle on nesting change

### DIFF
--- a/components/list/demo/demo-list-nav.js
+++ b/components/list/demo/demo-list-nav.js
@@ -123,14 +123,14 @@ class ListDemoNav extends LitElement {
 
 		this.requestUpdate();
 		await this.updateComplete;
-		await this.updateComplete;
 
 		if (e.detail.keyboardActive) {
-			setTimeout(() => {
+			setTimeout(async() => {
 				if (!this.shadowRoot) return;
 				const newItem = this.shadowRoot.querySelector('d2l-list').getListItemByKey(sourceListItems[0].key);
+				await newItem.waitForUpdateComplete();
 				newItem.activateDragHandle();
-			}, 50);
+			});
 		}
 	}
 

--- a/components/list/demo/demo-list-nested.js
+++ b/components/list/demo/demo-list-nested.js
@@ -134,14 +134,15 @@ class ListDemoNested extends LitElement {
 
 		this.requestUpdate();
 		await this.updateComplete;
-		await this.updateComplete;
 
 		if (e.detail.keyboardActive) {
-			setTimeout(() => {
+			this._keyThing = sourceListItems[0].key;
+			setTimeout(async() => {
 				if (!this.shadowRoot) return;
 				const newItem = this.shadowRoot.querySelector('d2l-list').getListItemByKey(sourceListItems[0].key);
+				await newItem.waitForUpdateComplete();
 				newItem.activateDragHandle();
-			}, 50);
+			});
 		}
 
 	}

--- a/components/list/demo/demo-list-nested.js
+++ b/components/list/demo/demo-list-nested.js
@@ -136,7 +136,6 @@ class ListDemoNested extends LitElement {
 		await this.updateComplete;
 
 		if (e.detail.keyboardActive) {
-			this._keyThing = sourceListItems[0].key;
 			setTimeout(async() => {
 				if (!this.shadowRoot) return;
 				const newItem = this.shadowRoot.querySelector('d2l-list').getListItemByKey(sourceListItems[0].key);

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -6,7 +6,7 @@ import './list-item-placement-marker.js';
 import '../tooltip/tooltip.js';
 import '../expand-collapse/expand-collapse-content.js';
 import { css, html, nothing, unsafeCSS } from 'lit';
-import { findComposedAncestor, getComposedParent } from '../../helpers/dom.js';
+import { findComposedAncestor, getComposedChildren, getComposedParent } from '../../helpers/dom.js';
 import { interactiveElements, isInteractiveInComposedPath } from '../../helpers/interactive.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { composeMixins } from '../../helpers/composeMixins.js';
@@ -24,6 +24,7 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import { waitForElem } from '../../helpers/internal/waitForElem.js';
 
 let tabPressed = false;
 let tabListenerAdded = false;
@@ -592,6 +593,12 @@ export const ListItemMixin = superclass => class extends composeMixins(
 
 	updateSiblingHasColor(siblingHasColor) {
 		this._siblingHasColor = siblingHasColor;
+	}
+
+	async waitForUpdateComplete() {
+		const predicate = () => true;
+		const composedChildren = getComposedChildren(this, predicate);
+		await Promise.all(composedChildren.map(child => waitForElem(child, predicate)));
 	}
 
 	_getFlattenedListItems(listItem) {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8190)

The timeouts still weren't behaving reliably. This follows the pattern dialog uses and adds a `waitForUpdateComplete` which checks for children being loaded. The drag & drop demo then waits for that in the moved list item before activating the drag handle. In local testing this seems to be working reliably.