### PR TITLE
Freeze localizeMarkup object

### DIFF
--- a/mixins/localize/localize-mixin.js
+++ b/mixins/localize/localize-mixin.js
@@ -83,7 +83,7 @@ export const LocalizeMixin = superclass => class extends _LocalizeMixinBase(supe
 export function localizeMarkup(strings, ...expressions) {
 	strings.forEach(str => validateMarkup(str, disallowedTagsRegex));
 	expressions.forEach(exp => validateMarkup(exp, disallowedTagsRegex));
-	return { ...html(strings, ...expressions), _localizeMarkup: true };
+	return Object.freeze({ ...html(strings, ...expressions), _localizeMarkup: true });
 }
 
 export function generateLink({ href, target }) {


### PR DESCRIPTION
[GAUD-8136](https://desire2learn.atlassian.net/browse/GAUD-8136): Call `Object.freeze` on localize resources to prevent unsafe hacking

Prevents hacking `localizeMarkup` objects to inject unsupported tags. This appears to already be at least partially the case for `html` templates, but we lose the freeze when we spread it into our new object.

[GAUD-8136]: https://desire2learn.atlassian.net/browse/GAUD-8136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ