### PR TITLE
[ignore] fix: Tooltip-help: Align start rather than center

### DIFF
--- a/components/tooltip/demo/tooltip.html
+++ b/components/tooltip/demo/tooltip.html
@@ -78,6 +78,18 @@
 
 	<d2l-demo-page page-title="d2l-tooltip">
 
+		<h2>Help Tooltip</h2>
+		<d2l-demo-snippet>
+			<template>
+				<div style="max-width: 100px;">
+					<d2l-tooltip-help text="Due: Jan 20, 2026">Other due date information</d2l-tooltip-help>
+					<p class="d2l-body-small" style="padding-top: 20px;">
+						This is some sample text.
+						<d2l-tooltip-help text="Due: Jan 20, 2026" inherit-font-style>Other due date information</d2l-tooltip-help>
+					</p>
+				</div>
+			</template>
+
 		<h2>Tooltip (info)</h2>
 		<d2l-demo-snippet>
 			<template>

--- a/components/tooltip/tooltip-help.js
+++ b/components/tooltip/tooltip-help.js
@@ -58,6 +58,7 @@ class TooltipHelp extends SlottedIconMixin(SkeletonMixin(FocusMixin(LitElement))
 				display: inline-flex;
 				font-family: inherit;
 				padding: 0;
+				text-align: start;
 				text-decoration-line: underline;
 				text-decoration-style: dashed;
 				text-decoration-thickness: 1px;


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8232)

**Problem**:
When the help tooltip contents wrap, they center align rather than start which looks a bit strange.
![e668dc6d-36f5-4b7a-9898-ad81169d7818](https://github.com/user-attachments/assets/200f8b4a-5755-4db6-99e0-183fc1750a4e)

I'll be running this by Jeff since the tooltip position is still centre. Also seeing if we should be flagging this in case this has a surprise impact somewhere.