### PR TITLE
fix: Tab: Add title

### DIFF
--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -89,6 +89,7 @@ class Tab extends TabMixin(LitElement) {
 
 		if (changedProperties.has('text')) {
 			this.dispatchContentChangeEvent();
+			this.title = this.text;
 		}
 	}
 


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8304)

The `text` property was used as the `title` in the old tab/tab-panel structure [here](https://github.com/BrightspaceUI/core/blob/main/components/tabs/tab-internal.js#L147) but did not get used with the new structure. This causes a problem when there is text past the max-width as it is not able to be seen in any way. 

It was discussed [here](https://github.com/BrightspaceUI/core/pull/5224#discussion_r1890322445) as to why this should not live in the mixin, so I have it being rendered in the tab component itself in the same way it was being rendered previously.

Note that this is not flagged because the new tab structure is not yet in use, other than the MVC backport which itself is flagged.