### PR TITLE
Update tag-list role description to include the list count.

### DIFF
--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -194,7 +194,7 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 				aria-label="${this.description}"
 				class="${classMap(containerClasses)}"
 				role="group"
-				aria-roledescription="${this.localize('components.tag-list.role-description')}"
+				aria-roledescription="${this.localize('components.tag-list.role-description', { count: this._items ? this._items.length : 0 })}"
 				@d2l-tag-list-item-clear="${this._handleItemDeleted}">
 				<slot @slotchange="${this._handleSlotChange}" @focusout="${this._handleSlotFocusOut}" @focusin="${this._handleSlotFocusIn}"></slot>
 				${overflowButton}

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "تمت إزالة عنصر قائمة العلامات {value}",
 	"components.tag-list.interactive-label": "قائمة العلامات، {count} من العناصر",
 	"components.tag-list.num-hidden": "زيادة {count} إضافي",
-	"components.tag-list.role-description": "قائمة العلامات",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "إظهار أقل",
 	"components.tag-list.show-more-description": "حدد لإظهار عناصر قائمة العلامات المخفية",
 	"components.tag-list-item.role-description": "العلامة",

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Wedi tynnu’r eitem rhestr tag {value}",
 	"components.tag-list.interactive-label": "Rhestr Tag, {count} o eitemau",
 	"components.tag-list.num-hidden": "+ {count} yn rhagor",
-	"components.tag-list.role-description": "Rhestr o Dagiau",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Dangos Llai",
 	"components.tag-list.show-more-description": "Dewis i ddangos eitemau rhestr tag cudd",
 	"components.tag-list-item.role-description": "Tag",

--- a/lang/da.js
+++ b/lang/da.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Fjernede taglisteelement {value}",
 	"components.tag-list.interactive-label": "Tagliste, {count} elementer",
 	"components.tag-list.num-hidden": "+ {count} mere",
-	"components.tag-list.role-description": "Tagliste",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Vis færre",
 	"components.tag-list.show-more-description": "Vælg for at få vist skjulte taglisteelementer",
 	"components.tag-list-item.role-description": "Tag",

--- a/lang/de.js
+++ b/lang/de.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Element {value} der Tag-Liste wurde entfernt",
 	"components.tag-list.interactive-label": "Tag-Liste, {count} Elemente",
 	"components.tag-list.num-hidden": "+ {count} weitere",
-	"components.tag-list.role-description": "Tag-Liste",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Weniger anzeigen",
 	"components.tag-list.show-more-description": "Wählen Sie diese Option, um ausgeblendete Elemente der Tag-Liste anzuzeigen",
 	"components.tag-list-item.role-description": "Tag",

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Removed tag list item {value}",
 	"components.tag-list.interactive-label": "Tag List, {count} items",
 	"components.tag-list.num-hidden": "+ {count} more",
-	"components.tag-list.role-description": "Tag List",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Show Less",
 	"components.tag-list.show-more-description": "Select to show hidden tag list items",
 	"components.tag-list-item.role-description": "Tag",

--- a/lang/en.js
+++ b/lang/en.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Removed tag list item {value}",
 	"components.tag-list.interactive-label": "Tag List, {count} items",
 	"components.tag-list.num-hidden": "+ {count} more",
-	"components.tag-list.role-description": "Tag List",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Show Less",
 	"components.tag-list.show-more-description": "Select to show hidden tag list items",
 	"components.tag-list-item.role-description": "Tag",

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Se ha eliminado el elemento {value} de la lista de etiquetas",
 	"components.tag-list.interactive-label": "Lista de etiquetas, {count} elementos",
 	"components.tag-list.num-hidden": "+ {count} más",
-	"components.tag-list.role-description": "Lista de etiquetas",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Mostrar menos",
 	"components.tag-list.show-more-description": "Seleccione esta opción para mostrar los elementos ocultos de la lista de etiquetas",
 	"components.tag-list-item.role-description": "Etiqueta",

--- a/lang/es.js
+++ b/lang/es.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Se eliminó el elemento {value} de la lista de etiquetas",
 	"components.tag-list.interactive-label": "Lista de etiquetas, {count} elementos",
 	"components.tag-list.num-hidden": "+ {count} más",
-	"components.tag-list.role-description": "Lista de etiquetas",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Mostrar menos",
 	"components.tag-list.show-more-description": "Seleccione para mostrar los elementos ocultos de la lista de etiquetas",
 	"components.tag-list-item.role-description": "Etiqueta",

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Suppression de l’élément de liste d’étiquettes {value}",
 	"components.tag-list.interactive-label": "Liste d’étiquettes, {count} éléments",
 	"components.tag-list.num-hidden": "{count} de plus",
-	"components.tag-list.role-description": "Liste d’étiquettes",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Afficher moins",
 	"components.tag-list.show-more-description": "Sélectionnez cette option pour afficher les éléments de la liste d’étiquettes masquées",
 	"components.tag-list-item.role-description": "Étiquette",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Élément {value} de la liste des balises supprimé",
 	"components.tag-list.interactive-label": "Liste des balises, {count} éléments",
 	"components.tag-list.num-hidden": "+ {count} de plus",
-	"components.tag-list.role-description": "Liste des balises",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Afficher moins",
 	"components.tag-list.show-more-description": "Sélectionnez cette option pour afficher les éléments de la liste des balises cachées",
 	"components.tag-list-item.role-description": "Marquer",

--- a/lang/haw.js
+++ b/lang/haw.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Wehe ʻia ka helu helu helu {value}",
 	"components.tag-list.interactive-label": "Papa inoa inoa, {count} mau mea",
 	"components.tag-list.num-hidden": "+ {count} hou aku",
-	"components.tag-list.role-description": "Papa inoa inoa",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Hōʻike liʻiliʻi",
 	"components.tag-list.show-more-description": "E koho e hōʻike i nā mea papa inoa inoa huna",
 	"components.tag-list-item.role-description": "Tag",

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "टैग लिस्ट आइटम {value} हटाए गए",
 	"components.tag-list.interactive-label": "टैग लिस्ट, {count} आइटम",
 	"components.tag-list.num-hidden": "+ {count} और",
-	"components.tag-list.role-description": "टैग सूची",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "कम दिखाएँ",
 	"components.tag-list.show-more-description": "छिपे हुए टैग लिस्ट आइटम दिखाने के लिए चुनें",
 	"components.tag-list-item.role-description": "टैग",

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -201,7 +201,11 @@ export default {
 	"components.tag-list.cleared-item": "タグリスト項目 {value} を削除しました",
 	"components.tag-list.interactive-label": "タグリスト、{count} 項目",
 	"components.tag-list.num-hidden": "+ {count} 件追加",
-	"components.tag-list.role-description": "タグリスト",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "少なく表示",
 	"components.tag-list.show-more-description": "選択すると、非表示のタグリスト項目が表示されます",
 	"components.tag-list-item.role-description": "タグ",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -201,7 +201,11 @@ export default {
 	"components.tag-list.cleared-item": "태그 목록 항목 {value}을(를) 제거했습니다",
 	"components.tag-list.interactive-label": "태그 목록, {count}개 항목",
 	"components.tag-list.num-hidden": "{count}개 더",
-	"components.tag-list.role-description": "태그 목록",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "간단히 표시",
 	"components.tag-list.show-more-description": "숨겨진 태그 목록 항목을 표시하려면 선택합니다",
 	"components.tag-list-item.role-description": "태그",

--- a/lang/mi.js
+++ b/lang/mi.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Kua tangohia te tūemi rārangi tūtohu {value}",
 	"components.tag-list.interactive-label": "Rārangi Tūtohu, {count} tūemi",
 	"components.tag-list.num-hidden": "+ {count} anō",
-	"components.tag-list.role-description": "Rārangi Tūtohu",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Whakaaturia mai kia iti iho",
 	"components.tag-list.show-more-description": "Tīpakohia hei whakaatu i ngā tūemi rārangi tūtohu hunahuna",
 	"components.tag-list-item.role-description": "Tūtohu",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Item {value} op de labellijst is verwijderd",
 	"components.tag-list.interactive-label": "Labellijst, {count} items",
 	"components.tag-list.num-hidden": "+ {count} extra",
-	"components.tag-list.role-description": "Labellijst",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Minder weergeven",
 	"components.tag-list.show-more-description": "Selecteer deze optie om verborgen items op labellijsten weer te geven",
 	"components.tag-list-item.role-description": "Label",

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Item {value} da lista de etiquetas removido",
 	"components.tag-list.interactive-label": "Lista de marcas, {count} itens",
 	"components.tag-list.num-hidden": "+ {count} mais",
-	"components.tag-list.role-description": "Lista de marcas",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Mostrar menos",
 	"components.tag-list.show-more-description": "Selecione para mostrar itens ocultos da lista de etiquetas",
 	"components.tag-list-item.role-description": "Marca",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Ta bort tagglistobjektet {value}",
 	"components.tag-list.interactive-label": "Tagglista, {count} objekt",
 	"components.tag-list.num-hidden": "+ {count} till",
-	"components.tag-list.role-description": "Tagglista",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Visa färre",
 	"components.tag-list.show-more-description": "Välj för att visa dolda tagglistobjekt",
 	"components.tag-list-item.role-description": "Tagg",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -209,7 +209,12 @@ export default {
 	"components.tag-list.cleared-item": "Kaldırılan etiket listesi öğesi {value}",
 	"components.tag-list.interactive-label": "Etiket Listesi, {count} öğe",
 	"components.tag-list.num-hidden": "+{count} tane daha",
-	"components.tag-list.role-description": "Etiket Listesi",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			one {Tag List with {count} item}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "Daha Azını Göster",
 	"components.tag-list.show-more-description": "Gizli etiket listesi öğelerini göstermek için seçin",
 	"components.tag-list-item.role-description": "Etiket",

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -201,7 +201,11 @@ export default {
 	"components.tag-list.cleared-item": "已移除标签列表项目 {value}",
 	"components.tag-list.interactive-label": "标签列表，{count} 个项目",
 	"components.tag-list.num-hidden": "+ {count} 个",
-	"components.tag-list.role-description": "标签列表",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "显示更少",
 	"components.tag-list.show-more-description": "选择以显示隐藏的标签列表项目",
 	"components.tag-list-item.role-description": "标记",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -202,7 +202,11 @@ export default {
 	"components.tag-list.cleared-item": "已移除標記清單項目 {value}",
 	"components.tag-list.interactive-label": "標記清單，{count} 個項目",
 	"components.tag-list.num-hidden": "還有 {count} 個",
-	"components.tag-list.role-description": "標記列表",
+	"components.tag-list.role-description":
+		`{count, plural,
+			=0 {Tag List with 0 items}
+			other {Tag List with {count} items}
+		}`,
 	"components.tag-list.show-less": "顯示更少",
 	"components.tag-list.show-more-description": "選取以顯示隱藏的標記清單項目",
 	"components.tag-list-item.role-description": "標記",


### PR DESCRIPTION
[GAUD-5257](https://desire2learn.atlassian.net/browse/GAUD-5257)

This PR adds the tag list count to the custom role description as desired. As such, the count will be announced when the browser/screen-reader announces the role context.

[GAUD-5257]: https://desire2learn.atlassian.net/browse/GAUD-5257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ