### PR TITLE
Delay querying for tag-list-item selector

### DIFF
--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -174,8 +174,6 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
-		const container = this.shadowRoot.querySelector('.tag-list-item-content');
-
 		this.addEventListener('focus', async(e) => {
 			// ignore focus events coming from inside the tag content
 			if (e.composedPath()[0] !== this) return;
@@ -198,7 +196,7 @@ export const TagListItemMixin = superclass => class extends LocalizeCoreElement(
 			await this.updateComplete;
 			// delay the focus to allow focusin to fire
 			setTimeout(() => {
-				container.focus();
+				this.shadowRoot.querySelector('.tag-list-item-content').focus();
 			});
 		});
 


### PR DESCRIPTION
[GAUD-8342](https://desire2learn.atlassian.net/browse/GAUD-8342): user-tag-list-item has no focus ring

In between the current query and the `focus()` call, the container may be updated/overwritten, leaving the container in memory disconnected from the DOM.

Run the query every time to be sure we have the currently connected container.

[GAUD-8342]: https://desire2learn.atlassian.net/browse/GAUD-8342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ