### PR TITLE
fix: Tabs: Do not dispatch d2l-tab-before-selected if tab is already selected

### DIFF
--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -141,6 +141,8 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	}
 
 	#handleClick() {
+		if (this.selected) return;
+
 		this._clicked = true;
 		const beforeSelectedEvent = new CustomEvent('d2l-tab-before-selected', {
 			detail: {

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -71,11 +71,33 @@ describe('d2l-tabs', () => {
 			await oneEvent(tabs, 'd2l-tab-selected');
 		});
 
+		it('does not dispatch d2l-tab-selected if already selected', async() => {
+			const el = await fixture(normalFixture);
+			let dispatched = false;
+			el.addEventListener('d2l-tab-selected', () => dispatched = true);
+
+			const tab = el.querySelectorAll('d2l-tab')[0]; // first tab is selected by default
+			await clickElem(tab);
+			expect(tab.selected).to.equal(true);
+			expect(dispatched).to.equal(false);
+		});
+
 		it('dispatches d2l-tab-content-change', async() => {
 			const el = await fixture(normalFixture);
 			const tab = el.querySelector('d2l-tab');
 			setTimeout(() => tab.setAttribute('text', 'new text'));
 			await oneEvent(tab, 'd2l-tab-content-change');
+		});
+
+		it('does not dispatch d2l-tab-before-selected if already selected', async() => {
+			const el = await fixture(normalFixture);
+			let dispatched = false;
+			el.addEventListener('d2l-tab-before-selected', () => dispatched = true);
+
+			const tab = el.querySelectorAll('d2l-tab')[0]; // first tab is selected by default
+			await clickElem(tab);
+			expect(tab.selected).to.equal(true);
+			expect(dispatched).to.equal(false);
 		});
 
 		describe('consumer manages state', () => {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8285)

Mark noticed when testing that if a tab was selected it would still fire the `d2l-tab-before-selected` event on click. This could lead to unintended impacts if consumers are relying on the event actually happening before selection rather than when already selected (e.g., in the LMS it could lead to duplicate page loads)