### PR TITLE
GAUD-8345 - Use new dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # update-package-lock workflow aready handles minor/patch updates
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    cooldown:
+      # update-package-lock workflow handles minor/patch updates - delay for a few weeks to give time to handle breaking change in those PRs
+      default-days: 25
+      semver-major-days: 5


### PR DESCRIPTION
A [new feature](https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/) for dependabot was released that allows you to set a "cooldown" period before a PR is opened to update to that version.

This should help with our current issue - right now, we ignore `minor` and `patch` updates from Dependabot because those are handled by `update-package-lock` and having both is super noisy. But this means we miss new `0.x` and `0.0x` versions bumps completely, unless someone notices. This is only usually a problem with dev dependencies, but would still be nice to fix.

The day counts I've chosen below are a guess at what could be nice - let's discuss! Figured we could have this run for a while here, then update all our repos if it works well.

