### PR TITLE
fix: Tabs: Tab/Tabpanel structure: Deselect panel when tab array de-selects tab

### DIFF
--- a/components/tabs/demo/tabs-array.js
+++ b/components/tabs/demo/tabs-array.js
@@ -1,0 +1,43 @@
+import '../tab.js';
+import '../tabs.js';
+import '../tab-panel.js';
+import { html, LitElement } from 'lit';
+
+class TabsArray extends LitElement {
+
+	static get properties() {
+		return {
+			_tabs: { type: Array }
+		};
+	}
+
+	constructor() {
+		super();
+		this._tabs = [{ text: 'Tab 1', selected: true }, { text: 'Tab 2' }, { text: 'Tab 3' }];
+	}
+
+	render() {
+		return html`
+			<d2l-tabs @d2l-tab-selected="${this._handleTabSelected}">
+				${this._tabs.map((tab, index) => html`
+					<d2l-tab text="${tab.text}" ?selected="${tab.selected}" slot="tabs" id="tab-${index}"></d2l-tab>
+					<d2l-tab-panel labelled-by="tab-${index}" slot="panels">
+						${tab.text} content goes here.
+					</d2l-tab-panel>`
+				)}
+			</d2l-tabs>
+		`;
+	}
+
+	_handleTabSelected(e) {
+		const selectedTab = e.target;
+		this._tabs = this._tabs.map(tab => {
+			return {
+				...tab,
+				selected: tab.text === selectedTab.text
+			};
+		});
+	}
+}
+
+customElements.define('d2l-tabs-array', TabsArray);

--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -16,6 +16,7 @@
 			import '../tabs.js';
 			import '../tab-panel.js';
 			import './tab-custom.js';
+			import './tabs-array.js';
 		</script>
 	</head>
 	<body unresolved>
@@ -334,6 +335,14 @@
 							}, 2000);
 						});
 					</script>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Tabs (array)</h2>
+
+			<d2l-demo-snippet>
+				<template>
+					<d2l-tabs-array></d2l-tabs-array>
 				</template>
 			</d2l-demo-snippet>
 

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -121,6 +121,11 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 				this.dispatchEvent(new CustomEvent(
 					'd2l-tab-selected', { bubbles: true, composed: true }
 				));
+			} else {
+				/** @ignore */
+				this.dispatchEvent(new CustomEvent(
+					'd2l-tab-deselected', { bubbles: true }
+				));
 			}
 		}
 	}

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -19,6 +19,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const overflowClipEnabled = getFlag('GAUD-7887-core-components-overflow-clipping', true);
+const newTabStructure = getFlag('GAUD-7146-tabs-new-structure', true);
 
 const scrollButtonWidth = 56;
 
@@ -371,6 +372,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 						<div class="d2l-tabs-container-list"
 							@d2l-tab-content-change="${this._handleTabContentChange}"
 							@d2l-tab-selected="${this._handleTabSelected}"
+							@d2l-tab-deselected="${this.#handleTabDeselected}"
 							@focusout="${this._handleFocusOut}"
 							aria-label="${ifDefined(this.text)}"
 							role="tablist"
@@ -1193,6 +1195,13 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 			}
 			this.#checkTabPanelMatchRequested = false;
 		}, 0);
+	}
+
+	#handleTabDeselected(e) {
+		if (!newTabStructure) return;
+
+		const panel = this._getPanel(e.target.id);
+		if (panel) panel.selected = false;
 	}
 
 	#isRTL() {

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -1,6 +1,7 @@
 import '../tab.js';
 import '../tabs.js';
 import '../tab-panel.js';
+import '../demo/tabs-array.js';
 import { clickElem, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { spy } from 'sinon';
 
@@ -128,10 +129,14 @@ describe('d2l-tabs', () => {
 
 	describe('behavior', () => {
 
-		function checkIfSelected(tab, isSelected) {
+		function checkIfSelected(tab, isSelected, panel) {
 			expect(tab.selected).to.equal(isSelected);
 			expect(tab.tabIndex).to.equal(isSelected ? 0 : -1);
 			expect(tab.ariaSelected).to.equal(isSelected.toString());
+
+			if (panel) {
+				expect(panel.selected).to.equal(isSelected);
+			}
 		}
 
 		it('should only have one panel selected at a time even if multiple have selected attribute', async() => {
@@ -257,6 +262,14 @@ describe('d2l-tabs', () => {
 			`);
 			expect(consoleSpy.called).to.be.true;
 			consoleSpy.restore();
+		});
+
+		it('should only have one panel selected at a time when tabs selected in an array', async() => {
+			const el = await fixture(html`<d2l-tabs-array></d2l-tabs-array>`);
+			const tabs = el.shadowRoot.querySelectorAll('d2l-tab');
+			await clickElem(tabs[2]);
+			checkIfSelected(tabs[0], false, el.shadowRoot.querySelectorAll('d2l-tab-panel')[0]);
+			checkIfSelected(tabs[2], true, el.shadowRoot.querySelectorAll('d2l-tab-panel')[2]);
 		});
 	});
 });


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8109)

**Problem**:
When tab/tabpanels are generated from an array, if a tab is deselected via the array then the panel does not get deselected. This is because when the loop happens to deselect the panel [here](https://github.com/BrightspaceUI/core/blob/main/components/tabs/tabs.js#L1246) the previously selected tab already has `selected` set to false.

This was found to be an issue during the my-courses backport due to the tabs being rendered based on an array which specifies `selected` state ([here](https://github.com/Brightspace/d2l-my-courses-ui/blob/master/src/d2l-my-courses-container.js#L113)). The problem would result in showing the tab panel contents of any tab that had been selected within a single tab panel.

We could also probably get rid of the old way of deselecting a panel if we use this method.