### PR TITLE
Update d2l-scroll-wrapper to no require an async update layout for print

### DIFF
--- a/components/scroll-wrapper/demo/scroll-wrapper.html
+++ b/components/scroll-wrapper/demo/scroll-wrapper.html
@@ -4,6 +4,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+		<script>
+			const urlParams = new URLSearchParams(window.location.search);
+			window.D2L = { LP: { Web: { UI: { Flags: { Flag: (key) => {
+				if (key === 'GAUD-8263-scroll-wrapper-media-print') return (urlParams.get('media-query-print') === 'true');
+				return false;
+			} } } } } };
+		</script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import './scroll-wrapper-test.js';

--- a/components/scroll-wrapper/demo/scroll-wrapper.html
+++ b/components/scroll-wrapper/demo/scroll-wrapper.html
@@ -20,6 +20,8 @@
 
 		<d2l-demo-page page-title="d2l-scroll-wrapper">
 
+			<button id="print">Print</button>
+
 			<h2>Actions</h2>
 			<d2l-demo-snippet>
 				<template>
@@ -48,5 +50,10 @@
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>
+		<script>
+			document.querySelector('#print').addEventListener('click', ()=> {
+				window.print();
+			});
+		</script>
 	</body>
 </html>

--- a/components/scroll-wrapper/demo/scroll-wrapper.html
+++ b/components/scroll-wrapper/demo/scroll-wrapper.html
@@ -4,12 +4,10 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script>
+		<script type="module">
+			import { mockFlag } from '../../../helpers/flags.js';
 			const urlParams = new URLSearchParams(window.location.search);
-			window.D2L = { LP: { Web: { UI: { Flags: { Flag: (key) => {
-				if (key === 'GAUD-8263-scroll-wrapper-media-print') return (urlParams.get('media-query-print') === 'true');
-				return false;
-			} } } } } };
+			mockFlag('GAUD-8263-scroll-wrapper-media-print', urlParams.get('media-query-print') === 'true');
 		</script>
 		<script type="module">
 			import '../../demo/demo-page.js';

--- a/components/scroll-wrapper/demo/scroll-wrapper.html
+++ b/components/scroll-wrapper/demo/scroll-wrapper.html
@@ -51,7 +51,7 @@
 
 		</d2l-demo-page>
 		<script>
-			document.querySelector('#print').addEventListener('click', ()=> {
+			document.querySelector('#print').addEventListener('click', () => {
 				window.print();
 			});
 		</script>

--- a/components/scroll-wrapper/scroll-wrapper.js
+++ b/components/scroll-wrapper/scroll-wrapper.js
@@ -165,8 +165,6 @@ class ScrollWrapper extends RtlMixin(LitElement) {
 				.d2l-scroll-wrapper-container.print-media-query-only {
 					border: none !important;
 					box-sizing: content-box !important;
-					overflow-x: visible !important;
-					overflow-y: visible !important;
 					overflow: visible !important;
 				}
 			}

--- a/components/scroll-wrapper/scroll-wrapper.js
+++ b/components/scroll-wrapper/scroll-wrapper.js
@@ -1,12 +1,18 @@
 import '../colors/colors.js';
 import '../icons/icon.js';
 import { css, html, LitElement } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { getFlag } from '../../helpers/flags.js';
 import { getFocusRingStyles } from '../../helpers/focus.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
+export const printMediaQueryOnlyFlag = getFlag('GAUD-8263-scroll-wrapper-media-print', false);
+
 const RTL_MULTIPLIER = navigator.userAgent.indexOf('Edge/') > 0 ? 1 : -1; /* legacy-Edge doesn't reverse scrolling in RTL */
 const SCROLL_AMOUNT = 0.8;
+
+// remove when cleaning up GAUD-8263-scroll-wrapper-media-print
 const PRINT_MEDIA_QUERY_LIST = matchMedia('print');
 
 let focusStyleSheet;
@@ -149,6 +155,22 @@ class ScrollWrapper extends RtlMixin(LitElement) {
 			:host([scrollbar-left]) .d2l-scroll-wrapper-button-left {
 				display: none;
 			}
+
+			@media print {
+				/* remove .print-media-query-only when cleaning up GAUD-8263-scroll-wrapper-media-print */
+				.d2l-scroll-wrapper-actions.print-media-query-only {
+					display: none;
+				}
+				/* remove .print-media-query-only when cleaning up GAUD-8263-scroll-wrapper-media-print */
+				.d2l-scroll-wrapper-container.print-media-query-only {
+					border: none !important;
+					box-sizing: content-box !important;
+					overflow-x: visible !important;
+					overflow-y: visible !important;
+					overflow: visible !important;
+				}
+			}
+
 		`;
 	}
 
@@ -160,26 +182,40 @@ class ScrollWrapper extends RtlMixin(LitElement) {
 		this._baseContainer = null;
 		this._container = null;
 		this._hScrollbar = true;
+
+		// remove when cleaning up GAUD-8263-scroll-wrapper-media-print
 		this._printMode = PRINT_MEDIA_QUERY_LIST.matches;
+
 		this._resizeObserver = new ResizeObserver(() => requestAnimationFrame(() => this.checkScrollbar()));
 		this._scrollbarLeft = false;
 		this._scrollbarRight = false;
 		this._syncDriver = null;
 		this._syncDriverTimeout = null;
 		this._checkScrollThresholds = this._checkScrollThresholds.bind(this);
+
+		// remove when cleaning up GAUD-8263-scroll-wrapper-media-print
 		this._handlePrintChange = this._handlePrintChange.bind(this);
+
 		this._synchronizeScroll = this._synchronizeScroll.bind(this);
 	}
 
 	connectedCallback() {
 		super.connectedCallback();
-		PRINT_MEDIA_QUERY_LIST.addEventListener?.('change', this._handlePrintChange);
+
+		// remove when cleaning up GAUD-8263-scroll-wrapper-media-print
+		if (!printMediaQueryOnlyFlag) {
+			PRINT_MEDIA_QUERY_LIST.addEventListener?.('change', this._handlePrintChange);
+		}
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this._disconnectAll();
-		PRINT_MEDIA_QUERY_LIST.removeEventListener?.('change', this._handlePrintChange);
+
+		// remove when cleaning up GAUD-8263-scroll-wrapper-media-print
+		if (!printMediaQueryOnlyFlag) {
+			PRINT_MEDIA_QUERY_LIST.removeEventListener?.('change', this._handlePrintChange);
+		}
 	}
 
 	firstUpdated(changedProperties) {
@@ -188,11 +224,21 @@ class ScrollWrapper extends RtlMixin(LitElement) {
 	}
 
 	render() {
-		// when printing, just get scroll-wrapper out of the way
-		if (this._printMode) return html`<slot></slot>`;
+
+		// when printing, just get scroll-wrapper out of the way; remove when cleaning up GAUD-8263-scroll-wrapper-media-print
+		if (this._printMode && !printMediaQueryOnlyFlag) return html`<slot></slot>`;
+
+		const containerClasses = {
+			'd2l-scroll-wrapper-container': true,
+			'print-media-query-only': printMediaQueryOnlyFlag // remove when cleaning up GAUD-8263-scroll-wrapper-media-print
+		};
+		const actionsClasses = {
+			'd2l-scroll-wrapper-actions': true,
+			'print-media-query-only': printMediaQueryOnlyFlag // remove when cleaning up GAUD-8263-scroll-wrapper-media-print
+		};
 
 		const actions = !this.hideActions ? html`
-			<div class="d2l-scroll-wrapper-actions">
+			<div class="${classMap(actionsClasses)}">
 				<div class="d2l-scroll-wrapper-button d2l-scroll-wrapper-button-left vdiff-target" @click="${this._scrollLeft}">
 					<d2l-icon icon="tier1:chevron-left"></d2l-icon>
 				</div>
@@ -202,7 +248,7 @@ class ScrollWrapper extends RtlMixin(LitElement) {
 			</div>` : null;
 		return html`
 			${actions}
-			<div class="d2l-scroll-wrapper-container"><slot></slot></div>
+			<div class="${classMap(containerClasses)}"><slot></slot></div>
 		`;
 	}
 
@@ -259,6 +305,7 @@ class ScrollWrapper extends RtlMixin(LitElement) {
 		}
 	}
 
+	// remove this handler when cleaning up GAUD-8263-scroll-wrapper-media-print
 	async _handlePrintChange() {
 		if (!this._printMode) {
 			this._disconnectAll();

--- a/components/table/demo/table.html
+++ b/components/table/demo/table.html
@@ -20,6 +20,8 @@
 
 		<d2l-demo-page page-title="d2l-table">
 
+			<button id="print">Print</button>
+
 			<h2>Default</h2>
 			<d2l-demo-snippet>
 				<template>
@@ -96,5 +98,10 @@
 
 			<div style="margin-bottom: 1000px;"></div>
 		</d2l-demo-page>
+		<script>
+			document.querySelector('#print').addEventListener('click', ()=> {
+				window.print();
+			});
+		</script>
 	</body>
 </html>

--- a/components/table/demo/table.html
+++ b/components/table/demo/table.html
@@ -4,12 +4,10 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
-		<script>
+		<script type="module">
+			import { mockFlag } from '../../../helpers/flags.js';
 			const urlParams = new URLSearchParams(window.location.search);
-			window.D2L = { LP: { Web: { UI: { Flags: { Flag: (key) => {
-				if (key === 'GAUD-8263-scroll-wrapper-media-print') return (urlParams.get('media-query-print') === 'true');
-				return false;
-			} } } } } };
+			mockFlag('GAUD-8263-scroll-wrapper-media-print', urlParams.get('media-query-print') === 'true');
 		</script>
 		<script type="module">
 			import '../../demo/demo-page.js';

--- a/components/table/demo/table.html
+++ b/components/table/demo/table.html
@@ -99,7 +99,7 @@
 			<div style="margin-bottom: 1000px;"></div>
 		</d2l-demo-page>
 		<script>
-			document.querySelector('#print').addEventListener('click', ()=> {
+			document.querySelector('#print').addEventListener('click', () => {
 				window.print();
 			});
 		</script>

--- a/components/table/demo/table.html
+++ b/components/table/demo/table.html
@@ -4,6 +4,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+		<script>
+			const urlParams = new URLSearchParams(window.location.search);
+			window.D2L = { LP: { Web: { UI: { Flags: { Flag: (key) => {
+				if (key === 'GAUD-8263-scroll-wrapper-media-print') return (urlParams.get('media-query-print') === 'true');
+				return false;
+			} } } } } };
+		</script>
 		<script type="module">
 			import '../../demo/demo-page.js';
 			import './table-test.js';


### PR DESCRIPTION
[GAUD-8353](https://desire2learn.atlassian.net/browse/GAUD-8353)

This PR updates `d2l-scroll-wrapper` to layout for print using a media-query only. Importantly, this avoids an async Lit update to re-layout, which is problematic because `window.print()` blocks JavaScript execution while the print dialog is open. Lit's async update cycle doesn't run in time.

The best practice should be to rely on a media-query alone, and _not_ rely on an async Lit update to re-layout the component for printing. It is possible to leverage the `beforeprint` / `afterprint` events, but again, the code must be synchronous. If we encounter cases where we really do need to wait for Lit's async life cycle to run before printing, we can wrap `window.print()` and manage the updates so that we don't call it until all the async updates are complete.

Flip the query-srtring param [here](https://live.d2l.dev/prs/BrightspaceUI/core/pr-5943/components/table/demo/table.html?media-query-print=true) to see it in action. (resize the page so scroll-wrapper buttons are displayed)

[GAUD-8353]: https://desire2learn.atlassian.net/browse/GAUD-8353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ