### PR TITLE
GAUD-8414 - Adding a demo to demonstrate `d2l-overflow-group` using Lit comments and spaces as the text for the chomped buttons

### DIFF
--- a/components/overflow-group/demo/demo-overflow-group.js
+++ b/components/overflow-group/demo/demo-overflow-group.js
@@ -1,0 +1,23 @@
+
+import '../../button/button.js';
+import '../overflow-group.js';
+import { html, LitElement } from 'lit';
+import { LocalizeCoreElement } from '../../../helpers/localize-core-element.js';
+
+class DemoOverflowGroup extends LocalizeCoreElement(LitElement) {
+	render() {
+		return html`
+			<d2l-overflow-group>
+				<d2l-button primary>${this.localize('components.more-less.more')}</d2l-button>
+				<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
+				<d2l-button>${this.localize('components.more-less.more')}</d2l-button>
+				<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
+				<d2l-button>${this.localize('components.more-less.more')}</d2l-button>
+				<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
+				<d2l-button> ${this.localize('components.more-less.more')}</d2l-button>
+				<d2l-button> ${this.localize('components.more-less.less')}</d2l-button>
+			</d2l-overflow-group>
+		`;
+	}
+}
+customElements.define('d2l-demo-overflow-group', DemoOverflowGroup);

--- a/components/overflow-group/demo/overflow-group.html
+++ b/components/overflow-group/demo/overflow-group.html
@@ -16,6 +16,26 @@
 			import '../../dropdown/dropdown-menu.js';
 			import '../../dropdown/dropdown.js';
 			import '../../link/link.js';
+			import { html, LitElement } from 'lit';
+			import { LocalizeCoreElement } from '../../../helpers/localize-core-element.js';
+
+			class DemoOverflowGroup extends LocalizeCoreElement(LitElement) {
+				render() {
+					return html`
+						<d2l-overflow-group>
+							<d2l-button primary>${this.localize('components.more-less.more')}</d2l-button>
+							<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
+							<d2l-button>${this.localize('components.more-less.more')}</d2l-button>
+							<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
+							<d2l-button>${this.localize('components.more-less.more')}</d2l-button>
+							<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
+							<d2l-button> ${this.localize('components.more-less.more')}</d2l-button>
+							<d2l-button> ${this.localize('components.more-less.less')}</d2l-button>
+						</d2l-overflow-group>
+					`;
+				}
+			}
+			customElements.define('d2l-demo-overflow-group', DemoOverflowGroup);
 		</script>
 	</head>
 	<body unresolved>
@@ -95,6 +115,13 @@
 						<d2l-button-subtle text="Import"></d2l-button-subtle>
 						<d2l-button-subtle text="Delete"></d2l-button-subtle>
 					</d2l-overflow-group>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>Overflow Group with Localized Text and Spaces</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-demo-overflow-group></d2l-demo-overflow-group>
 				</template>
 			</d2l-demo-snippet>
 		</d2l-demo-page>

--- a/components/overflow-group/demo/overflow-group.html
+++ b/components/overflow-group/demo/overflow-group.html
@@ -16,26 +16,7 @@
 			import '../../dropdown/dropdown-menu.js';
 			import '../../dropdown/dropdown.js';
 			import '../../link/link.js';
-			import { html, LitElement } from 'lit';
-			import { LocalizeCoreElement } from '../../../helpers/localize-core-element.js';
-
-			class DemoOverflowGroup extends LocalizeCoreElement(LitElement) {
-				render() {
-					return html`
-						<d2l-overflow-group>
-							<d2l-button primary>${this.localize('components.more-less.more')}</d2l-button>
-							<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
-							<d2l-button>${this.localize('components.more-less.more')}</d2l-button>
-							<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
-							<d2l-button>${this.localize('components.more-less.more')}</d2l-button>
-							<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
-							<d2l-button> ${this.localize('components.more-less.more')}</d2l-button>
-							<d2l-button> ${this.localize('components.more-less.less')}</d2l-button>
-						</d2l-overflow-group>
-					`;
-				}
-			}
-			customElements.define('d2l-demo-overflow-group', DemoOverflowGroup);
+			import './demo-overflow-group.js';
 		</script>
 	</head>
 	<body unresolved>
@@ -59,7 +40,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-overflow-group auto-show>
-						<d2l-button  disabled primary>New</d2l-button>
+						<d2l-button disabled primary>New</d2l-button>
 						<d2l-dropdown-button text="Explore Topics" class="d2l-button-group-show">
 							<d2l-dropdown-menu id="dropdown">
 								<d2l-menu label="Astronomy">


### PR DESCRIPTION
We don't have to merge this if we don't think it's useful, but this reproduces the `d2l-overflow-group` issue I mentioned in standup.