### PR TITLE
MAN-4282: Add panic timer to LoadingCompleteMixin

### DIFF
--- a/mixins/loading-complete/README.md
+++ b/mixins/loading-complete/README.md
@@ -26,7 +26,7 @@ async removeSkeleton() {
 }
 ```
 
-If for any reason `resolveLoadingComplete` is never called, `loadingComplete` won't resolve and any consumers will hang.
+If for any reason `resolveLoadingComplete` is never called, `loadingComplete` won't resolve and any consumers will hang. A warning will be thrown indicating that the component has entered a bad state.
 
 ### `getLoadingComplete`
 

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -22,7 +22,18 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	#loadingCompleteResolve;
 
 	#loadingCompletePromise = !Object.prototype.hasOwnProperty.call(this.constructor.prototype, 'getLoadingComplete')
-		? new Promise(resolve => this.#loadingCompleteResolve = resolve)
+		? new Promise(resolve => {
+			const TIMEOUT_MS = 1000 * 10;
+
+			const timeout = setTimeout(() => {
+				console.warn(`Failed to resolve ${this.localName} in ${TIMEOUT_MS}ms: resolveLoadingComplete was not called`);
+			}, TIMEOUT_MS);
+
+			this.#loadingCompleteResolve = () => {
+				clearTimeout(timeout);
+				resolve();
+			};
+		})
 		: Promise.resolve();
 
 });

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -23,7 +23,7 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 
 	#loadingCompletePromise = !Object.prototype.hasOwnProperty.call(this.constructor.prototype, 'getLoadingComplete')
 		? new Promise(resolve => {
-			const TIMEOUT_MS = 1000 * 10;
+			const TIMEOUT_MS = 1000 * 30;
 
 			const timeout = setTimeout(() => {
 				console.warn(`Failed to resolve ${this.localName} in ${TIMEOUT_MS}ms: resolveLoadingComplete was not called`);

--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -1,5 +1,7 @@
 import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
+const timeoutMs = 30000;
+
 export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends superclass {
 	get loadingComplete() {
 		return this.getLoadingComplete();
@@ -23,11 +25,9 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 
 	#loadingCompletePromise = !Object.prototype.hasOwnProperty.call(this.constructor.prototype, 'getLoadingComplete')
 		? new Promise(resolve => {
-			const TIMEOUT_MS = 1000 * 30;
-
 			const timeout = setTimeout(() => {
-				console.warn(`Failed to resolve ${this.localName} in ${TIMEOUT_MS}ms: resolveLoadingComplete was not called`);
-			}, TIMEOUT_MS);
+				console.warn(`Failed to load ${this.localName} in ${timeoutMs}ms: resolveLoadingComplete was not called`);
+			}, timeoutMs);
 
 			this.#loadingCompleteResolve = () => {
 				clearTimeout(timeout);


### PR DESCRIPTION
We recently ran into an issue where resolveLoadingComplete was not called for a certain component state and found it would be valuable to trace back to the component where a promise has been left hanging

Ideally this message should only print in dev, though having this make it out into the wild may indicate other performance/usability issues.