### PR TITLE
GAUD-8414 - Fix d2l-overflow-group using localize with d2l-button

### DIFF
--- a/components/overflow-group/demo/demo-overflow-group.js
+++ b/components/overflow-group/demo/demo-overflow-group.js
@@ -1,5 +1,8 @@
 
 import '../../button/button.js';
+import '../../button/button-icon.js';
+import '../../button/button-subtle.js';
+import '../../selection/selection-action.js';
 import '../overflow-group.js';
 import { html, LitElement } from 'lit';
 import { LocalizeCoreElement } from '../../../helpers/localize-core-element.js';
@@ -15,7 +18,10 @@ class DemoOverflowGroup extends LocalizeCoreElement(LitElement) {
 				<d2l-button>${this.localize('components.more-less.more')}</d2l-button>
 				<d2l-button>${this.localize('components.more-less.less')}</d2l-button>
 				<d2l-button> ${this.localize('components.more-less.more')}</d2l-button>
-				<d2l-button> ${this.localize('components.more-less.less')}</d2l-button>
+				<button>${this.localize('components.more-less.less')}</button>
+				<d2l-button-icon icon="tier1:gear" text="${this.localize('components.more-less.more')}"></d2l-button-icon>
+				<d2l-button-subtle text="${this.localize('components.more-less.less')}"></d2l-button-subtle>
+				<d2l-selection-action icon="tier1:bookmark-hollow" text="${this.localize('components.more-less.more')}"></d2l-selection-action>
 			</d2l-overflow-group>
 		`;
 	}

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -20,7 +20,18 @@ const OPENER_STYLE = {
 };
 
 function createMenuItem(node) {
-	const childText = node.text || node.firstChild && (node.firstChild.label || node.firstChild.text || node.firstChild.textContent.trim());
+	let childText = node.text;
+	if (!childText) {
+		const childNode = Array.from(node.childNodes).find(childNode => {
+			if (childNode.nodeType === Node.COMMENT_NODE) return false;
+			if (childNode.nodeType === Node.TEXT_NODE && !childNode.textContent.trim()) return false;
+			return true;
+		});
+		if (childNode) {
+			childText = childNode.label || childNode.text || childNode.textContent.trim();
+		}
+	}
+
 	const disabled = !!node.disabled;
 	const handleItemSelect = () => {
 		node.dispatchEvent(new CustomEvent('d2l-button-ghost-click'));

--- a/components/overflow-group/test/overflow-group.test.js
+++ b/components/overflow-group/test/overflow-group.test.js
@@ -1,6 +1,28 @@
 import '../overflow-group.js';
 import '../../button/button.js';
-import { fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import '../../button/button-icon.js';
+import '../../button/button-subtle.js';
+import '../../selection/selection-action.js';
+import { defineCE, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { LitElement } from 'lit';
+import { LocalizeCoreElement } from '../../../helpers/localize-core-element.js';
+
+const tagName = defineCE(
+	class extends LocalizeCoreElement(LitElement) {
+		render() {
+			return html`
+				<d2l-overflow-group min-to-show="0" max-to-show="0">
+					<d2l-button>${this.localize('components.overflow-group.moreActions')}</d2l-button>
+					<d2l-button> ${this.localize('components.overflow-group.moreActions')}</d2l-button>
+					<button>${this.localize('components.overflow-group.moreActions')}</button>
+					<d2l-button-icon icon="tier1:gear" text="${this.localize('components.overflow-group.moreActions')}"></d2l-button-icon>
+					<d2l-button-subtle text="${this.localize('components.overflow-group.moreActions')}"></d2l-button-subtle>
+					<d2l-selection-action icon="tier1:bookmark-hollow" text="${this.localize('components.overflow-group.moreActions')}"></d2l-selection-action>
+				</d2l-overflow-group>
+			`;
+		}
+	}
+);
 
 describe('d2l-overflow-group', () => {
 	describe('constructor', () => {
@@ -34,6 +56,17 @@ describe('d2l-overflow-group', () => {
 			await oneEvent(container, 'd2l-overflow-group-updated');
 		});
 
+	});
+
+	it('use correct node to grab text for menu item', async() => {
+		const container = await fixture(`<${tagName}></${tagName}>`);
+		const overflowGroup = container.shadowRoot.querySelector('d2l-overflow-group');
+		await overflowGroup.updateComplete;
+
+		const menuItems = overflowGroup.shadowRoot.querySelectorAll('d2l-menu-item');
+		Array.from(menuItems).forEach(item => {
+			expect(item.text).to.equal('More Actions');
+		});
 	});
 
 });


### PR DESCRIPTION
Putting this up for early review, will look at adding some tests.

Currently, `d2l-overflow-group` doesn't work with a `d2l-button` using `this.localize` - when chomped, it grabs the Lit comment as the first node:
<img width="403" height="368" alt="image" src="https://github.com/user-attachments/assets/6c0a1116-9f19-4aeb-8abb-a93bfc8296cd" />

This filters out comment nodes (and empty text nodes - do we want this?).

I'm currently not flagging this because:
1. The product running into this bug can't use our feature flags, as far as I know. It's also not released yet.
2. From what I can tell, this is not currently an issue anywhere. It only happens for `d2l-button` or `button` (`d2l-button-subtle`, `d2l-button-icon`, and `d2l-selection-action` have `text` values that are used). There are only a few uses of `d2l-overflow-group`, and they either use `subtle-button` or are in the LMS (which doesn't use `localize`, so no Lit comments).

Thoughts? Does the change itself seem risky?