### PR TITLE
Remove RtlMixin from breadcrumbs.

### DIFF
--- a/components/breadcrumbs/breadcrumb.js
+++ b/components/breadcrumbs/breadcrumb.js
@@ -4,12 +4,11 @@ import { findComposedAncestor } from '../../helpers/dom.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { linkStyles } from '../link/link.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * An entry within a <d2l-breadcrumbs> parent.
  */
-class Breadcrumb extends RtlMixin(FocusMixin(LitElement)) {
+class Breadcrumb extends FocusMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -59,25 +58,13 @@ class Breadcrumb extends RtlMixin(FocusMixin(LitElement)) {
 			.d2l-link:focus {
 				outline-offset: -2px;
 			}
-
 			d2l-icon {
 				height: 8px;
-				padding-left: 8px;
-				padding-right: 3px;
+				padding-inline: 8px 3px;
 				width: 8px;
 			}
-			:host([dir="rtl"]) d2l-icon {
-				padding-left: 3px;
-				padding-right: 8px;
-			}
-
 			d2l-icon[icon="tier1:chevron-left"] {
-				padding-left: 0;
-				padding-right: 8px;
-			}
-			:host([dir="rtl"]) d2l-icon[icon="tier1:chevron-left"] {
-				padding-left: 8px;
-				padding-right: 0;
+				padding-inline: 0 8px;
 			}
 		`];
 	}

--- a/components/breadcrumbs/breadcrumbs.js
+++ b/components/breadcrumbs/breadcrumbs.js
@@ -3,7 +3,6 @@ import { css, html, LitElement } from 'lit';
 import { getFlag } from '../../helpers/flags.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { overflowEllipsisDeclarations } from '../../helpers/overflow.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 const overflowClipEnabled = getFlag('GAUD-7887-core-components-overflow-clipping', true);
 
@@ -11,7 +10,8 @@ const overflowClipEnabled = getFlag('GAUD-7887-core-components-overflow-clipping
  * Help users understand where they are within the application, and provide useful clues about how the space is organized. They also provide a convenient navigation mechanism.
  * @slot - Breadcrumb items
  */
-class Breadcrumbs extends LocalizeCoreElement(RtlMixin(LitElement)) {
+class Breadcrumbs extends LocalizeCoreElement(LitElement) {
+
 	static get properties() {
 		return {
 			/**
@@ -38,23 +38,15 @@ class Breadcrumbs extends LocalizeCoreElement(RtlMixin(LitElement)) {
 			:host([hidden]) {
 				display: none;
 			}
-
 			:host::after {
-				background: linear-gradient(to right, rgba(255, 255, 255, 0), rgb(251, 252, 252));
-				bottom: 0;
+				background: linear-gradient(to var(--d2l-inline-end, right), rgba(255, 255, 255, 0), rgb(251, 252, 252));
 				content: "";
+				inset-block: 0;
+				inset-inline-end: 0;
 				pointer-events: none;
 				position: absolute;
-				right: 0;
-				top: 0;
 				width: 10px;
 			}
-			:host([dir="rtl"])::after {
-				background: linear-gradient(to left, rgba(255, 255, 255, 0), rgb(251, 252, 252));
-				left: 0;
-				right: auto;
-			}
-
 			:host([compact]) ::slotted(d2l-breadcrumb:not(:last-of-type)),
 			:host([compact]) ::slotted(d2l-breadcrumb-current-page) {
 				display: none;


### PR DESCRIPTION
[GAUD-8429](https://desire2learn.atlassian.net/browse/GAUD-8429)

Update `d2l-breadcrumbs` and `d2l-breadcrumb` to use CSS logical properties instead of `RtlMixin`, etc.

[GAUD-8429]: https://desire2learn.atlassian.net/browse/GAUD-8429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ