### PR TITLE
Remove RtlMixin from d2l-card-footer-link.

### DIFF
--- a/components/card/card-footer-link.js
+++ b/components/card/card-footer-link.js
@@ -5,13 +5,12 @@ import { css, html, LitElement } from 'lit';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * An icon link that can be placed in the `footer` slot.
  * @slot tooltip - slot for the link tooltip
  */
-class CardFooterLink extends FocusMixin(RtlMixin(LitElement)) {
+class CardFooterLink extends FocusMixin(LitElement) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
[GAUD-8432](https://desire2learn.atlassian.net/browse/GAUD-8432)

This PR removes `RtlMixin` from `d2l-card-footer-link` since it is no longer needed. The mixin was previously needed because `offscreenStyles` relied on it, but those styles were converted to CSS logical properties a while ago.

[GAUD-8432]: https://desire2learn.atlassian.net/browse/GAUD-8432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ