### PR TITLE
Remove RtlMixin from d2l-pager-load-more.

### DIFF
--- a/components/paging/pager-load-more.js
+++ b/components/paging/pager-load-more.js
@@ -10,7 +10,6 @@ import { labelStyles } from '../typography/styles.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
 import { PageableSubscriberMixin } from './pageable-subscriber-mixin.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 const nativeFocus = document.createElement('div').focus;
 
@@ -19,7 +18,7 @@ const nativeFocus = document.createElement('div').focus;
  * @fires d2l-pager-load-more - Dispatched when the user clicks the load-more button. Consumers must call the provided "complete" method once items have been loaded.
  * @fires d2l-pager-load-more-loaded - Dispatched after more items have been loaded.
  */
-class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(RtlMixin(LitElement)))) {
+class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(LitElement))) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
[GAUD-8442](https://desire2learn.atlassian.net/browse/GAUD-8442)

This PR removes the `RtlMixin` from `d2l-pager-load-more`. It was no longer needed since `offscreenStyles` were previously updated to use CSS logical properties.

[GAUD-8442]: https://desire2learn.atlassian.net/browse/GAUD-8442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ