### PR TITLE
Remove RtlMixin from DialogMixin and dialog components.

### DIFF
--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -93,11 +93,8 @@ class DialogFullscreen extends PropertyRequiredMixin(LocalizeCoreElement(AsyncCo
 
 				.d2l-dialog-header > div > d2l-button-icon {
 					flex: none;
-					margin: -2px -12px 0 0;
-				}
-
-				:host([dir="rtl"]) .d2l-dialog-header > div > d2l-button-icon {
-					margin: -2px 0 0 -12px;
+					margin-block: -2px 0;
+					margin-inline: 0 -12px;
 				}
 
 				dialog.d2l-dialog-outer,

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -8,7 +8,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { tryGetIfrauBackdropService } from '../../helpers/ifrauBackdropService.js';
 import { waitForElem } from '../../helpers/internal/waitForElem.js';
@@ -29,7 +28,7 @@ const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const abortAction = 'abort';
 const defaultMargin = { top: 75, right: 30, bottom: 30, left: 30 };
 
-export const DialogMixin = superclass => class extends RtlMixin(superclass) {
+export const DialogMixin = superclass => class extends superclass {
 
 	static get properties() {
 		return {

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -159,12 +159,7 @@ export const dialogStyles = css`
 
 	.d2l-dialog-footer ::slotted(*) {
 		margin-bottom: 18px;
-		margin-right: 18px;
-	}
-
-	:host([dir="rtl"]) .d2l-dialog-footer ::slotted(*) {
-		margin-left: 18px;
-		margin-right: 0;
+		margin-inline-end: 18px;
 	}
 
 	dialog.d2l-dialog-outer.d2l-dialog-fullscreen-within,
@@ -185,11 +180,8 @@ export const dialogStyles = css`
 			padding: 14px 20px 16px 20px;
 		}
 		.d2l-dialog-fullscreen-mobile .d2l-dialog-header > div > d2l-button-icon {
-			margin: -8px -13px 0 15px;
-		}
-		:host([dir="rtl"]) .d2l-dialog-fullscreen-mobile .d2l-dialog-header > div > d2l-button-icon {
-			margin-left: -13px;
-			margin-right: 15px;
+			margin-block: -8px 0;
+			margin-inline: 15px -13px;
 		}
 		.d2l-dialog-content {
 			--d2l-list-controls-padding: 20px;

--- a/components/dialog/dialog-styles.js
+++ b/components/dialog/dialog-styles.js
@@ -158,7 +158,7 @@ export const dialogStyles = css`
 	}
 
 	.d2l-dialog-footer ::slotted(*) {
-		margin-bottom: 18px;
+		margin-block-end: 18px;
 		margin-inline-end: 18px;
 	}
 

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -67,12 +67,8 @@ class Dialog extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMix
 
 			.d2l-dialog-header > div > d2l-button-icon {
 				flex: none;
-				margin: -4px -15px 0 15px;
-			}
-
-			:host([dir="rtl"]) .d2l-dialog-header > div > d2l-button-icon {
-				margin-left: -15px;
-				margin-right: 15px;
+				margin-block: -4px 0;
+				margin-inline: 15px -15px;
 			}
 
 			.d2l-dialog-content > div {


### PR DESCRIPTION
[GAUD-8435](https://desire2learn.atlassian.net/browse/GAUD-8435)

This PR removes `RtlMixin` from `DialogMixin` and the core dialog components.

There are [additional usages](https://search.d2l.dev/search?project=Brightspace&project=BrightspaceHypermediaComponents&project=BrightspaceUI&project=BrightspaceUILabs&project=D2L-LCS&project=lms&full=%22DialogMixin%28%22&defs=&refs=&path=&hist=&type=&xrd=&nn=6&si=full&si=full) of `DialogMixin` that will need to be switched to CSS logical properties before this can be merged, since they unfortunately assume that `DialogMixin` is including the `RtlMixin`.

[GAUD-8435]: https://desire2learn.atlassian.net/browse/GAUD-8435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ