### PR TITLE
Remove RtlMixin from d2l-dropdown-button.

### DIFF
--- a/components/dropdown/dropdown-button.js
+++ b/components/dropdown/dropdown-button.js
@@ -3,13 +3,12 @@ import '../icons/icon.js';
 import { css, html, LitElement } from 'lit';
 import { DropdownOpenerMixin } from './dropdown-opener-mixin.js';
 import { dropdownOpenerStyles } from './dropdown-opener-styles.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * A "d2l-button" opener for dropdown content.
  * @slot - Dropdown content (e.g., "d2l-dropdown-content", "d2l-dropdown-menu" or "d2l-dropdown-tabs")
  */
-class DropdownButton extends DropdownOpenerMixin(RtlMixin(LitElement)) {
+class DropdownButton extends DropdownOpenerMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -36,16 +35,12 @@ class DropdownButton extends DropdownOpenerMixin(RtlMixin(LitElement)) {
 		return [dropdownOpenerStyles, css`
 			d2l-icon {
 				height: 0.8rem;
-				margin-left: 0.6rem;
+				margin-inline-start: 0.6rem;
 				pointer-events: none;
 				width: 0.8rem;
 			}
 			:host([primary]) d2l-icon {
 				color: white;
-			}
-			:host([dir="rtl"]) d2l-icon {
-				margin-left: 0;
-				margin-right: 0.6rem;
 			}
 			d2l-button {
 				width: 100%;


### PR DESCRIPTION
[GAUD-8467](https://desire2learn.atlassian.net/browse/GAUD-8467)

This PR removes RtlMixin from the `d2l-dropdown-button` opener.

[GAUD-8467]: https://desire2learn.atlassian.net/browse/GAUD-8467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ