### PR TITLE
Remove RtlMixin from meter components.

### DIFF
--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -4,12 +4,11 @@ import { css, html, LitElement, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { MeterMixin } from './meter-mixin.js';
 import { meterStyles } from './meter-styles.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * A circular progress indicator.
  */
-class MeterCircle extends MeterMixin(RtlMixin(LitElement)) {
+class MeterCircle extends MeterMixin(LitElement) {
 	static get styles() {
 		return [ bodySmallStyles, bodyStandardStyles, meterStyles, css`
 		:host {

--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -2,12 +2,11 @@ import { css, html, LitElement, nothing } from 'lit';
 import { bodySmallStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { MeterMixin } from './meter-mixin.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * A horizontal progress bar.
  */
-class MeterLinear extends MeterMixin(RtlMixin(LitElement)) {
+class MeterLinear extends MeterMixin(LitElement) {
 	static get properties() {
 		return {
 			/**
@@ -86,7 +85,7 @@ class MeterLinear extends MeterMixin(RtlMixin(LitElement)) {
 				align-self: flex-end;
 			}
 
-			:host([dir="rtl"]) .d2l-meter-linear-primary-ltr {
+			.d2l-meter-linear-primary-ltr {
 				direction: ltr;
 			}
 		`];

--- a/components/meter/meter-radial.js
+++ b/components/meter/meter-radial.js
@@ -4,12 +4,11 @@ import { css, html, LitElement, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { MeterMixin } from './meter-mixin.js';
 import { meterStyles } from './meter-styles.js';
-import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 /**
  * A half-circle progress indicator.
  */
-class MeterRadial extends MeterMixin(RtlMixin(LitElement)) {
+class MeterRadial extends MeterMixin(LitElement) {
 	static get styles() {
 		return [ heading4Styles, bodySmallStyles, meterStyles, css`
 		:host {

--- a/components/meter/meter-styles.js
+++ b/components/meter/meter-styles.js
@@ -34,7 +34,7 @@ export const meterStyles = css`
 		color: white;
 		fill: white;
 	}
-	:host([dir="rtl"]) .d2l-meter-text-ltr {
+	.d2l-meter-text-ltr {
 		direction: ltr;
 	}
 `;


### PR DESCRIPTION
[GAUD-8441](https://desire2learn.atlassian.net/browse/GAUD-8441)

This PR removes `RtlMixin` from the meter components. It was being used to force the writing direction to `ltr` when fractions are rendered (i.e. not percent).

[GAUD-8441]: https://desire2learn.atlassian.net/browse/GAUD-8441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ