### PR TITLE
Remove RtlMixin from d2l-table-wrapper and table styles.

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -178,13 +178,10 @@ export const tableStyles = css`
 	/* all sticky cells */
 	d2l-table-wrapper[sticky-headers] .d2l-table > * > tr > .d2l-table-sticky-cell,
 	d2l-table-wrapper[sticky-headers] .d2l-table > * > tr > [sticky] {
+		inset-inline-start: 0;
 		position: -webkit-sticky;
 		position: sticky;
 		z-index: 1;
-	}
-	d2l-table-wrapper[sticky-headers] .d2l-table > * > tr > .d2l-table-sticky-cell,
-	d2l-table-wrapper[sticky-headers] .d2l-table > * > tr > [sticky] {
-		inset-inline-start: 0;
 	}
 
 	/* non-header sticky cells */


### PR DESCRIPTION
[GAUD-8445](https://desire2learn.atlassian.net/browse/GAUD-8445)

This PR converts the exported `tableStyles` to use CSS logical properties and removes the `RtlMixin` from `d2l-table-wrapper`.

[GAUD-8445]: https://desire2learn.atlassian.net/browse/GAUD-8445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ