### PR TITLE
Experiment with supporting a form around primary/secondary template

### DIFF
--- a/components/form/form-error-summary.js
+++ b/components/form/form-error-summary.js
@@ -9,7 +9,9 @@ class FormErrorSummary extends LocalizeCoreElement(LitElement) {
 	static get properties() {
 		return {
 			errors: { type: Object, attribute: false },
-			_expanded: { type: Boolean, attribute: false }
+			_expanded: { type: Boolean, attribute: false },
+			_hasBottomMargin: { type: Boolean, attribute: '_has-bottom-margin', reflect: true },
+			_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
 		};
 	}
 
@@ -19,9 +21,11 @@ class FormErrorSummary extends LocalizeCoreElement(LitElement) {
 			:host {
 				display: block;
 			}
-
 			:host([hidden]) {
 				display: none;
+			}
+			:host([_has-bottom-margin][_has-errors]) {
+				margin-block-end: 1rem;
 			}
 
 			.d2l-form-error-summary-header {
@@ -54,6 +58,7 @@ class FormErrorSummary extends LocalizeCoreElement(LitElement) {
 		super();
 		this.errors = [];
 		this._expanded = true;
+		this._hasBottomMargin = false;
 	}
 
 	render() {
@@ -80,6 +85,13 @@ class FormErrorSummary extends LocalizeCoreElement(LitElement) {
 			</d2l-alert>
 		`;
 		return this.errors.length > 0 ? errorSummary : nothing;
+	}
+
+	willUpdate(changedProperties) {
+		super.willUpdate(changedProperties);
+		if (changedProperties.has('errors')) {
+			this._hasErrors = this.errors.length > 0;
+		}
 	}
 
 	async focus() {

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -1,9 +1,9 @@
-import './form-errory-summary.js';
+import './form-error-summary.js';
 import '../tooltip/tooltip.js';
 import '../link/link.js';
 import { css, html, LitElement } from 'lit';
+import { findComposedAncestor, querySelectorComposed } from '../../helpers/dom.js';
 import { findFormElements, flattenMap, getFormElementData, isCustomFormElement, isNativeFormElement } from './form-helper.js';
-import { findComposedAncestor } from '../../helpers/dom.js';
 import { getComposedActiveElement } from '../../helpers/focus.js';
 import { getFlag } from '../../helpers/flags.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
@@ -107,7 +107,13 @@ class Form extends LocalizeCoreElement(LitElement) {
 			const errors = [...flattenMap(this._errors)]
 				.filter(([, eleErrors]) => eleErrors.length > 0)
 				.map(([ele, eleErrors]) => ({ href: `#${ele.id}`, message: eleErrors[0], onClick: () => ele.focus() }));
-			errorSummary = html`<d2l-form-error-summary .errors=${errors}></d2l-form-error-summary>`;
+			const existingSummary = querySelectorComposed(this, 'd2l-form-error-summary');
+			if (existingSummary) {
+				existingSummary.errors = errors;
+				existingSummary._hasBottomMargin = true;
+			} else {
+				errorSummary = html`<d2l-form-error-summary .errors=${errors}></d2l-form-error-summary>`;
+			}
 		}
 		return html`
 			${errorSummary}

--- a/components/form/test/form-error-summary.test.js
+++ b/components/form/test/form-error-summary.test.js
@@ -1,4 +1,4 @@
-import '../form-errory-summary.js';
+import '../form-error-summary.js';
 import { expect, fixture, runConstructor } from '@brightspace-ui/testing';
 import { html } from 'lit';
 

--- a/components/form/test/form-error-summary.vdiff.js
+++ b/components/form/test/form-error-summary.vdiff.js
@@ -1,4 +1,4 @@
-import '../form-errory-summary.js';
+import '../form-error-summary.js';
 import { clickElem, expect, fixture, html } from '@brightspace-ui/testing';
 
 const errors = [

--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
 		<li><a href="templates/primary-secondary/demo/width-type-normal.html">Primary Secondary Template (normal width)</a></li>
 		<li><a href="templates/primary-secondary/demo/overflow-hidden.html">Primary Secondary Template (hidden primary overflow)</a></li>
 		<li><a href="templates/primary-secondary/demo/integration.html">Primary Secondary Template (integration with other components)</a></li>
+		<li><a href="templates/primary-secondary/demo/form.html">Primary Secondary Template (surrounding form)</a></li>
 	</ul>
 
 </body>

--- a/templates/primary-secondary/demo/form.html
+++ b/templates/primary-secondary/demo/form.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../../components/demo/styles.css" type="text/css">
+		<script type="module">
+			import '../../../components/button/button.js';
+			import '../../../components/demo/demo-page.js';
+			import '../../../components/inputs/input-group.js';
+			import '../../../components/inputs/input-radio-group.js';
+			import '../../../components/inputs/input-radio.js';
+			import '../../../components/inputs/input-text.js';
+			import '../../../components/inputs/input-textarea.js';
+			import '../../../components/form/form.js';
+			import '../../../components/form/form-error-summary.js';
+			import '../primary-secondary.js';
+		</script>
+		<style>
+			div[slot="primary"] {
+				padding: 20px;
+			}
+			div[slot="secondary"] {
+				padding: 10px;
+			}
+		</style>
+	</head>
+	<body>
+		<d2l-form>
+			<d2l-template-primary-secondary background-shading="secondary" width-type="normal">
+				<div slot="primary">
+					<d2l-form-error-summary></d2l-form-error-summary>
+					<d2l-input-group>
+						<d2l-input-text name="name" label="Name" required></d2l-input-text>
+						<d2l-input-textarea name="description" label="Description"></d2l-input-textarea>
+					</d2l-input-group>
+				</div>
+				<div slot="secondary">
+					<d2l-input-radio-group name="band" label="Band" required>
+						<d2l-input-radio label="FM" value="fm"></d2l-input-radio>
+						<d2l-input-radio label="AM" value="am"></d2l-input-radio>
+					</d2l-input-radio-group>
+				</div>
+				<div slot="footer">
+					<d2l-button primary>Save</d2l-button>
+				</div>
+			</d2l-template-primary-secondary>
+		</d2l-form>
+		<script>
+			const form = document.querySelector('d2l-form');
+			document
+				.querySelector('d2l-button')
+				.addEventListener('click', () => form.submit());
+			form.addEventListener('d2l-form-submit', (e) => {
+				console.log('Form submitted!', e.detail.formData);
+			});
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
We currently have no way to support the use of our primary/secondary template with a `<d2l-form>` that encapsulates both panels. If consumers wrap their form around the template, the error summary displays in the wrong spot.

A few ideas preceded this one:
1. Use a special "form" slot where the consumer can pass the template their form and it puts it in a place that surrounds both panels. This doesn't work because the form needs to contain the panels and therefore can't be a sibling slot.
2. Have consumers use 3 forms -- one around everything and one inside each panel -- and designate one of them as the the place where the summary should render. I didn't try this as forcing consumers to use 3 forms didn't seem great.
3. Have the primary/secondary template render the summary inside the primary panel, and then have the form search for that. This didn't work because the primary panel doesn't come with any preset padding (the consumer handles this), resulting in the summary having no padding around it.

I landed on a variation of 3). The form does search for a nested `<d2l-form-error-summary>` before displaying its own, but instead of it being provided by the page template, it's provided by the consumer.