### PR TITLE
MAN-3474 -- Fixed incorrect alignment of leaf nodes in nested d2l-list elements

### DIFF
--- a/components/list/list-item-expand-collapse-mixin.js
+++ b/components/list/list-item-expand-collapse-mixin.js
@@ -22,6 +22,7 @@ export const ListItemExpandCollapseMixin = superclass => class extends SkeletonM
 			 * @type {boolean}
 			 */
 			expanded: { type: Boolean, reflect: true },
+			_isNested: { state: true },
 			_siblingHasNestedItems: { state: true },
 			_renderExpandCollapseSlot: { type: Boolean, reflect: true, attribute: '_render-expand-collapse-slot' },
 			_showNestedLoadingSpinner: { state: true }
@@ -93,7 +94,7 @@ export const ListItemExpandCollapseMixin = superclass => class extends SkeletonM
 
 	updated(changedProperties) {
 		if (changedProperties.has('_siblingHasNestedItems') || changedProperties.has('expandable')) {
-			this._renderExpandCollapseSlot = this.expandable || this._siblingHasNestedItems;
+			this._renderExpandCollapseSlot = this.expandable || this._siblingHasNestedItems || this._isNested;
 		}
 		if (changedProperties.has('_draggingOver') && this._draggingOver && this.dropNested && !this.expanded && this.expandable) {
 			let elapsedHoverTime = 0;

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -360,6 +360,7 @@ class List extends PageableMixin(SelectionMixin(LitElement)) {
 		let aChildHasColor = false;
 		let aChildHasToggleEnabled = false;
 		for (const item of items) {
+			item._isNested = true;
 			if (item.color) aChildHasColor = true;
 			if (item.expandable) aChildHasToggleEnabled = true;
 			if (aChildHasToggleEnabled && aChildHasColor) break;


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/MAN-3474

Converting a page specific fix (https://github.com/Brightspace/d2l-outcomes/pull/2204) into a more general fix.

This change fixes inconsistent and very confusing indentation of nested lists. Previously, leaf nodes would have the same indentation as their parent, making it extremely confusing which elements are children and which are siblings. Now, with this change, all nodes at the same level are indented the same amount.

Previous behaviour (outcomes management page):
<img width="1234" height="786" alt="471644229-25e43bbb-da49-4b79-88f1-57a73800ffca" src="https://github.com/user-attachments/assets/ceb9f9d2-09f2-4263-836e-957a49ade9cd" />

New behaviour (outcomes management page):
<img width="1226" height="789" alt="image" src="https://github.com/user-attachments/assets/50795497-9bbd-4989-a461-11f21b0dc2c7" />
