### PR TITLE
fix: Selection Summary: Announce changes to screen reader users [a11y audit]

### DIFF
--- a/components/selection/selection-summary.js
+++ b/components/selection/selection-summary.js
@@ -39,7 +39,7 @@ class Summary extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) {
 			return nothing;
 		}
 		return html`
-			<p class="d2l-body-compact">${this._summary}</p>
+			<p class="d2l-body-compact" role="status" aria-atomic="true">${this._summary}</p>
 		`;
 	}
 


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8528)

Problem:
Changes to selection-summary are not announced to screen reader users. The defect is specifically referring to a table search, which this change would fix along with any other cases (e.g., selection change).

This change is based on example 1 [here](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22). In some places `role="status"` is treated as atomic (e.g., VoiceOver + Safari worked fine) but according to that w3c page that is not always the case.