### PR TITLE
fix: [cert] lang terms: update HAW and MI terms that were incorrect in Aug release

### DIFF
--- a/lang/haw.js
+++ b/lang/haw.js
@@ -211,9 +211,9 @@ export default {
 	"components.tag-list.num-hidden": "+ {count} hou aku",
 	"components.tag-list.role-description":
 		`{count, plural,
-			=0 {Tag List with 0 items}
-			one {Tag List with {count}i mea}
-			other {Tag List with {count}a ʻē aʻe}
+			=0 {Papa inoa me 0 mau mea}
+			one {Papa inoa me {count} mau mea}
+			other {Papa inoa me {count} mau mea}
 		}`,
 	"components.tag-list.show-less": "Hōʻike liʻiliʻi",
 	"components.tag-list.show-more-description": "E koho e hōʻike i nā mea papa inoa inoa huna",

--- a/lang/mi.js
+++ b/lang/mi.js
@@ -211,9 +211,9 @@ export default {
 	"components.tag-list.num-hidden": "+ {count} anō",
 	"components.tag-list.role-description":
 		`{count, plural,
-			=0 {Tag List with 0 items}
-			one {Tag List with {count}ahi te mea}
-			other {Tag List with {count}ētahi atu tūemi}
+			=0 {Rarangi Tohu me nga mea 0}
+			one {Rarangi Tohu me nga mea {count}}
+			other {Rarangi Tohu me nga mea {count}}
 		}`,
 	"components.tag-list.show-less": "Whakaaturia mai kia iti iho",
 	"components.tag-list.show-more-description": "Tīpakohia hei whakaatu i ngā tūemi rārangi tūtohu hunahuna",


### PR DESCRIPTION
cert fix of https://github.com/BrightspaceUI/core/pull/6055
confirmed with Naomi that we do not need to hotfix this into August
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8561)