### PR TITLE
fix: Menu focus disrupts filter layout

### DIFF
--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -144,7 +144,9 @@ class Menu extends PropertyRequiredMixin(ThemeMixin(HierarchicalViewMixin(LitEle
 		if (this.getMenuType() === 'menu-radio') {
 			this._focusSelected();
 		} else {
-			this._focusFirst();
+			const lastFocused = this._items.find(i => i.getAttribute('tabindex') === '0');
+			if (lastFocused) this._focusItem(lastFocused);
+			else this._focusFirst();
 		}
 	}
 
@@ -192,11 +194,13 @@ class Menu extends PropertyRequiredMixin(ThemeMixin(HierarchicalViewMixin(LitEle
 	}
 
 	_focusNext(item) {
+		item.setAttribute('tabindex', '-1');
 		item = this._tryGetNextFocusable(item);
 		item ? this._focusItem(item) : this._focusFirst();
 	}
 
 	_focusPrevious(item) {
+		item.setAttribute('tabindex', '-1');
 		item = this._tryGetPreviousFocusable(item);
 		item ? this._focusItem(item) : this._focusLast();
 	}


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-8518)

Two birds with one stone: menu items would keep their `tablist=0` attribute after being navigated into. 
- This means that d2l-menu was not following the [W3C menu pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).
- This also meant that inside filter, moving the focus after the list would attempt to focus on the next menu item, scrolling the view and messing with the layout as the ticket shows

