### PR TITLE
GAUD-8589 - Switch focus-visible to a CSS-only solution

### DIFF
--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -1,5 +1,6 @@
 import { css, unsafeCSS } from 'lit';
 import { getComposedChildren, getComposedParent, getFirstVisibleAncestor, getNextAncestorSibling, getPreviousAncestorSibling, isVisible } from './dom.js';
+import { getFlag } from './flags.js';
 
 const focusableElements = {
 	a: true,
@@ -13,6 +14,8 @@ const focusableElements = {
 	select: true,
 	textarea: true
 };
+
+const focusVisibleSupportChangesEnabled = getFlag('focus-visible-support-changes-for-focus-rings', true);
 
 export function getComposedActiveElement() {
 	let node = document.activeElement;
@@ -76,6 +79,22 @@ export function getFocusPseudoClass() {
 	return isFocusVisibleSupported() ? 'focus-visible' : 'focus';
 }
 export function getFocusRingStyles(selector, { extraStyles = null } = {}) {
+	// Remove when cleaning up focus-visible-support-changes-for-focus-rings
+	if (!focusVisibleSupportChangesEnabled) {
+		const selectorDelegate = typeof selector === 'string' ? pseudoClass => `${selector}:${pseudoClass}` : selector;
+		const cssSelector = unsafeCSS(selectorDelegate(getFocusPseudoClass()));
+		return css`${cssSelector} {
+			${extraStyles ?? css``}
+			outline: 2px solid var(--d2l-focus-ring-color, var(--d2l-color-celestine));
+			outline-offset: var(--d2l-focus-ring-offset, 2px);
+		}
+		@media (prefers-contrast: more) {
+			${cssSelector} {
+				outline-color: Highlight;
+			}
+		}`;
+	}
+
 	const stylesDelegate = selector => css`
 		${selector} {
 			${extraStyles ?? css``}

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -75,19 +75,34 @@ export function getFocusableDescendants(node, options) {
 export function getFocusPseudoClass() {
 	return isFocusVisibleSupported() ? 'focus-visible' : 'focus';
 }
-export function getFocusRingStyles(selector, { applyOnHover = false, extraStyles = null } = {}) {
-	const selectorDelegate = typeof selector === 'string' ? pseudoClass => `${selector}:${pseudoClass}` : selector;
-	const cssSelector = unsafeCSS(`${selectorDelegate(getFocusPseudoClass())}${applyOnHover ? `, ${selectorDelegate('hover')}` : ''}`);
-	return css`${cssSelector} {
-		${extraStyles ?? css``}
-		outline: 2px solid var(--d2l-focus-ring-color, var(--d2l-color-celestine));
-		outline-offset: var(--d2l-focus-ring-offset, 2px);
-	}
-	@media (prefers-contrast: more) {
-		${cssSelector} {
-			outline-color: Highlight;
+export function getFocusRingStyles(selector, { extraStyles = null } = {}) {
+	const stylesDelegate = selector => css`
+		${selector} {
+			${extraStyles ?? css``}
+			outline: 2px solid var(--d2l-focus-ring-color, var(--d2l-color-celestine));
+			outline-offset: var(--d2l-focus-ring-offset, 2px);
 		}
-	}`;
+		@media (prefers-contrast: more) {
+			${selector} {
+				outline-color: Highlight;
+			}
+		}
+	`;
+	return getFocusVisibleStyles(selector, stylesDelegate);
+}
+
+export function getFocusVisibleStyles(selector, stylesDelegate) {
+	const selectorDelegate = typeof selector === 'string' ? pseudoClass => `${selector}:${pseudoClass}` : selector;
+	const focusSelector = unsafeCSS(selectorDelegate('focus'));
+	const focusVisibleSelector = unsafeCSS(selectorDelegate('focus-visible'));
+	return unsafeCSS(css`
+		@supports not selector(:focus-visible) {
+			${stylesDelegate(focusSelector)}
+		}
+		@supports selector(:focus-visible) {
+			${stylesDelegate(focusVisibleSelector)}
+		}
+	`);
 }
 
 export function getLastFocusableDescendant(node, includeHidden) {


### PR DESCRIPTION
BSI needs to be able to get these focus ring styles outside of a browser context (at build time). This new CSS-only method supports that, and still falls back to `focus` styles in older browsers.

My plan is to flag this, but let BSI override that flag so it'll get the new styles every time. It means we'll be able to flag some of it, which feels better than none of it.