### PR TITLE
GAUD-7874 - Expose link styles for BSI to use

### DIFF
--- a/components/link/link-styles.js
+++ b/components/link/link-styles.js
@@ -1,6 +1,6 @@
 import '../colors/colors.js';
 import { css, unsafeCSS } from 'lit';
-import { _isValidCssSelector } from '../typography/styles.js';
+import { _isValidCssSelector } from '../../helpers/internal/css.js';
 import { getFocusRingStyles } from '../../helpers/focus.js';
 
 /**

--- a/components/link/link-styles.js
+++ b/components/link/link-styles.js
@@ -32,7 +32,7 @@ export const _generateLinkStyles = (selector, includeSkeleton = true) => {
 			color: var(--d2l-color-celestine-minus-1);
 			text-decoration: underline;
 		}
-		${getFocusRingStyles('.d2l-link', { extraStyles: css`border-radius: 2px; text-decoration: underline;` })}
+		${getFocusRingStyles(selector, { extraStyles: css`border-radius: 2px; text-decoration: underline;` })}
 		${selectorCSS}.d2l-link-main {
 			font-weight: 700;
 		}

--- a/components/link/link-styles.js
+++ b/components/link/link-styles.js
@@ -1,0 +1,51 @@
+import '../colors/colors.js';
+import { css, unsafeCSS } from 'lit';
+import { _isValidCssSelector } from '../typography/styles.js';
+import { getFocusRingStyles } from '../../helpers/focus.js';
+
+/**
+ * A private helper method that should not be used by general consumers
+ */
+export const _generateLinkStyles = (selector, includeSkeleton = true) => {
+	if (!_isValidCssSelector(selector)) return;
+
+	const selectorCSS = unsafeCSS(selector);
+	const skeletonStyles = includeSkeleton ? css`
+		:host([skeleton])  ${selectorCSS}.d2l-skeletize::before {
+			bottom: 0.2rem;
+			top: 0.2rem;
+		}
+		:host([skeleton]) ${selectorCSS}.d2l-link-small.d2l-skeletize::before {
+			bottom: 0.15rem;
+			top: 0.15rem;
+		}
+	` : unsafeCSS('');
+	return css`
+		${selectorCSS}, ${selectorCSS}:visited, ${selectorCSS}:active, ${selectorCSS}:link {
+			--d2l-focus-ring-offset: 1px;
+			color: var(--d2l-color-celestine);
+			cursor: pointer;
+			outline-style: none;
+			text-decoration: none;
+		}
+		${selectorCSS}:hover {
+			color: var(--d2l-color-celestine-minus-1);
+			text-decoration: underline;
+		}
+		${getFocusRingStyles('.d2l-link', { extraStyles: css`border-radius: 2px; text-decoration: underline;` })}
+		${selectorCSS}.d2l-link-main {
+			font-weight: 700;
+		}
+		${selectorCSS}.d2l-link-small {
+			font-size: 0.7rem;
+			letter-spacing: 0.01rem;
+			line-height: 1.05rem;
+		}
+		@media print {
+			${selectorCSS}, ${selectorCSS}:visited, ${selectorCSS}:active, ${selectorCSS}:link {
+				color: var(--d2l-color-ferrite);
+			}
+		}
+		${skeletonStyles}
+	`;
+};

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -2,10 +2,10 @@ import '../colors/colors.js';
 import '../icons/icon.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { getOverflowDeclarations, overflowEllipsisDeclarations } from '../../helpers/overflow.js';
+import { _generateLinkStyles } from './link-styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { getFlag } from '../../helpers/flags.js';
-import { getFocusRingStyles } from '../../helpers/focus.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
@@ -13,41 +13,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 const overflowClipEnabled = getFlag('GAUD-7887-core-components-overflow-clipping', true);
 
-export const linkStyles = css`
-	.d2l-link, .d2l-link:visited, .d2l-link:active, .d2l-link:link {
-		--d2l-focus-ring-offset: 1px;
-		color: var(--d2l-color-celestine);
-		cursor: pointer;
-		outline-style: none;
-		text-decoration: none;
-	}
-	:host([skeleton]) .d2l-link.d2l-skeletize::before {
-		bottom: 0.2rem;
-		top: 0.2rem;
-	}
-	.d2l-link:hover {
-		color: var(--d2l-color-celestine-minus-1);
-		text-decoration: underline;
-	}
-	${getFocusRingStyles('.d2l-link', { extraStyles: css`border-radius: 2px; text-decoration: underline;` })}
-	.d2l-link.d2l-link-main {
-		font-weight: 700;
-	}
-	.d2l-link.d2l-link-small {
-		font-size: 0.7rem;
-		letter-spacing: 0.01rem;
-		line-height: 1.05rem;
-	}
-	:host([skeleton]) .d2l-link.d2l-link-small.d2l-skeletize::before {
-		bottom: 0.15rem;
-		top: 0.15rem;
-	}
-	@media print {
-		.d2l-link, .d2l-link:visited, .d2l-link:active, .d2l-link:link {
-			color: var(--d2l-color-ferrite);
-		}
-	}
-`;
+export const linkStyles = _generateLinkStyles('.d2l-link', true);
 
 /**
  * This component can be used just like the native anchor tag.

--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -1,23 +1,7 @@
 import '../colors/colors.js';
 import { css, unsafeCSS } from 'lit';
+import { _isValidCssSelector } from '../../helpers/internal/css.js';
 import { svgToCSS } from '../../helpers/svg-to-css.js';
-
-export const _isValidCssSelector = (selector) => {
-	const partIsValid = (part) => {
-		const re = /([a-zA-Z0-9-_ >.#]+)(\[[a-zA-Z0-9-_]+\])?([a-zA-Z0-9-_ >.#]+)?/g;
-		if (part === ':host') return true;
-		const match = part.match(re);
-		const isValid = !!match && match.length === 1 && match[0].length === part.length;
-		if (!isValid) {
-			console.warn(`Invalid CSS selector: "${part}"`);
-		}
-		return isValid;
-	};
-
-	const parts = selector.split(',');
-	const allValid = parts.every(part => partIsValid(part));
-	return allValid;
-};
 
 /**
  * A private helper method that should not be used by general consumers

--- a/components/typography/test/styles.test.js
+++ b/components/typography/test/styles.test.js
@@ -1,4 +1,4 @@
-import { _isValidCssSelector } from '../styles.js';
+import { _isValidCssSelector } from '../../../helpers/internal/css.js';
 import { expect } from '@brightspace-ui/testing';
 
 describe('_isValidCssSelector', () => {

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -1,5 +1,6 @@
 import { css, unsafeCSS } from 'lit';
 import { getComposedChildren, getComposedParent, getFirstVisibleAncestor, getNextAncestorSibling, getPreviousAncestorSibling, isVisible } from './dom.js';
+import { getFlag } from './flags.js';
 
 const focusableElements = {
 	a: true,
@@ -13,6 +14,8 @@ const focusableElements = {
 	select: true,
 	textarea: true
 };
+
+const focusVisibleSupportChangesEnabled = getFlag('focus-visible-support-changes-for-focus-rings', true);
 
 export function getComposedActiveElement() {
 	let node = document.activeElement;
@@ -76,6 +79,22 @@ export function getFocusPseudoClass() {
 	return isFocusVisibleSupported() ? 'focus-visible' : 'focus';
 }
 export function getFocusRingStyles(selector, { extraStyles = null } = {}) {
+	// Remove when cleaning up focus-visible-support-changes-for-focus-rings
+	if (!focusVisibleSupportChangesEnabled) {
+		const selectorDelegate = typeof selector === 'string' ? pseudoClass => `${selector}:${pseudoClass}` : selector;
+		const cssSelector = unsafeCSS(selectorDelegate(getFocusPseudoClass()));
+		return css`${cssSelector} {
+			${extraStyles ?? css``}
+			outline: 2px solid var(--d2l-focus-ring-color, var(--d2l-color-celestine));
+			outline-offset: var(--d2l-focus-ring-offset, 2px);
+		}
+		@media (prefers-contrast: more) {
+			${cssSelector} {
+				outline-color: Highlight;
+			}
+		}`;
+	}
+
 	const stylesDelegate = selector => css`
 		${selector} {
 			${extraStyles ?? css``}

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -15,6 +15,7 @@ const focusableElements = {
 	textarea: true
 };
 
+// The default here cannot be changed, as BSI relies on it being true. Do not flip this without adding a way for BSI to override it.
 const focusVisibleSupportChangesEnabled = getFlag('focus-visible-support-changes-for-focus-rings', true);
 
 export function getComposedActiveElement() {

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -75,19 +75,34 @@ export function getFocusableDescendants(node, options) {
 export function getFocusPseudoClass() {
 	return isFocusVisibleSupported() ? 'focus-visible' : 'focus';
 }
-export function getFocusRingStyles(selector, { applyOnHover = false, extraStyles = null } = {}) {
-	const selectorDelegate = typeof selector === 'string' ? pseudoClass => `${selector}:${pseudoClass}` : selector;
-	const cssSelector = unsafeCSS(`${selectorDelegate(getFocusPseudoClass())}${applyOnHover ? `, ${selectorDelegate('hover')}` : ''}`);
-	return css`${cssSelector} {
-		${extraStyles ?? css``}
-		outline: 2px solid var(--d2l-focus-ring-color, var(--d2l-color-celestine));
-		outline-offset: var(--d2l-focus-ring-offset, 2px);
-	}
-	@media (prefers-contrast: more) {
-		${cssSelector} {
-			outline-color: Highlight;
+export function getFocusRingStyles(selector, { extraStyles = null } = {}) {
+	const stylesDelegate = selector => css`
+		${selector} {
+			${extraStyles ?? css``}
+			outline: 2px solid var(--d2l-focus-ring-color, var(--d2l-color-celestine));
+			outline-offset: var(--d2l-focus-ring-offset, 2px);
 		}
-	}`;
+		@media (prefers-contrast: more) {
+			${selector} {
+				outline-color: Highlight;
+			}
+		}
+	`;
+	return getFocusVisibleStyles(selector, stylesDelegate);
+}
+
+export function getFocusVisibleStyles(selector, stylesDelegate) {
+	const selectorDelegate = typeof selector === 'string' ? pseudoClass => `${selector}:${pseudoClass}` : selector;
+	const focusSelector = unsafeCSS(selectorDelegate('focus'));
+	const focusVisibleSelector = unsafeCSS(selectorDelegate('focus-visible'));
+	return unsafeCSS(css`
+		@supports not selector(:focus-visible) {
+			${stylesDelegate(focusSelector)}
+		}
+		@supports selector(:focus-visible) {
+			${stylesDelegate(focusVisibleSelector)}
+		}
+	`);
 }
 
 export function getLastFocusableDescendant(node, includeHidden) {

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -15,7 +15,7 @@ const focusableElements = {
 	textarea: true
 };
 
-// The default here cannot be changed, as BSI relies on it being true. Do not flip this without adding a way for BSI to override it.
+// The default here cannot be changed, as BSI relies on it being true. Do not change the default without adding a way for BSI to override it.
 const focusVisibleSupportChangesEnabled = getFlag('focus-visible-support-changes-for-focus-rings', true);
 
 export function getComposedActiveElement() {

--- a/helpers/internal/css.js
+++ b/helpers/internal/css.js
@@ -1,0 +1,16 @@
+export function _isValidCssSelector(selector) {
+	const partIsValid = (part) => {
+		const re = /([a-zA-Z0-9-_ >.#]+)(\[[a-zA-Z0-9-_]+\])?([a-zA-Z0-9-_ >.#]+)?/g;
+		if (part === ':host') return true;
+		const match = part.match(re);
+		const isValid = !!match && match.length === 1 && match[0].length === part.length;
+		if (!isValid) {
+			console.warn(`Invalid CSS selector: "${part}"`);
+		}
+		return isValid;
+	};
+
+	const parts = selector.split(',');
+	const allValid = parts.every(part => partIsValid(part));
+	return allValid;
+}


### PR DESCRIPTION
Exposing a method for BSI to use to get the link styles used by the component, rather than the [Sass file](https://github.com/BrightspaceUI/core/blob/a989989114bbf0a0649116b4c2fd285c820ae6ef/components/link/link.scss).

This copies the same pattern that [`typography` uses](https://github.com/BrightspaceUI/core/blob/a989989114bbf0a0649116b4c2fd285c820ae6ef/components/typography/styles.js).

BSI PR is here: https://github.com/Brightspace/brightspace-integration/pull/15610