### PR TITLE
Adjust for actual intl implementation

### DIFF
--- a/components/calendar/README.md
+++ b/components/calendar/README.md
@@ -16,7 +16,7 @@ The `d2l-calendar` component can be used to display a responsively sized calenda
 <!-- docs: start hidden content -->
 ### Properties
 
-Note: All `*-value` properties should be in ISO 8601 calendar date format (`YYYY-MM-DD`) and should be localized to the user's timezone (if applicable).
+Note: All `*-value` properties should be in ISO 8601 calendar date format (`YYYY-MM-DD`) and should be localized to the user's time zone (if applicable).
 
 | Property | Type | Description |
 |--|--|--|

--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -17,7 +17,7 @@ Use date and time inputs to set dates and times in forms. They are available as
 <!-- docs: start dos -->
 * Use short but descriptive labels like "Start Date" or "Due Date"
 * Offer reasonable defaults whenever possible
-* Use date and time values relative to the user's [timezone](#timezone)
+* Use date and time values relative to the user's [time zone](#time-zone)
 <!-- docs: end dos -->
 
 <!-- docs: start donts -->
@@ -29,7 +29,7 @@ Use date and time inputs to set dates and times in forms. They are available as
 
 Use the `<d2l-input-date>` component when users need to choose a single date. It consists of a text input field for typing a date and an attached calendar (`<d2l-calendar>`) dropdown. The dropdown opens on click of the text input, or on enter or down arrow press if the text input is focused. It displays the `value` if one is specified, or a placeholder if not, and reflects the selected value when one is selected in the `d2l-calendar` or entered in the text input.
 
-Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-MM-DD`) and should be [localized to the user's timezone](#timezone) (if applicable).
+Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-MM-DD`) and should be [localized to the user's time zone](#time-zone) (if applicable).
 
 <!-- docs: demo code properties name:d2l-input-date sandboxTitle:'Date Input' align:flex-start autoSize:false size:xlarge -->
 ```html
@@ -115,7 +115,7 @@ Note: All `*value` properties should be in ISO 8601 calendar date format (`YYYY-
 
 Use the `<d2l-input-time>` component when users need to enter a time, without a date. The component consists of a text input field for typing a time and an attached dropdown for time selection. The dropdown opens on click of the text input, or on enter or down arrow press if the text input is focused. It displays the `value` if one is specified, or a fallback time if not, and reflects the selected value when one is selected in the dropdown or entered in the text input.
 
-Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's timezone](#timezone) (if applicable).
+Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's time zone](#time-zone) (if applicable).
 
 <!-- docs: demo code properties name:d2l-input-time sandboxTitle:'Time Input' align:flex-start autoSize:false size:large -->
 ```html
@@ -140,9 +140,9 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 | `name` | String | Name of the form control. Submitted with the form as part of a name/value pair. |
 | `opened` | Boolean | Indicates if the dropdown is open |
 | `required` | Boolean | Indicates that a value is required |
-| `timezone-hidden` | Boolean | Hides the timezone inside the selection dropdown. Should only be used when the input uses a different timezone than the document's settings |
+| `time-zone-hidden` | Boolean | Hides the time zone inside the selection dropdown. Should only be used when the input value is not related to any one timezone |
 | `time-interval` | String, default: `thirty` | Number of minutes between times shown in dropdown. Valid values include `five`, `ten`, `fifteen`, `twenty`, `thirty`, and `sixty`. |
-| `value` | String, default `''` | Value of the input. This should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's timezone](#timezone) (if applicable). |
+| `value` | String, default `''` | Value of the input. This should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's time zone](#time-zone) (if applicable). |
 
 ### Events
 
@@ -157,7 +157,7 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 
 Use the `<d2l-input-time-range>` component when users need to enter two times in a range, and the date is already known. The component consists of two input-time components - one for the start of a range and one for the end of a range. Values specified for these components (through the `start-value` and/or `end-value` attributes) are displayed if specified, and selected values are reflected.
 
-Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's timezone](#timezone) (if applicable).
+Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and should be [localized to the user's time zone](#time-zone) (if applicable).
 
 <!-- docs: demo code properties name:d2l-input-time-range sandboxTitle:'Time Range Input' align:flex-start autoSize:false size:large -->
 ```html
@@ -199,7 +199,7 @@ Note: All `*value` properties should be in ISO 8601 time format (`hh:mm:ss`) and
 
 Use the `<d2l-input-date-time>` component when users need to enter a single date and time, like a due date. The component consists of a `<d2l-input-date>` and a `<d2l-input-time>` component. The time input only appears once a date is selected. This component displays the `value` if one is specified, and reflects the selected value when one is selected or entered.
 
-Note: All `*value` properties should be in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time (i.e., do NOT localize to the user's timezone).
+Note: All `*value` properties should be in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time (i.e., do NOT localize to the user's time zone).
 
 <!-- docs: demo code properties name:d2l-input-date-time sandboxTitle:'Date-Time Input' align:flex-start autoSize:false size:xlarge -->
 ```html
@@ -219,7 +219,7 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 | `disabled` | Boolean | Disables the input |
 | `label-hidden` | Boolean | Hides the fieldset label visually |
 | `labelled-by` | String | HTML id of an element in the same shadow root which acts as the input's label |
-| `localized` | Boolean | Indicates that any timezone localization will be handeld by the consumer and so any values will not be converted from/to UTC |
+| `localized` | Boolean | Indicates that any time zone localization will be handeld by the consumer and so any values will not be converted from/to UTC |
 | `max-value` | String | Maximum valid date/time that could be selected by a user |
 | `min-value` | String | Minimum valid date/time that could be selected by a user |
 | `name` | String | Name of the form control. Submitted with the form as part of a name/value pair. |
@@ -241,7 +241,7 @@ Note: All `*value` properties should be in ISO 8601 combined date and time forma
 
 Use the `<d2l-input-date-time-range>` component when users need to enter two dates and times in a range, like an assignment start and end date/time. The component consists of two input-date-time components - one for the start of a range and one for the end of a range. Values specified for these components (through the `start-value` and/or `end-value` attributes) are displayed if specified, and selected values are reflected.
 
-Note: All `*value` properties should be in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time (i.e., do NOT localize to the user's timezone).
+Note: All `*value` properties should be in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`) and in UTC time (i.e., do NOT localize to the user's time zone).
 
 <!-- docs: demo code properties name:d2l-input-date-time-range sandboxTitle:'Date-Time Range Input' align:flex-start autoSize:false size:xlarge -->
 ```html
@@ -294,8 +294,8 @@ A few notable accessibility-related features of these components are:
 
 ## Timezone
 
-The `input-date-time` and `input-date-time-range` components expect input in UTC (`YYYY-MM-DDTHH:mm:ss.sssZ`). These components will convert values automatically to the user's timezone to display the date/time to them, and then will provide the value back in UTC. No timezone conversions are needed.
+The `input-date-time` and `input-date-time-range` components expect input in UTC (`YYYY-MM-DDTHH:mm:ss.sssZ`). These components will convert values automatically to the user's time zone to display the date/time to them, and then will provide the value back in UTC. No time zone conversions are needed.
 
-The `input-date`, `input-date-range`, `input-time`, and `input-time-range` components do not handle timezone and so require the input to be in the user's timezone (if applicable), which corresponds to the user's timezone as specified in their account settings. The consumer of the component will need to handle any necessary UTC to local to UTC conversions. The following methods can be used for these conversions:
-* `getLocalDateTimeFromUTCDateTime(utcDateTime)` (where `utcDateTime` is the date/time in the format `YYYY-MM-DDTHH:mm:ss.sssZ`) returns the date/time in the format `YYYY-MM-DDTHH:mm:ss.sss` in the user's local timezone
-* `getUTCDateTimeFromLocalDateTime(localDate, localTime)` (where `localDate` and `localTime` are the date and time in the user's local timezone) returns the date/time in the format `YYYY-MM-DDTHH:mm:ss.sssZ` in UTC
+The `input-date`, `input-date-range`, `input-time`, and `input-time-range` components do not handle time zone and so require the input to be in the user's time zone (if applicable), which corresponds to the user's time zone as specified in their account settings. The consumer of the component will need to handle any necessary UTC to local to UTC conversions. The following methods can be used for these conversions:
+* `getLocalDateTimeFromUTCDateTime(utcDateTime)` (where `utcDateTime` is the date/time in the format `YYYY-MM-DDTHH:mm:ss.sssZ`) returns the date/time in the format `YYYY-MM-DDTHH:mm:ss.sss` in the user's local time zone
+* `getUTCDateTimeFromLocalDateTime(localDate, localTime)` (where `localDate` and `localTime` are the date and time in the user's local time zone) returns the date/time in the format `YYYY-MM-DDTHH:mm:ss.sssZ` in UTC

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -28,7 +28,7 @@ export function getShiftedEndDate(startValue, endValue, prevStartValue, inclusiv
 }
 
 /**
- * A component consisting of two input-date components - one for start of range and one for end of range. Values specified for these components (through start-value and/or end-value attributes) should be localized to the user's timezone if applicable and must be in ISO 8601 calendar date format ("YYYY-MM-DD").
+ * A component consisting of two input-date components - one for start of range and one for end of range. Values specified for these components (through start-value and/or end-value attributes) should be localized to the user's time zone if applicable and must be in ISO 8601 calendar date format ("YYYY-MM-DD").
  * @slot inline-help - Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
  * @fires change - Dispatched when there is a change to selected start date or selected end date. `start-value` and `end-value` correspond to the selected values and are formatted in ISO 8601 calendar date format (`YYYY-MM-DD`).
  */

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -86,6 +86,16 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 			 */
 			timeDefaultValue: { attribute: 'time-default-value', reflect: true, type: String },
 			/**
+			 * Timezone identifier for the time input to use.
+			 * @type {string}
+			 */
+			timeZoneId: { type: String },
+			/**
+			 * Hides the time zone inside the time selection dropdown. Should only be used when the time input value is not related to any one time zone
+			 * @type {Boolean}
+			 */
+			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
+			/**
 			 * Value of the input
 			 * @type {string}
 			 */

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -34,7 +34,7 @@ function getValidISOTimeAtInterval(val, timeInterval) {
 }
 
 /**
- * A component consisting of two input-time components - one for start of range and one for end of range. Values specified for these components (through start-value and/or end-value attributes) should be localized to the user's timezone if applicable and must be in ISO 8601 time format ("hh:mm:ss").
+ * A component consisting of two input-time components - one for start of range and one for end of range. Values specified for these components (through start-value and/or end-value attributes) should be localized to the user's time zone if applicable and must be in ISO 8601 time format ("hh:mm:ss").
  * @slot inline-help - Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
  * @fires change - Dispatched when there is a change to selected start time or selected end time. `start-value` and `end-value` correspond to the selected values and are formatted in ISO 8601 calendar time format (`hh:mm:ss`).
  */
@@ -119,7 +119,17 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(LocalizeC
 			 * Number of minutes between times shown in dropdown menu
 			 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
 			 */
-			timeInterval: { attribute: 'time-interval', reflect: true, type: String }
+			timeInterval: { attribute: 'time-interval', reflect: true, type: String },
+			/**
+			 * Timezone identifier for the inputs to use.
+			 * @type {string}
+			 */
+			timeZoneId: { type: String },
+			/**
+			 * Hides the time zone inside the selection dropdowns. Should only be used when the input values are not related to any one time zone
+			 * @type {Boolean}
+			 */
+			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
 		};
 	}
 
@@ -251,6 +261,8 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(LocalizeC
 						?skeleton="${this.skeleton}"
 						slot="left"
 						time-interval="${ifDefined(timeInterval)}"
+						time-zone-id="${ifDefined(this.timeZoneId)}"
+						?time-zone-hidden="${this.timeZoneHidden}"
 						value="${ifDefined(this.startValue)}">
 					</d2l-input-time>
 					<d2l-input-time

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -402,7 +402,7 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 						root-view>
 						${menuItems}
 					</d2l-menu>
-					${!this.timeZoneHidden ? html`<div class=${classMap(timeZoneClassMap)} id="${dropdownIdTimezone}" slot="footer">
+					${!this.timeZoneHidden && this._timeZone ? html`<div class=${classMap(timeZoneClassMap)} id="${dropdownIdTimezone}" slot="footer">
 						${customTimezone ? html`<d2l-icon icon="tier1:browser"></d2l-icon>` : nothing}
 						${this._timeZone}
 					</div>` : nothing}
@@ -428,9 +428,8 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 			if (validateTimeZone(this.timeZoneId)) {
 				const tzData = await getTimeZoneData(this.timeZoneId);
 				this._timeZone = tzData.friendlyName;
-				this.timeZoneHidden = false;
 			} else {
-				this.timeZoneHidden = true;
+				this._timeZone = null;
 			}
 		}
 	}

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -7,10 +7,12 @@ import '../icons/icon.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { formatDateInISOTime, getDateFromISOTime, getToday } from '../../helpers/dateTime.js';
 import { formatTime, parseTime } from '@brightspace-ui/intl/lib/dateTime.js';
+import { getTimeZoneData, validateTimeZone } from '@brightspace-ui/intl/lib/timeZones.js';
 import { bodySmallStyles } from '../typography/styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 import { FormElementMixin } from '../form/form-element-mixin.js';
+import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { InputInlineHelpMixin } from './input-inline-help.js';
@@ -26,7 +28,7 @@ const START_OF_DAY = new Date(2020, 0, 1, 0, 1, 0);
 const END_OF_DAY = new Date(2020, 0, 1, 23, 59, 59);
 const INTERVALS = new Map();
 
-const defaultTimezone = formatTime(new Date(), { format: 'ZZZ' });
+const defaultTimezone = getDocumentLocaleSettings().timezone.identifier || new Intl.DateTimeFormat().timeZone;
 
 export function getIntervalNumber(size) {
 	switch (size) {
@@ -168,15 +170,15 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 			 */
 			timeInterval: { type: String, attribute: 'time-interval' },
 			/**
-			 * Timezone for the input to use.
+			 * Timezone identifier for the input to use.
 			 * @type {string}
 			 */
-			timezone: { type: String },
+			timeZoneId: { type: String, attribute: 'time-zone-id' },
 			/**
-			 * Hides the timezone inside the selection dropdown. Should only be used when the input uses a different timezone than the document's settings
+			 * Hides the time zone inside the selection dropdown. Should only be used when the input value is not related to any one timezone
 			 * @type {Boolean}
 			 */
-			timezoneHidden: { type: Boolean, attribute: 'timezone-hidden' },
+			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
 			/**
 			 * Value of the input
 			 * @type {string}
@@ -184,7 +186,8 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 			value: { type: String },
 			_dropdownFirstOpened: { type: Boolean },
 			_formattedValue: { type: String },
-			_hiddenContentWidth: { type: String }
+			_hiddenContentWidth: { type: String },
+			_timeZone: { state: true },
 		};
 	}
 
@@ -211,13 +214,13 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 					display: inline-block;
 					vertical-align: top;
 				}
-				.d2l-input-time-timezone {
+				.d2l-input-time-time-zone {
 					line-height: 1.8rem;
 					text-align: center;
 					vertical-align: middle;
 					width: auto;
 				}
-				.d2l-input-time-timezone.d2l-input-time-timezone-custom {
+				.d2l-input-time-time-zone.d2l-input-time-time-zone-custom {
 					align-items: center;
 					column-gap: 0.3rem;
 					display: flex;
@@ -247,11 +250,11 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 		this.opened = false;
 		this.required = false;
 		this.timeInterval = 'thirty';
-		this.timezoneHidden = false;
+		this.timeZoneHidden = false;
 		this._dropdownFirstOpened = false;
 		this._dropdownId = getUniqueId();
 		this._hiddenContentWidth = '6rem';
-		this.timezone = defaultTimezone;
+		this.timeZoneId = defaultTimezone;
 		this._inlineHelpId = getUniqueId();
 	}
 
@@ -347,13 +350,13 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 		const formattedWideTimeAM = formatTime(new Date(2020, 0, 1, 10, 23, 0));
 		const formattedWideTimePM = formatTime(new Date(2020, 0, 1, 23, 23, 0));
 		const opened = this.opened && !this.disabled && !this.skeleton;
-		const dropdownIdTimezone = `${this._dropdownId}-timezone`;
+		const dropdownIdTimezone = `${this._dropdownId}-time-zone`;
 		const ariaDescribedByIds = `${this._dropdownId ? dropdownIdTimezone : ''} ${this._hasInlineHelp ? this._inlineHelpId : ''}`.trim();
-		const customTimezone = this.timezone !== defaultTimezone;
+		const customTimezone = this.timeZoneId !== defaultTimezone;
 		const timeZoneClassMap = {
-			'd2l-input-time-timezone': true,
+			'd2l-input-time-time-zone': true,
 			'd2l-body-small': true,
-			'd2l-input-time-timezone-custom': customTimezone
+			'd2l-input-time-time-zone-custom': customTimezone
 		};
 
 		return html`
@@ -399,9 +402,9 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 						root-view>
 						${menuItems}
 					</d2l-menu>
-					${!this.timezoneHidden ? html`<div class=${classMap(timeZoneClassMap)} id="${dropdownIdTimezone}" slot="footer">
+					${!this.timeZoneHidden ? html`<div class=${classMap(timeZoneClassMap)} id="${dropdownIdTimezone}" slot="footer">
 						${customTimezone ? html`<d2l-icon icon="tier1:browser"></d2l-icon>` : nothing}
-						${this.timezone}
+						${this._timeZone}
 					</div>` : nothing}
 				</d2l-dropdown-menu>
 			</d2l-dropdown>
@@ -417,9 +420,19 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 		});
 	}
 
-	willUpdate(changedProperties) {
+	async willUpdate(changedProperties) {
 		super.willUpdate(changedProperties);
 		this.style.maxWidth = `calc(${this._hiddenContentWidth} + 1.5rem + 3px)`; // text and icon width + left & right padding + border width + 1
+
+		if ((changedProperties.has('timeZoneId') || changedProperties.has('localize'))) {
+			if (validateTimeZone(this.timeZoneId)) {
+				const tzData = await getTimeZoneData(this.timeZoneId);
+				this._timeZone = tzData.friendlyName;
+				this.timeZoneHidden = false;
+			} else {
+				this.timeZoneHidden = true;
+			}
+		}
 	}
 
 	getTime() {

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -170,7 +170,7 @@ class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMi
 			 */
 			timeInterval: { type: String, attribute: 'time-interval' },
 			/**
-			 * Timezone identifier for the input to use.
+			 * Time zone identifier for the input to use.
 			 * @type {string}
 			 */
 			timeZoneId: { type: String, attribute: 'time-zone-id' },

--- a/components/inputs/test/input-date-time-range.test.js
+++ b/components/inputs/test/input-date-time-range.test.js
@@ -39,7 +39,7 @@ describe('d2l-input-date-time-range', () => {
 			describe(`getShiftedEndDateTime in ${timeZone}`, () => {
 
 				before(async() => {
-					documentLocaleSettings.timeZone.identifier = timeZone;
+					documentLocaleSettings.timezone.identifier = timeZone;
 					await aTimeout(10); // Fixes flaky tests likely caused by time zone not yet being set
 				});
 

--- a/components/inputs/test/input-date-time-range.test.js
+++ b/components/inputs/test/input-date-time-range.test.js
@@ -33,14 +33,14 @@ describe('d2l-input-date-time-range', () => {
 	});
 
 	describe('utility', () => {
-		['America/Toronto', 'Australia/Eucla'].forEach((timezone) => {
+		['America/Toronto', 'Australia/Eucla'].forEach((timeZone) => {
 			const inclusive = false;
 
-			describe(`getShiftedEndDateTime in ${timezone}`, () => {
+			describe(`getShiftedEndDateTime in ${timeZone}`, () => {
 
 				before(async() => {
-					documentLocaleSettings.timezone.identifier = timezone;
-					await aTimeout(10); // Fixes flaky tests likely caused by timezone not yet being set
+					documentLocaleSettings.timeZone.identifier = timeZone;
+					await aTimeout(10); // Fixes flaky tests likely caused by time zone not yet being set
 				});
 
 				after(() => {
@@ -58,7 +58,7 @@ describe('d2l-input-date-time-range', () => {
 				it('should shift as expected when times are different but dates the same because of UTC', () => {
 					let prevStartValue, start, prevEnd, newEndValue;
 
-					if (timezone === 'America/Toronto') {
+					if (timeZone === 'America/Toronto') {
 						prevStartValue = '2020-10-14T12:00:00.000Z';
 						prevEnd = '2020-10-15T02:00:00.000Z';
 						start = '2020-10-14T08:00:00.000Z';
@@ -76,7 +76,7 @@ describe('d2l-input-date-time-range', () => {
 					const prevStartValue = '2020-10-20T02:00:00.000Z';
 					const start = '2020-10-20T03:00:00.000Z';
 					let prevEnd;
-					if (timezone === 'America/Toronto') {
+					if (timeZone === 'America/Toronto') {
 						prevEnd = '2020-10-20T06:00:00.000Z';
 					} else {
 						prevEnd = '2020-10-20T20:00:00.000Z';
@@ -87,10 +87,10 @@ describe('d2l-input-date-time-range', () => {
 			});
 
 			[true, false].forEach((localized) => {
-				describe(`getShiftedEndDateTime in ${timezone} with localized ${localized}`, () => {
+				describe(`getShiftedEndDateTime in ${timeZone} with localized ${localized}`, () => {
 
 					beforeEach(async() => {
-						documentLocaleSettings.timezone.identifier = timezone;
+						documentLocaleSettings.timezone.identifier = timeZone;
 					});
 
 					afterEach(() => {
@@ -185,7 +185,7 @@ describe('d2l-input-date-time-range', () => {
 
 						it('should only shift at latest to 11:59 PM', () => {
 							let prevStartValue, prevEnd, start, newEndValue;
-							if (timezone === 'America/Toronto') {
+							if (timeZone === 'America/Toronto') {
 								prevStartValue = '2020-10-15T06:00:00.000Z';
 								prevEnd = '2020-10-15T20:00:00.000Z';
 								start = '2020-10-15T14:00:00.000Z';

--- a/components/inputs/test/input-date-time.test.js
+++ b/components/inputs/test/input-date-time.test.js
@@ -35,14 +35,14 @@ describe('d2l-input-date-time', () => {
 
 	describe('min and max value', () => {
 		it('should set correct min and max on d2l-input-date', async() => {
-			await aTimeout(5); // Fixes flaky test potentially caused by timezone not yet being set
+			await aTimeout(5); // Fixes flaky test potentially caused by time zone not yet being set
 			const elem = await fixture(minMaxFixture);
 			const inputElem = getChildElem(elem, 'd2l-input-date');
 			expect(inputElem.minValue).to.equal('2018-08-26');
 			expect(inputElem.maxValue).to.equal('2018-09-30');
 		});
 
-		it('should set correct min and max on d2l-input-date in Australia/Eucla timezone', async() => {
+		it('should set correct min and max on d2l-input-date in Australia/Eucla time zone', async() => {
 			documentLocaleSettings.timezone.identifier = 'Australia/Eucla';
 			const elem = await fixture(minMaxFixture);
 			const inputElem = getChildElem(elem, 'd2l-input-date');
@@ -360,8 +360,8 @@ describe('d2l-input-date-time', () => {
 			expect(elem.value).to.equal('');
 		});
 
-		describe('timezone', () => {
-			it('should return expected day in Australia/Eucla timezone', async() => {
+		describe('time zone', () => {
+			it('should return expected day in Australia/Eucla time zone', async() => {
 				documentLocaleSettings.timezone.identifier = 'Australia/Eucla';
 				const elem = await fixture('<d2l-input-date-time label="label text" value="2018-03-03T08:00:00.000Z"></d2l-input-date-time>');
 				const inputElem = getChildElem(elem, 'd2l-input-time');

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -79,7 +79,7 @@ describe('d2l-input-time', () => {
 			expect(elem.shadowRoot.querySelector('.d2l-input-time-time-zone')).to.not.be.null;
 		});
 
-		it('should hide timezone when timezone-hidden', async() => {
+		it('should hide timezone when time-zone-hidden', async() => {
 			const elem = await fixture(tzHiddenFixture);
 			expect(elem.shadowRoot.querySelector('.d2l-input-time-time-zone')).to.be.null;
 		});

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -1,6 +1,5 @@
 import '../input-time.js';
 import { aTimeout, expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
-import { formatTime } from '@brightspace-ui/intl/lib/dateTime.js';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import sinon from 'sinon';
 
@@ -71,7 +70,7 @@ describe('d2l-input-time', () => {
 		it('should default "timeZoneId" property to default value', async() => {
 			documentLocaleSettings.sync();
 			const elem = await fixture(basicFixture);
-			expect(elem.timeZoneId).to.equal(formatTime(new Date(), { format: 'ZZZ' }));
+			expect(elem.timeZoneId).to.equal(documentLocaleSettings.timezone.identifier);
 		});
 
 		it('should display time zone by default', async() => {

--- a/components/inputs/test/input-time.test.js
+++ b/components/inputs/test/input-time.test.js
@@ -9,7 +9,7 @@ const fixtureWithValue = '<d2l-input-time value="11:22:33" label="label text"></
 const hourLongIntervals = '<d2l-input-time label="label text" time-interval="sixty"></d2l-input-time>';
 const hourLongIntervalsEnforced = '<d2l-input-time label="label text" time-interval="sixty" enforce-time-intervals></d2l-input-time>';
 const labelHiddenFixture = '<d2l-input-time label="label text" label-hidden time-interval="sixty"></d2l-input-time>';
-const tzHiddenFixture = '<d2l-input-time label="label text" timezone-hidden time-interval="sixty"></d2l-input-time>';
+const tzHiddenFixture = '<d2l-input-time label="label text" time-zone-hidden time-interval="sixty"></d2l-input-time>';
 
 function dispatchEvent(elem, eventType, composed) {
 	const e = new Event(
@@ -66,22 +66,22 @@ describe('d2l-input-time', () => {
 		});
 	});
 
-	describe('timezone', () => {
+	describe('timeZoneId', () => {
 
-		it('should default "timezone" property to default value', async() => {
+		it('should default "timeZoneId" property to default value', async() => {
 			documentLocaleSettings.sync();
 			const elem = await fixture(basicFixture);
-			expect(elem.timezone).to.equal(formatTime(new Date(), { format: 'ZZZ' }));
+			expect(elem.timeZoneId).to.equal(formatTime(new Date(), { format: 'ZZZ' }));
 		});
 
-		it('should display timezone by default', async() => {
+		it('should display time zone by default', async() => {
 			const elem = await fixture(basicFixture);
-			expect(elem.shadowRoot.querySelector('.d2l-input-time-timezone')).to.not.be.null;
+			expect(elem.shadowRoot.querySelector('.d2l-input-time-time-zone')).to.not.be.null;
 		});
 
 		it('should hide timezone when timezone-hidden', async() => {
 			const elem = await fixture(tzHiddenFixture);
-			expect(elem.shadowRoot.querySelector('.d2l-input-time-timezone')).to.be.null;
+			expect(elem.shadowRoot.querySelector('.d2l-input-time-time-zone')).to.be.null;
 		});
 	});
 
@@ -139,7 +139,7 @@ describe('d2l-input-time', () => {
 			clock.restore();
 		});
 
-		it('should default to next interval when timezone is Australia', async() => {
+		it('should default to next interval when time zone is Australia', async() => {
 			documentLocaleSettings.timezone.identifier = 'Australia/Eucla';
 			const newToday = new Date('2018-02-12T11:33Z');
 			const clock = sinon.useFakeTimers({ now: newToday.getTime(), toFake: ['Date'] });

--- a/components/inputs/test/input-time.vdiff.js
+++ b/components/inputs/test/input-time.vdiff.js
@@ -5,7 +5,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { inlineHelpFixtures } from './input-shared-content.js';
 
 const create = (opts = {}) => {
-	const { disabled, enforceTimeIntervals, label, labelHidden, opened, required, skeleton, timezone, value } = {
+	const { disabled, enforceTimeIntervals, label, labelHidden, opened, required, skeleton, timeZoneId, value } = {
 		disabled: false,
 		enforceTimeIntervals: false,
 		label: 'Start Time',
@@ -13,7 +13,7 @@ const create = (opts = {}) => {
 		opened: false,
 		required: false,
 		skeleton: false,
-		timezone: undefined,
+		timeZoneId: undefined,
 		value: undefined,
 		...opts
 	};
@@ -26,7 +26,7 @@ const create = (opts = {}) => {
 			?opened="${opened}"
 			?required="${required}"
 			?skeleton="${skeleton}"
-			timezone="${ifDefined(timezone)}"
+			time-zone-id="${ifDefined(timeZoneId)}"
 			value="${ifDefined(value)}">
 			</d2l-input-time>
 	`;
@@ -48,7 +48,7 @@ describe('d2l-input-time', () => {
 		{ name: 'label-hidden', template: create({ value: '3:00:00' }) },
 		{ name: 'label-hidden-skeleton', template: create({ skeleton: true, value: '3:00:00' }) },
 		{ name: 'required', template: create({ label: 'End Time', labelHidden: false, required: true }) },
-		{ name: 'timezone-custom', template: create({ timezone: 'Australia/Eucla', opened: true }) },
+		{ name: 'time-zone-custom', template: create({ timeZoneId: 'Australia/Eucla', opened: true }) },
 		{
 			name: 'inline-help',
 			template: new inlineHelpFixtures().time()

--- a/helpers/test/dateTime.test.js
+++ b/helpers/test/dateTime.test.js
@@ -181,14 +181,14 @@ describe('date-time', () => {
 		});
 	});
 
-	['America/Toronto', 'Australia/Eucla'].forEach((timezone) => {
-		describe(`getClosestValidDate in ${timezone}`, () => {
+	['America/Toronto', 'Australia/Eucla'].forEach((timeZone) => {
+		describe(`getClosestValidDate in ${timeZone}`, () => {
 			let clock;
 			const today = '2018-02-12T20:00:00.000Z';
-			const todayDate = timezone === 'America/Toronto' ? '2018-02-12' : '2018-02-13';
+			const todayDate = timeZone === 'America/Toronto' ? '2018-02-12' : '2018-02-13';
 
 			before(() => {
-				documentLocaleSettings.timezone.identifier = timezone;
+				documentLocaleSettings.timezone.identifier = timeZone;
 				const newToday = new Date(today);
 				clock = sinon.useFakeTimers({ now: newToday.getTime(), toFake: ['Date'] });
 			});
@@ -255,11 +255,11 @@ describe('date-time', () => {
 			});
 		});
 
-		describe(`getUTCDateTimeRange in ${timezone}`, () => {
+		describe(`getUTCDateTimeRange in ${timeZone}`, () => {
 			let clock;
 
 			before(() => {
-				documentLocaleSettings.timezone.identifier = timezone;
+				documentLocaleSettings.timezone.identifier = timeZone;
 				const newToday = new Date('2018-02-12T20:00:00Z');
 				clock = sinon.useFakeTimers({ now: newToday.getTime(), toFake: ['Date'] });
 			});
@@ -294,10 +294,10 @@ describe('date-time', () => {
 
 			it('returns expected startValue and endValue for today when type is days and diff is 0', async() => {
 				const res = getUTCDateTimeRange('days', 0);
-				if (timezone === 'America/Toronto') {
+				if (timeZone === 'America/Toronto') {
 					expect(res.startValue).to.equal('2018-02-12T05:00:00.000Z');
 					expect(res.endValue).to.equal('2018-02-13T04:59:59.000Z');
-				} else if (timezone === 'Australia/Eucla') {
+				} else if (timeZone === 'Australia/Eucla') {
 					expect(res.startValue).to.equal('2018-02-12T15:15:00.000Z');
 					expect(res.endValue).to.equal('2018-02-13T15:14:59.000Z');
 				}
@@ -326,7 +326,7 @@ describe('date-time', () => {
 			expect(getDateFromISODateTime('2019-01-30T12:30:00Z')).to.deep.equal(new Date(2019, 0, 30, 7, 30, 0));
 		});
 
-		it('should return expected date in Australia/Eucla timezone', () => {
+		it('should return expected date in Australia/Eucla time zone', () => {
 			documentLocaleSettings.timezone.identifier = 'Australia/Eucla';
 			expect(getDateFromISODateTime('2019-01-30T12:30:00Z')).to.deep.equal(new Date(2019, 0, 30, 21, 15, 0));
 		});
@@ -369,11 +369,11 @@ describe('date-time', () => {
 			documentLocaleSettings.timezone.identifier = 'America/Toronto';
 		});
 
-		it('should return expected day in America/Toronto timezone', () => {
+		it('should return expected day in America/Toronto time zone', () => {
 			expect(getToday()).to.deep.equal({ year: 2018, month: 2, date: 12, hours: 15, minutes: 0, seconds: 0 });
 		});
 
-		it('should return expected day in Australia/Eucla timezone', () => {
+		it('should return expected day in Australia/Eucla time zone', () => {
 			documentLocaleSettings.timezone.identifier = 'Australia/Eucla';
 			expect(getToday()).to.deep.equal({ year: 2018, month: 2, date: 13, hours: 4, minutes: 45, seconds: 0 });
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@brightspace-ui/intl": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.30.0.tgz",
-      "integrity": "sha512-TTbxv7EgZTdIojrWpIpq8ui0PWipvyimtNjqGE5+i+J62UUf55q1kKexSWQPC2c6EWdpYVih7YXQdgCzErkjAQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.30.1.tgz",
+      "integrity": "sha512-1ulbIbb8aqeYRg07iPpmX7lG1ISP0nM7v2zWXasjUDJO+of0Ex3DsmrcokBkkCnXtrSiiFnBZf8IROq0qMujfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "intl-messageformat": "^10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@brightspace-ui/intl": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.29.0.tgz",
-      "integrity": "sha512-mJUNSXB8H7S4z3bQ71F0Bzl5ZwFRinAjOOwtDUkgE0KN+0eykpcrs7H9G5MLmYPAWwC4OPFuzprQdYNUijHKRA==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.30.0.tgz",
+      "integrity": "sha512-TTbxv7EgZTdIojrWpIpq8ui0PWipvyimtNjqGE5+i+J62UUf55q1kKexSWQPC2c6EWdpYVih7YXQdgCzErkjAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "intl-messageformat": "^10"


### PR DESCRIPTION
- Adjusts #6081 for actual `intl` implementation ([@brightspaceui/intl](https://github.com/BrightspaceUI/intl/pull/273))
- Moves "timezone" to "time zone" where possible

[JIRA](https://desire2learn.atlassian.net/browse/GAUD-8587)