### PR TITLE
SHIELD-12649 - Set up default MathJax context instead of early exiting if no context is provided

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -38,8 +38,17 @@ class HtmlBlockMathRenderer {
 
 	async render(elem, options) {
 		if (!options.contextValues) return elem;
-		const context = options.contextValues.get(mathjaxContextKey);
-		if (context === undefined) return elem;
+		let context = options.contextValues.get(mathjaxContextKey);
+
+		// For 20.25.11, update to default to true if flag helper can't be found
+		if (window.D2L?.LP?.Web?.UI?.Flags?.Flag('shield-12649-mathjax-default-context', false)) {
+			context = context || {
+				renderLatex: false,
+				outputScale: 1
+			};
+		} else {
+			if (context === undefined) return elem;
+		}
 
 		if (!elem.querySelector('math') && !(context.renderLatex && /\$\$|\\\(|\\\[|\\begin{|\\ref{|\\eqref{/.test(elem.innerHTML))) return elem;
 


### PR DESCRIPTION
In order to make sure C+ can support math rendering properly in Content files, we need to make sure that the `html-block` component can do this same thing. That means we need to allow the MathJax helper to work properly even if no context object is provided.

The flag stuff here is kind of weird. I want this change to be flagged just in case it introduces issues, but the C+ context isn't going to be able to make use of the flag because that content gets loaded in an HTML file. The C+ folks also want their end to only go live in 20.25.11, but I would prefer we get as much soak time in the LMS is possible. So here's my strategy:
1. Make the change behind the flag check, defaulting to the existing behaviour (for now) if the flag helper can't be fetched (i.e. we're not in an LMS context).
2. When 20.25.11 rolls around, update this code to default to the new behaviour if the flag helper can't be fetched. This means new code outside of the LMS (or inside Content files) will take on the new behaviour no matter what, but we can turn the behaviour off elsewhere if it causes a problem.
3. Remove the flag check entirely after the usual 3 month soak period Shield usually keeps.

The above is a bit convoluted and isn't without risk, but short of shoehorning flags into Content files (which I think comes with a bunch of required considerations that I don't _really_ want to address right now), this will at least accomplish our goals.