### PR TITLE
Add time zone support to more time components

### DIFF
--- a/components/inputs/docs/input-date-time.md
+++ b/components/inputs/docs/input-date-time.md
@@ -292,7 +292,7 @@ A few notable accessibility-related features of these components are:
 * When the date input is opened with the keyboard, focus goes to either selected date, today, or earliest valid date if today is prior to `min-date`
 * Extensive intuitive keyboard interaction support
 
-## Timezone
+## Time Zone
 
 The `input-date-time` and `input-date-time-range` components expect input in UTC (`YYYY-MM-DDTHH:mm:ss.sssZ`). These components will convert values automatically to the user's time zone to display the date/time to them, and then will provide the value back in UTC. No time zone conversions are needed.
 

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -151,6 +151,16 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 			 * @type {string}
 			 */
 			startValue: { attribute: 'start-value', reflect: true, type: String },
+			/**
+			 * Timezone identifier for the time inputs to use.
+			 * @type {string}
+			 */
+			timeZoneId: { type: String },
+			/**
+			 * Hides the time zone inside the time selection dropdowns. Should only be used when the time input values are not related to any one time zone
+			 * @type {Boolean}
+			 */
+			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
 			_slotOccupied: { type: Boolean }
 		};
 	}
@@ -251,6 +261,8 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 							?required="${this.required}"
 							?skeleton="${this.skeleton}"
 							time-default-value="startOfDay"
+							time-zone-id="${ifDefined(this.timeZoneId)}"
+							?time-zone-hidden="${this.timeZoneHidden}"
 							value="${ifDefined(this.startValue)}">
 						</d2l-input-date-time>
 						<slot name="start" @slotchange="${this._onSlotChange}"></slot>
@@ -273,6 +285,8 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 							?required="${this.required}"
 							?skeleton="${this.skeleton}"
 							time-default-value="endOfDay"
+							time-zone-id="${ifDefined(this.timeZoneId)}"
+							?time-zone-hidden="${this.timeZoneHidden}"
 							value="${ifDefined(this.endValue)}">
 						</d2l-input-date-time>
 						<slot name="end" @slotchange="${this._onSlotChange}"></slot>

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -254,6 +254,8 @@ class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMi
 				max-height="430"
 				?required="${this.required}"
 				?skeleton="${this.skeleton}"
+				time-zone-id="${ifDefined(this.timeZoneId)}"
+				?time-zone-hidden="${this.timeZoneHidden}"
 				.value="${parsedValue}">
 			</d2l-input-time>` : null;
 

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -281,6 +281,8 @@ class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(LocalizeC
 						?skeleton="${this.skeleton}"
 						slot="right"
 						time-interval="${ifDefined(timeInterval)}"
+						time-zone-id="${ifDefined(this.timeZoneId)}"
+						?time-zone-hidden="${this.timeZoneHidden}"
 						value="${ifDefined(this.endValue)}">
 					</d2l-input-time>
 				</d2l-input-date-time-range-to>


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-8587)

In #6081 I missed some components that should pass timezone attribute values through to `d2l-input-time`