### PR TITLE
feat: add role and label to scroll wrapper buttons

### DIFF
--- a/components/scroll-wrapper/scroll-wrapper.js
+++ b/components/scroll-wrapper/scroll-wrapper.js
@@ -5,6 +5,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { getFlag } from '../../helpers/flags.js';
 import { getFocusRingStyles } from '../../helpers/focus.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
+import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 
 export const printMediaQueryOnlyFlag = getFlag('GAUD-8263-scroll-wrapper-media-print', false);
 
@@ -43,7 +44,7 @@ function getStyleSheetInsertionPoint(elem) {
  * Wraps content which may overflow its horizontal boundaries, providing left/right scroll buttons.
  * @slot - User provided content to wrap
  */
-class ScrollWrapper extends LitElement {
+class ScrollWrapper extends LocalizeCoreElement(LitElement) {
 
 	static get properties() {
 		return {
@@ -227,10 +228,10 @@ class ScrollWrapper extends LitElement {
 
 		const actions = !this.hideActions ? html`
 			<div class="${classMap(actionsClasses)}">
-				<div class="d2l-scroll-wrapper-button d2l-scroll-wrapper-button-left vdiff-target" @click="${this._scrollLeft}">
+				<div role="button" aria-label="${this.localize('components.scroll-wrapper.scroll-left')}" class="d2l-scroll-wrapper-button d2l-scroll-wrapper-button-left vdiff-target" @click="${this._scrollLeft}">
 					<d2l-icon icon="tier1:chevron-left"></d2l-icon>
 				</div>
-				<div class="d2l-scroll-wrapper-button d2l-scroll-wrapper-button-right vdiff-target" @click="${this._scrollRight}">
+				<div role="button" aria-label="${this.localize('components.scroll-wrapper.scroll-right')}" class="d2l-scroll-wrapper-button d2l-scroll-wrapper-button-right vdiff-target" @click="${this._scrollRight}">
 					<d2l-icon icon="tier1:chevron-right"></d2l-icon>
 				</div>
 			</div>` : null;

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "تحميل المزيد",
 	"components.pager-load-more.action-with-page-size": "تحميل {count} إضافي",
 	"components.pager-load-more.status-loading": "تحميل المزيد من المواد",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {يتم التعطيل عند تحديد أكثر من {countFormatted} عنصر}

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Llwytho Mwy",
 	"components.pager-load-more.action-with-page-size": "Lwytho {count} Arall",
 	"components.pager-load-more.status-loading": "Llwytho rhagor o eitemau",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Wedi’i analluogi pan fydd mwy nag {countFormatted} eitem yn cael ei ddewis}

--- a/lang/da.js
+++ b/lang/da.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Indlæs flere",
 	"components.pager-load-more.action-with-page-size": "Indlæs {count} mere",
 	"components.pager-load-more.status-loading": "Indlæser flere elementer",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Deaktiveret, når mere end {countFormatted} element er valgt}

--- a/lang/de.js
+++ b/lang/de.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Mehr laden",
 	"components.pager-load-more.action-with-page-size": "{count} weitere laden",
 	"components.pager-load-more.status-loading": "Weitere Elemente werden geladen",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Deaktiviert, wenn mehr als {countFormatted} Element ausgewählt ist}

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Load More",
 	"components.pager-load-more.action-with-page-size": "Load {count} More",
 	"components.pager-load-more.status-loading": "Loading more items",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Disabled when more than {countFormatted} item is selected}

--- a/lang/en.js
+++ b/lang/en.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Load More",
 	"components.pager-load-more.action-with-page-size": "Load {count} More",
 	"components.pager-load-more.status-loading": "Loading more items",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Disabled when more than {countFormatted} item is selected}

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Cargar más",
 	"components.pager-load-more.action-with-page-size": "Cargar {count} más",
 	"components.pager-load-more.status-loading": "Cargando más elementos",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Deshabilitado cuando se selecciona más de {countFormatted} elemento}

--- a/lang/es.js
+++ b/lang/es.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Cargar más",
 	"components.pager-load-more.action-with-page-size": "Cargar {count} más",
 	"components.pager-load-more.status-loading": "Cargando más elementos",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Se desactiva cuando se selecciona más de {countFormatted} elemento}

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Charger plus",
 	"components.pager-load-more.action-with-page-size": "Charger {count} supplémentaire(s)",
 	"components.pager-load-more.status-loading": "Charger plus d’éléments",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {désactivé lorsque plus de {countFormatted} élément est sélectionné}

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "En télécharger plus",
 	"components.pager-load-more.action-with-page-size": "Charger {count} de plus",
 	"components.pager-load-more.status-loading": "Chargement d’autres d’éléments",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Désactivé lorsque plus de {countFormatted} élément est sélectionné}

--- a/lang/haw.js
+++ b/lang/haw.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Hoʻouka hou aku",
 	"components.pager-load-more.action-with-page-size": "Hoʻouka {count} Mea hou aku",
 	"components.pager-load-more.status-loading": "Ke hoʻouka nei i nā mea hou aʻe",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Hoʻopaʻa ʻia ke ʻoi aku ma mua o {countFormatted} koho ʻia ka mea}

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "और लोड करें",
 	"components.pager-load-more.action-with-page-size": "{count} और लोड करें",
 	"components.pager-load-more.status-loading": "और आइटम लोड करना",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {{countFormatted} से अधिक आइटम चुने जाने पर अक्षम किया गया जाता है}

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -154,6 +154,8 @@ export default {
 	"components.pager-load-more.action": "さらに読み込む",
 	"components.pager-load-more.action-with-page-size": "さらに {count} 件を読み込む",
 	"components.pager-load-more.status-loading": "さらに項目を読み込み中",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			other {{countFormatted} 個を超える項目が選択されている場合は無効になります}

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -154,6 +154,8 @@ export default {
 	"components.pager-load-more.action": "더 많이 로드",
 	"components.pager-load-more.action-with-page-size": "{count}개 더 로드",
 	"components.pager-load-more.status-loading": "더 많은 항목 로드",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			other {{countFormatted}개 이상의 항목이 선택되면 비활성화됨}

--- a/lang/mi.js
+++ b/lang/mi.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Utaina Anō",
 	"components.pager-load-more.action-with-page-size": "Utaina {count} Ētahi atu",
 	"components.pager-load-more.status-loading": "Uta ana i ētahi atu tūemi",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Kua whakakorehia ina neke atu i te {countFormatted} o ngā tūemi i tīpakohia}

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Meer laden",
 	"components.pager-load-more.action-with-page-size": "Laad nog {count} extra",
 	"components.pager-load-more.status-loading": "Er worden meer items geladen",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Uitgeschakeld als meer dan {countFormatted} item is geselecteerd}

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Carregar Mais",
 	"components.pager-load-more.action-with-page-size": "Carregar mais {count}",
 	"components.pager-load-more.status-loading": "Carregando mais itens",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {Desativado quando mais de {countFormatted} item é selecionado}

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Läs in fler",
 	"components.pager-load-more.action-with-page-size": "Läs in {count} till",
 	"components.pager-load-more.status-loading": "Läser in fler objekt",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {inaktiveras när fler än {countFormatted} objekt väljs}

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -161,6 +161,8 @@ export default {
 	"components.pager-load-more.action": "Daha Fazla Yükle",
 	"components.pager-load-more.action-with-page-size": "{count} Tane Daha Yükle",
 	"components.pager-load-more.status-loading": "Daha fazla öğe yükleniyor",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			one {{countFormatted} öğeden fazlası seçildiğinde devre dışı bırakılır}

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -154,6 +154,8 @@ export default {
 	"components.pager-load-more.action": "加载更多",
 	"components.pager-load-more.action-with-page-size": "再加载 {count} 个",
 	"components.pager-load-more.status-loading": "加载更多项目",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			other {选择的项目超过 {countFormatted} 个时禁用}

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -155,6 +155,8 @@ export default {
 	"components.pager-load-more.action": "載入更多",
 	"components.pager-load-more.action-with-page-size": "再載入 {count} 個",
 	"components.pager-load-more.status-loading": "正在載入更多項目",
+	"components.scroll-wrapper.scroll-left": "Scroll left",
+	"components.scroll-wrapper.scroll-right": "Scroll right",
 	"components.selection.action-max-hint":
 		`{count, plural,
 			other {選取超過 {countFormatted} 個項目時即停用}


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-8477)

Adds role and label to scroll icons, the change solves some WCAG criteria violations with the downside that AT now exposes the icons as 'Scroll right, button' rather than simply 'image'.