### PR TITLE
fix: don't sync column widths if table isn't set

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -628,6 +628,7 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 	}
 
 	_syncColumnWidths() {
+		if (!this._table) return;
 		const head = this._table.querySelector('thead');
 		const body = this._table.querySelector('tbody');
 


### PR DESCRIPTION
I noticed this error happening a bunch of times in the insights repo CI logs:
```
TypeError: can't access property "querySelector", this._table is undefined
        at _syncColumnWidths (node_modules/@brightspace-ui/core/components/table/table-wrapper.js:631:16)
        at _handleTableChange (node_modules/@brightspace-ui/core/components/table/table-wrapper.js:617:32)
        at async*_handleSlotChange (node_modules/@brightspace-ui/core/components/table/table-wrapper.js:583:8)
```

They are using `<d2l-table-wrapper>` with no `<table>` in it (I'll fix that separately in their repo), but even trying that I can't reproduce the error. Putting this guard in can't hurt though!