### PR TITLE
fix: Tab: Do not dispatch d2l-tab-selected on initial load if consumer specified selected

### DIFF
--- a/components/tabs/demo/tabs.html
+++ b/components/tabs/demo/tabs.html
@@ -482,6 +482,9 @@
 			document.addEventListener('d2l-tab-panel-selected', (e) => {
 				console.log('tab panel selected', e);
 			});
+			document.addEventListener('d2l-tab-selected', (e) => {
+				console.log('tab selected', e);
+			});
 			document.addEventListener('d2l-tab-panel-text-changed', (e) => {
 				console.log('tab panel text changed', e);
 			});

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -102,6 +102,8 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		this.addEventListener('click', this.#handleClick);
 		this.addEventListener('keydown', this.#handleKeydown);
 		this.addEventListener('keyup', this.#handleKeyup);
+
+		this.#hasInitialized = true;
 	}
 
 	render() {
@@ -116,6 +118,8 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 
 		if (changedProperties.has('selected')) {
 			this.ariaSelected = `${this.selected}`;
+			if (!this.#hasInitialized) return; // Only fire events if selected changes after initial render
+
 			if (this.selected) {
 				/** Dispatched when a tab is selected */
 				this.dispatchEvent(new CustomEvent(
@@ -144,6 +148,8 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		console.warn('Subclasses to implement/override renderContent');
 		return html`<div>Default Tab Content</div>`;
 	}
+
+	#hasInitialized = false;
 
 	#handleClick() {
 		if (this.selected) return;

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -1,5 +1,6 @@
 import '../colors/colors.js';
 import { css, html } from 'lit';
+import { getFlag } from '../../helpers/flags.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 const keyCodes = {
@@ -94,6 +95,7 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		this.tabIndex = -1;
 
 		this._clicked = false;
+		this._noInitialSelectedEvent = getFlag('GAUD-8605-tab-no-initial-selected-event', false);
 	}
 
 	firstUpdated(changedProperties) {
@@ -118,7 +120,7 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 
 		if (changedProperties.has('selected')) {
 			this.ariaSelected = `${this.selected}`;
-			if (!this.#hasInitialized) return; // Only fire events if selected changes after initial render
+			if (!this.#hasInitialized && this._noInitialSelectedEvent) return; // Only fire events if selected changes after initial render
 
 			if (this.selected) {
 				/** Dispatched when a tab is selected */

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -72,6 +72,38 @@ describe('d2l-tabs', () => {
 			await oneEvent(tabs, 'd2l-tab-selected');
 		});
 
+		it('dispatches d2l-tab-selected on initial render when no tab selected by consumer', async() => {
+			let eventFired = false;
+
+			document.addEventListener('d2l-tab-selected', () => {
+				eventFired = true;
+			});
+			await fixture(normalFixture);
+
+			expect(eventFired).to.equal(true);
+		});
+
+		it('does not dispatch d2l-tab-selected on initial render when consumer has selected tab', async() => {
+			let eventFired = false;
+
+			document.addEventListener('d2l-tab-selected', () => {
+				eventFired = true;
+			});
+
+			await fixture(html`
+				<div>
+					<d2l-tabs>
+						<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+						<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+						<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+					</d2l-tabs>
+				</div>
+			`);
+
+			expect(eventFired).to.equal(false);
+		});
+
 		it('does not dispatch d2l-tab-selected if already selected', async() => {
 			const el = await fixture(normalFixture);
 			let dispatched = false;

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -3,6 +3,7 @@ import '../tabs.js';
 import '../tab-panel.js';
 import '../demo/tabs-array.js';
 import { clickElem, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { mockFlag, resetFlag } from '../../../helpers/flags.js';
 import { spy } from 'sinon';
 
 const defaultFixture = html`
@@ -48,6 +49,8 @@ describe('d2l-tabs', () => {
 
 	describe('events', () => {
 
+		afterEach(() => resetFlag('GAUD-8605-tab-no-initial-selected-event'));
+
 		// remove after d2l-tab/d2l-tab-panel backport
 		it('dispatches d2l-tab-panel-selected', async() => {
 			const el = await fixture(defaultFixture);
@@ -83,7 +86,8 @@ describe('d2l-tabs', () => {
 			expect(eventFired).to.equal(true);
 		});
 
-		it('does not dispatch d2l-tab-selected on initial render when consumer has selected tab', async() => {
+		it('does not dispatch d2l-tab-selected on initial render when consumer has selected tab (flag enabled)', async() => {
+			mockFlag('GAUD-8605-tab-no-initial-selected-event', true);
 			let eventFired = false;
 
 			document.addEventListener('d2l-tab-selected', () => {
@@ -102,6 +106,28 @@ describe('d2l-tabs', () => {
 			`);
 
 			expect(eventFired).to.equal(false);
+		});
+
+		// remove test with GAUD-8605-tab-no-initial-selected-event clean up
+		it('dispatches d2l-tab-selected on initial render when consumer has selected tab (flag disabled)', async() => {
+			mockFlag('GAUD-8605-tab-no-initial-selected-event', false);
+			let eventFired = false;
+
+			document.addEventListener('d2l-tab-selected', () => {
+				eventFired = true;
+			});
+			await fixture(html`
+				<div>
+					<d2l-tabs>
+						<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+						<d2l-tab id="biology" text="Biology" slot="tabs" selected></d2l-tab>
+						<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+					</d2l-tabs>
+				</div>
+			`);
+
+			expect(eventFired).to.equal(true);
 		});
 
 		it('does not dispatch d2l-tab-selected if already selected', async() => {


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8605)

FYI @dlockhart 

**Problem**:
On initial load, the `d2l-tab-selected` event gets fired. This is potentially an issue if the consumer has specified `selected` and yet nothing new has been `selected`. I did keep the event firing on initial load if the tabs component itself is selecting which tab is `selected`.

This is consistent with the legacy behaviour where `d2l-tab-panel-selected` also fired on load. There could be consumers relying on this behaviour. Since the backport is still in progress there aren't many using this event yet, but I'll be testing them all out just in case.

Let me know thoughts on this. On one hand it makes sense to me to not fire an event when the state hasn't actually changed. On the other hand, if there is any logic that needs to be run when a certain tab is selected, it would likely make sense to have that in one place (though that could just also be called in `firstUpdated`); this might not actually be a problem and it could cause worse issues having it fire.