### PR TITLE
SHIELD-12736 - Default MathJax context feature to true for non-LMS contexts

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -42,8 +42,7 @@ class HtmlBlockMathRenderer {
 		if (!options.contextValues) return elem;
 		let context = options.contextValues.get(mathjaxContextKey);
 
-		// For 20.25.11, update to default to true if flag helper can't be found
-		if (getFlag('shield-12649-mathjax-default-context', false)) {
+		if (getFlag('shield-12649-mathjax-default-context', true)) {
 			context = context || {
 				renderLatex: false,
 				outputScale: 1


### PR DESCRIPTION
To be merged after 20.25.11 branches.

We're just flipping the default if we can't find the flag for non-LMS cases, or cases like inside Content files where our LMS helpers aren't available.