### PR TITLE
fix: GAUD-8660 - Swap div and slot closing tags in the primary-secondary template footer

### DIFF
--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -1074,7 +1074,7 @@ class TemplatePrimarySecondary extends LocalizeCoreElement(LitElement) {
 					${this.secondaryFirst && !this._isMobile ? primarySection : secondarySection}
 				</div>
 				<footer ?hidden="${!this._hasFooter}">
-					<div class="d2l-template-primary-secondary-footer"><slot name="footer" @slotchange="${this._handleFooterSlotChange}"></div></slot>
+					<div class="d2l-template-primary-secondary-footer"><slot name="footer" @slotchange="${this._handleFooterSlotChange}"></slot></div>
 				</footer>
 			</div>
 		`;


### PR DESCRIPTION
Noticed this while spiking into templates. This has been there since the template was first written, and the browsers have just been  handling it. Shouldn't result in any changes.