### PR TITLE
SHIELD-12881 - Backport changes to 20.25.9

### DIFF
--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -1,3 +1,5 @@
+import { getFlag } from './flags.js';
+
 /* When updating MathJax, update mathjaxBaseUrl to use the new version
  * and verify that the font mappings included in mathjaxFontMappings
  * match what's present in the MathJax-src repo.
@@ -38,8 +40,17 @@ class HtmlBlockMathRenderer {
 
 	async render(elem, options) {
 		if (!options.contextValues) return elem;
-		const context = options.contextValues.get(mathjaxContextKey);
-		if (context === undefined) return elem;
+		let context = options.contextValues.get(mathjaxContextKey);
+
+		// For 20.25.11, update to default to true if flag helper can't be found
+		if (getFlag('shield-12649-mathjax-default-context', false)) {
+			context = context || {
+				renderLatex: false,
+				outputScale: 1
+			};
+		} else {
+			if (context === undefined) return elem;
+		}
 
 		if (!elem.querySelector('math') && !(context.renderLatex && /\$\$|\\\(|\\\[|\\begin{|\\ref{|\\eqref{/.test(elem.innerHTML))) return elem;
 

--- a/helpers/mathjax.js
+++ b/helpers/mathjax.js
@@ -42,8 +42,7 @@ class HtmlBlockMathRenderer {
 		if (!options.contextValues) return elem;
 		let context = options.contextValues.get(mathjaxContextKey);
 
-		// For 20.25.11, update to default to true if flag helper can't be found
-		if (getFlag('shield-12649-mathjax-default-context', false)) {
+		if (getFlag('shield-12649-mathjax-default-context', true)) {
 			context = context || {
 				renderLatex: false,
 				outputScale: 1


### PR DESCRIPTION
I guess we also need these changes back in 20.25.9. 🤷 

This is an amalgamation of these two PRs: https://github.com/BrightspaceUI/core/pull/6100, https://github.com/BrightspaceUI/core/pull/6134