### PR TITLE
nim-5095

### DIFF
--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -198,18 +198,19 @@ class MoreLess extends LocalizeCoreElement(LitElement) {
 
 	__adjustToContent_makeActive() {
 		this.inactive = false;
-		this.__maxHeight = this.height;
+		// Include 1px of given room to account for issues with rounding the content's scroll height
+		this.__maxHeight = `${this.height + 1}px`;
 	}
 
 	__adjustToContent_makeInactive() {
 		this.inactive = true;
 		this.expanded = false;
-		// Include 1px of given room to account for issues with Firefox rounding the content's scroll height
+		// Include 1px of given room to account for issues with rounding the content's scroll height
 		this.__maxHeight = `${this.__content.scrollHeight + 1}px`;
 	}
 
 	__adjustToContent_resize(contentHeight) {
-		// Include 1px of given room to account for issues with Firefox rounding the content's scroll height
+		// Include 1px of given room to account for issues with rounding the content's scroll height
 		this.__maxHeight = `${contentHeight + 1}px`;
 	}
 


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/NIM-5095

Add 1px for rounding purposes when calling `makeActive` for `d2l-more-less`

Similar to what was previously done here: https://github.com/BrightspaceUI/core/pull/3825

Slack thread with additional context: https://d2l.slack.com/archives/C0PHG3QB0/p1758822799244209

Please see attached video for fix in action and rationale.

https://github.com/user-attachments/assets/1d1c6d87-a3e8-4635-8ec5-7c625905713e