### PR TITLE
Wire up popover media-query handlers like old dropdown content mixin.

### DIFF
--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -335,6 +335,9 @@ export const PopoverMixin = superclass => class extends superclass {
 			};
 		}
 		this._trapFocus = properties?.trapFocus ?? false;
+
+		this.#removeMediaQueryHandlers();
+		this.#addMediaQueryHandlers();
 	}
 
 	async open(opener, applyFocus = true) {

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -266,9 +266,9 @@ export const PopoverMixin = superclass => class extends superclass {
 		super.connectedCallback();
 		if (this._opened) {
 			this.#addAutoCloseHandlers();
-			this.#addMediaQueryHandlers();
 			this.#addRepositionHandlers();
 		}
+		this.#addMediaQueryHandlers();
 	}
 
 	disconnectedCallback() {
@@ -341,8 +341,6 @@ export const PopoverMixin = superclass => class extends superclass {
 		if (this._opened) return;
 
 		const ifrauBackdropService = await tryGetIfrauBackdropService();
-
-		this.#addMediaQueryHandlers();
 
 		this._rtl = document.documentElement.getAttribute('dir') === 'rtl';
 		this._applyFocus = applyFocus !== undefined ? applyFocus : true;


### PR DESCRIPTION
[GAUD-8718](https://desire2learn.atlassian.net/browse/GAUD-8718)

This PR updates the `PopoverMixin` wire-up of media-query handlers to be earlier, like `DropdownContentMixin`. I was optimistic in deferring this until the popover is opened, however the [opener code](https://github.com/BrightspaceUI/core/blob/main/components/dropdown/dropdown-opener-mixin.js#L234) relies on knowing the mobile mode when determining whether to open the popover when `open-on-hover` is being used. 

This fix is needed to address [this diff](https://github.com/BrightspaceHypermediaComponents/users/pull/494/files#r2394857904) using the new popover.

[GAUD-8718]: https://desire2learn.atlassian.net/browse/GAUD-8718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ