### PR TITLE
fix: List item drag & drop: Check for setDragImage

### DIFF
--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -633,15 +633,15 @@ export const ListItemDragDropMixin = superclass => class extends superclass {
 					}
 				}
 			}
-			e.dataTransfer.setDragImage(getDragImage(selectionInfo.keys.length, includePlus), 24, 26);
+			if (e.dataTransfer.setDragImage) e.dataTransfer.setDragImage(getDragImage(selectionInfo.keys.length, includePlus), 24, 26);
 		} else if (rootList.dragMultiple && this.expandable) {
 			const flattenedListItems = this._getFlattenedListItems(this);
-			e.dataTransfer.setDragImage(getDragImage(flattenedListItems.listItems.size, flattenedListItems.lazyLoadListItems.size > 0), 24, 26);
+			if (e.dataTransfer.setDragImage) e.dataTransfer.setDragImage(getDragImage(flattenedListItems.listItems.size, flattenedListItems.lazyLoadListItems.size > 0), 24, 26);
 		} else {
 			if (this.shadowRoot) {
 				const nodeImage = this.shadowRoot.querySelector('.d2l-list-item-drag-image') || this;
 				nodeImage.classList.add('dragging');
-				e.dataTransfer.setDragImage(nodeImage, 50, 50);
+				if (e.dataTransfer.setDragImage) e.dataTransfer.setDragImage(nodeImage, 50, 50);
 			}
 		}
 


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-8690)

**Problem**:
Drag & drop is currently broken on mobile. There's a console error about `setDragImage` not existing.

**Solution Notes**:
On mobile we simulate the drag and drop events so I believe there just isn't `setDragImage` available. Mobile dragging now works but there isn't a drag image. Not sure if there are thoughts on that or if we're okay with it just working.