### PR TITLE
Fix tabindex typo to tabIndex in input-text.js

### DIFF
--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -481,7 +481,7 @@ class InputText extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(La
 						size="${ifDefined(this.size)}"
 						step="${ifDefined(this.step)}"
 						style="${styleMap(inputStyles)}"
-						tabindex="${ifDefined(this.tabindex)}"
+						tabindex="${ifDefined(this.tabIndex)}"
 						title="${ifDefined(this.title)}"
 						type="${this._getType()}">
 					<div class="d2l-input-inside-before" @keypress="${this._suppressEvent}">${this.dir === 'rtl' ? unit : ''}<slot name="${firstSlotName}" @slotchange="${this._handleSlotChange}"></slot></div>


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/BSPACE-283

Hmm. It looks like the name is intentional, and the tabindex property might have existed before. Doesn't look like this is an issue right now, but maybe safe to remove? Since I'm not sure, I'll close this for now.