### PR TITLE
Fix slot name in input-color.js

### DIFF
--- a/components/inputs/input-color.js
+++ b/components/inputs/input-color.js
@@ -82,7 +82,7 @@ const SWATCH_TRANSPARENT = `<svg xmlns="http://www.w3.org/2000/svg" width="24" h
 
 /**
  * This component allows for inputting a HEX color value.
- * @slot inline-help - Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
+ * @slot - Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
  * @fires change - Dispatched when an alteration to the value is committed by the user.
  */
 class InputColor extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {


### PR DESCRIPTION
The slot: https://github.com/BrightspaceUI/core/blob/2084389abca99cefdad7c7405d019e7df9b42ad3/components/inputs/input-color.js#L339 is unnamed