### PR TITLE
Update backdrop to support table loading state

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -1,5 +1,7 @@
 import '../colors/colors.js';
 import '../scroll-wrapper/scroll-wrapper.js';
+import '../backdrop/backdrop.js';
+import '../loading-spinner/loading-spinner.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { cssSizes } from '../inputs/input-checkbox.js';
 import { getComposedParent } from '../../helpers/dom.js';
@@ -307,6 +309,10 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 				reflect: true,
 				type: String
 			},
+			loading: {
+				reflect: true,
+				type: String
+			},
 			_controlsScrolled: { state: true },
 			_noScrollWidth: {
 				attribute: '_no-scroll-width',
@@ -363,6 +369,14 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 			slot[name="pager"]::slotted(*) {
 				margin-top: 12px;
 			}
+			d2l-loading-spinner {
+				position: absolute;
+				z-index: 1000;
+				left: 50%;
+				transform: (-50%, 0);
+				top: 100px;
+				display: block;
+			}
 		`;
 	}
 
@@ -372,6 +386,7 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 		this.stickyHeaders = false;
 		this.stickyHeadersScrollWrapper = false;
 		this.type = 'default';
+		this.loading = false;
 
 		this._controls = null;
 		this._controlsMutationObserver = null;
@@ -410,7 +425,11 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 	}
 
 	render() {
-		const slot = html`<slot @slotchange="${this._handleSlotChange}"></slot>`;
+		const slot = html`
+			<slot @slotchange="${this._handleSlotChange}"></slot>
+			<d2l-backdrop contained ?shown=${this.loading} for-target="loading-spinner"></d2l-backdrop>
+			${this.loading ? html`<d2l-loading-spinner id="loading-spinner"></d2l-loading-spinner>` : nothing}
+		`;
 		const useScrollWrapper = this.stickyHeadersScrollWrapper || !this.stickyHeaders;
 		return html`
 			<slot name="controls" @slotchange="${this._handleControlsSlotChange}"></slot>


### PR DESCRIPTION
[Downstream ticket ](https://desire2learn.atlassian.net/browse/NTNGL-4559?atlOrigin=eyJpIjoiMjA0NGVmOWEwMzlkNDJjNmI0NDhmYmJkZTBiN2NjMzEiLCJwIjoiaiJ9)
[Upstream ticket](https://desire2learn.atlassian.net/browse/GAUD-7166)

We want to add a visual loading state to the table in the event that the data needs to be refreshed. This can occur after filters are applied, sort orders are changed, and possibly in future when we move to a new page.

In this PR, I'm updating the existing backdrop component in a few ways to make it compatible with this solution:
- I'm adding a `contained` option which limits the backdrop to the containing block instead of attaching it to the viewport
- When the backdrop is `contained`, it doesn't prevent body scrolling
- When aria-hiding elements, it now stops at the first positioned element rather than going all the way up to the document itself

## Video Demo

https://github.com/user-attachments/assets/ac381794-6de6-40b4-ac69-035b8ba5f690

