### PR TITLE
[WIP][DNM] Enable downstream consumers to skeletize until load is complete

### DIFF
--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -15,10 +15,10 @@ export const skeletonStyles = css`
 		75% { background-color: var(--d2l-color-sylvite); }
 		100% { background-color: var(--d2l-color-sylvite); }
 	}
-	:host([skeleton]) {
+	:host([skeleton]), .d2l-force-skeletize {
 		isolation: isolate;
 	}
-	:host([skeleton]) .d2l-skeletize::before {
+	:host([skeleton]) .d2l-skeletize::before, .d2l-force-skeletize::before {
 		animation: ${animation};
 		background-color: var(--d2l-color-sylvite);
 		border-radius: 0.2rem;
@@ -36,7 +36,8 @@ export const skeletonStyles = css`
 		}
 	}
 	:host([skeleton]) .d2l-skeletize,
-	:host([skeleton]) .d2l-skeletize-container {
+	:host([skeleton]) .d2l-skeletize-container,
+	.d2l-force-skeletize {
 		background-color: transparent;
 		border-color: var(--d2l-color-sylvite);
 		box-shadow: none;

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -416,6 +416,13 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 		this._tableResizeObserver?.disconnect();
 	}
 
+	async getUpdateComplete() {
+		const result = await super.getUpdateComplete();
+		const wrapper = this.shadowRoot.querySelector('d2l-scroll-wrapper');
+		if (wrapper) await wrapper.updateComplete;
+		return result;
+	}
+
 	render() {
 		const slot = html`
 			<slot @slotchange="${this._handleSlotChange}"></slot>


### PR DESCRIPTION
A hacky little inspiration demo I've been working on to cut out blank frames when loading tables. The downstream component is here: https://github.com/Brightspace/insights/pull/1333

TL;DR:
- Expose special 'force skeleton' classes which allow downstream users to still display elements as skeletons after the host loses the skeleton attribute
  - This is helpful when the time to render the children of the element is significant even after the data has arrived, and we want to hide that rendering process with the skeleton box.
- Have the table wait for the wrapper before reporting back that it's finished updating, so that downstream consumers can use `updateComplete` promises on this element and be sure that the render has actually completed down the chain.