### PR TITLE
Wrap slot with backdrop

### DIFF
--- a/components/backdrop/backdrop-loading.js
+++ b/components/backdrop/backdrop-loading.js
@@ -1,7 +1,6 @@
 import '../colors/colors.js';
 import '../loading-spinner/loading-spinner.js';
 import { css, html, LitElement, nothing } from 'lit';
-import { getOffsetParent } from '../../helpers/dom.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 const BACKDROP_DELAY_MS = 800;
@@ -33,6 +32,10 @@ class LoadingBackdrop extends LitElement {
 	static get styles() {
 		return css`
 			:host {
+				position: relative;
+			}
+
+			#backdrop-styling-wrapper {
 				display: none;
 				height: 100%;
 				justify-content: center;
@@ -41,9 +44,9 @@ class LoadingBackdrop extends LitElement {
 				width: 100%;
 				z-index: 999;
 			}
-			:host([_state="showing"]),
-			:host([_state="shown"]),
-			:host([_state="hiding"]) {
+			:host([_state="showing"]) #backdrop-styling-wrapper,
+			:host([_state="shown"]) #backdrop-styling-wrapper,
+			:host([_state="hiding"]) #backdrop-styling-wrapper {
 				display: flex;
 			}
 
@@ -88,10 +91,17 @@ class LoadingBackdrop extends LitElement {
 	}
 
 	render() {
-		if (this._state === 'hidden') return nothing;
+		const backdrop = this._state === 'hidden' ? nothing :
+			html`
+				<div id="backdrop-styling-wrapper">
+					<div class="backdrop" @transitionend="${this.#handleTransitionEnd}" @transitioncancel="${this.#hide}"></div>
+					<d2l-loading-spinner style=${styleMap({ top: `${this._spinnerTop}px` })} size="${LOADING_SPINNER_SIZE}"></d2l-loading-spinner>
+				</div>
+		`;
+
 		return html`
-			<div class="backdrop" @transitionend="${this.#handleTransitionEnd}" @transitioncancel="${this.#hide}"></div>
-			<d2l-loading-spinner style=${styleMap({ top: `${this._spinnerTop}px` })} size="${LOADING_SPINNER_SIZE}"></d2l-loading-spinner>
+			${backdrop}
+			<slot></slot>
 		`;
 	}
 	updated(changedProperties) {
@@ -164,18 +174,13 @@ class LoadingBackdrop extends LitElement {
 	#hide() {
 		this._state = 'hidden';
 
-		const containingBlock = getOffsetParent(this);
+		this.inert = false;
 
-		if (containingBlock.dataset.initiallyInert !== '1') containingBlock.removeAttribute('inert');
 	}
 	#show() {
 		this._state = reduceMotion ? 'shown' : 'showing';
 
-		const containingBlock = getOffsetParent(this);
-
-		if (containingBlock.getAttribute('inert') !== null) containingBlock.dataset.initiallyInert = '1';
-
-		containingBlock.setAttribute('inert', 'inert');
+		this.inert = true;
 	}
 
 }

--- a/components/table/demo/table-test.js
+++ b/components/table/demo/table-test.js
@@ -97,11 +97,15 @@ class TestTable extends DemoPassthroughMixin(TableWrapper, 'd2l-table-wrapper') 
 						icon="tier1:${this.stickyHeaders ? 'check' : 'close-default'}"
 						@d2l-selection-action-click="${this._toggleStickyHeaders}"
 					></d2l-selection-action>
-					<d2l-selection-action
-						text="Loading"
-						icon="tier1:${this.loading ? 'check' : 'close-default'}"
-						@d2l-selection-action-click="${this._toggleLoading}"
-					></d2l-selection-action>
+					${
+						this.backdrop ? html`
+							<d2l-selection-action
+								text="Loading"
+								icon="tier1:${this.loading ? 'check' : 'close-default'}"
+								@d2l-selection-action-click="${this._toggleLoading}"
+							></d2l-selection-action>
+							` : nothing
+					}
 				</d2l-table-controls>
 
 				<table class="d2l-table">

--- a/components/table/demo/table.html
+++ b/components/table/demo/table.html
@@ -22,6 +22,13 @@
 				</template>
 			</d2l-demo-snippet>
 
+			<h2>Default, Backdrop</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-test-table type="default" sticky-controls show-buttons backdrop></d2l-test-table>
+				</template>
+			</d2l-demo-snippet>
+
 			<h2>Default, Sticky</h2>
 			<d2l-demo-snippet>
 				<template>

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -311,13 +311,22 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 				type: Boolean,
 			},
 			/**
-			 * Whether or not to display a loading backdrop. Set this property when the content in the table is being refreshed.
+			 * Whether or not the loading backdrop should be currently displayed, if enabled.
 			 * @type {boolean}
 			 */
 			loading: {
 				reflect: true,
 				type: Boolean
 			},
+
+			/**
+			 * Whether or not to render a loading backdrop. Set this property when the content in the table is being refreshed.
+			 * @type {boolean}
+			 */
+			backdrop: {
+				reflect: true,
+				type: Boolean
+			}
 		};
 	}
 
@@ -419,15 +428,13 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 	}
 
 	render() {
-		const slot = html`
-			<slot @slotchange="${this._handleSlotChange}"></slot>
-			<d2l-backdrop-loading ?shown=${this.loading}></d2l-backdrop-loading>
-		`;
+		const slot = html`<slot @slotchange="${this._handleSlotChange}"></slot>`;
+		const slotWithBackdrop = this.backdrop ? html`<d2l-backdrop-loading ?shown=${this.loading}>${slot}</d2l-backdrop-loading>` : slot;
 		const useScrollWrapper = this.stickyHeadersScrollWrapper || !this.stickyHeaders;
 		return html`
 			<slot name="controls" @slotchange="${this._handleControlsSlotChange}"></slot>
 			${this.stickyHeaders && this._controlsScrolled ? html`<div class="d2l-sticky-headers-backdrop"></div>` : nothing}
-			${useScrollWrapper ? html`<d2l-scroll-wrapper scroll-area-offset=${ifDefined(this._excludeStickyColumnsFromScrollCalculations ? this._stickyWidth : undefined)} .customScrollers="${this._tableScrollers}">${slot}</d2l-scroll-wrapper>` : slot}
+			${useScrollWrapper ? html`<d2l-scroll-wrapper scroll-area-offset=${ifDefined(this._excludeStickyColumnsFromScrollCalculations ? this._stickyWidth : undefined)} .customScrollers="${this._tableScrollers}">${slotWithBackdrop}</d2l-scroll-wrapper>` : slotWithBackdrop}
 			${this._renderPagerContainer()}
 		`;
 	}


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/NTNGL-5471?atlOrigin=eyJpIjoiMTIyODVmNjAyOGEyNGQ1ZmI2YzBkY2YzNGE5ZDNkMDAiLCJwIjoiaiJ9

TL;DR: Making the containing parent of the loading backdrop inert isn't precise enough. Instead, we should make the backdrop itself inert and place the content under it via a `slot` element.

## Problem

While working towards the addition of an "Apply" button while in a dirty state to refresh data, I ran into an issue regarding how the `inert` property was distributed on the table.

In the original design, the backdrop would search up the DOM tree looking for a relatively positioned ancestor which it would then make `inert`, causing all children to become `inert` and remove them from the accessibility tree as desired.

This worked well for the one user of `loading`, the insights platform that we build, because we always use the scroll wrapper. On the demo tables however, I noticed that this could bubble up to also make the controls inert if the scroll wrapper wasn't present:
<img width="1323" height="1136" alt="image" src="https://github.com/user-attachments/assets/e8db9945-5f70-4a5c-9b16-699ad4189416" />

It also causes issues when trying to build the apply button into the `backdrop-loading` component- since everything within the scroll wrapper was inert, the overlaid box which allowed a refresh was also inert, making the button non-interactive.

## Proposed Solution

Instead of living alongside the content, the backdrop wraps the content and is responsible for applying the `inert` property onto the inner content (in this case, the table). For now, it does this by making itself inert, but in follow up PRs in which the backdrop may inherit the responsibility of surfacing a refresh button, it'll likely apply it to one of its children.

Unlike the prior solution, this means that the backdrop is always included in the DOM, even when the loading state isn't enabled. To prevent this change from unnecessarily increasing the blast radius of the backdrop-loading feature, I've added an opt-in table prop which prevents the `backdrop` code from being included at all when not included.

## Demo

Nothing has changed about the functionality of this component- but for posterity, I've uploaded demos anyway.

Demo with backdrop enabled: 
https://github.com/user-attachments/assets/a4f5f74c-ef9e-4205-a829-604ac6a40a58

Insights Platform downstream usage:
https://github.com/user-attachments/assets/f32db48a-fbfc-47a3-8194-a49c9ab7aac7

