### PR TITLE
GAUD-9689 - Fix alert test failure state

### DIFF
--- a/components/alert/test/alert-toast.vdiff.js
+++ b/components/alert/test/alert-toast.vdiff.js
@@ -192,11 +192,14 @@ describe('alert-toast', () => {
 
 			it('open quickly then wait', async() => {
 				disableReducedMotionForTesting();
-				const elem = await fixture(multipleAlertsAutoClose, { viewport });
-				await openAlerts(elem);
-				clock.tick(4100);
-				await expect(document).to.be.golden();
-				restoreReducedMotionForTesting();
+				try {
+					const elem = await fixture(multipleAlertsAutoClose, { viewport });
+					await openAlerts(elem);
+					clock.tick(4100);
+					await expect(document).to.be.golden();
+				} finally {
+					restoreReducedMotionForTesting();
+				}
 			});
 
 		});


### PR DESCRIPTION
The latest `playwright` bump exposed some weird `alert-toast` vdiff errors. This PR pre-fixes them.

The failing vdiffs are coming from newer tests added about six months ago, added to the bottom of the file after this test. When this test fails, reduce motion is never turned back on. This issue didn't come up when it was the last test. The playwright bump brings byte changes (and therefore test failures) for every single test, so this problem popped up.

The fix is to make sure `restoreReducedMotionForTesting` always runs, regardless of the test outcome.