### PR TITLE
GAUD-7881: Removes the no-auto-fit atrtibute

### DIFF
--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -254,7 +254,6 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 				@d2l-dropdown-focus-enter="${this._handleFocusTrapEnter}"
 				max-width="335"
 				min-height="415"
-				?no-auto-fit="${!mediaQueryList.matches}"
 				trap-focus
 				no-auto-focus
 				mobile-tray="bottom"
@@ -362,10 +361,10 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 			: this.validationError;
 
 		return html`
-			<d2l-tooltip 
-				align="start" 
-				announced 
-				class="vdiff-target" 
+			<d2l-tooltip
+				align="start"
+				announced
+				class="vdiff-target"
 				for="${this._inputId}"
 				?force-show="${this._showRevertTooltip}"
 				state="error">
@@ -383,10 +382,10 @@ class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(
 			: this.localize('components.input-date.useDateFormat', { format: shortDateFormat });
 
 		return html`
-			<d2l-tooltip 
-				align="start" 
-				announced 
-				class="vdiff-target" 
+			<d2l-tooltip
+				align="start"
+				announced
+				class="vdiff-target"
 				for="${this._inputId}"
 				?force-show="${this._showRevertTooltip}">
 				<div>${revertMessage}</div>


### PR DESCRIPTION
### Jira

[GAUD-7881](https://desire2learn.atlassian.net/browse/GAUD-7881)

### Issue

For small but wider VPs, the calendar could get cutoff

### Fix

- For the input date to adapt to the viewport size, we need to remove the no-auto-fit attribute (we are getting rid of supporting this)

[GAUD-7881]: https://desire2learn.atlassian.net/browse/GAUD-7881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ