### PR TITLE
Update registerSemanticVariableForSvgImageUrl to update existing rules

### DIFF
--- a/components/colors/colors.js
+++ b/components/colors/colors.js
@@ -217,6 +217,10 @@ function formatCSSVariable([key, value]) {
 	else return `${key}: ${value};`;
 }
 
+function isCustomPropertyDefined(rule, name) {
+	return rule.style.getPropertyValue(name).trim() !== '';
+}
+
 function resolvePrimitive(variableName, variables) {
 	const value = variables.get(variableName);
 	if (!value) return;
@@ -275,6 +279,9 @@ const osRule = style.sheet.cssRules[2].cssRules[0];
 export function registerSemanticVariableForSvgImageUrl(name, value) {
 	if (!name || typeof value !== 'string') {
 		throw new TypeError('registerSemanticVariableForSvgImageUrl requires both a name and value');
+	}
+	if (isCustomPropertyDefined(lightRule, name)) {
+		console.warn(`registerSemanticVariableForSvgImageUrl called for ${name} but a custom property is already defined with this name`);
 	}
 
 	const replacedLightValue = svgToCSS(replaceSemanticVariables(value, lightVariables));

--- a/components/colors/colors.js
+++ b/components/colors/colors.js
@@ -248,9 +248,7 @@ if (globalThis.document !== undefined && !globalThis.document.head.querySelector
 			/* primary accent */
 			--d2l-color-primary-accent-action: var(--d2l-color-celestine);
 			--d2l-color-primary-accent-indicator: var(--d2l-color-carnelian);
-		}
 
-		html {
 			${lightCSS}
 		}
 		html[data-color-mode="dark"] {
@@ -270,17 +268,19 @@ if (globalThis.document !== undefined && !globalThis.document.head.querySelector
 	globalThis.document.head.appendChild(style);
 }
 
+const lightRule = style.sheet.cssRules[0];
+const darkRule = style.sheet.cssRules[1];
+const osRule = style.sheet.cssRules[2].cssRules[0];
+
 export function registerSemanticVariableForSvgImageUrl(name, value) {
 	if (!name || typeof value !== 'string') {
 		throw new TypeError('registerSemanticVariableForSvgImageUrl requires both a name and value');
 	}
 
 	const replacedLightValue = svgToCSS(replaceSemanticVariables(value, lightVariables));
-	style.sheet.insertRule(`html { ${ name }: ${ replacedLightValue } }`, 0);
+	lightRule.style.setProperty(name, replacedLightValue);
 
 	const replacedDarkValue = svgToCSS(replaceSemanticVariables(value, darkVariables));
-	style.sheet.insertRule(`html[data-color-mode="dark"] { ${ name }: ${ replacedDarkValue } }`, 1);
-	style.sheet.insertRule(`@media (prefers-color-scheme: dark) {
-		html[data-color-mode="os"] { ${ name }: ${ replacedDarkValue } }
-	}`, 2);
+	darkRule.style.setProperty(name, replacedDarkValue);
+	osRule.style.setProperty(name, replacedDarkValue);
 };

--- a/components/colors/test/colors.test.js
+++ b/components/colors/test/colors.test.js
@@ -26,7 +26,7 @@ describe('colors', () => {
 
 			registerSemanticVariableForSvgImageUrl(variableName, image);
 
-			expect(style.sheet.cssRules.length).to.equal(ruleCount + 3);
+			expect(style.sheet.cssRules.length).to.equal(ruleCount);
 
 			const mediaRule = style.sheet.cssRules[2].cssText;
 			expect(mediaRule).to.contain('@media (prefers-color-scheme: dark)');


### PR DESCRIPTION
[GAUD-9450](https://desire2learn.atlassian.net/browse/GAUD-9450)

This PR updates `registerSemanticVariableForSvgImageUrl` to set new variables on existing rules instead of creating new ones. This approach is preferred/motivated by avoiding a growing list of duplicate selectors (ex. `html { ... }` for each time this is called), but also the benefit of maintaining one selector block for each mode / single source of truth.


[GAUD-9450]: https://desire2learn.atlassian.net/browse/GAUD-9450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ