### PR TITLE
feat: Checkbox input: Remove not-tabbable

### DIFF
--- a/components/inputs/docs/input-checkbox.md
+++ b/components/inputs/docs/input-checkbox.md
@@ -87,7 +87,6 @@ When provided with a `name`, the checkbox will participate in forms if it is `ch
 | `label` | String, required | Label for the input |
 | `label-hidden` | Boolean | Hides the label visually (moves it to the input's `aria-label` attribute) |
 | `name` | String | Name of the form control. Submitted with the form as part of a name/value pair. |
-| `not-tabbable` | Boolean | Sets `tabindex="-1"` on the checkbox. Note that an alternative method of focusing is necessary to implement if using this property. |
 | `supporting-hidden-when-unchecked` | Boolean | Hides the supporting slot when unchecked. |
 | `value` | String | Value of the input |
 

--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -169,11 +169,6 @@ class InputCheckbox extends FormElementMixin(InputInlineHelpMixin(FocusMixin(Ske
 			 */
 			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
 			/**
-			 * ACCESSIBILITY: ADVANCED: Sets "tabindex="-1"" on the checkbox. Note that an alternative method of focusing is necessary to implement if using this property.
-			 * @type {boolean}
-			 */
-			notTabbable: { type: Boolean, attribute: 'not-tabbable' },
-			/**
 			 * Hides the supporting slot when unchecked
 			 * @type {boolean}
 			 */
@@ -251,7 +246,6 @@ class InputCheckbox extends FormElementMixin(InputInlineHelpMixin(FocusMixin(Ske
 		this.label = '';
 		this.labelHidden = false;
 		this.name = '';
-		this.notTabbable = false;
 		this.supportingHiddenWhenUnchecked = false;
 		this.value = 'on';
 		this._hasSupporting = false;
@@ -263,7 +257,6 @@ class InputCheckbox extends FormElementMixin(InputInlineHelpMixin(FocusMixin(Ske
 	}
 
 	render() {
-		const tabindex = this.notTabbable ? -1 : undefined;
 		const supportingContentVisible = this._hasSupporting && (this.checked || !this.supportingHiddenWhenUnchecked);
 		const textClasses = {
 			'd2l-input-checkbox-text': true,
@@ -296,7 +289,6 @@ class InputCheckbox extends FormElementMixin(InputInlineHelpMixin(FocusMixin(Ske
 					id="${this.#inputId}"
 					.indeterminate="${this.indeterminate}"
 					name="${ifDefined(this.name)}"
-					tabindex="${ifDefined(tabindex)}"
 					type="checkbox"
 					.value="${this.value}"></span><span class="${classMap(textClasses)}">${label}<slot></slot></span>
 			</label>

--- a/components/inputs/test/input-checkbox.test.js
+++ b/components/inputs/test/input-checkbox.test.js
@@ -32,7 +32,7 @@ describe('d2l-input-checkbox', () => {
 			elem = await fixture(checkboxFixtures.unchecked);
 		});
 
-		['checked', 'disabled', 'indeterminate', 'notTabbable', 'supportingHiddenWhenUnchecked'].forEach((name) => {
+		['checked', 'disabled', 'indeterminate', 'supportingHiddenWhenUnchecked'].forEach((name) => {
 			it(`should default "${name}" property to "false"`, () => {
 				expect(elem[name]).to.be.false;
 			});
@@ -134,20 +134,6 @@ describe('d2l-input-checkbox', () => {
 			expect(elem.checked).to.be.true;
 			expect(elem.indeterminate).to.be.false;
 			expect(getInput(elem).hasAttribute('aria-checked')).to.be.false;
-		});
-
-	});
-
-	describe('not tabbable', () => {
-
-		it('should not put a tabindex on the checkbox by default', async() => {
-			const elem = await fixture(checkboxFixtures.unchecked);
-			expect(getInput(elem).hasAttribute('tabindex')).to.be.false;
-		});
-
-		it('should apply -1 tabindex when set', async() => {
-			const elem = await fixture(html`<d2l-input-checkbox not-tabbable label="not-tabbable"></d2l-input-checkbox>`);
-			expect(getInput(elem).getAttribute('tabindex')).to.equal('-1');
 		});
 
 	});


### PR DESCRIPTION
[GAUD-9654](https://desire2learn.atlassian.net/browse/GAUD-9654)

Usages of `not-tabbable` have been removed so we are cleaning it up from code.

[GAUD-9654]: https://desire2learn.atlassian.net/browse/GAUD-9654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ