### PR TITLE
Add color-scheme meta element to demo pages.

### DIFF
--- a/components/demo/demo-page-settings.js
+++ b/components/demo/demo-page-settings.js
@@ -60,7 +60,14 @@ class DemoPageSettings extends LitElement {
 		} else {
 			this._language = getDocumentLocaleSettings().language;
 		}
+
 		this._colorMode = document.documentElement.dataset.colorMode || defaultColorMode;
+
+		const colorSchemeElem = document.createElement('meta');
+		colorSchemeElem.name = 'color-scheme';
+		document.head.insertBefore(colorSchemeElem, document.head.firstChild);
+		this.#updateColorSchemeMeta();
+
 	}
 
 	connectedCallback() {
@@ -176,6 +183,8 @@ class DemoPageSettings extends LitElement {
 			this.#updateDefaultColorMode(newColorMode);
 		}
 
+		this.#updateColorSchemeMeta();
+
 		url.searchParams.set('color-mode', newColorMode);
 		window.history.replaceState({}, '', url.toString());
 	}
@@ -206,6 +215,13 @@ class DemoPageSettings extends LitElement {
 		if (useAsDefault) {
 			this.#updateDefaultColorMode(this.shadowRoot.querySelector('#colorMode').value);
 		}
+	}
+
+	#updateColorSchemeMeta() {
+		const elem = document.querySelector('meta[name="color-scheme"]');
+		if (document.documentElement.dataset.colorMode === 'dark') elem.content = 'dark';
+		else if (document.documentElement.dataset.colorMode === 'os') elem.content = 'light dark';
+		else elem.content = 'light';
 	}
 
 	#updateDefaultColorMode(colorMode) {

--- a/components/demo/demo-page-settings.js
+++ b/components/demo/demo-page-settings.js
@@ -63,11 +63,7 @@ class DemoPageSettings extends LitElement {
 
 		this._colorMode = document.documentElement.dataset.colorMode || defaultColorMode;
 
-		const colorSchemeElem = document.createElement('meta');
-		colorSchemeElem.name = 'color-scheme';
-		document.head.insertBefore(colorSchemeElem, document.head.firstChild);
 		this.#updateColorSchemeMeta();
-
 	}
 
 	connectedCallback() {
@@ -218,7 +214,12 @@ class DemoPageSettings extends LitElement {
 	}
 
 	#updateColorSchemeMeta() {
-		const elem = document.querySelector('meta[name="color-scheme"]');
+		let elem = document.querySelector('meta[name="color-scheme"]');
+		if (!elem) {
+			elem = document.createElement('meta');
+			elem.name = 'color-scheme';
+			document.head.insertBefore(elem, document.head.firstChild);
+		}
 		if (document.documentElement.dataset.colorMode === 'dark') elem.content = 'dark';
 		else if (document.documentElement.dataset.colorMode === 'os') elem.content = 'light dark';
 		else elem.content = 'light';


### PR DESCRIPTION
[GAUD-9786](https://desire2learn.atlassian.net/browse/GAUD-9786)

This PR updates our demo components so that they render the `<meta name="color-scheme" content="..." />` element. This is required in order for native browser UI to render with the light or dark mode scheme. For example, native scrollbars in scrollable elements.

[GAUD-9786]: https://desire2learn.atlassian.net/browse/GAUD-9786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ