### PR TITLE
Dunk.prop req

### DIFF
--- a/mixins/property-required/property-required-mixin.js
+++ b/mixins/property-required/property-required-mixin.js
@@ -79,6 +79,7 @@ export const PropertyRequiredMixin = dedupeMixin(superclass => class extends sup
 		if (!this._requiredProperties.has(name) || !this.isConnected) return;
 
 		const info = this._requiredProperties.get(name);
+		if (!info.timeout) return;
 		clearTimeout(info.timeout);
 		info.timeout = null;
 

--- a/mixins/property-required/property-required-mixin.js
+++ b/mixins/property-required/property-required-mixin.js
@@ -40,7 +40,7 @@ export const PropertyRequiredMixin = dedupeMixin(superclass => class extends sup
 	updated(changedProperties) {
 		super.updated(changedProperties);
 		this._requiredProperties.forEach((value, name) => {
-			const doValidate = changedProperties.has(name) || value.dependentProps.includes(name);
+			const doValidate = changedProperties.has(name) || value.dependentProps.find((prop) => changedProperties.has(prop));
 			if (doValidate) this._validateRequiredProperty(name);
 		});
 	}


### PR DESCRIPTION
<!-- https://desire2learn.atlassian.net/browse/CMMDI-3 -->

While using this mixin I noticed that updates weren't being enqueued when I changed the dependent property. On further inspection, I found that the condition for triggering updates on dependent properties wasn't working as expected.

I've updated both that line and the test utility issue that prevented it from being caught in CI.