### PR TITLE
PHNX-4516: Smart Curriculum > Updating @brightspace-ui/core to v3.233.0 breaks CI

### DIFF
--- a/components/colors/colors.js
+++ b/components/colors/colors.js
@@ -284,6 +284,9 @@ export function registerSemanticVariableForSvgImageUrl(name, value) {
 	if (!name || typeof value !== 'string') {
 		throw new TypeError('registerSemanticVariableForSvgImageUrl requires both a name and value');
 	}
+
+	if (!style) return;
+
 	if (isCustomPropertyDefined(lightRule, name)) {
 		console.warn(`registerSemanticVariableForSvgImageUrl called for ${name} but a custom property is already defined with this name`);
 	}


### PR DESCRIPTION
## Jira Ticket 🎫 
- PHNX-4516: https://desire2learn.atlassian.net/browse/PHNX-4516

## Description 🗒️ 
- [This PR](https://github.com/BrightspaceUI/core/pull/6814) updates basic input components (`input-styles.js`, `input-checkbox.js`, `input-radio-styles.js`, `input-select-styles.js`, `input-label-styles.js`) to use semantic color variables by calling `registerSemanticVariableForSvgImageUrl()` at module load time
- `registerSemanticVariableForSvgImageUrl()` accesses `lightRule`, `darkRule`, and `osRule`, which are `undefined` in non-DOM environments (e.g. `Jest` in `smart-curriculum` -> [this logic](https://github.com/BrightspaceUI/core/blob/main/components/colors/colors.js#L244) which adds styling doesn't get executed)
- This is causing [toc-test.js](https://github.com/Brightspace/smart-curriculum/blob/master/tests/components/toc/toc-test.js) to fail -> a transitive import chain pulls in the changed core input modules, which crash when `registerSemanticVariableForSvgImageUrl()` tries to call `isCustomPropertyDefined(lightRule, name)` on `undefined`
- Example failing CI run: [smart-curriculum/actions/runs/24837202307](https://github.com/Brightspace/smart-curriculum/actions/runs/24837202307/job/72700693977?pr=3124)

## Changes 📝 
- I have added an early return guard `if (!style) return;` to the `registerSemanticVariableForSvgImageUrl()` function in `colors.js` -> This will prevent crashes when called in environments where the DOM style element is not created

