### PR TITLE
GAUD-9789: delay column calcs until intersected and tweak noScrollWidth logic

### DIFF
--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -447,6 +447,10 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 		}
 	}
 
+	#hasIntersected = false;
+
+	#noScrollWidthTimeout = null;
+
 	_applyClassNames() {
 		if (!this._table) return;
 
@@ -581,6 +585,7 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 				this._tableIntersectionObserver = new IntersectionObserver((entries) => {
 					entries.forEach((entry) => {
 						if (entry.isIntersecting) {
+							this.#hasIntersected = true;
 							this._handleTableChange();
 						}
 					});
@@ -647,11 +652,12 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 		const head = this._table.querySelector('thead');
 		const body = this._table.querySelector('tbody');
 
-		const maxScrollWidth = Math.max(head?.scrollWidth, body?.scrollWidth);
-		setTimeout(() => {
-			this._noScrollWidth = this.clientWidth === maxScrollWidth;
+		clearTimeout(this.#noScrollWidthTimeout);
+		this.#noScrollWidthTimeout = setTimeout(() => {
+			const maxScrollWidth = Math.max(head?.scrollWidth, body?.scrollWidth);
+			this._noScrollWidth = (maxScrollWidth <= this.clientWidth);
 		});
-		if (!head || !body || !this._table || !this.stickyHeaders || !this.stickyHeadersScrollWrapper || this._noScrollWidth) return;
+		if (!head || !body || !this.stickyHeaders || !this.stickyHeadersScrollWrapper || this._noScrollWidth || !this.#hasIntersected) return;
 
 		const candidateRowHeadCells = [];
 

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -10,6 +10,8 @@ import { isPopoverSupported } from '../popover/popover-mixin.js';
 import { PageableMixin } from '../paging/pageable-mixin.js';
 import { SelectionMixin } from '../selection/selection-mixin.js';
 
+const enableStickyScrollyFix = getFlag('table-sticky-scrolly-fix', true);
+
 export const tableStyles = css`
 	.d2l-table {
 		border-collapse: separate; /* needed to override reset stylesheets */
@@ -652,12 +654,20 @@ export class TableWrapper extends PageableMixin(SelectionMixin(LitElement)) {
 		const head = this._table.querySelector('thead');
 		const body = this._table.querySelector('tbody');
 
-		clearTimeout(this.#noScrollWidthTimeout);
-		this.#noScrollWidthTimeout = setTimeout(() => {
+		if (enableStickyScrollyFix) {
+			clearTimeout(this.#noScrollWidthTimeout);
+			this.#noScrollWidthTimeout = setTimeout(() => {
+				const maxScrollWidth = Math.max(head?.scrollWidth, body?.scrollWidth);
+				this._noScrollWidth = (maxScrollWidth <= this.clientWidth);
+			});
+			if (!head || !body || !this.stickyHeaders || !this.stickyHeadersScrollWrapper || this._noScrollWidth || !this.#hasIntersected) return;
+		} else {
 			const maxScrollWidth = Math.max(head?.scrollWidth, body?.scrollWidth);
-			this._noScrollWidth = (maxScrollWidth <= this.clientWidth);
-		});
-		if (!head || !body || !this.stickyHeaders || !this.stickyHeadersScrollWrapper || this._noScrollWidth || !this.#hasIntersected) return;
+			setTimeout(() => {
+				this._noScrollWidth = this.clientWidth === maxScrollWidth;
+			});
+			if (!head || !body || !this._table || !this.stickyHeaders || !this.stickyHeadersScrollWrapper || this._noScrollWidth) return;
+		}
 
 		const candidateRowHeadCells = [];
 


### PR DESCRIPTION
~Ignore for now, just trying out this fix to see how terrifying the vdiff failures are.~ Oh thank goodness. 😅 

Under certain scenarios, it was noticed that tables with scroll wrappers + sticky headers can be put into scroll mode (i.e. overflow their allotted space) when they wouldn't without sticky headers. This typically happens when the available space is right on the threshold of needing scrollbars vs. not -- but ideally sticky header tables would act the same as non-sticky.

In case you've forgotten (or blocked it out because 🤮), the way scroll + sticky works is that the widths of the header cells and the body cells get "synced" using `min-width` and then scrolling within one scrolls the other.

More details about the solution inline.