### PR TITLE
GAUD-9817: increase fullscreen dialog test timeout

### DIFF
--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -541,6 +541,8 @@ export const DialogMixin = superclass => class extends superclass {
 		const elementToFocus = this._findAutofocusElement(content) ?? getNextFocusable(content);
 		if (isComposedAncestor(content, elementToFocus)) {
 			this.focusableContentElemPresent = true;
+			/** @ignore */
+			this.dispatchEvent(new CustomEvent('d2l-dialog-focusable-elem-present', { bubbles: false, composed: false }));
 		}
 		return elementToFocus;
 	}

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -541,8 +541,6 @@ export const DialogMixin = superclass => class extends superclass {
 		const elementToFocus = this._findAutofocusElement(content) ?? getNextFocusable(content);
 		if (isComposedAncestor(content, elementToFocus)) {
 			this.focusableContentElemPresent = true;
-			/** @ignore */
-			this.dispatchEvent(new CustomEvent('d2l-dialog-focusable-elem-present', { bubbles: false, composed: false }));
 		}
 		return elementToFocus;
 	}

--- a/components/dialog/test/dialog-fullscreen.test.js
+++ b/components/dialog/test/dialog-fullscreen.test.js
@@ -1,5 +1,5 @@
 import '../dialog-fullscreen.js';
-import { expect, fixture, html, runConstructor, waitUntil } from '@brightspace-ui/testing';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { createMessage } from '../../../mixins/property-required/property-required-mixin.js';
 
 describe('d2l-dialog-fullscreen', () => {
@@ -28,7 +28,7 @@ describe('d2l-dialog-fullscreen', () => {
 			const el = await fixture(html`<d2l-dialog-fullscreen opened></d2l-dialog-fullscreen>`);
 			expect(el.focusableContentElemPresent).to.be.false;
 			el.appendChild(document.createElement('button'));
-			await waitUntil(() => el.focusableContentElemPresent, 'focusableContentElemPresent never became true');
+			await oneEvent(el, 'd2l-dialog-focusable-elem-present');
 		});
 
 	});

--- a/components/dialog/test/dialog-fullscreen.test.js
+++ b/components/dialog/test/dialog-fullscreen.test.js
@@ -1,5 +1,5 @@
 import '../dialog-fullscreen.js';
-import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { expect, fixture, html, runConstructor, waitUntil } from '@brightspace-ui/testing';
 import { createMessage } from '../../../mixins/property-required/property-required-mixin.js';
 
 describe('d2l-dialog-fullscreen', () => {
@@ -28,8 +28,8 @@ describe('d2l-dialog-fullscreen', () => {
 			const el = await fixture(html`<d2l-dialog-fullscreen opened></d2l-dialog-fullscreen>`);
 			expect(el.focusableContentElemPresent).to.be.false;
 			el.appendChild(document.createElement('button'));
-			await oneEvent(el, 'd2l-dialog-focusable-elem-present');
-		});
+			await waitUntil(() => el.focusableContentElemPresent, 'focusableContentElemPresent never became true');
+		}).timeout(3000);;
 
 	});
 


### PR DESCRIPTION
I've been seeing a lot of flake with this test in Safari -- the reporting data says it has failed 14 times in the last week.

While I couldn't reproduce it locally with the 2000ms timeout, if I reduced the timeout to 100ms I could. I tried using an event to signal that a focusable had been found, and that was less flaky but still flaked. So unfortunately resorted to just increasing the timeout, which we've had to do for a few tests already.

I've run this 5 times in a row and this particular test didn't fail.