### PR TITLE
GAUD-9818: fix skipped dialog confirm tests

### DIFF
--- a/components/dialog/test/dialog-confirm.test.js
+++ b/components/dialog/test/dialog-confirm.test.js
@@ -3,6 +3,7 @@ import '../dialog-confirm.js';
 import { expect, fixture, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '../../../helpers/focus.js';
 import { html } from 'lit';
+import { isComposedAncestor } from '../../../helpers/dom.js';
 
 describe('d2l-dialog-confirm', () => {
 
@@ -14,17 +15,17 @@ describe('d2l-dialog-confirm', () => {
 
 	});
 
-	describe.skip('focus management', () => {
+	describe('focus management', () => {
 
 		it('should focus on first non-primary button', async() => {
 			const el = await fixture(html`
 				<d2l-dialog-confirm opened>
 					<d2l-button slot="footer" primary>Yes</d2l-button>
-					<d2l-button slot="footer">No</d2l-button>
+					<d2l-button id="no" slot="footer">No</d2l-button>
 				</d2l-dialog-confirm>
 			`);
 			await oneEvent(el, 'd2l-dialog-open');
-			expect(getComposedActiveElement().innerText).to.equal('No');
+			expect(isComposedAncestor(el.querySelector('#no'), getComposedActiveElement())).to.be.true;
 		});
 
 		it('should focus on primary button if no others', async() => {
@@ -34,7 +35,7 @@ describe('d2l-dialog-confirm', () => {
 				</d2l-dialog-confirm>
 			`);
 			await oneEvent(el, 'd2l-dialog-open');
-			expect(getComposedActiveElement().innerText).to.equal('Yes');
+			expect(isComposedAncestor(el.querySelector('d2l-button'), getComposedActiveElement())).to.be.true;
 		});
 
 	});


### PR DESCRIPTION
Hopefully fixing these skipped tests. From [the original PR](https://github.com/BrightspaceUI/core/pull/1351) where they were added:

> Too many issues with the new dialog focus management tests in Firefox & Safari, so I'm going to skip them for now so we can get the fix to the JS error that's breaking FACE released. Then we can tackle those issues -- which aren't new AFAIK -- later.

~I'll re-run this a bunch of times to make sure the Firefox/Safari issues are behind us.~ This has now run 5 times with no failures.