### PR TITLE
GAUD-9165 - Implement the d2l-page skeleton

### DIFF
--- a/components/page/README.md
+++ b/components/page/README.md
@@ -1,0 +1,5 @@
+# Page
+
+The `d2l-page` and page layout components are in progress.
+
+Please reach out before using them!

--- a/components/page/demo/page-component.js
+++ b/components/page/demo/page-component.js
@@ -1,0 +1,191 @@
+import '../../collapsible-panel/collapsible-panel.js';
+import '../page.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { navStyles } from './temp-nav-styles.js';
+import { selectStyles } from '../../inputs/input-select-styles.js';
+
+/**
+ * Component for d2l-page demos and tests
+ */
+class PageDemo extends LitElement {
+
+	static properties = {
+		demoMode: { type: Boolean, attribute: 'demo-mode' },
+		hasFooter: { type: Boolean, attribute: 'has-footer' },
+		hasSideNavPanel: { type: Boolean, attribute: 'has-side-nav-panel' },
+		hasSupportingPanel: { type: Boolean, attribute: 'has-supporting-panel' },
+		navType: { type: String, attribute: 'nav-type' },
+		widthType: { type: String, attribute: 'width-type' },
+		_allowThreePanels: { state: true }
+	};
+
+	static styles = [navStyles, selectStyles, css`
+		.demo-controls {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.75rem;
+		}
+	`];
+
+	constructor() {
+		super();
+		this._allowThreePanels = false; // Temp for dev/testing
+		this.demoMode = false;
+		this.hasFooter = false;
+		this.hasSideNavPanel = false;
+		this.hasSupportingPanel = false;
+		this.navType = 'full';
+		/** @type {'normal'|'wide'|'fullscreen'} */
+		this.widthType = 'normal';
+	}
+
+	render() {
+		return html`
+			<d2l-page width-type="${this.widthType}">
+				${this.navType === 'full' ? this.#renderFullNav() : this.#renderImmersiveNav()}
+				${this.#renderSideNavPanel()}
+				${this.#renderMainPanel()}
+				${this.#renderSupportingPanel()}
+				${this.#renderFooter()}
+			</d2l-page>
+		`;
+	}
+
+	#handleAllowThreePanelsChange(e) {
+		this._allowThreePanels = e.target.on;
+		if (!this._allowThreePanels && this.hasSideNavPanel && this.hasSupportingPanel) {
+			this.shadowRoot.querySelector('#switch-supporting-panel').on = false;
+			this.hasSupportingPanel = false;
+		}
+	}
+
+	#handleNavTypeChange(e) {
+		this.navType = e.target.on ? 'immersive' : 'full';
+	}
+
+	#handleVisibilityChange(e) {
+		const key = e.target.dataset.key;
+		this[key] = e.target.on;
+
+		if (this._allowThreePanels) return;
+		if (e.target.on && key === 'hasSideNavPanel' && this.hasSupportingPanel) {
+			this.shadowRoot.querySelector('#switch-supporting-panel').on = false;
+			this.hasSupportingPanel = false;
+		} else if (e.target.on && key === 'hasSupportingPanel' && this.hasSideNavPanel) {
+			this.shadowRoot.querySelector('#switch-side-nav-panel').on = false;
+			this.hasSideNavPanel = false;
+		}
+	}
+
+	#handleWidthTypeChange(e) {
+		this.widthType = e.target.value;
+	}
+
+	#renderFooter() {
+		return this.hasFooter ? html`
+			<div slot="footer">
+				I'm in the <b>footer</b> slot of the <b>d2l-page</b> component!
+			</div>
+		` : nothing;
+	}
+
+	#renderFullNav() {
+		// Update with navigation components once available
+		return html`
+			<div slot="header" class="full-nav-wrapper">
+				<div class="nav-band"></div>
+				<div class="full-nav-header">
+					<div class="full-nav-header-left">
+						<span class="full-nav-logo">Logo</span>
+						<div class="full-nav-separator"></div>
+						<button class="nav-icon-btn">📚 Courses</button>
+					</div>
+					<div class="full-nav-header-spacer"></div>
+					<div class="full-nav-header-right">
+						<button class="nav-icon-btn" title="Alerts">🔔</button>
+						<button class="nav-icon-btn" title="Settings">⚙️</button>
+						<button class="nav-icon-btn" title="Profile">👤</button>
+					</div>
+				</div>
+				<div class="full-nav-footer">
+					<div class="full-nav-footer-inner">
+						<a class="full-nav-footer-link" href="javascript:void(0)">Content</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Assignments</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Quizzes</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Grades</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Classlist</a>
+					</div>
+				</div>
+				<div class="nav-shadow"></div>
+			</div>
+		`;
+	}
+
+	#renderImmersiveNav() {
+		// Update with navigation components once available
+		return html`
+			<div id="immersive-nav" slot="header" class="immersive-wrapper">
+				<div class="nav-band"></div>
+				<div class="immersive-container">
+					<div class="immersive-left">
+						<a class="immersive-back-link" href="javascript:void(0)">
+							<span class="immersive-back-icon">‹</span>
+							Back to Course
+						</a>
+					</div>
+					<div class="immersive-middle">
+						Assignment 1 - Introduction to Economics
+					</div>
+					<div class="immersive-right">
+						<button class="nav-icon-btn">‹ Prev</button>
+						<button class="nav-icon-btn">Next ›</button>
+					</div>
+				</div>
+				<div class="nav-shadow"></div>
+			</div>
+		`;
+	}
+
+	#renderMainPanel() {
+		return html`
+			<div style="height: 1000px;">
+				${this.demoMode ? html`
+					<d2l-collapsible-panel panel-title="Demo Controls" expanded>
+						<div class="demo-controls">
+							<select class="d2l-input-select" name="width-type" aria-label="Width type" @change="${this.#handleWidthTypeChange}">
+								<option value="normal" ?selected="${this.widthType === 'normal'}">Normal Width</option>
+								<option value="wide" ?selected="${this.widthType === 'wide'}">Wide Width</option>
+								<option value="fullscreen" ?selected="${this.widthType === 'fullscreen'}">Fullscreen</option>
+							</select>
+							<d2l-switch id="switch-nav-type" text="Immersive Nav" @change="${this.#handleNavTypeChange}"></d2l-switch>
+							<d2l-switch id="switch-side-nav-panel" text="Side Nav Panel" data-key="hasSideNavPanel" @change="${this.#handleVisibilityChange}"></d2l-switch>
+							<d2l-switch id="switch-supporting-panel" text="Supporting Panel" data-key="hasSupportingPanel" @change="${this.#handleVisibilityChange}"></d2l-switch>
+							<d2l-switch id="switch-footer" text="Footer" data-key="hasFooter" @change="${this.#handleVisibilityChange}"></d2l-switch>
+							<d2l-switch id="switch-allow-three-panels" text="Allow Three Panels" @change="${this.#handleAllowThreePanelsChange}"></d2l-switch>
+						</div>
+					</d2l-collapsible-panel>
+				` : nothing}
+				<p>I'm in the <b>default</b> slot of the <b>d2l-page</b> component!</p>
+			</div>
+			<div>End of Content</div>
+		`;
+	}
+
+	#renderSideNavPanel() {
+		return this.hasSideNavPanel ? html`
+			<div style="background-color: lavender; height: 1000px;" slot="side-nav">
+				I'm in the <b>side-nav</b> slot of the <b>d2l-page</b> component!
+			</div>
+		` : nothing;
+	}
+
+	#renderSupportingPanel() {
+		return this.hasSupportingPanel ? html`
+			<div style="background-color: aliceblue; height: 1000px;" slot="supporting">
+				I'm in the <b>supporting</b> slot of the <b>d2l-page</b> component!
+			</div>
+		` : nothing;
+	}
+}
+
+customElements.define('d2l-page-demo', PageDemo);

--- a/components/page/demo/page-component.js
+++ b/components/page/demo/page-component.js
@@ -54,7 +54,6 @@ class PageDemo extends LitElement {
 	#handleAllowThreePanelsChange(e) {
 		this._allowThreePanels = e.target.on;
 		if (!this._allowThreePanels && this.hasSideNavPanel && this.hasSupportingPanel) {
-			this.shadowRoot.querySelector('#switch-supporting-panel').on = false;
 			this.hasSupportingPanel = false;
 		}
 	}
@@ -69,16 +68,33 @@ class PageDemo extends LitElement {
 
 		if (this._allowThreePanels) return;
 		if (e.target.on && key === 'hasSideNavPanel' && this.hasSupportingPanel) {
-			this.shadowRoot.querySelector('#switch-supporting-panel').on = false;
 			this.hasSupportingPanel = false;
 		} else if (e.target.on && key === 'hasSupportingPanel' && this.hasSideNavPanel) {
-			this.shadowRoot.querySelector('#switch-side-nav-panel').on = false;
 			this.hasSideNavPanel = false;
 		}
 	}
 
 	#handleWidthTypeChange(e) {
 		this.widthType = e.target.value;
+	}
+
+	#renderDemoMainControls() {
+		return this.demoMode ? html`
+			<d2l-collapsible-panel panel-title="Demo Controls" expanded>
+				<div class="demo-controls">
+					<select class="d2l-input-select" name="width-type" aria-label="Width type" @change="${this.#handleWidthTypeChange}">
+						<option value="normal" ?selected="${this.widthType === 'normal'}">Normal Width</option>
+						<option value="wide" ?selected="${this.widthType === 'wide'}">Wide Width</option>
+						<option value="fullscreen" ?selected="${this.widthType === 'fullscreen'}">Fullscreen</option>
+					</select>
+					<d2l-switch id="switch-nav-type" text="Immersive Nav" @change="${this.#handleNavTypeChange}"></d2l-switch>
+					<d2l-switch id="switch-side-nav-panel" text="Side Nav Panel" data-key="hasSideNavPanel" @change="${this.#handleVisibilityChange}" ?on="${this.hasSideNavPanel}"></d2l-switch>
+					<d2l-switch id="switch-supporting-panel" text="Supporting Panel" data-key="hasSupportingPanel" @change="${this.#handleVisibilityChange}" ?on="${this.hasSupportingPanel}"></d2l-switch>
+					<d2l-switch id="switch-footer" text="Footer" data-key="hasFooter" @change="${this.#handleVisibilityChange}"></d2l-switch>
+					<d2l-switch id="switch-allow-three-panels" text="Allow Three Panels" @change="${this.#handleAllowThreePanelsChange}"></d2l-switch>
+				</div>
+			</d2l-collapsible-panel>
+		` : nothing;
 	}
 
 	#renderFooter() {
@@ -149,22 +165,7 @@ class PageDemo extends LitElement {
 	#renderMainPanel() {
 		return html`
 			<div style="height: 1000px;">
-				${this.demoMode ? html`
-					<d2l-collapsible-panel panel-title="Demo Controls" expanded>
-						<div class="demo-controls">
-							<select class="d2l-input-select" name="width-type" aria-label="Width type" @change="${this.#handleWidthTypeChange}">
-								<option value="normal" ?selected="${this.widthType === 'normal'}">Normal Width</option>
-								<option value="wide" ?selected="${this.widthType === 'wide'}">Wide Width</option>
-								<option value="fullscreen" ?selected="${this.widthType === 'fullscreen'}">Fullscreen</option>
-							</select>
-							<d2l-switch id="switch-nav-type" text="Immersive Nav" @change="${this.#handleNavTypeChange}"></d2l-switch>
-							<d2l-switch id="switch-side-nav-panel" text="Side Nav Panel" data-key="hasSideNavPanel" @change="${this.#handleVisibilityChange}"></d2l-switch>
-							<d2l-switch id="switch-supporting-panel" text="Supporting Panel" data-key="hasSupportingPanel" @change="${this.#handleVisibilityChange}"></d2l-switch>
-							<d2l-switch id="switch-footer" text="Footer" data-key="hasFooter" @change="${this.#handleVisibilityChange}"></d2l-switch>
-							<d2l-switch id="switch-allow-three-panels" text="Allow Three Panels" @change="${this.#handleAllowThreePanelsChange}"></d2l-switch>
-						</div>
-					</d2l-collapsible-panel>
-				` : nothing}
+				${this.#renderDemoMainControls()}
 				<p>I'm in the <b>default</b> slot of the <b>d2l-page</b> component!</p>
 			</div>
 			<div>End of Content</div>

--- a/components/page/demo/page-component.js
+++ b/components/page/demo/page-component.js
@@ -164,11 +164,11 @@ class PageDemo extends LitElement {
 
 	#renderMainPanel() {
 		return html`
-			<div style="height: 1000px;">
-				${this.#renderDemoMainControls()}
+			<div>
 				<p>I'm in the <b>default</b> slot of the <b>d2l-page</b> component!</p>
+				${this.#renderDemoMainControls()}
+				<div style="align-items: end; display: flex; height: 500px;">End of Content</div>
 			</div>
-			<div>End of Content</div>
 		`;
 	}
 

--- a/components/page/demo/page.html
+++ b/components/page/demo/page.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+		<script type="module">
+			import '../../demo/demo-page.js';
+			import './page-component.js';
+		</script>
+	</head>
+	<body>
+		<d2l-page-demo demo-mode></d2l-page-demo>
+	</body>
+</html>

--- a/components/page/demo/page.html
+++ b/components/page/demo/page.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+		<title>d2l-page</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta charset="UTF-8">
 		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">

--- a/components/page/demo/temp-nav-styles.js
+++ b/components/page/demo/temp-nav-styles.js
@@ -110,6 +110,7 @@ export const navStyles = css`
 	.full-nav-footer-inner {
 		align-items: center;
 		display: flex;
+		flex-wrap: wrap;
 		gap: 4px;
 		margin-inline: var(--d2l-page-margin-inline);
 		max-width: var(--d2l-page-header-max-width);

--- a/components/page/demo/temp-nav-styles.js
+++ b/components/page/demo/temp-nav-styles.js
@@ -45,6 +45,7 @@ export const navStyles = css`
 
 	/* Full Nav Styles */
 	.full-nav-wrapper {
+		background-color: white;
 		position: relative;
 	}
 	.full-nav-header {

--- a/components/page/demo/temp-nav-styles.js
+++ b/components/page/demo/temp-nav-styles.js
@@ -1,0 +1,217 @@
+/**
+ * Temporary navigation demo styles
+ * These can be removed once we have official navigation components to use
+ */
+
+import { css } from 'lit';
+
+export const navStyles = css`
+
+	/* Shared Styles */
+	.nav-shadow {
+		background-color: rgba(0, 0, 0, 0.02);
+		bottom: -4px;
+		display: block;
+		height: 4px;
+		pointer-events: none;
+		position: absolute;
+		width: 100%;
+		z-index: 1;
+	}
+	.nav-band {
+		background: linear-gradient(180deg, var(--d2l-color-celestine) 1.5rem, #ffffff 0%);
+		min-height: 4px;
+	}
+	.nav-icon-btn {
+		align-items: center;
+		background: none;
+		border: none;
+		border-radius: 4px;
+		color: var(--d2l-color-ferrite);
+		cursor: pointer;
+		display: inline-flex;
+		font-size: 0.8rem;
+		gap: 4px;
+		justify-content: center;
+		min-height: 42px;
+		min-width: 42px;
+		padding: 6px;
+	}
+	.nav-icon-btn:hover,
+	.nav-icon-btn:focus-visible {
+		background-color: var(--d2l-color-gypsum);
+		color: var(--d2l-color-celestine);
+	}
+
+	/* Full Nav Styles */
+	.full-nav-wrapper {
+		position: relative;
+	}
+	.full-nav-header {
+		align-items: center;
+		display: flex;
+		height: 90px;
+		margin-inline: var(--d2l-page-margin-inline);
+		max-width: var(--d2l-page-header-max-width);
+		padding: 0 30px;
+	}
+	@media (max-width: 767px) {
+		.full-nav-header {
+			height: 72px;
+		}
+	}
+	@media (max-width: 615px) {
+		.full-nav-header {
+			padding: 0 15px;
+		}
+	}
+	.full-nav-header-left {
+		align-items: center;
+		display: flex;
+		flex: 0 1 auto;
+		gap: 12px;
+		height: 100%;
+	}
+	.full-nav-header-spacer {
+		flex: 1 1 auto;
+		min-width: 30px;
+	}
+	@media (max-width: 615px) {
+		.full-nav-header-spacer {
+			min-width: 15px;
+		}
+	}
+	.full-nav-header-right {
+		align-items: center;
+		display: flex;
+		flex: 0 0 auto;
+		gap: 6px;
+		height: 100%;
+	}
+	.full-nav-logo {
+		background-color: var(--d2l-color-celestine);
+		border-radius: 4px;
+		color: white;
+		font-size: 0.8rem;
+		font-weight: 700;
+		padding: 8px 14px;
+	}
+	.full-nav-separator {
+		background-color: var(--d2l-color-mica);
+		height: 26px;
+		margin: 0 6px;
+		width: 1px;
+	}
+	.full-nav-footer {
+		border-bottom: 1px solid rgba(124, 134, 149, 0.18);
+		border-top: 1px solid rgba(124, 134, 149, 0.18);
+	}
+	.full-nav-footer-inner {
+		align-items: center;
+		display: flex;
+		gap: 4px;
+		margin-inline: var(--d2l-page-margin-inline);
+		max-width: var(--d2l-page-header-max-width);
+		padding: 0 30px;
+	}
+	@media (max-width: 615px) {
+		.full-nav-footer-inner {
+			padding: 0 15px;
+		}
+	}
+	.full-nav-footer-link {
+		border-bottom: 4px solid transparent;
+		color: var(--d2l-color-ferrite);
+		display: inline-block;
+		font-size: 0.7rem;
+		padding: 8px 12px;
+		text-decoration: none;
+	}
+	.full-nav-footer-link:hover,
+	.full-nav-footer-link:focus-visible {
+		border-bottom-color: var(--d2l-color-celestine);
+		color: var(--d2l-color-celestine);
+	}
+
+	/* Immersive Nav Styles */
+	.immersive-wrapper {
+		background-color: white;
+		border-bottom: 1px solid var(--d2l-color-mica);
+		position: relative;
+	}
+	.immersive-container {
+		align-items: center;
+		display: flex;
+		height: 3.1rem;
+		justify-content: space-between;
+		margin-inline: var(--d2l-page-margin-inline);
+		max-width: var(--d2l-page-header-max-width);
+		overflow: hidden;
+		padding: 0 30px;
+	}
+	@media (max-width: 929px) {
+		.immersive-container {
+			padding: 0 24px;
+		}
+	}
+	@media (max-width: 767px) {
+		.immersive-container {
+			padding: 0 18px;
+		}
+	}
+	@media (max-width: 615px) {
+		.immersive-container {
+			height: 2.8rem;
+		}
+	}
+	.immersive-left {
+		align-items: center;
+		color: var(--d2l-color-tungsten);
+		display: flex;
+		flex: 0 0 auto;
+		font-size: 0.8rem;
+		letter-spacing: 0.2px;
+	}
+	.immersive-back-link {
+		align-items: center;
+		color: var(--d2l-color-tungsten);
+		display: inline-flex;
+		gap: 4px;
+		text-decoration: none;
+	}
+	.immersive-back-link:hover,
+	.immersive-back-link:focus-visible {
+		color: var(--d2l-color-celestine);
+	}
+	.immersive-back-icon {
+		font-size: 1rem;
+	}
+	.immersive-middle {
+		border-inline-end: 1px solid var(--d2l-color-gypsum);
+		border-inline-start: 1px solid var(--d2l-color-gypsum);
+		flex: 0 1 auto;
+		font-size: 0.8rem;
+		margin: 0 24px;
+		min-width: 0;
+		overflow: hidden;
+		padding: 0 24px;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		width: 100%;
+	}
+	@media (max-width: 615px) {
+		.immersive-middle {
+			margin: 0 18px;
+			padding: 0 18px;
+		}
+	}
+	.immersive-right {
+		align-items: center;
+		display: flex;
+		flex: 0 0 auto;
+		gap: 8px;
+	}
+	.immersive-right .nav-icon-btn {
+		font-size: 0.7rem;
+	}
+`;

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -44,7 +44,6 @@ class Page extends LocalizeCoreElement(LitElement) {
 		}
 
 		.header {
-			background-color: white;
 			z-index: 2; /* To be over divider and main contents */
 		}
 		.page.header-sticky .header {

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -194,7 +194,6 @@ class Page extends LocalizeCoreElement(LitElement) {
 		const key = e.target.name;
 		const nodes = e.target.assignedNodes();
 		this._slotVisibility = { ...this._slotVisibility, [key]: nodes.length !== 0 };
-		this.requestUpdate();
 	}
 
 	#renderFloatingButtons(footerContents) {

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -62,14 +62,18 @@ class Page extends LocalizeCoreElement(LitElement) {
 		main {
 			flex: 1;
 			min-width: 400px; /* TBD */
+			overflow: clip;
+			position: relative;
+			z-index: 0;
 		}
 
 		.side-nav-panel,
 		.supporting-panel {
 			height: calc(100vh - var(--d2l-page-footer-height, 0));
-			overflow-y: auto;
+			overflow: clip auto;
 			position: sticky;
 			top: 0;
+			z-index: 0;
 		}
 		.page.header-sticky .side-nav-panel,
 		.page.header-sticky .supporting-panel {
@@ -94,7 +98,7 @@ class Page extends LocalizeCoreElement(LitElement) {
 			inset: auto 0 0;
 			padding: 0.75rem 0;
 			position: fixed;
-			z-index: 1; /* To be over divider and main contents */
+			z-index: 1; /* To be over divider */
 		}
 		.floating-footer {
 			padding-block-end: 0.75rem;

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -116,18 +116,16 @@ class Page extends LocalizeCoreElement(LitElement) {
 
 	connectedCallback() {
 		super.connectedCallback();
+
+		const header = this.shadowRoot.querySelector('.header');
+		const footer = this.shadowRoot.querySelector('.footer');
+		if (header) this.#resizeObserver.observe(header);
+		if (footer) this.#resizeObserver.observe(footer);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.#resizeObserver.disconnect();
-	}
-
-	firstUpdated() {
-		const header = this.shadowRoot.querySelector('.header');
-		const footer = this.shadowRoot.querySelector('.footer');
-		if (header) this.#resizeObserver.observe(header);
-		if (footer) this.#resizeObserver.observe(footer);
 	}
 
 	render() {

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -43,12 +43,10 @@ class Page extends LocalizeCoreElement(LitElement) {
 			--d2l-page-footer-max-width: 100%;
 		}
 
-		.header {
-			z-index: 2; /* To be over divider and main contents */
-		}
 		.page.header-sticky .header {
 			position: sticky;
 			top: 0;
+			z-index: 15; /* To be over sticky content of our core components */
 		}
 
 		.content {
@@ -62,8 +60,6 @@ class Page extends LocalizeCoreElement(LitElement) {
 			flex: 1;
 			min-width: 400px; /* TBD */
 			overflow: clip;
-			position: relative;
-			z-index: 0;
 		}
 
 		.side-nav-panel,
@@ -72,7 +68,6 @@ class Page extends LocalizeCoreElement(LitElement) {
 			overflow: clip auto;
 			position: sticky;
 			top: 0;
-			z-index: 0;
 		}
 		.page.header-sticky .side-nav-panel,
 		.page.header-sticky .supporting-panel {
@@ -84,7 +79,6 @@ class Page extends LocalizeCoreElement(LitElement) {
 			background-color: var(--d2l-color-gypsum);
 			flex: none;
 			width: 4px;
-			z-index: 1;
 		}
 
 		.footer:not([hidden]),
@@ -97,7 +91,6 @@ class Page extends LocalizeCoreElement(LitElement) {
 			inset: auto 0 0;
 			padding: 0.75rem 0;
 			position: fixed;
-			z-index: 1; /* To be over divider */
 		}
 		.floating-footer {
 			padding-block-end: 0.75rem;

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -56,7 +56,7 @@ class Page extends LocalizeCoreElement(LitElement) {
 			display: flex;
 			margin-inline: var(--d2l-page-margin-inline, 0);
 			max-width: var(--d2l-page-content-max-width, 100%);
-			padding-bottom: var(--d2l-page-footer-height, 0px); /* Reserve space for fixed footer */
+			padding-bottom: var(--d2l-page-footer-height, 0); /* Reserve space for fixed footer */
 		}
 
 		main {
@@ -66,15 +66,15 @@ class Page extends LocalizeCoreElement(LitElement) {
 
 		.side-nav-panel,
 		.supporting-panel {
+			height: calc(100vh - var(--d2l-page-footer-height, 0));
 			overflow-y: auto;
 			position: sticky;
 			top: 0;
-			height: calc(100vh - var(--d2l-page-footer-height, 0px));
 		}
 		.page.header-sticky .side-nav-panel,
 		.page.header-sticky .supporting-panel {
-			top: var(--d2l-page-header-height, 0px);
-			height: calc(100vh - var(--d2l-page-header-height, 0px) - var(--d2l-page-footer-height, 0px));
+			height: calc(100vh - var(--d2l-page-header-height, 0) - var(--d2l-page-footer-height, 0));
+			top: var(--d2l-page-header-height, 0);
 		}
 
 		.divider {

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -86,9 +86,6 @@ class Page extends LocalizeCoreElement(LitElement) {
 			padding: 0.75rem 0;
 			position: fixed;
 		}
-		.floating-footer {
-			padding-block-end: 0.75rem;
-		}
 		.footer-contents {
 			margin-inline: var(--d2l-page-margin-inline, 0);
 			max-width: var(--d2l-page-footer-max-width, 100%);
@@ -168,7 +165,7 @@ class Page extends LocalizeCoreElement(LitElement) {
 		return html`
 			<div class="floating-buttons-container">
 				<d2l-floating-buttons>
-					<div class="floating-footer">${footerContents}</div>
+					${footerContents}
 				</d2l-floating-buttons>
 			</div>
 		`;

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -1,0 +1,223 @@
+import '../button/floating-buttons.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
+
+/**
+ * Page template with header, optional footer and optional navigation panel or supporting panel
+ * @slot - The main content of the page (expecting d2l-page-main)
+ * @slot header - The header content of the page (expecting d2l-page-header-*)
+ * @slot side-nav - The side navigation content of the page (expecting d2l-page-side-nav)
+ * @slot supporting - The supporting content of the page (expecting d2l-page-supporting)
+ * @slot footer - The footer content of the page (expecting d2l-page-footer)
+ */
+class Page extends LocalizeCoreElement(LitElement) {
+
+	static properties = {
+		/**
+		 * Width type of the page and its underlying pieces
+		 * @type {'normal'|'wide'|'fullscreen'}
+		 */
+		widthType: { type: String, attribute: 'width-type' },
+		_headerIsSticky: { state: true },
+		_slotVisibility: { state: true }
+	};
+
+	static styles = css`
+		:host {
+			--d2l-page-header-max-width: 1230px;
+			--d2l-page-content-max-width: 1230px;
+			--d2l-page-footer-max-width: 1230px;
+			--d2l-page-margin-inline: auto;
+		}
+
+		:host([width-type="wide"]) {
+			--d2l-page-header-max-width: 1440px;
+			--d2l-page-content-max-width: 1440px;
+			--d2l-page-footer-max-width: 1440px;
+		}
+
+		:host([width-type="fullscreen"]) {
+			--d2l-page-header-max-width: 100%;
+			--d2l-page-content-max-width: 100%;
+			--d2l-page-footer-max-width: 100%;
+		}
+
+		.header {
+			background-color: white;
+			z-index: 2; /* To be over divider and main contents */
+		}
+		.page.header-sticky .header {
+			position: sticky;
+			top: 0;
+		}
+
+		.content {
+			display: flex;
+			margin-inline: var(--d2l-page-margin-inline, 0);
+			max-width: var(--d2l-page-content-max-width, 100%);
+			padding-bottom: var(--d2l-page-footer-height, 0px); /* Reserve space for fixed footer */
+		}
+
+		main {
+			flex: 1;
+			min-width: 400px; /* TBD */
+		}
+
+		.side-nav-panel,
+		.supporting-panel {
+			overflow-y: auto;
+			position: sticky;
+			top: 0;
+			height: calc(100vh - var(--d2l-page-footer-height, 0px));
+		}
+		.page.header-sticky .side-nav-panel,
+		.page.header-sticky .supporting-panel {
+			top: var(--d2l-page-header-height, 0px);
+			height: calc(100vh - var(--d2l-page-header-height, 0px) - var(--d2l-page-footer-height, 0px));
+		}
+
+		.divider {
+			background-color: var(--d2l-color-gypsum);
+			flex: none;
+			width: 4px;
+			z-index: 1;
+		}
+
+		.footer:not([hidden]),
+		.floating-buttons-container {
+			display: inline;
+		}
+		.fixed-footer {
+			background-color: white;
+			box-shadow: 0 -2px 4px rgba(32, 33, 34, 0.2); /* ferrite */
+			inset: auto 0 0;
+			padding: 0.75rem 0;
+			position: fixed;
+			z-index: 1; /* To be over divider and main contents */
+		}
+		.floating-footer {
+			padding-block-end: 0.75rem;
+		}
+		.footer-contents {
+			margin-inline: var(--d2l-page-margin-inline, 0);
+			max-width: var(--d2l-page-footer-max-width, 100%);
+		}
+	`;
+
+	constructor() {
+		super();
+
+		this.widthType = 'normal';
+		this._headerIsSticky = false;
+		this._slotVisibility = {};
+		this.#resizeObserver = new ResizeObserver(entries => {
+			for (const entry of entries) {
+				if (entry.target.classList.contains('header')) {
+					const height = entry.target.offsetHeight;
+					this.style.setProperty('--d2l-page-header-height', `${height}px`);
+				} else if (entry.target.classList.contains('footer')) {
+					const height = entry.target.classList.contains('fixed-footer') ? entry.target.offsetHeight : 0;
+					this.style.setProperty('--d2l-page-footer-height', `${height}px`);
+				}
+			}
+		});
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.#resizeObserver.disconnect();
+	}
+
+	firstUpdated() {
+		const header = this.shadowRoot.querySelector('.header');
+		const footer = this.shadowRoot.querySelector('.footer');
+		if (header) this.#resizeObserver.observe(header);
+		if (footer) this.#resizeObserver.observe(footer);
+	}
+
+	render() {
+		const pageClasses = {
+			'page': true,
+			'header-sticky': this._headerIsSticky
+		};
+
+		const header = html`
+			<header class="header">
+				<nav aria-label="${this.localize('components.page.header-nav-label')}">
+					<slot name="header" @slotchange="${this.#handleHeaderSlotChange}"></slot>
+				</nav>
+			</header>`;
+
+		const mainContent = html`
+			<main>
+				<slot></slot>
+			</main>`;
+
+		const sideNavPanel = html`
+			<nav class="side-nav-panel" ?hidden="${!this._slotVisibility['side-nav']}" aria-label="${this.localize('components.page.side-nav-label')}">
+				<slot name="side-nav" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
+			</nav>
+			${this._slotVisibility['side-nav'] ? html`<div class="divider"></div>` : nothing}
+			`;
+
+		const supportingPanel = html`
+			${this._slotVisibility['supporting'] ? html`<div class="divider"></div>` : nothing}
+			<aside class="supporting-panel" ?hidden="${!this._slotVisibility['supporting']}">
+				<slot name="supporting" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
+			</aside>`;
+
+		const fixedFooter = this._slotVisibility['side-nav'] || this._slotVisibility['supporting'];
+		const footerContainerClasses = { 'footer': true, 'fixed-footer': fixedFooter };
+		const footerContents = html`<div class="footer-contents"><slot name="footer" @slotchange="${this.#handleSlotVisibilityChange}"></slot></div>`;
+		const footer = html`
+			<div class="${classMap(footerContainerClasses)}" ?hidden="${!this._slotVisibility['footer']}">
+				${fixedFooter ? footerContents : this.#renderFloatingButtons(footerContents)}	
+			</div>`;
+
+		return html`
+			<div class="${classMap(pageClasses)}">
+				${header}
+				<div class="content">
+					${sideNavPanel}
+					${mainContent}
+					${supportingPanel}
+				</div>
+				${footer}
+			</div>
+		`;
+	}
+
+	#resizeObserver;
+
+	#handleHeaderSlotChange(e) {
+		const nodes = e.target.assignedNodes();
+		//this._headerIsSticky = nodes.some(node => node.tagName.toLowerCase() === 'd2l-page-header-immersive');
+		this._headerIsSticky = nodes.some(node => node.id === 'immersive-nav'); // temp until the official component exists
+	}
+
+	#handleSlotVisibilityChange(e) {
+		const key = e.target.name;
+		const nodes = e.target.assignedNodes();
+		this._slotVisibility = { ...this._slotVisibility, [key]: nodes.length !== 0 };
+		this.requestUpdate();
+	}
+
+	#renderFloatingButtons(footerContents) {
+		// Floating buttons needs to be wrapped as it spawns a sibling element that should be cleaned up as one by Lit
+		return html`
+			<div class="floating-buttons-container">
+				<d2l-floating-buttons>
+					<div class="floating-footer">${footerContents}</div>
+				</d2l-floating-buttons>
+			</div>
+		`;
+	}
+
+}
+
+customElements.define('d2l-page', Page);

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -134,48 +134,15 @@ class Page extends LocalizeCoreElement(LitElement) {
 			'header-sticky': this._headerIsSticky
 		};
 
-		const header = html`
-			<header class="header">
-				<nav aria-label="${this.localize('components.page.header-nav-label')}">
-					<slot name="header" @slotchange="${this.#handleHeaderSlotChange}"></slot>
-				</nav>
-			</header>`;
-
-		const mainContent = html`
-			<main>
-				<slot></slot>
-			</main>`;
-
-		const sideNavPanel = html`
-			<nav class="side-nav-panel" ?hidden="${!this._slotVisibility['side-nav']}" aria-label="${this.localize('components.page.side-nav-label')}">
-				<slot name="side-nav" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
-			</nav>
-			${this._slotVisibility['side-nav'] ? html`<div class="divider"></div>` : nothing}
-			`;
-
-		const supportingPanel = html`
-			${this._slotVisibility['supporting'] ? html`<div class="divider"></div>` : nothing}
-			<aside class="supporting-panel" ?hidden="${!this._slotVisibility['supporting']}">
-				<slot name="supporting" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
-			</aside>`;
-
-		const fixedFooter = this._slotVisibility['side-nav'] || this._slotVisibility['supporting'];
-		const footerContainerClasses = { 'footer': true, 'fixed-footer': fixedFooter };
-		const footerContents = html`<div class="footer-contents"><slot name="footer" @slotchange="${this.#handleSlotVisibilityChange}"></slot></div>`;
-		const footer = html`
-			<div class="${classMap(footerContainerClasses)}" ?hidden="${!this._slotVisibility['footer']}">
-				${fixedFooter ? footerContents : this.#renderFloatingButtons(footerContents)}	
-			</div>`;
-
 		return html`
 			<div class="${classMap(pageClasses)}">
-				${header}
+				${this.#renderHeader()}
 				<div class="content">
-					${sideNavPanel}
-					${mainContent}
-					${supportingPanel}
+					${this.#renderSideNavPanel()}
+					<main><slot></slot></main>
+					${this.#renderSupportingPanel()}
 				</div>
-				${footer}
+				${this.#renderFooter()}
 			</div>
 		`;
 	}
@@ -202,6 +169,45 @@ class Page extends LocalizeCoreElement(LitElement) {
 					<div class="floating-footer">${footerContents}</div>
 				</d2l-floating-buttons>
 			</div>
+		`;
+	}
+
+	#renderFooter() {
+		const fixedFooter = this._slotVisibility['side-nav'] || this._slotVisibility['supporting'];
+		const footerContainerClasses = { 'footer': true, 'fixed-footer': fixedFooter };
+		const footerContents = html`<div class="footer-contents"><slot name="footer" @slotchange="${this.#handleSlotVisibilityChange}"></slot></div>`;
+		return html`
+			<div class="${classMap(footerContainerClasses)}" ?hidden="${!this._slotVisibility['footer']}">
+				${fixedFooter ? footerContents : this.#renderFloatingButtons(footerContents)}	
+			</div>
+		`;
+	}
+
+	#renderHeader() {
+		return html`
+			<header class="header">
+				<nav aria-label="${this.localize('components.page.header-nav-label')}">
+					<slot name="header" @slotchange="${this.#handleHeaderSlotChange}"></slot>
+				</nav>
+			</header>
+		`;
+	}
+
+	#renderSideNavPanel() {
+		return html`
+			<nav class="side-nav-panel" ?hidden="${!this._slotVisibility['side-nav']}" aria-label="${this.localize('components.page.side-nav-label')}">
+				<slot name="side-nav" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
+			</nav>
+			${this._slotVisibility['side-nav'] ? html`<div class="divider"></div>` : nothing}
+		`;
+	}
+
+	#renderSupportingPanel() {
+		return html`
+			${this._slotVisibility['supporting'] ? html`<div class="divider"></div>` : nothing}
+			<aside class="supporting-panel" ?hidden="${!this._slotVisibility['supporting']}">
+				<slot name="supporting" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
+			</aside>
 		`;
 	}
 

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -59,7 +59,6 @@ class Page extends LocalizeCoreElement(LitElement) {
 		main {
 			flex: 1;
 			min-width: 400px; /* TBD */
-			overflow: clip;
 		}
 
 		.side-nav-panel,

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -1,3 +1,4 @@
+import '../colors/colors.js';
 import '../button/floating-buttons.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
@@ -110,10 +111,6 @@ class Page extends LocalizeCoreElement(LitElement) {
 				}
 			}
 		});
-	}
-
-	connectedCallback() {
-		super.connectedCallback();
 	}
 
 	disconnectedCallback() {

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -116,16 +116,18 @@ class Page extends LocalizeCoreElement(LitElement) {
 
 	connectedCallback() {
 		super.connectedCallback();
-
-		const header = this.shadowRoot.querySelector('.header');
-		const footer = this.shadowRoot.querySelector('.footer');
-		if (header) this.#resizeObserver.observe(header);
-		if (footer) this.#resizeObserver.observe(footer);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.#resizeObserver.disconnect();
+	}
+
+	firstUpdated() {
+		const header = this.shadowRoot.querySelector('.header');
+		const footer = this.shadowRoot.querySelector('.footer');
+		if (header) this.#resizeObserver.observe(header);
+		if (footer) this.#resizeObserver.observe(footer);
 	}
 
 	render() {

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -4,7 +4,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 
 /**
- * Page template with header, optional footer and optional navigation panel or supporting panel
+ * Component for laying out a page, with header, optional footer and optional navigation or supporting panels
  * @slot - The main content of the page (expecting d2l-page-main)
  * @slot header - The header content of the page (expecting d2l-page-header-*)
  * @slot side-nav - The side navigation content of the page (expecting d2l-page-side-nav)

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -63,14 +63,9 @@ class Page extends LocalizeCoreElement(LitElement) {
 
 		.side-nav-panel,
 		.supporting-panel {
-			height: calc(100vh - var(--d2l-page-footer-height, 0));
+			height: calc(100vh - var(--d2l-page-header-height, 0) - var(--d2l-page-footer-height, 0));
 			overflow: clip auto;
 			position: sticky;
-			top: 0;
-		}
-		.page.header-sticky .side-nav-panel,
-		.page.header-sticky .supporting-panel {
-			height: calc(100vh - var(--d2l-page-header-height, 0) - var(--d2l-page-footer-height, 0));
 			top: var(--d2l-page-header-height, 0);
 		}
 
@@ -109,7 +104,7 @@ class Page extends LocalizeCoreElement(LitElement) {
 		this.#resizeObserver = new ResizeObserver(entries => {
 			for (const entry of entries) {
 				if (entry.target.classList.contains('header')) {
-					const height = entry.target.offsetHeight;
+					const height = this._headerIsSticky ? entry.target.offsetHeight : 0;
 					this.style.setProperty('--d2l-page-header-height', `${height}px`);
 				} else if (entry.target.classList.contains('footer')) {
 					const height = entry.target.classList.contains('fixed-footer') ? entry.target.offsetHeight : 0;

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -58,7 +58,7 @@ class Page extends LocalizeCoreElement(LitElement) {
 
 		main {
 			flex: 1;
-			min-width: 400px; /* TBD */
+			min-width: min(400px, 100%); /* Actual min width TBD */
 		}
 
 		.side-nav-panel,

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -85,6 +85,7 @@ class Page extends LocalizeCoreElement(LitElement) {
 			inset: auto 0 0;
 			padding: 0.75rem 0;
 			position: fixed;
+			z-index: 10; /* To be over sticky content of our core components */
 		}
 		.footer-contents {
 			margin-inline: var(--d2l-page-margin-inline, 0);

--- a/components/page/test/page.axe.js
+++ b/components/page/test/page.axe.js
@@ -1,0 +1,40 @@
+import '../page.js';
+import { expect, fixture, html } from '@brightspace-ui/testing';
+
+describe('page', () => {
+
+	it('single panel', async() => {
+		const elem = await fixture(html`
+			<d2l-page>
+				<div slot="header">Header</div>
+				<div>Content</div>
+				<div slot="footer">Footer</div>
+			</d2l-page>
+		`);
+		await expect(elem).to.be.accessible();
+	});
+
+	it('with side-nav panel', async() => {
+		const elem = await fixture(html`
+			<d2l-page>
+				<div slot="header">Header</div>
+				<div>Content</div>
+				<div slot="side-nav">Side Nav</div>
+				<div slot="footer">Footer</div>
+			</d2l-page>
+		`);
+		await expect(elem).to.be.accessible();
+	});
+
+	it('with supporting panel', async() => {
+		const elem = await fixture(html`
+			<d2l-page>
+				<div slot="header">Header</div>
+				<div>Content</div>
+				<div slot="supporting">Supporting</div>
+				<div slot="footer">Footer</div>
+			</d2l-page>
+		`);
+		await expect(elem).to.be.accessible();
+	});
+});

--- a/components/page/test/page.test.js
+++ b/components/page/test/page.test.js
@@ -1,0 +1,10 @@
+import '../page.js';
+import { runConstructor } from '@brightspace-ui/testing';
+
+describe('page', () => {
+
+	it('should construct', () => {
+		runConstructor('d2l-page');
+	});
+
+});

--- a/index.html
+++ b/index.html
@@ -153,6 +153,7 @@
 		<li><a href="components/more-less/demo/more-less.html">d2l-more-less</a></li>
 		<li><a href="components/object-property-list/demo/object-property-list.html">d2l-object-property-list</a></li>
 		<li><a href="components/offscreen/demo/offscreen.html">d2l-offscreen</a></li>
+		<li><a href="components/page/demo/page.html">d2l-page</a></li>
 		<li><a href="components/progress/demo/progress.html">d2l-progress</a></li>
 		<li><a href="components/overflow-group/demo/overflow-group.html">d2l-overflow-group</a></li>
 		<li><a href="components/paging/demo/pager-load-more.html">d2l-pager-load-more</a></li>

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "المزيد",
 	"components.object-property-list.item-placeholder-text": "عنصر نائب",
 	"components.overflow-group.moreActions": "مزيد من الإجراءات",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} مادة واحد}

--- a/lang/ca.js
+++ b/lang/ca.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "more",
 	"components.object-property-list.item-placeholder-text": "Placeholder Item",
 	"components.overflow-group.moreActions": "More Actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "mwy",
 	"components.object-property-list.item-placeholder-text": "Eitem Dalfan",
 	"components.overflow-group.moreActions": "Rhagor o Gamau Gweithredu",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} eitem}

--- a/lang/da.js
+++ b/lang/da.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "flere",
 	"components.object-property-list.item-placeholder-text": "Pladsholder-element",
 	"components.overflow-group.moreActions": "Flere handlinger",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} element}

--- a/lang/de.js
+++ b/lang/de.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "mehr",
 	"components.object-property-list.item-placeholder-text": "Platzhalterelement",
 	"components.overflow-group.moreActions": "Weitere Aktionen",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} Element}

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "more",
 	"components.object-property-list.item-placeholder-text": "Placeholder Item",
 	"components.overflow-group.moreActions": "More Actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/en.js
+++ b/lang/en.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "more",
 	"components.object-property-list.item-placeholder-text": "Placeholder Item",
 	"components.overflow-group.moreActions": "More Actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "más",
 	"components.object-property-list.item-placeholder-text": "Elemento de marcador de posición",
 	"components.overflow-group.moreActions": "Más acciones",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} elemento}

--- a/lang/es.js
+++ b/lang/es.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "más",
 	"components.object-property-list.item-placeholder-text": "Elemento de marcador de posición",
 	"components.overflow-group.moreActions": "Más acciones",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} elemento}

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "plus",
 	"components.object-property-list.item-placeholder-text": "Élément d’espace réservé",
 	"components.overflow-group.moreActions": "Plus d’actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} élément}

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "plus",
 	"components.object-property-list.item-placeholder-text": "Élément de paramètre fictif",
 	"components.overflow-group.moreActions": "Plus d’actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} élément}

--- a/lang/haw.js
+++ b/lang/haw.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "hou aku",
 	"components.object-property-list.item-placeholder-text": "Mea Paʻa Wahi",
 	"components.overflow-group.moreActions": "Nā Hana Hou",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} mea}

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "अधिक",
 	"components.object-property-list.item-placeholder-text": "प्लेसहोल्डर आइटम",
 	"components.overflow-group.moreActions": "अधिक क्रियाएँ",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} आइटम}

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -147,6 +147,8 @@ export default {
 	"components.more-less.more": "増やす",
 	"components.object-property-list.item-placeholder-text": "プレースホルダの項目",
 	"components.overflow-group.moreActions": "その他のアクション",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 個の項目}

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -147,6 +147,8 @@ export default {
 	"components.more-less.more": "더 보기",
 	"components.object-property-list.item-placeholder-text": "자리표시자 항목",
 	"components.overflow-group.moreActions": "추가 작업",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {해당 항목 수 {countFormatted}개}

--- a/lang/mi.js
+++ b/lang/mi.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "ētahi atu",
 	"components.object-property-list.item-placeholder-text": "Tūemi Puriwāhi",
 	"components.overflow-group.moreActions": "Ētahi atu Hohenga",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} Tūemi}

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "meer",
 	"components.object-property-list.item-placeholder-text": "Item tijdelijke aanduiding",
 	"components.overflow-group.moreActions": "Meer acties",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "mais",
 	"components.object-property-list.item-placeholder-text": "Item de espaço reservado",
 	"components.overflow-group.moreActions": "Mais ações",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "mer",
 	"components.object-property-list.item-placeholder-text": "Platshållarobjekt",
 	"components.overflow-group.moreActions": "Fler åtgärder",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} objekt}

--- a/lang/th.js
+++ b/lang/th.js
@@ -148,6 +148,8 @@ export default {
 	"components.more-less.more": "เพิ่มเติม",
 	"components.object-property-list.item-placeholder-text": "รายการตัวแทน",
 	"components.overflow-group.moreActions": "การดำเนินการเพิ่มเติม",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} รายการ}

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "daha fazla",
 	"components.object-property-list.item-placeholder-text": "Yer Tutucu Öğesi",
 	"components.overflow-group.moreActions": "Daha Fazla Eylem",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} öğe}

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -146,6 +146,8 @@ export default {
 	"components.more-less.more": "thêm",
 	"components.object-property-list.item-placeholder-text": "Mục giữ chỗ",
 	"components.overflow-group.moreActions": "Thêm các Tác vụ",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} mục}

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -147,6 +147,8 @@ export default {
 	"components.more-less.more": "更多",
 	"components.object-property-list.item-placeholder-text": "占位符项目",
 	"components.overflow-group.moreActions": "更多操作",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 项}

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -148,6 +148,8 @@ export default {
 	"components.more-less.more": "較多",
 	"components.object-property-list.item-placeholder-text": "預留位置項目",
 	"components.overflow-group.moreActions": "其他動作",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 個項目}


### PR DESCRIPTION
This adds `d2l-page` with the discussed slots. It uses the full body scroll demonstrated in https://github.com/BrightspaceUI/core/pull/6875. The demo page is bare bones and will be fleshed out in the next PR.

Still tweaking a bit, experimenting with what we want vdiffs to look like, etc. but this should be good to go. Will add notes inline. I still want to give this one more go-through but I've been looking at it too long - will check Monday with fresh eyes.