### PR TITLE
GAUD-9165 - Example of how we could apply fix to our sticky components

### DIFF
--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -173,15 +173,17 @@ class CollapsiblePanel extends SkeletonMixin(FocusMixin(LitElement)) {
 				border-radius: 0;
 				outline-offset: -2px;
 			}
-			.d2l-collapsible-panel.scrolled .d2l-collapsible-panel-header {
+			.d2l-collapsible-panel .d2l-collapsible-panel-header {
 				background-color: var(--d2l-theme-background-color-base);
-				box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
 				position: sticky;
-				top: 0;
+				top: var(--d2l-sticky-offset, 0px);
 				z-index: 11; /* must be greater greater than list-items with open dropdowns or tooltips */
 			}
+			.d2l-collapsible-panel.scrolled .d2l-collapsible-panel-header {
+				box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
+			}
 			.d2l-collapsible-panel.focused.scrolled .d2l-collapsible-panel-header {
-				top: 2px;
+				top: calc(var(--d2l-sticky-offset, 0px) + 2px);
 			}
 			.d2l-collapsible-panel-title {
 				flex: 1;

--- a/components/page/README.md
+++ b/components/page/README.md
@@ -1,0 +1,5 @@
+# Page
+
+The `d2l-page` and page layout components are in progress.
+
+Please reach out before using them!

--- a/components/page/demo/page-component.js
+++ b/components/page/demo/page-component.js
@@ -1,0 +1,191 @@
+import '../../collapsible-panel/collapsible-panel.js';
+import '../page.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { navStyles } from './temp-nav-styles.js';
+import { selectStyles } from '../../inputs/input-select-styles.js';
+
+/**
+ * Component for d2l-page demos and tests
+ */
+class PageDemo extends LitElement {
+
+	static properties = {
+		demoMode: { type: Boolean, attribute: 'demo-mode' },
+		hasFooter: { type: Boolean, attribute: 'has-footer' },
+		hasSideNavPanel: { type: Boolean, attribute: 'has-side-nav-panel' },
+		hasSupportingPanel: { type: Boolean, attribute: 'has-supporting-panel' },
+		navType: { type: String, attribute: 'nav-type' },
+		widthType: { type: String, attribute: 'width-type' },
+		_allowThreePanels: { state: true }
+	};
+
+	static styles = [navStyles, selectStyles, css`
+		.demo-controls {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.75rem;
+		}
+	`];
+
+	constructor() {
+		super();
+		this._allowThreePanels = false; // Temp for dev/testing
+		this.demoMode = false;
+		this.hasFooter = false;
+		this.hasSideNavPanel = false;
+		this.hasSupportingPanel = false;
+		this.navType = 'full';
+		/** @type {'normal'|'wide'|'fullscreen'} */
+		this.widthType = 'normal';
+	}
+
+	render() {
+		return html`
+			<d2l-page width-type="${this.widthType}">
+				${this.navType === 'full' ? this.#renderFullNav() : this.#renderImmersiveNav()}
+				${this.#renderSideNavPanel()}
+				${this.#renderMainPanel()}
+				${this.#renderSupportingPanel()}
+				${this.#renderFooter()}
+			</d2l-page>
+		`;
+	}
+
+	#handleAllowThreePanelsChange(e) {
+		this._allowThreePanels = e.target.on;
+		if (!this._allowThreePanels && this.hasSideNavPanel && this.hasSupportingPanel) {
+			this.shadowRoot.querySelector('#switch-supporting-panel').on = false;
+			this.hasSupportingPanel = false;
+		}
+	}
+
+	#handleNavTypeChange(e) {
+		this.navType = e.target.on ? 'immersive' : 'full';
+	}
+
+	#handleVisibilityChange(e) {
+		const key = e.target.dataset.key;
+		this[key] = e.target.on;
+
+		if (this._allowThreePanels) return;
+		if (e.target.on && key === 'hasSideNavPanel' && this.hasSupportingPanel) {
+			this.shadowRoot.querySelector('#switch-supporting-panel').on = false;
+			this.hasSupportingPanel = false;
+		} else if (e.target.on && key === 'hasSupportingPanel' && this.hasSideNavPanel) {
+			this.shadowRoot.querySelector('#switch-side-nav-panel').on = false;
+			this.hasSideNavPanel = false;
+		}
+	}
+
+	#handleWidthTypeChange(e) {
+		this.widthType = e.target.value;
+	}
+
+	#renderFooter() {
+		return this.hasFooter ? html`
+			<div slot="footer">
+				I'm in the <b>footer</b> slot of the <b>d2l-page</b> component!
+			</div>
+		` : nothing;
+	}
+
+	#renderFullNav() {
+		// Update with navigation components once available
+		return html`
+			<div slot="header" class="full-nav-wrapper">
+				<div class="nav-band"></div>
+				<div class="full-nav-header">
+					<div class="full-nav-header-left">
+						<span class="full-nav-logo">Logo</span>
+						<div class="full-nav-separator"></div>
+						<button class="nav-icon-btn">📚 Courses</button>
+					</div>
+					<div class="full-nav-header-spacer"></div>
+					<div class="full-nav-header-right">
+						<button class="nav-icon-btn" title="Alerts">🔔</button>
+						<button class="nav-icon-btn" title="Settings">⚙️</button>
+						<button class="nav-icon-btn" title="Profile">👤</button>
+					</div>
+				</div>
+				<div class="full-nav-footer">
+					<div class="full-nav-footer-inner">
+						<a class="full-nav-footer-link" href="javascript:void(0)">Content</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Assignments</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Quizzes</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Grades</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Classlist</a>
+					</div>
+				</div>
+				<div class="nav-shadow"></div>
+			</div>
+		`;
+	}
+
+	#renderImmersiveNav() {
+		// Update with navigation components once available
+		return html`
+			<div id="immersive-nav" slot="header" class="immersive-wrapper">
+				<div class="nav-band"></div>
+				<div class="immersive-container">
+					<div class="immersive-left">
+						<a class="immersive-back-link" href="javascript:void(0)">
+							<span class="immersive-back-icon">‹</span>
+							Back to Course
+						</a>
+					</div>
+					<div class="immersive-middle">
+						Assignment 1 - Introduction to Economics
+					</div>
+					<div class="immersive-right">
+						<button class="nav-icon-btn">‹ Prev</button>
+						<button class="nav-icon-btn">Next ›</button>
+					</div>
+				</div>
+				<div class="nav-shadow"></div>
+			</div>
+		`;
+	}
+
+	#renderMainPanel() {
+		return html`
+			<div style="height: 1000px;">
+				${this.demoMode ? html`
+					<d2l-collapsible-panel panel-title="Demo Controls" expanded>
+						<div class="demo-controls">
+							<select class="d2l-input-select" name="width-type" aria-label="Width type" @change="${this.#handleWidthTypeChange}">
+								<option value="normal" ?selected="${this.widthType === 'normal'}">Normal Width</option>
+								<option value="wide" ?selected="${this.widthType === 'wide'}">Wide Width</option>
+								<option value="fullscreen" ?selected="${this.widthType === 'fullscreen'}">Fullscreen</option>
+							</select>
+							<d2l-switch id="switch-nav-type" text="Immersive Nav" @change="${this.#handleNavTypeChange}"></d2l-switch>
+							<d2l-switch id="switch-side-nav-panel" text="Side Nav Panel" data-key="hasSideNavPanel" @change="${this.#handleVisibilityChange}"></d2l-switch>
+							<d2l-switch id="switch-supporting-panel" text="Supporting Panel" data-key="hasSupportingPanel" @change="${this.#handleVisibilityChange}"></d2l-switch>
+							<d2l-switch id="switch-footer" text="Footer" data-key="hasFooter" @change="${this.#handleVisibilityChange}"></d2l-switch>
+							<d2l-switch id="switch-allow-three-panels" text="Allow Three Panels" @change="${this.#handleAllowThreePanelsChange}"></d2l-switch>
+						</div>
+					</d2l-collapsible-panel>
+				` : nothing}
+				<p>I'm in the <b>default</b> slot of the <b>d2l-page</b> component!</p>
+			</div>
+			<div>End of Content</div>
+		`;
+	}
+
+	#renderSideNavPanel() {
+		return this.hasSideNavPanel ? html`
+			<div style="background-color: lavender; height: 1000px;" slot="side-nav">
+				I'm in the <b>side-nav</b> slot of the <b>d2l-page</b> component!
+			</div>
+		` : nothing;
+	}
+
+	#renderSupportingPanel() {
+		return this.hasSupportingPanel ? html`
+			<div style="background-color: aliceblue; height: 1000px;" slot="supporting">
+				I'm in the <b>supporting</b> slot of the <b>d2l-page</b> component!
+			</div>
+		` : nothing;
+	}
+}
+
+customElements.define('d2l-page-demo', PageDemo);

--- a/components/page/demo/page-component.js
+++ b/components/page/demo/page-component.js
@@ -1,8 +1,24 @@
+import '../../button/button-subtle.js';
 import '../../collapsible-panel/collapsible-panel.js';
+import '../../collapsible-panel/collapsible-panel-group.js';
+import '../../collapsible-panel/collapsible-panel-summary-item.js';
+import '../../demo/demo-page-settings.js';
+import '../../inputs/input-checkbox.js';
+import '../../inputs/input-date.js';
+import '../../inputs/input-number.js';
+import '../../inputs/input-text.js';
+import '../../list/list.js';
+import '../../list/list-controls.js';
+import '../../list/list-item.js';
+import '../../list/list-item-content.js';
+import '../../list/list-item-nav.js';
+import '../../selection/selection-action.js';
+import '../../table/table-controls.js';
 import '../page.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { navStyles } from './temp-nav-styles.js';
 import { selectStyles } from '../../inputs/input-select-styles.js';
+import { tableStyles } from '../../table/table-wrapper.js';
 
 /**
  * Component for d2l-page demos and tests
@@ -19,7 +35,7 @@ class PageDemo extends LitElement {
 		_allowThreePanels: { state: true }
 	};
 
-	static styles = [navStyles, selectStyles, css`
+	static styles = [navStyles, selectStyles, tableStyles, css`
 		.demo-controls {
 			display: flex;
 			flex-wrap: wrap;
@@ -148,7 +164,8 @@ class PageDemo extends LitElement {
 
 	#renderMainPanel() {
 		return html`
-			<div style="height: 1000px;">
+			<div>
+				<p>I'm in the <b>default</b> slot of the <b>d2l-page</b> component!</p>
 				${this.demoMode ? html`
 					<d2l-collapsible-panel panel-title="Demo Controls" expanded>
 						<div class="demo-controls">
@@ -165,24 +182,311 @@ class PageDemo extends LitElement {
 						</div>
 					</d2l-collapsible-panel>
 				` : nothing}
-				<p>I'm in the <b>default</b> slot of the <b>d2l-page</b> component!</p>
+
+				<h3>List with Sticky Controls (extend-separators)</h3>
+				<d2l-list extend-separators>
+					<d2l-list-controls slot="controls">
+						<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
+						<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
+					</d2l-list-controls>
+					<d2l-list-item key="item-1" label="Introduction to Economics" selectable>
+						<d2l-list-item-content>
+							<div>Introduction to Economics</div>
+							<div slot="secondary">Chapter 1 — Fundamentals</div>
+							<div slot="supporting-info">Due: May 15, 2026</div>
+						</d2l-list-item-content>
+					</d2l-list-item>
+					<d2l-list-item key="item-2" label="Supply and Demand" selectable>
+						<d2l-list-item-content>
+							<div>Supply and Demand</div>
+							<div slot="secondary">Chapter 2 — Market Forces</div>
+							<div slot="supporting-info">Due: May 22, 2026</div>
+						</d2l-list-item-content>
+					</d2l-list-item>
+					<d2l-list-item key="item-3" label="Market Equilibrium" selectable>
+						<d2l-list-item-content>
+							<div>Market Equilibrium</div>
+							<div slot="secondary">Chapter 3 — Price Discovery</div>
+							<div slot="supporting-info">Due: May 29, 2026</div>
+						</d2l-list-item-content>
+					</d2l-list-item>
+				</d2l-list>
+
+				<h3>List with Sticky Controls (no extend-separators)</h3>
+				<d2l-list>
+					<d2l-list-controls slot="controls">
+						<d2l-selection-action icon="tier1:plus-default" text="Add"></d2l-selection-action>
+						<d2l-selection-action icon="tier1:delete" text="Delete" requires-selection></d2l-selection-action>
+					</d2l-list-controls>
+					<d2l-list-item key="assign-1" label="Assignment 1" selectable>
+						<d2l-list-item-content>
+							<div>Assignment 1: Research Proposal</div>
+							<div slot="secondary">Weight: 20%</div>
+							<div slot="supporting-info">Submissions: 14/30</div>
+						</d2l-list-item-content>
+					</d2l-list-item>
+					<d2l-list-item key="assign-2" label="Assignment 2" selectable>
+						<d2l-list-item-content>
+							<div>Assignment 2: Literature Review</div>
+							<div slot="secondary">Weight: 30%</div>
+							<div slot="supporting-info">Submissions: 8/30</div>
+						</d2l-list-item-content>
+					</d2l-list-item>
+					<d2l-list-item key="assign-3" label="Assignment 3" selectable>
+						<d2l-list-item-content>
+							<div>Assignment 3: Final Paper</div>
+							<div slot="secondary">Weight: 50%</div>
+							<div slot="supporting-info">Submissions: 0/30</div>
+						</d2l-list-item-content>
+					</d2l-list-item>
+				</d2l-list>
+
+				<h3>Table with Sticky Controls</h3>
+				<d2l-table-wrapper>
+					<d2l-table-controls slot="controls">
+						<d2l-selection-action icon="tier1:download" text="Export"></d2l-selection-action>
+						<d2l-selection-action icon="tier1:email" text="Email" requires-selection></d2l-selection-action>
+					</d2l-table-controls>
+					<table class="d2l-table">
+						<thead>
+							<tr>
+								<th>Course</th>
+								<th>Enrolled</th>
+								<th>Completion Rate</th>
+								<th>Avg Grade</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Introduction to Biology</th>
+								<td>145</td>
+								<td>87%</td>
+								<td>B+</td>
+							</tr>
+							<tr>
+								<th scope="row">Advanced Chemistry</th>
+								<td>62</td>
+								<td>79%</td>
+								<td>B</td>
+							</tr>
+							<tr>
+								<th scope="row">World History</th>
+								<td>98</td>
+								<td>92%</td>
+								<td>A-</td>
+							</tr>
+						</tbody>
+					</table>
+				</d2l-table-wrapper>
+
+				<h3>Sticky Table</h3>
+				<d2l-table-wrapper sticky-headers sticky-headers-scroll-wrapper>
+					<table class="d2l-table">
+						<thead>
+							<tr>
+								<th>Student</th>
+								<th>Assignment 1</th>
+								<th>Assignment 2</th>
+								<th>Final Exam</th>
+								<th>Total</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th scope="row">Alice Johnson</th>
+								<td>92</td>
+								<td>88</td>
+								<td>95</td>
+								<td>91.7</td>
+							</tr>
+							<tr>
+								<th scope="row">Bob Smith</th>
+								<td>85</td>
+								<td>79</td>
+								<td>82</td>
+								<td>82.0</td>
+							</tr>
+							<tr>
+								<th scope="row">Carol Davis</th>
+								<td>78</td>
+								<td>91</td>
+								<td>87</td>
+								<td>85.3</td>
+							</tr>
+							<tr>
+								<th scope="row">David Lee</th>
+								<td>95</td>
+								<td>93</td>
+								<td>90</td>
+								<td>92.7</td>
+							</tr>
+							<tr>
+								<th scope="row">Emily Chen</th>
+								<td>88</td>
+								<td>84</td>
+								<td>91</td>
+								<td>87.7</td>
+							</tr>
+						</tbody>
+					</table>
+				</d2l-table-wrapper>
 			</div>
-			<div>End of Content</div>
+			<div style="align-items: end; display: flex; height: 500px;">End of Content</div>
 		`;
 	}
 
 	#renderSideNavPanel() {
 		return this.hasSideNavPanel ? html`
-			<div style="background-color: lavender; height: 1000px;" slot="side-nav">
-				I'm in the <b>side-nav</b> slot of the <b>d2l-page</b> component!
+			<div slot="side-nav">
+				<p>I'm in the <b>side-nav</b> slot of the <b>d2l-page</b> component!</p>
+				<d2l-list grid style="width: 100%;">
+					<d2l-list-item-nav key="nav-1" label="Course Overview" action-href="javascript:void(0)" prevent-navigation>
+						<d2l-list-item-content>
+							<div>Course Overview</div>
+						</d2l-list-item-content>
+					</d2l-list-item-nav>
+					<d2l-list-item-nav key="nav-2" label="Unit 1: Foundations" expandable expanded action-href="javascript:void(0)" prevent-navigation>
+						<d2l-list-item-content>
+							<div>Unit 1: Foundations</div>
+							<div slot="secondary">3 items</div>
+						</d2l-list-item-content>
+						<d2l-list slot="nested" grid>
+							<d2l-list-item-nav key="nav-2-1" label="Reading: Core Concepts" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Reading: Core Concepts</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+							<d2l-list-item-nav key="nav-2-2" label="Discussion: Key Takeaways" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Discussion: Key Takeaways</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+							<d2l-list-item-nav key="nav-2-3" label="Quiz: Chapter 1" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Quiz: Chapter 1</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+						</d2l-list>
+					</d2l-list-item-nav>
+					<d2l-list-item-nav key="nav-3" label="Unit 2: Applications" expandable action-href="javascript:void(0)" prevent-navigation>
+						<d2l-list-item-content>
+							<div>Unit 2: Applications</div>
+							<div slot="secondary">4 items</div>
+						</d2l-list-item-content>
+						<d2l-list slot="nested" grid>
+							<d2l-list-item-nav key="nav-3-1" label="Case Study Analysis" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Case Study Analysis</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+							<d2l-list-item-nav key="nav-3-2" label="Group Project" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Group Project</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+							<d2l-list-item-nav key="nav-3-3" label="Lab: Data Collection" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Lab: Data Collection</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+							<d2l-list-item-nav key="nav-3-4" label="Reflection Journal" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Reflection Journal</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+						</d2l-list>
+					</d2l-list-item-nav>
+					<d2l-list-item-nav key="nav-4" label="Unit 3: Research Methods" expandable action-href="javascript:void(0)" prevent-navigation>
+						<d2l-list-item-content>
+							<div>Unit 3: Research Methods</div>
+							<div slot="secondary">5 items</div>
+						</d2l-list-item-content>
+						<d2l-list slot="nested" grid>
+							<d2l-list-item-nav key="nav-4-1" label="Introduction to Research Design" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Introduction to Research Design</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+							<d2l-list-item-nav key="nav-4-2" label="Qualitative vs Quantitative" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Qualitative vs Quantitative</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+							<d2l-list-item-nav key="nav-4-3" label="Survey Design Workshop" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Survey Design Workshop</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+							<d2l-list-item-nav key="nav-4-4" label="Ethics in Research" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Ethics in Research</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+							<d2l-list-item-nav key="nav-4-5" label="Quiz: Research Methods" action-href="javascript:void(0)" prevent-navigation>
+								<d2l-list-item-content>
+									<div>Quiz: Research Methods</div>
+								</d2l-list-item-content>
+							</d2l-list-item-nav>
+						</d2l-list>
+					</d2l-list-item-nav>
+				</d2l-list>
+				<div style="align-items: end; display: flex; height: 150px;">End of Content</div>
 			</div>
 		` : nothing;
 	}
 
 	#renderSupportingPanel() {
 		return this.hasSupportingPanel ? html`
-			<div style="background-color: aliceblue; height: 1000px;" slot="supporting">
-				I'm in the <b>supporting</b> slot of the <b>d2l-page</b> component!
+			<div slot="supporting">
+				<d2l-demo-page-settings panel-title="d2l-page"></d2l-demo-page-settings>
+				<p>I'm in the <b>supporting</b> slot of the <b>d2l-page</b> component!</p>
+				<d2l-collapsible-panel-group>
+					<d2l-collapsible-panel panel-title="Availability Dates and Conditions" expanded>
+						<d2l-collapsible-panel-summary-item slot="summary" text="Available: May 1 – Jun 30, 2026"></d2l-collapsible-panel-summary-item>
+						<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+							<d2l-input-date label="Start Date" value="2026-05-01"></d2l-input-date>
+							<d2l-input-date label="End Date" value="2026-06-30"></d2l-input-date>
+							<d2l-input-checkbox checked>Has start date</d2l-input-checkbox>
+							<d2l-input-checkbox checked>Has end date</d2l-input-checkbox>
+							<d2l-button-subtle text="Manage Release Conditions"></d2l-button-subtle>
+						</div>
+					</d2l-collapsible-panel>
+					<d2l-collapsible-panel panel-title="Grading and Assessment">
+						<d2l-collapsible-panel-summary-item slot="summary" text="Weight: 20% | Rubric attached"></d2l-collapsible-panel-summary-item>
+						<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+							<d2l-input-text label="Grade Item Name" value="Assignment 1: Research Proposal"></d2l-input-text>
+							<d2l-input-number label="Points" value="100"></d2l-input-number>
+							<d2l-input-number label="Weight (%)" value="20"></d2l-input-number>
+							<select class="d2l-input-select" aria-label="Grade scheme">
+								<option selected>Percentage</option>
+								<option>Letter Grade</option>
+								<option>Pass/Fail</option>
+							</select>
+							<d2l-input-checkbox checked>Include in final grade calculation</d2l-input-checkbox>
+							<d2l-button-subtle text="Attach Rubric"></d2l-button-subtle>
+						</div>
+					</d2l-collapsible-panel>
+					<d2l-collapsible-panel panel-title="Submission and Completion">
+						<d2l-collapsible-panel-summary-item slot="summary" text="Individual submission, 1 attempt"></d2l-collapsible-panel-summary-item>
+						<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+							<select class="d2l-input-select" aria-label="Submission type">
+								<option selected>Individual submission</option>
+								<option>Group submission</option>
+							</select>
+							<d2l-input-number label="Attempts allowed" value="1" min="1" max="10"></d2l-input-number>
+							<d2l-input-checkbox>Allow learners to retract submissions</d2l-input-checkbox>
+							<d2l-input-checkbox checked>Notify instructor on submission</d2l-input-checkbox>
+							<select class="d2l-input-select" aria-label="Accepted file types">
+								<option selected>All file types</option>
+								<option>PDF only</option>
+								<option>Documents (.doc, .docx, .pdf)</option>
+								<option>Images (.png, .jpg, .gif)</option>
+							</select>
+							<d2l-input-text label="Completion message" value="Thank you for your submission!"></d2l-input-text>
+						</div>
+					</d2l-collapsible-panel>
+				</d2l-collapsible-panel-group>
+				<div style="align-items: end; display: flex; height: 150px;">End of Content</div>
 			</div>
 		` : nothing;
 	}

--- a/components/page/demo/page-component.js
+++ b/components/page/demo/page-component.js
@@ -1,8 +1,10 @@
+import '../../button/button.js';
 import '../../button/button-subtle.js';
 import '../../collapsible-panel/collapsible-panel.js';
 import '../../collapsible-panel/collapsible-panel-group.js';
 import '../../collapsible-panel/collapsible-panel-summary-item.js';
 import '../../demo/demo-page-settings.js';
+import '../../dialog/dialog.js';
 import '../../inputs/input-checkbox.js';
 import '../../inputs/input-date.js';
 import '../../inputs/input-number.js';
@@ -73,6 +75,15 @@ class PageDemo extends LitElement {
 			this.shadowRoot.querySelector('#switch-supporting-panel').on = false;
 			this.hasSupportingPanel = false;
 		}
+	}
+
+	// TO DO: Don't commit this! Fix the dialog and add this in the main header
+	#handleDialogBrokenClick() {
+		this.shadowRoot.querySelector('#broken-dialog').opened = true;
+	}
+
+	#handleDialogNativeClick() {
+		this.shadowRoot.querySelector('#native-dialog').opened = true;
 	}
 
 	#handleNavTypeChange(e) {
@@ -186,6 +197,8 @@ class PageDemo extends LitElement {
 				<h3>List with Sticky Controls (extend-separators)</h3>
 				<d2l-list extend-separators>
 					<d2l-list-controls slot="controls">
+						<d2l-selection-action icon="tier1:alert" text="Broken Dialog" @d2l-selection-action-click="${this.#handleDialogBrokenClick}"></d2l-selection-action>
+						<d2l-selection-action icon="tier1:fullscreen" text="Native Dialog" @d2l-selection-action-click="${this.#handleDialogNativeClick}"></d2l-selection-action>
 						<d2l-selection-action icon="tier1:bookmark-hollow" text="Bookmark" requires-selection></d2l-selection-action>
 						<d2l-selection-action icon="tier1:gear" text="Settings"></d2l-selection-action>
 					</d2l-list-controls>
@@ -330,6 +343,26 @@ class PageDemo extends LitElement {
 						</tbody>
 					</table>
 				</d2l-table-wrapper>
+				<d2l-dialog id="broken-dialog" title-text="Broken Dialog">
+					<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+						<d2l-input-text label="Assignment Name" required></d2l-input-text>
+						<d2l-input-number label="Weight (%)" min="0" max="100"></d2l-input-number>
+						<d2l-input-date label="Due Date"></d2l-input-date>
+						<d2l-input-checkbox>Allow late submissions</d2l-input-checkbox>
+					</div>
+					<d2l-button slot="footer" primary data-dialog-action="add">Add</d2l-button>
+					<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+				</d2l-dialog>
+				<d2l-dialog id="native-dialog" title-text="Native Dialog" prefer-native>
+					<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+						<d2l-input-text label="Assignment Name" required></d2l-input-text>
+						<d2l-input-number label="Weight (%)" min="0" max="100"></d2l-input-number>
+						<d2l-input-date label="Due Date"></d2l-input-date>
+						<d2l-input-checkbox>Allow late submissions</d2l-input-checkbox>
+					</div>
+					<d2l-button slot="footer" primary data-dialog-action="add">Add</d2l-button>
+					<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+				</d2l-dialog>
 			</div>
 			<div style="align-items: end; display: flex; height: 500px;">End of Content</div>
 		`;

--- a/components/page/demo/page.html
+++ b/components/page/demo/page.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<link rel="stylesheet" href="../../demo/styles.css" type="text/css">
+		<script type="module">
+			import '../../demo/demo-page.js';
+			import './page-component.js';
+		</script>
+	</head>
+	<body>
+		<d2l-page-demo demo-mode></d2l-page-demo>
+	</body>
+</html>

--- a/components/page/demo/temp-nav-styles.js
+++ b/components/page/demo/temp-nav-styles.js
@@ -1,0 +1,217 @@
+/**
+ * Temporary navigation demo styles
+ * These can be removed once we have official navigation components to use
+ */
+
+import { css } from 'lit';
+
+export const navStyles = css`
+
+	/* Shared Styles */
+	.nav-shadow {
+		background-color: rgba(0, 0, 0, 0.02);
+		bottom: -4px;
+		display: block;
+		height: 4px;
+		pointer-events: none;
+		position: absolute;
+		width: 100%;
+		z-index: 1;
+	}
+	.nav-band {
+		background: linear-gradient(180deg, var(--d2l-color-celestine) 1.5rem, #ffffff 0%);
+		min-height: 4px;
+	}
+	.nav-icon-btn {
+		align-items: center;
+		background: none;
+		border: none;
+		border-radius: 4px;
+		color: var(--d2l-color-ferrite);
+		cursor: pointer;
+		display: inline-flex;
+		font-size: 0.8rem;
+		gap: 4px;
+		justify-content: center;
+		min-height: 42px;
+		min-width: 42px;
+		padding: 6px;
+	}
+	.nav-icon-btn:hover,
+	.nav-icon-btn:focus-visible {
+		background-color: var(--d2l-color-gypsum);
+		color: var(--d2l-color-celestine);
+	}
+
+	/* Full Nav Styles */
+	.full-nav-wrapper {
+		position: relative;
+	}
+	.full-nav-header {
+		align-items: center;
+		display: flex;
+		height: 90px;
+		margin-inline: var(--d2l-page-margin-inline);
+		max-width: var(--d2l-page-header-max-width);
+		padding: 0 30px;
+	}
+	@media (max-width: 767px) {
+		.full-nav-header {
+			height: 72px;
+		}
+	}
+	@media (max-width: 615px) {
+		.full-nav-header {
+			padding: 0 15px;
+		}
+	}
+	.full-nav-header-left {
+		align-items: center;
+		display: flex;
+		flex: 0 1 auto;
+		gap: 12px;
+		height: 100%;
+	}
+	.full-nav-header-spacer {
+		flex: 1 1 auto;
+		min-width: 30px;
+	}
+	@media (max-width: 615px) {
+		.full-nav-header-spacer {
+			min-width: 15px;
+		}
+	}
+	.full-nav-header-right {
+		align-items: center;
+		display: flex;
+		flex: 0 0 auto;
+		gap: 6px;
+		height: 100%;
+	}
+	.full-nav-logo {
+		background-color: var(--d2l-color-celestine);
+		border-radius: 4px;
+		color: white;
+		font-size: 0.8rem;
+		font-weight: 700;
+		padding: 8px 14px;
+	}
+	.full-nav-separator {
+		background-color: var(--d2l-color-mica);
+		height: 26px;
+		margin: 0 6px;
+		width: 1px;
+	}
+	.full-nav-footer {
+		border-bottom: 1px solid rgba(124, 134, 149, 0.18);
+		border-top: 1px solid rgba(124, 134, 149, 0.18);
+	}
+	.full-nav-footer-inner {
+		align-items: center;
+		display: flex;
+		gap: 4px;
+		margin-inline: var(--d2l-page-margin-inline);
+		max-width: var(--d2l-page-header-max-width);
+		padding: 0 30px;
+	}
+	@media (max-width: 615px) {
+		.full-nav-footer-inner {
+			padding: 0 15px;
+		}
+	}
+	.full-nav-footer-link {
+		border-bottom: 4px solid transparent;
+		color: var(--d2l-color-ferrite);
+		display: inline-block;
+		font-size: 0.7rem;
+		padding: 8px 12px;
+		text-decoration: none;
+	}
+	.full-nav-footer-link:hover,
+	.full-nav-footer-link:focus-visible {
+		border-bottom-color: var(--d2l-color-celestine);
+		color: var(--d2l-color-celestine);
+	}
+
+	/* Immersive Nav Styles */
+	.immersive-wrapper {
+		background-color: white;
+		border-bottom: 1px solid var(--d2l-color-mica);
+		position: relative;
+	}
+	.immersive-container {
+		align-items: center;
+		display: flex;
+		height: 3.1rem;
+		justify-content: space-between;
+		margin-inline: var(--d2l-page-margin-inline);
+		max-width: var(--d2l-page-header-max-width);
+		overflow: hidden;
+		padding: 0 30px;
+	}
+	@media (max-width: 929px) {
+		.immersive-container {
+			padding: 0 24px;
+		}
+	}
+	@media (max-width: 767px) {
+		.immersive-container {
+			padding: 0 18px;
+		}
+	}
+	@media (max-width: 615px) {
+		.immersive-container {
+			height: 2.8rem;
+		}
+	}
+	.immersive-left {
+		align-items: center;
+		color: var(--d2l-color-tungsten);
+		display: flex;
+		flex: 0 0 auto;
+		font-size: 0.8rem;
+		letter-spacing: 0.2px;
+	}
+	.immersive-back-link {
+		align-items: center;
+		color: var(--d2l-color-tungsten);
+		display: inline-flex;
+		gap: 4px;
+		text-decoration: none;
+	}
+	.immersive-back-link:hover,
+	.immersive-back-link:focus-visible {
+		color: var(--d2l-color-celestine);
+	}
+	.immersive-back-icon {
+		font-size: 1rem;
+	}
+	.immersive-middle {
+		border-inline-end: 1px solid var(--d2l-color-gypsum);
+		border-inline-start: 1px solid var(--d2l-color-gypsum);
+		flex: 0 1 auto;
+		font-size: 0.8rem;
+		margin: 0 24px;
+		min-width: 0;
+		overflow: hidden;
+		padding: 0 24px;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		width: 100%;
+	}
+	@media (max-width: 615px) {
+		.immersive-middle {
+			margin: 0 18px;
+			padding: 0 18px;
+		}
+	}
+	.immersive-right {
+		align-items: center;
+		display: flex;
+		flex: 0 0 auto;
+		gap: 8px;
+	}
+	.immersive-right .nav-icon-btn {
+		font-size: 0.7rem;
+	}
+`;

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -62,14 +62,18 @@ class Page extends LocalizeCoreElement(LitElement) {
 		main {
 			flex: 1;
 			min-width: 400px; /* TBD */
+			overflow: clip;
+			position: relative;
+			z-index: 0;
 		}
 
 		.side-nav-panel,
 		.supporting-panel {
 			height: calc(100vh - var(--d2l-page-footer-height, 0));
-			overflow-y: auto;
+			overflow: clip auto;
 			position: sticky;
 			top: 0;
+			z-index: 0;
 		}
 		.page.header-sticky .side-nav-panel,
 		.page.header-sticky .supporting-panel {
@@ -94,7 +98,7 @@ class Page extends LocalizeCoreElement(LitElement) {
 			inset: auto 0 0;
 			padding: 0.75rem 0;
 			position: fixed;
-			z-index: 1; /* To be over divider and main contents */
+			z-index: 1; /* To be over divider */
 		}
 		.floating-footer {
 			padding-block-end: 0.75rem;

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -56,7 +56,7 @@ class Page extends LocalizeCoreElement(LitElement) {
 			display: flex;
 			margin-inline: var(--d2l-page-margin-inline, 0);
 			max-width: var(--d2l-page-content-max-width, 100%);
-			padding-bottom: var(--d2l-page-footer-height, 0px); /* Reserve space for fixed footer */
+			padding-bottom: var(--d2l-page-footer-height, 0); /* Reserve space for fixed footer */
 		}
 
 		main {
@@ -66,15 +66,15 @@ class Page extends LocalizeCoreElement(LitElement) {
 
 		.side-nav-panel,
 		.supporting-panel {
+			height: calc(100vh - var(--d2l-page-footer-height, 0));
 			overflow-y: auto;
 			position: sticky;
 			top: 0;
-			height: calc(100vh - var(--d2l-page-footer-height, 0px));
 		}
 		.page.header-sticky .side-nav-panel,
 		.page.header-sticky .supporting-panel {
-			top: var(--d2l-page-header-height, 0px);
-			height: calc(100vh - var(--d2l-page-header-height, 0px) - var(--d2l-page-footer-height, 0px));
+			height: calc(100vh - var(--d2l-page-header-height, 0) - var(--d2l-page-footer-height, 0));
+			top: var(--d2l-page-header-height, 0);
 		}
 
 		.divider {

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -1,0 +1,223 @@
+import '../button/floating-buttons.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
+
+/**
+ * Page template with header, optional footer and optional navigation panel or supporting panel
+ * @slot - The main content of the page (expecting d2l-page-main)
+ * @slot header - The header content of the page (expecting d2l-page-header-*)
+ * @slot side-nav - The side navigation content of the page (expecting d2l-page-side-nav)
+ * @slot supporting - The supporting content of the page (expecting d2l-page-supporting)
+ * @slot footer - The footer content of the page (expecting d2l-page-footer)
+ */
+class Page extends LocalizeCoreElement(LitElement) {
+
+	static properties = {
+		/**
+		 * Width type of the page and its underlying pieces
+		 * @type {'normal'|'wide'|'fullscreen'}
+		 */
+		widthType: { type: String, attribute: 'width-type' },
+		_headerIsSticky: { state: true },
+		_slotVisibility: { state: true }
+	};
+
+	static styles = css`
+		:host {
+			--d2l-page-header-max-width: 1230px;
+			--d2l-page-content-max-width: 1230px;
+			--d2l-page-footer-max-width: 1230px;
+			--d2l-page-margin-inline: auto;
+		}
+
+		:host([width-type="wide"]) {
+			--d2l-page-header-max-width: 1440px;
+			--d2l-page-content-max-width: 1440px;
+			--d2l-page-footer-max-width: 1440px;
+		}
+
+		:host([width-type="fullscreen"]) {
+			--d2l-page-header-max-width: 100%;
+			--d2l-page-content-max-width: 100%;
+			--d2l-page-footer-max-width: 100%;
+		}
+
+		.header {
+			background-color: white;
+			z-index: 2; /* To be over divider and main contents */
+		}
+		.page.header-sticky .header {
+			position: sticky;
+			top: 0;
+		}
+
+		.content {
+			display: flex;
+			margin-inline: var(--d2l-page-margin-inline, 0);
+			max-width: var(--d2l-page-content-max-width, 100%);
+			padding-bottom: var(--d2l-page-footer-height, 0px); /* Reserve space for fixed footer */
+		}
+
+		main {
+			flex: 1;
+			min-width: 400px; /* TBD */
+		}
+
+		.side-nav-panel,
+		.supporting-panel {
+			overflow-y: auto;
+			position: sticky;
+			top: 0;
+			height: calc(100vh - var(--d2l-page-footer-height, 0px));
+		}
+		.page.header-sticky .side-nav-panel,
+		.page.header-sticky .supporting-panel {
+			top: var(--d2l-page-header-height, 0px);
+			height: calc(100vh - var(--d2l-page-header-height, 0px) - var(--d2l-page-footer-height, 0px));
+		}
+
+		.divider {
+			background-color: var(--d2l-color-gypsum);
+			flex: none;
+			width: 4px;
+			z-index: 1;
+		}
+
+		.footer:not([hidden]),
+		.floating-buttons-container {
+			display: inline;
+		}
+		.fixed-footer {
+			background-color: white;
+			box-shadow: 0 -2px 4px rgba(32, 33, 34, 0.2); /* ferrite */
+			inset: auto 0 0;
+			padding: 0.75rem 0;
+			position: fixed;
+			z-index: 1; /* To be over divider and main contents */
+		}
+		.floating-footer {
+			padding-block-end: 0.75rem;
+		}
+		.footer-contents {
+			margin-inline: var(--d2l-page-margin-inline, 0);
+			max-width: var(--d2l-page-footer-max-width, 100%);
+		}
+	`;
+
+	constructor() {
+		super();
+
+		this.widthType = 'normal';
+		this._headerIsSticky = false;
+		this._slotVisibility = {};
+		this.#resizeObserver = new ResizeObserver(entries => {
+			for (const entry of entries) {
+				if (entry.target.classList.contains('header')) {
+					const height = entry.target.offsetHeight;
+					this.style.setProperty('--d2l-page-header-height', `${height}px`);
+				} else if (entry.target.classList.contains('footer')) {
+					const height = entry.target.classList.contains('fixed-footer') ? entry.target.offsetHeight : 0;
+					this.style.setProperty('--d2l-page-footer-height', `${height}px`);
+				}
+			}
+		});
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.#resizeObserver.disconnect();
+	}
+
+	firstUpdated() {
+		const header = this.shadowRoot.querySelector('.header');
+		const footer = this.shadowRoot.querySelector('.footer');
+		if (header) this.#resizeObserver.observe(header);
+		if (footer) this.#resizeObserver.observe(footer);
+	}
+
+	render() {
+		const pageClasses = {
+			'page': true,
+			'header-sticky': this._headerIsSticky
+		};
+
+		const header = html`
+			<header class="header">
+				<nav aria-label="${this.localize('components.page.header-nav-label')}">
+					<slot name="header" @slotchange="${this.#handleHeaderSlotChange}"></slot>
+				</nav>
+			</header>`;
+
+		const mainContent = html`
+			<main>
+				<slot></slot>
+			</main>`;
+
+		const sideNavPanel = html`
+			<nav class="side-nav-panel" ?hidden="${!this._slotVisibility['side-nav']}" aria-label="${this.localize('components.page.side-nav-label')}">
+				<slot name="side-nav" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
+			</nav>
+			${this._slotVisibility['side-nav'] ? html`<div class="divider"></div>` : nothing}
+			`;
+
+		const supportingPanel = html`
+			${this._slotVisibility['supporting'] ? html`<div class="divider"></div>` : nothing}
+			<aside class="supporting-panel" ?hidden="${!this._slotVisibility['supporting']}">
+				<slot name="supporting" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
+			</aside>`;
+
+		const fixedFooter = this._slotVisibility['side-nav'] || this._slotVisibility['supporting'];
+		const footerContainerClasses = { 'footer': true, 'fixed-footer': fixedFooter };
+		const footerContents = html`<div class="footer-contents"><slot name="footer" @slotchange="${this.#handleSlotVisibilityChange}"></slot></div>`;
+		const footer = html`
+			<div class="${classMap(footerContainerClasses)}" ?hidden="${!this._slotVisibility['footer']}">
+				${fixedFooter ? footerContents : this.#renderFloatingButtons(footerContents)}	
+			</div>`;
+
+		return html`
+			<div class="${classMap(pageClasses)}">
+				${header}
+				<div class="content">
+					${sideNavPanel}
+					${mainContent}
+					${supportingPanel}
+				</div>
+				${footer}
+			</div>
+		`;
+	}
+
+	#resizeObserver;
+
+	#handleHeaderSlotChange(e) {
+		const nodes = e.target.assignedNodes();
+		//this._headerIsSticky = nodes.some(node => node.tagName.toLowerCase() === 'd2l-page-header-immersive');
+		this._headerIsSticky = nodes.some(node => node.id === 'immersive-nav'); // temp until the official component exists
+	}
+
+	#handleSlotVisibilityChange(e) {
+		const key = e.target.name;
+		const nodes = e.target.assignedNodes();
+		this._slotVisibility = { ...this._slotVisibility, [key]: nodes.length !== 0 };
+		this.requestUpdate();
+	}
+
+	#renderFloatingButtons(footerContents) {
+		// Floating buttons needs to be wrapped as it spawns a sibling element that should be cleaned up as one by Lit
+		return html`
+			<div class="floating-buttons-container">
+				<d2l-floating-buttons>
+					<div class="floating-footer">${footerContents}</div>
+				</d2l-floating-buttons>
+			</div>
+		`;
+	}
+
+}
+
+customElements.define('d2l-page', Page);

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -66,6 +66,9 @@ class Page extends LocalizeCoreElement(LitElement) {
 			position: relative;
 			z-index: 0;
 		}
+		.page.header-sticky main {
+			--d2l-sticky-offset: var(--d2l-page-header-height, 0px);
+		}
 
 		.side-nav-panel,
 		.supporting-panel {

--- a/components/page/test/page.axe.js
+++ b/components/page/test/page.axe.js
@@ -1,0 +1,40 @@
+import '../page.js';
+import { expect, fixture, html } from '@brightspace-ui/testing';
+
+describe('page', () => {
+
+	it('single panel', async() => {
+		const elem = await fixture(html`
+			<d2l-page>
+				<div slot="header">Header</div>
+				<div>Content</div>
+				<div slot="footer">Footer</div>
+			</d2l-page>
+		`);
+		await expect(elem).to.be.accessible();
+	});
+
+	it('with side-nav panel', async() => {
+		const elem = await fixture(html`
+			<d2l-page>
+				<div slot="header">Header</div>
+				<div>Content</div>
+				<div slot="side-nav">Side Nav</div>
+				<div slot="footer">Footer</div>
+			</d2l-page>
+		`);
+		await expect(elem).to.be.accessible();
+	});
+
+	it('with supporting panel', async() => {
+		const elem = await fixture(html`
+			<d2l-page>
+				<div slot="header">Header</div>
+				<div>Content</div>
+				<div slot="supporting">Supporting</div>
+				<div slot="footer">Footer</div>
+			</d2l-page>
+		`);
+		await expect(elem).to.be.accessible();
+	});
+});

--- a/components/page/test/page.test.js
+++ b/components/page/test/page.test.js
@@ -1,0 +1,10 @@
+import '../page.js';
+import { runConstructor } from '@brightspace-ui/testing';
+
+describe('page', () => {
+
+	it('should construct', () => {
+		runConstructor('d2l-page');
+	});
+
+});

--- a/components/selection/selection-controls.js
+++ b/components/selection/selection-controls.js
@@ -50,7 +50,7 @@ export class SelectionControls extends PageableSubscriberMixin(SelectionObserver
 			:host {
 				display: block;
 				position: sticky;
-				top: 0;
+				top: var(--d2l-sticky-offset, 0px);
 			}
 			:host([no-sticky]) {
 				position: static;

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -241,7 +241,7 @@ export const tableStyles = css`
 	d2l-table-wrapper[sticky-headers][sticky-headers-scroll-wrapper] .d2l-table > thead {
 		display: block;
 		position: sticky;
-		top: calc(var(--d2l-table-sticky-top, 0px) + var(--d2l-table-border-radius-sticky-offset, 0px));
+		top: calc(var(--d2l-sticky-offset, 0px) + var(--d2l-table-sticky-top, 0px) + var(--d2l-table-border-radius-sticky-offset, 0px));
 		z-index: 2;
 	}
 
@@ -382,7 +382,7 @@ export class TableWrapper extends PropertyRequiredMixin(PageableMixin(SelectionM
 			}
 			.d2l-sticky-headers-backdrop {
 				position: sticky;
-				top: calc(var(--d2l-table-sticky-top, 0px) + var(--d2l-table-border-radius));
+				top: calc(var(--d2l-sticky-offset, 0px) + var(--d2l-table-sticky-top, 0px) + var(--d2l-table-border-radius));
 				width: 100%;
 				z-index: 2; /* Must sit under d2l-table sticky-headers but over sticky columns and regular cells */
 			}
@@ -832,7 +832,7 @@ export class TableWrapper extends PropertyRequiredMixin(PageableMixin(SelectionM
 
 		const stickyRows = Array.from(this._table.querySelectorAll(SELECTORS.headers));
 		stickyRows.forEach(r => {
-			const thTop = hasStickyControls ? `${rowTop}px` : `calc(${rowTop}px + var(--d2l-table-border-radius-sticky-offset, 0px))`;
+			const thTop = hasStickyControls ? `calc(var(--d2l-sticky-offset, 0px) + ${rowTop}px)` : `calc(var(--d2l-sticky-offset, 0px) + ${rowTop}px + var(--d2l-table-border-radius-sticky-offset, 0px))`;
 			const ths = Array.from(r.querySelectorAll('th,td'));
 			ths.forEach(th => th.style.top = thTop);
 

--- a/index.html
+++ b/index.html
@@ -153,6 +153,7 @@
 		<li><a href="components/more-less/demo/more-less.html">d2l-more-less</a></li>
 		<li><a href="components/object-property-list/demo/object-property-list.html">d2l-object-property-list</a></li>
 		<li><a href="components/offscreen/demo/offscreen.html">d2l-offscreen</a></li>
+		<li><a href="components/page/demo/page.html">d2l-page</a></li>
 		<li><a href="components/progress/demo/progress.html">d2l-progress</a></li>
 		<li><a href="components/overflow-group/demo/overflow-group.html">d2l-overflow-group</a></li>
 		<li><a href="components/paging/demo/pager-load-more.html">d2l-pager-load-more</a></li>

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "المزيد",
 	"components.object-property-list.item-placeholder-text": "عنصر نائب",
 	"components.overflow-group.moreActions": "مزيد من الإجراءات",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} مادة واحد}

--- a/lang/ca.js
+++ b/lang/ca.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "more",
 	"components.object-property-list.item-placeholder-text": "Placeholder Item",
 	"components.overflow-group.moreActions": "More Actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "mwy",
 	"components.object-property-list.item-placeholder-text": "Eitem Dalfan",
 	"components.overflow-group.moreActions": "Rhagor o Gamau Gweithredu",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} eitem}

--- a/lang/da.js
+++ b/lang/da.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "flere",
 	"components.object-property-list.item-placeholder-text": "Pladsholder-element",
 	"components.overflow-group.moreActions": "Flere handlinger",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} element}

--- a/lang/de.js
+++ b/lang/de.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "mehr",
 	"components.object-property-list.item-placeholder-text": "Platzhalterelement",
 	"components.overflow-group.moreActions": "Weitere Aktionen",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} Element}

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "more",
 	"components.object-property-list.item-placeholder-text": "Placeholder Item",
 	"components.overflow-group.moreActions": "More Actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/en.js
+++ b/lang/en.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "more",
 	"components.object-property-list.item-placeholder-text": "Placeholder Item",
 	"components.overflow-group.moreActions": "More Actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "más",
 	"components.object-property-list.item-placeholder-text": "Elemento de marcador de posición",
 	"components.overflow-group.moreActions": "Más acciones",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} elemento}

--- a/lang/es.js
+++ b/lang/es.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "más",
 	"components.object-property-list.item-placeholder-text": "Elemento de marcador de posición",
 	"components.overflow-group.moreActions": "Más acciones",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} elemento}

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "plus",
 	"components.object-property-list.item-placeholder-text": "Élément d’espace réservé",
 	"components.overflow-group.moreActions": "Plus d’actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} élément}

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "plus",
 	"components.object-property-list.item-placeholder-text": "Élément de paramètre fictif",
 	"components.overflow-group.moreActions": "Plus d’actions",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} élément}

--- a/lang/haw.js
+++ b/lang/haw.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "hou aku",
 	"components.object-property-list.item-placeholder-text": "Mea Paʻa Wahi",
 	"components.overflow-group.moreActions": "Nā Hana Hou",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} mea}

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "अधिक",
 	"components.object-property-list.item-placeholder-text": "प्लेसहोल्डर आइटम",
 	"components.overflow-group.moreActions": "अधिक क्रियाएँ",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} आइटम}

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -147,6 +147,8 @@ export default {
 	"components.more-less.more": "増やす",
 	"components.object-property-list.item-placeholder-text": "プレースホルダの項目",
 	"components.overflow-group.moreActions": "その他のアクション",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 個の項目}

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -147,6 +147,8 @@ export default {
 	"components.more-less.more": "더 보기",
 	"components.object-property-list.item-placeholder-text": "자리표시자 항목",
 	"components.overflow-group.moreActions": "추가 작업",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {해당 항목 수 {countFormatted}개}

--- a/lang/mi.js
+++ b/lang/mi.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "ētahi atu",
 	"components.object-property-list.item-placeholder-text": "Tūemi Puriwāhi",
 	"components.overflow-group.moreActions": "Ētahi atu Hohenga",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} Tūemi}

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "meer",
 	"components.object-property-list.item-placeholder-text": "Item tijdelijke aanduiding",
 	"components.overflow-group.moreActions": "Meer acties",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "mais",
 	"components.object-property-list.item-placeholder-text": "Item de espaço reservado",
 	"components.overflow-group.moreActions": "Mais ações",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "mer",
 	"components.object-property-list.item-placeholder-text": "Platshållarobjekt",
 	"components.overflow-group.moreActions": "Fler åtgärder",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} objekt}

--- a/lang/th.js
+++ b/lang/th.js
@@ -148,6 +148,8 @@ export default {
 	"components.more-less.more": "เพิ่มเติม",
 	"components.object-property-list.item-placeholder-text": "รายการตัวแทน",
 	"components.overflow-group.moreActions": "การดำเนินการเพิ่มเติม",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} รายการ}

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -152,6 +152,8 @@ export default {
 	"components.more-less.more": "daha fazla",
 	"components.object-property-list.item-placeholder-text": "Yer Tutucu Öğesi",
 	"components.overflow-group.moreActions": "Daha Fazla Eylem",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} öğe}

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -146,6 +146,8 @@ export default {
 	"components.more-less.more": "thêm",
 	"components.object-property-list.item-placeholder-text": "Mục giữ chỗ",
 	"components.overflow-group.moreActions": "Thêm các Tác vụ",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} mục}

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -147,6 +147,8 @@ export default {
 	"components.more-less.more": "更多",
 	"components.object-property-list.item-placeholder-text": "占位符项目",
 	"components.overflow-group.moreActions": "更多操作",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 项}

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -148,6 +148,8 @@ export default {
 	"components.more-less.more": "較多",
 	"components.object-property-list.item-placeholder-text": "預留位置項目",
 	"components.overflow-group.moreActions": "其他動作",
+	"components.page.header-nav-label": "Main",
+	"components.page.side-nav-label": "Side",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 個項目}


### PR DESCRIPTION
Example of what we need to do to fix all our sticky components with immersive-nav in a world with `body` scroll. I haven't tested all this, just quickly applied it to the components in the demo pages to show how it can fix it. It's not perfect, because if these things were nested in _another_ scrolling component, the consumer would need to know to set this variable back to `--d2l-sticky-offset` at that level.

But I haven't found a different way to cleanly do this with body scroll. Putting this up so others can experiment.