### PR TITLE
GAUD-9867: Tabs clean up: Remove unnecessary event from floating buttons demo

### DIFF
--- a/components/button/demo/floating-buttons-in-tabs.html
+++ b/components/button/demo/floating-buttons-in-tabs.html
@@ -169,10 +169,6 @@
 				tabTwo.classList.remove('vui-tabmenu-item-select');
 				tabTwo.classList.add('vui-tabmenu-item-select-next');
 				ctnTwo.classList.add('d2l-hidden');
-
-				tabOne.dispatchEvent(new CustomEvent(
-					'd2l-tab-panel-selected', { bubbles: true, composed: true }
-				));
 			});
 			tabTwo.addEventListener('click', () => {
 				tabOne.classList.add('vui-tabmenu-item-select-prev');
@@ -181,10 +177,6 @@
 				tabTwo.classList.remove('vui-tabmenu-item-select-next');
 				tabTwo.classList.add('vui-tabmenu-item-select');
 				ctnTwo.classList.remove('d2l-hidden');
-
-				tabTwo.dispatchEvent(new CustomEvent(
-					'd2l-tab-panel-selected', { bubbles: true, composed: true }
-				));
 			});
 			/* end: faux tabbing functionality */
 			let page_buttonCount = 0;


### PR DESCRIPTION
[Jira ticket](https://desire2learn.atlassian.net/browse/GAUD-9867)

Cleaning up the `d2l-tab-panel-selected` event usages and this doesn't seem to actually do anything at all. Let me know if I'm missing something.