### PR TITLE
fix: Tabs: Fix adding a selected tab when the first tab is already selected

### DIFF
--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -844,15 +844,15 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 		let selectedTab = null;
 		const newTabIds = {};
 		this._tabs?.forEach((tab) => {
-			if (this._initialized && !reduceMotion && this._tabs.length !== Object.keys(this._tabIds).length) {
+			const isNew = this._initialized && !this._tabIds[tab.id];
+			if (isNew && !reduceMotion && this._tabs.length !== Object.keys(this._tabIds).length) {
 				// if it's a new tab, update state to animate addition
-				if (!this._tabIds[tab.id]) {
-					this._tabIds[tab.id] = true;
-					tab.setAttribute('data-state', 'adding');
-				}
+				this._tabIds[tab.id] = true;
+				tab.setAttribute('data-state', 'adding');
 			}
-			if (!selectedTab && tab.selected && tab.getAttribute('data-state') !== 'removing') {
-				selectedTab = tab;
+			if (tab.selected && tab.getAttribute('data-state') !== 'removing') {
+				// Newly added tabs with selected=true take priority over existing selected tabs
+				if (!selectedTab || isNew) selectedTab = tab;
 			}
 			newTabIds[tab.id] = true;
 		});

--- a/components/tabs/test/tabs.test.js
+++ b/components/tabs/test/tabs.test.js
@@ -2,7 +2,7 @@ import '../tab.js';
 import '../tabs.js';
 import '../tab-panel.js';
 import '../demo/tabs-array.js';
-import { clickElem, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, html, nextFrame, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { spy } from 'sinon';
 
 const defaultFixture = html`
@@ -302,6 +302,42 @@ describe('d2l-tabs', () => {
 			await clickElem(tabs[2]);
 			checkIfSelected(tabs[0], false, el.shadowRoot.querySelectorAll('d2l-tab-panel')[0]);
 			checkIfSelected(tabs[2], true, el.shadowRoot.querySelectorAll('d2l-tab-panel')[2]);
+		});
+
+		it('should select newly-added tab with selected=true after a remove', async() => {
+			const el = await fixture(html`
+				<div>
+					<d2l-tabs>
+						<d2l-tab id="all" text="All" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="all" slot="panels">Tab content for All</d2l-tab-panel>
+						<d2l-tab id="biology" text="Biology" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="biology" slot="panels">Tab content for Biology</d2l-tab-panel>
+						<d2l-tab id="chemistry" text="Chemistry" slot="tabs"></d2l-tab>
+						<d2l-tab-panel labelled-by="chemistry" slot="panels">Tab content for Chemistry</d2l-tab-panel>
+					</d2l-tabs>
+				</div>
+			`);
+			const tabs = el.querySelector('d2l-tabs');
+
+			checkIfSelected(el.querySelector('#all'), true);
+
+			// Add a new selected tab
+			const newPanel = document.createElement('d2l-tab-panel');
+			newPanel.textContent = 'Content for New Tab';
+			newPanel.slot = 'panels';
+			newPanel.setAttribute('labelled-by', 'newTab');
+			tabs.appendChild(newPanel);
+
+			const newTab = document.createElement('d2l-tab');
+			newTab.text = 'New Tab';
+			newTab.slot = 'tabs';
+			newTab.id = 'newTab';
+			newTab.selected = true;
+			tabs.appendChild(newTab);
+			await nextFrame();
+
+			checkIfSelected(el.querySelector('#all'), false);
+			checkIfSelected(el.querySelector('#newTab'), true);
 		});
 	});
 });


### PR DESCRIPTION
[GAUD-9950](https://desire2learn.atlassian.net/browse/GAUD-9950)

**Problem**:
In the "Tabs (with slot)" demo, which has buttons for removing and adding tabs, I noticed that if I removed a tab, causing the first tab to be selected, then added a selected tab it wouldn't actually select.

**Solution Notes**:
This turns out to be an issue with the tab change code. It will favour the first tab it finds with selected state rather than taking a new tab that is selected into consideration.

[GAUD-9950]: https://desire2learn.atlassian.net/browse/GAUD-9950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ