### PR TITLE
Ensure backdrop remains to fadeout after apply is clicked

### DIFF
--- a/components/backdrop/backdrop-loading.js
+++ b/components/backdrop/backdrop-loading.js
@@ -153,17 +153,26 @@ class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitEleme
 
 	render() {
 		const forcedOffscreenSizelessStyles = OffSCREEN_SIZELESS ? {} : { height: '0px', width: '0px' };
-		const dirtyStateVisible = this._state !== 'hidden' && this.dataState === 'dirty';
+		const backdropVisible = this._state !== 'hidden';
 
 		return html`
-			${this._state === 'hidden' ? nothing :
+			${backdropVisible ?
 					html`<div id="visible">
 						<div class="backdrop" @transitionend="${this.#handleTransitionEnd}" @transitioncancel="${this.#handleTransitionEnd}"></div>
 						<d2l-loading-spinner style=${styleMap({ top: `${this._spinnerTop}px` })} size="${LOADING_SPINNER_SIZE}"></d2l-loading-spinner>
-					</div>`
+					</div>` : nothing
 			}
-			<div aria-live="polite" class="${classMap({ 'd2l-offscreen': !dirtyStateVisible })}" style="${styleMap(dirtyStateVisible ? {} : forcedOffscreenSizelessStyles)}">
-				${this.dataState === 'dirty' ? this.#renderDirtyOverlay() : this._ariaContent}
+			<div aria-live="polite" class="${classMap({ 'd2l-offscreen': !backdropVisible })}" style="${styleMap(backdropVisible ? {} : forcedOffscreenSizelessStyles)}">
+				${backdropVisible ?
+					html`<d2l-backdrop-dirty-overlay
+						style=${styleMap({ top: `${this._dirtyDialogTop}px` })}
+						description="${this.dirtyText}"
+						action="${this.dirtyButtonText}"
+						?inert=${this.dataState !== 'dirty'}
+					></d2l-backdrop-dirty-overlay>` : nothing }
+			</div>
+			<div aria-live="polite" class="${classMap({ 'd2l-offscreen': true })}" style="${styleMap(forcedOffscreenSizelessStyles)}">
+				${this._ariaContent}
 			</div>
 		`;
 	}
@@ -257,7 +266,7 @@ class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitEleme
 	#fade() {
 		let hideImmediately = reduceMotion || this._state === 'showing';
 		if (this._state === 'shown') {
-			const currentOpacity = getComputedStyle(this.shadowRoot.querySelector('.backdrop')).opacity;
+			const currentOpacity = getComputedStyle(this.shadowRoot.querySelector('d2l-backdrop-dirty-overlay')).opacity;
 			hideImmediately ||= (currentOpacity === '0');
 		}
 
@@ -294,14 +303,6 @@ class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitEleme
 		const containingBlock = this.#getBackdropTarget();
 
 		if (containingBlock.dataset.initiallyInert !== '1') containingBlock.removeAttribute('inert');
-	}
-
-	#renderDirtyOverlay() {
-		return html`<d2l-backdrop-dirty-overlay
-			style=${styleMap({ top: `${this._dirtyDialogTop}px` })}
-			description="${this.dirtyText}"
-			action="${this.dirtyButtonText}"
-		></d2l-backdrop-dirty-overlay>`;
 	}
 
 	#setLiveArea(content, { delay } = {}) {

--- a/components/backdrop/backdrop-loading.js
+++ b/components/backdrop/backdrop-loading.js
@@ -3,7 +3,6 @@ import '../loading-spinner/loading-spinner.js';
 import './backdrop-dirty-overlay.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { getComposedChildren, getComposedParent } from '../../helpers/dom.js';
-import { classMap } from 'lit/directives/class-map.js';
 import { getFlag } from '../../helpers/flags.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
@@ -162,17 +161,17 @@ class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitEleme
 						<d2l-loading-spinner style=${styleMap({ top: `${this._spinnerTop}px` })} size="${LOADING_SPINNER_SIZE}"></d2l-loading-spinner>
 					</div>` : nothing
 			}
-			<div aria-live="polite" class="${classMap({ 'd2l-offscreen': !backdropVisible })}" style="${styleMap(backdropVisible ? {} : forcedOffscreenSizelessStyles)}">
+			<div aria-live="polite" id="d2l-live-region">
 				${backdropVisible ?
 					html`<d2l-backdrop-dirty-overlay
-						style=${styleMap({ top: `${this._dirtyDialogTop}px` })}
+						style=${styleMap({ top: `${this._dirtyDialogTop}px`, display: backdropVisible ? undefined : 'none' })}
 						description="${this.dirtyText}"
 						action="${this.dirtyButtonText}"
 						?inert=${this.dataState !== 'dirty'}
 					></d2l-backdrop-dirty-overlay>` : nothing }
-			</div>
-			<div aria-live="polite" class="${classMap({ 'd2l-offscreen': true })}" style="${styleMap(forcedOffscreenSizelessStyles)}">
-				${this._ariaContent}
+				<d2l-offscreen style="${styleMap(forcedOffscreenSizelessStyles)}">
+					${this._ariaContent}
+				</div>
 			</div>
 		`;
 	}
@@ -266,7 +265,7 @@ class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitEleme
 	#fade() {
 		let hideImmediately = reduceMotion || this._state === 'showing';
 		if (this._state === 'shown') {
-			const currentOpacity = getComputedStyle(this.shadowRoot.querySelector('d2l-backdrop-dirty-overlay')).opacity;
+			const currentOpacity = getComputedStyle(this.shadowRoot.querySelector('#d2l-live-region')).opacity;
 			hideImmediately ||= (currentOpacity === '0');
 		}
 

--- a/components/backdrop/backdrop-loading.js
+++ b/components/backdrop/backdrop-loading.js
@@ -3,13 +3,10 @@ import '../loading-spinner/loading-spinner.js';
 import './backdrop-dirty-overlay.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { getComposedChildren, getComposedParent } from '../../helpers/dom.js';
-import { getFlag } from '../../helpers/flags.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 
 import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
-
-const OffSCREEN_SIZELESS = getFlag('d2l-offscreen-sizeless', true);
 
 const BACKDROP_DELAY_MS = 800;
 const FADE_DURATION_MS = 500;

--- a/components/backdrop/backdrop-loading.js
+++ b/components/backdrop/backdrop-loading.js
@@ -5,7 +5,6 @@ import { css, html, LitElement, nothing } from 'lit';
 import { getComposedChildren, getComposedParent } from '../../helpers/dom.js';
 import { getFlag } from '../../helpers/flags.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
-import { offscreenStyles } from '../offscreen/offscreen.js';
 
 import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -138,7 +137,7 @@ class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitEleme
 			@media (prefers-reduced-motion: reduce) {
 				* { transition: none; }
 			}
-		`, offscreenStyles];
+		`];
 	}
 
 	constructor() {
@@ -151,7 +150,6 @@ class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitEleme
 	}
 
 	render() {
-		const forcedOffscreenSizelessStyles = OffSCREEN_SIZELESS ? {} : { height: '0px', width: '0px' };
 		const backdropVisible = this._state !== 'hidden';
 
 		return html`
@@ -164,14 +162,14 @@ class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitEleme
 			<div aria-live="polite" id="d2l-live-region">
 				${backdropVisible ?
 					html`<d2l-backdrop-dirty-overlay
-						style=${styleMap({ top: `${this._dirtyDialogTop}px`, display: backdropVisible ? undefined : 'none' })}
+						style=${styleMap({ top: `${this._dirtyDialogTop}px` })}
 						description="${this.dirtyText}"
 						action="${this.dirtyButtonText}"
 						?inert=${this.dataState !== 'dirty'}
 					></d2l-backdrop-dirty-overlay>` : nothing }
-				<d2l-offscreen style="${styleMap(forcedOffscreenSizelessStyles)}">
+				<d2l-offscreen>
 					${this._ariaContent}
-				</div>
+				</d2l-offscreen>
 			</div>
 		`;
 	}


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/NTNGL-5471?atlOrigin=eyJpIjoiMWYyNDEzMjUyMWIzNDRjYmJkYWQ2NTg1N2QxYmUyNjAiLCJwIjoiaiJ9

While working on adding the dirty overlay to the list component, I noticed that recent accessibility changes were preventing the backdrop from fading out.

I'll point out what went wrong with inline comments.

This PR resolves the issue, as seen in this before/after:

**Before**

https://github.com/user-attachments/assets/c35b2823-a1e9-46a5-b045-08cded9c0ab8

**After**

https://github.com/user-attachments/assets/75a22cc7-b6f0-4f91-9b2f-99c8ae3d6da4

