### PR TITLE
GAUD-9889: refactor demo full nav

### DIFF
--- a/components/page/demo/page-component.js
+++ b/components/page/demo/page-component.js
@@ -32,6 +32,7 @@ import '../page-header-separator.js';
 import '../page-main.js';
 import '../page-side-nav.js';
 import '../page-supporting.js';
+import './page-header-full.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { navStyles } from './temp-nav-styles.js';
 import { selectStyles } from '../../inputs/input-select-styles.js';
@@ -86,7 +87,7 @@ class PageDemo extends LitElement {
 	render() {
 		return html`
 			<d2l-page width-type="${this.widthType}">
-				${this.navType === 'full' ? this.#renderFullNav() : this.#renderImmersiveNav()}
+				${this.navType === 'full' ? this.#renderHeaderFull() : this.#renderHeaderImmersive()}
 				${this.#renderSideNavPanel()}
 				${this.#renderMainPanel()}
 				${this.#renderSupportingPanel()}
@@ -175,38 +176,11 @@ class PageDemo extends LitElement {
 		` : nothing;
 	}
 
-	#renderFullNav() {
-		return html`
-			<d2l-page-header-custom has-skip-nav slot="header">
-				<div class="full-nav-header" slot="top">
-					<div class="full-nav-header-left">
-						<span class="full-nav-logo">Logo</span>
-						<d2l-page-header-separator></d2l-page-header-separator>
-						Course
-					</div>
-					<div class="full-nav-header-spacer"></div>
-					<div class="full-nav-header-right">
-						<d2l-page-header-button icon="tier3:classes" text="Select a course..." text-hidden></d2l-page-header-button>
-						<d2l-page-header-separator></d2l-page-header-separator>
-						<d2l-page-header-button icon="tier3:email" text="Message alerts" text-hidden></d2l-page-header-button>
-						<d2l-page-header-button icon="tier3:discussions" text="Subscription alerts" text-hidden></d2l-page-header-button>
-						<d2l-page-header-button icon="tier3:notification-bell" text="Update alerts" text-hidden></d2l-page-header-button>
-					</div>
-				</div>
-				<div class="full-nav-footer" slot="bottom">
-					<div class="full-nav-footer-inner">
-						<a class="full-nav-footer-link" href="javascript:void(0)">Content</a>
-						<a class="full-nav-footer-link" href="javascript:void(0)">Assignments</a>
-						<a class="full-nav-footer-link" href="javascript:void(0)">Quizzes</a>
-						<a class="full-nav-footer-link" href="javascript:void(0)">Grades</a>
-						<a class="full-nav-footer-link" href="javascript:void(0)">Classlist</a>
-					</div>
-				</div>
-			</d2l-page-header-custom>
-		`;
+	#renderHeaderFull() {
+		return html`<d2l-page-header-full-demo slot="header"></d2l-page-header-full-demo>`;
 	}
 
-	#renderImmersiveNav() {
+	#renderHeaderImmersive() {
 		return html`
 			<d2l-page-header-custom id="immersive-nav" slot="header">
 				<div class="immersive-container" slot="top">

--- a/components/page/demo/page-header-full.js
+++ b/components/page/demo/page-header-full.js
@@ -1,0 +1,96 @@
+import '../../colors/colors.js';
+import '../page-header-button.js';
+import '../page-header-custom.js';
+import '../page-header-separator.js';
+import { css, html, LitElement } from 'lit';
+
+class PageHeaderFullDemo extends LitElement {
+
+	static styles = css`
+		.full-nav-header {
+			align-items: center;
+			display: flex;
+			height: 90px;
+		}
+		.full-nav-header-left {
+			align-items: center;
+			display: flex;
+			flex: 0 1 auto;
+			gap: 5px;
+			height: 100%;
+		}
+		.full-nav-header-spacer {
+			flex: 1 1 auto;
+			min-width: 30px;
+		}
+		.full-nav-header-right {
+			align-items: center;
+			display: flex;
+			flex: 0 0 auto;
+			height: 100%;
+		}
+		.full-nav-header-right d2l-page-header-button {
+			margin-inline: 15px;
+		}
+		.full-nav-logo {
+			background-color: var(--d2l-color-celestine);
+			border-radius: 4px;
+			color: white;
+			font-size: 0.8rem;
+			font-weight: 700;
+			padding: 8px 14px;
+		}
+		.full-nav-footer-inner {
+			align-items: center;
+			display: flex;
+			flex-wrap: wrap;
+			gap: 20px;
+		}
+		.full-nav-footer-link {
+			border-bottom: 4px solid transparent;
+			color: var(--d2l-color-ferrite);
+			display: inline-block;
+			padding: 8px 0;
+			text-decoration: none;
+		}
+		.full-nav-footer-link:hover,
+		.full-nav-footer-link:focus-visible {
+			border-bottom-color: var(--d2l-color-celestine);
+			color: var(--d2l-color-celestine);
+		}
+	`;
+
+	render() {
+		return html`
+			<d2l-page-header-custom has-skip-nav>
+				<div class="full-nav-header" slot="top">
+					<div class="full-nav-header-left">
+						<span class="full-nav-logo">Logo</span>
+						<d2l-page-header-separator></d2l-page-header-separator>
+						Course
+					</div>
+					<div class="full-nav-header-spacer"></div>
+					<div class="full-nav-header-right">
+						<d2l-page-header-button icon="tier3:classes" text="Select a course..." text-hidden></d2l-page-header-button>
+						<d2l-page-header-separator></d2l-page-header-separator>
+						<d2l-page-header-button icon="tier3:email" text="Message alerts" text-hidden></d2l-page-header-button>
+						<d2l-page-header-button icon="tier3:discussions" text="Subscription alerts" text-hidden></d2l-page-header-button>
+						<d2l-page-header-button icon="tier3:notification-bell" text="Update alerts" text-hidden></d2l-page-header-button>
+					</div>
+				</div>
+				<div class="full-nav-footer" slot="bottom">
+					<div class="full-nav-footer-inner">
+						<a class="full-nav-footer-link" href="javascript:void(0)">Content</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Assignments</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Quizzes</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Grades</a>
+						<a class="full-nav-footer-link" href="javascript:void(0)">Classlist</a>
+					</div>
+				</div>
+			</d2l-page-header-custom>
+		`;
+	}
+
+}
+
+customElements.define('d2l-page-header-full-demo', PageHeaderFullDemo);

--- a/components/page/demo/temp-nav-styles.js
+++ b/components/page/demo/temp-nav-styles.js
@@ -6,60 +6,6 @@
 import { css } from 'lit';
 
 export const navStyles = css`
-
-	/* Full Nav Styles */
-	.full-nav-header {
-		align-items: center;
-		display: flex;
-		height: 90px;
-	}
-	.full-nav-header-left {
-		align-items: center;
-		display: flex;
-		flex: 0 1 auto;
-		gap: 5px;
-		height: 100%;
-	}
-	.full-nav-header-spacer {
-		flex: 1 1 auto;
-		min-width: 30px;
-	}
-	.full-nav-header-right {
-		align-items: center;
-		display: flex;
-		flex: 0 0 auto;
-		height: 100%;
-	}
-	.full-nav-header-right d2l-page-header-button {
-		margin-inline: 15px;
-	}
-	.full-nav-logo {
-		background-color: var(--d2l-color-celestine);
-		border-radius: 4px;
-		color: white;
-		font-size: 0.8rem;
-		font-weight: 700;
-		padding: 8px 14px;
-	}
-	.full-nav-footer-inner {
-		align-items: center;
-		display: flex;
-		flex-wrap: wrap;
-		gap: 20px;
-	}
-	.full-nav-footer-link {
-		border-bottom: 4px solid transparent;
-		color: var(--d2l-color-ferrite);
-		display: inline-block;
-		padding: 8px 0;
-		text-decoration: none;
-	}
-	.full-nav-footer-link:hover,
-	.full-nav-footer-link:focus-visible {
-		border-bottom-color: var(--d2l-color-celestine);
-		color: var(--d2l-color-celestine);
-	}
-
 	/* Immersive Nav Styles */
 	.immersive-container {
 		align-items: center;

--- a/components/page/page-header-button.js
+++ b/components/page/page-header-button.js
@@ -76,7 +76,7 @@ class PageHeaderButton extends FocusMixin(LitElement) {
 		const highlightBorder = !this.disabled ? html`<span class="d2l-page-header-highlight-border"></span>` : nothing;
 		const icon = html`<d2l-icon icon="${this.icon}"></d2l-icon>`;
 		return html`
-			<button id="${ifDefined(id)}" ?disabled="${this.disabled}" aria-label="${ifDefined(ariaLabel)}" type="button">
+			<button class="d2l-page-header-highlight-button" id="${ifDefined(id)}" ?disabled="${this.disabled}" aria-label="${ifDefined(ariaLabel)}" type="button">
 				${highlightBorder}
 				${this.iconPosition === 'start' ? icon : nothing}
 				${text}

--- a/components/page/page-header-styles.js
+++ b/components/page/page-header-styles.js
@@ -20,7 +20,7 @@ export const highlightBorderStyles = css`
 `;
 
 export const highlightButtonStyles = css`
-	button {
+	button.d2l-page-header-highlight-button {
 		align-items: center;
 		background: transparent;
 		border: none;
@@ -41,17 +41,17 @@ export const highlightButtonStyles = css`
 		white-space: nowrap;
 	}
 	/* Firefox includes a hidden border which messes up button dimensions */
-	button::-moz-focus-inner {
+	button.d2l-page-header-highlight-button::-moz-focus-inner {
 		border: 0;
 	}
-	button:not([disabled]):hover,
-	button:not([disabled]):focus,
-	button[active] {
+	button.d2l-page-header-highlight-button:not([disabled]):hover,
+	button.d2l-page-header-highlight-button:not([disabled]):focus,
+	button.d2l-page-header-highlight-button[active] {
 		--d2l-icon-fill-color: var(--d2l-color-celestine);
 		color: var(--d2l-color-celestine);
 		outline: none;
 	}
-	button[disabled] {
+	button.d2l-page-header-highlight-button[disabled] {
 		cursor: default;
 		opacity: 0.5;
 	}


### PR DESCRIPTION
Just doing a small refactor in preparation for the immersive nav work. This splits the "full nav" (aka LMS nav) out into its own component. The way I'm planning to communicate whether the headers are "sticky" or not is via events, so this being in its own demo component makes that easier. It's also closer to what consumers will actual do.