### PR TITLE
Remove d2l-test-runner config

### DIFF
--- a/d2l-test-runner.config.js
+++ b/d2l-test-runner.config.js
@@ -1,3 +1,0 @@
-export default {
-	pattern: type => `**/test/*.${type}.js`
-};


### PR DESCRIPTION
[GAUD-10033](https://desire2learn.atlassian.net/browse/GAUD-10033): Remove core d2l-test-runner config

Since BrightspaceUI/testing#979, we no longer need a custom file `pattern`.

[GAUD-10033]: https://desire2learn.atlassian.net/browse/GAUD-10033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ