### PR TITLE
GAUD-10045: removed golden/ auto approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 *       @BrightspaceUI/gaudi-dev
-golden/
 .vdiff.json
 package-lock.json


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/GAUD-10045

From discussion in above jira task. Right now the repo is set up for PRs changing `golden/ ` to be auto approved, but that folder doesn't exist at the root. Even if it does nothing, it sort of implies changes to goldens should be auto approved. So I'm removing that line. 

[Guide to set up auto approval of certain PRs](
https://github.com/BrightspaceUI/actions/tree/main/update-package-lock#setting-up-auto-approval)