### PR TITLE
Revert "GAUD-10045: removed golden/ auto approval"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 *       @BrightspaceUI/gaudi-dev
+golden/
 .vdiff.json
 package-lock.json


### PR DESCRIPTION
Reverts BrightspaceUI/core#7002 per [slack thread](https://d2l.slack.com/archives/G03Q166G2/p1779308561117639)