### PR TITLE
fix: Refocus only on internal components

### DIFF
--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -374,7 +374,7 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 		}
 		this._contentReady = true;
 		await this.updateComplete;
-		refocus.focus?.();
+		refocus?.focus?.();
 	}
 
 	async _handleSlotChange() {
@@ -407,7 +407,7 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 			this._refocus = this.shadowRoot.querySelector('.d2l-tag-list-button');
 		}
 		await this._refocus?.updateComplete;
-		(this._refocus || refocus).focus?.();
+		(this._refocus || refocus)?.focus?.();
 		this._refocus = null;
 	}
 

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -356,7 +356,8 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 	}
 
 	async _handleResize() {
-		const refocus = getComposedActiveElement();
+		let refocus = getComposedActiveElement();
+		if (!isComposedAncestor(this, refocus)) refocus = null;
 		this._contentReady = false;
 		this._chompIndex = 10000;
 		await this.updateComplete;
@@ -378,7 +379,8 @@ class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitEle
 
 	async _handleSlotChange() {
 		if (!this._hasResized) return;
-		const refocus = getComposedActiveElement();
+		let refocus = getComposedActiveElement();
+		if (!isComposedAncestor(this, refocus)) refocus = null;
 		this._contentReady = false;
 		await this.updateComplete;
 

--- a/components/tag-list/test/tag-list.test.js
+++ b/components/tag-list/test/tag-list.test.js
@@ -1,8 +1,9 @@
 import './tag-list-item-mixin-consumer.js';
 import '../tag-list.js';
 import '../tag-list-item.js';
-import { clickElem, expect, fixture, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, focusElem, html, oneEvent, runConstructor, sendKeysElem } from '@brightspace-ui/testing';
 import { getComposedActiveElement, getPreviousFocusable } from '../../../helpers/focus.js';
+import { spy } from 'sinon';
 
 const basicFixture = html`
 	<d2l-tag-list description="Testing Tags">
@@ -72,6 +73,33 @@ describe('d2l-tag-list', () => {
 			clickElem(button);
 
 			await oneEvent(elem, 'd2l-tag-list-clear');
+		});
+	});
+
+	describe('focus management', () => {
+		// Resizing logic removes focus from items, so we test proper focus management here
+
+		it('should keep focus on resize', async() => {
+			const elem = await fixture(basicFixture);
+			const item = elem._items[0];
+			const itemContent = item.shadowRoot.querySelector('.tag-list-item-content');
+			await focusElem(itemContent);
+			expect(getComposedActiveElement()).to.equal(itemContent);
+			await elem._handleResize();
+			expect(getComposedActiveElement()).to.equal(itemContent);
+		});
+
+		it('should not re-focus external elements on resize', async() => {
+			const elem = await fixture(html`<div>
+				${basicFixture}
+				<button id="external-button">External Button</button>
+			</div>`);
+			const button = elem.querySelector('#external-button');
+			await focusElem(button);
+			spy(button, 'focus');
+			await elem.querySelector('d2l-tag-list')._handleResize();
+			expect(getComposedActiveElement()).to.equal(button);
+			expect(button.focus.called).to.be.false;
 		});
 	});
 });


### PR DESCRIPTION
[GAUD-9997](https://desire2learn.atlassian.net/browse/GAUD-9997)

The resize logic was refocusing on the active element since the calculations were setting `visibility: hidden` and causing focus to be lost. However, it was refocusing on ANY element in the DOM, causing components like the html editor to loose their current state(e.g. editing).

This PR simply adds guards to check that the focus element is actually part of the tag-list

[GAUD-9997]: https://desire2learn.atlassian.net/browse/GAUD-9997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ