### PR TITLE
GAUD-10113 - Handle disconnected dialog more gracefully

### DIFF
--- a/components/backdrop/test/backdrop.test.js
+++ b/components/backdrop/test/backdrop.test.js
@@ -191,4 +191,19 @@ describe('d2l-backdrop', () => {
 
 	});
 
+	describe('on disconnect', () => {
+		it('should re-enable body scrolling when disconnected', async() => {
+			const elem = await fixture(backdropFixture);
+			const backdrop = elem.querySelector('d2l-backdrop');
+
+			backdrop.shown = true;
+			await backdrop.updateComplete;
+
+			expect(document.body.style.overflow).to.equal('hidden');
+
+			backdrop.remove();
+			expect(document.body.style.overflow).to.equal('');
+		});
+	});
+
 });

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -108,11 +108,10 @@ export const DialogMixin = superclass => class extends superclass {
 		super.disconnectedCallback();
 		window.removeEventListener('d2l-mvc-dialog-open', this._handleMvcDialogOpen);
 
-		// remove handlers, reset state and allow body scrolling if dialog is removed from the DOM before fully closing
-		this._removeHandlers();
-		this._state = null;
-		this.opened = false;
-		if (this._useNative) allowBodyScroll(this);
+		// If the dialog is disconnected before the close animation finishes
+		if (this.opened) {
+			this._handleClose();
+		}
 	}
 
 	async updated(changedProperties) {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -5,6 +5,7 @@ import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, getComposedChildren, isComposedAncestor } from '../../helpers/dom.js';
 import { getComposedActiveElement, getFirstFocusableDescendant, getFirstFocusableRelative, getNextFocusable, isFocusable } from '../../helpers/focus.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { getFlag } from '../../helpers/flags.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -24,6 +25,8 @@ window.D2L.DialogMixin.hasNative = (window.HTMLDialogElement !== undefined);
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const abortAction = 'abort';
 const defaultMargin = { top: 75, right: 30, bottom: 30, left: 30 };
+
+const closeDialogWhenDisconnectedFlag = getFlag('GAUD-10113-close-dialog-when-disconnected', true);
 
 export const DialogMixin = superclass => class extends superclass {
 
@@ -109,7 +112,7 @@ export const DialogMixin = superclass => class extends superclass {
 		window.removeEventListener('d2l-mvc-dialog-open', this._handleMvcDialogOpen);
 
 		// If the dialog is disconnected before the close animation finishes
-		if (this.opened) {
+		if (this.opened && closeDialogWhenDisconnectedFlag) {
 			this._handleClose();
 		}
 	}

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -107,6 +107,12 @@ export const DialogMixin = superclass => class extends superclass {
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		window.removeEventListener('d2l-mvc-dialog-open', this._handleMvcDialogOpen);
+
+		// remove handlers, reset state and allow body scrolling if dialog is removed from the DOM before fully closing
+		this._removeHandlers();
+		this._state = null;
+		this.opened = false;
+		if (this._useNative) allowBodyScroll(this);
 	}
 
 	async updated(changedProperties) {

--- a/components/dialog/test/dialog-mixin.test.js
+++ b/components/dialog/test/dialog-mixin.test.js
@@ -74,4 +74,27 @@ describe('dialog-mixin', () => {
 
 	});
 
+	describe('on disconnect', () => {
+		it('should close dialog and re-enable body scrolling when disconnected', async() => {
+			const elem = await fixture(`<${tagName} opened></${tagName}>`);
+			await oneEvent(elem, 'd2l-dialog-open');
+			expect(document.body.style.overflow).to.equal('hidden');
+
+			elem.remove();
+			expect(elem.opened).to.be.false;
+			expect(document.body.style.overflow).to.equal('');
+		});
+
+		it('should close dialog and re-enable body scrolling when disconnected for native dialogs', async() => {
+			const elem = await fixture(`<${tagName}></${tagName}>`);
+			elem._useNative = true;
+			elem.opened = true;
+			await oneEvent(elem, 'd2l-dialog-open');
+			expect(document.body.style.overflow).to.equal('hidden');
+
+			elem.remove();
+			expect(elem.opened).to.be.false;
+			expect(document.body.style.overflow).to.equal('');
+		});
+	});
 });


### PR DESCRIPTION
Right now, dialog doesn't do a great job of cleaning up after itself if it's ripped from the DOM before its close animation happens (which can happen if a dialog actions triggers a navigation).

This came up in the context of native dialogs not re-enabling scroll on the `body`, but I also found that dialog (native or not) leaves a `resize` event listener on the `window` as well. We're flagging this change as it does affect all dialogs.