### PR TITLE
feat: GAUD-10113 - Add back disconnect dialog more gracefully

### DIFF
--- a/components/backdrop/test/backdrop.test.js
+++ b/components/backdrop/test/backdrop.test.js
@@ -191,4 +191,19 @@ describe('d2l-backdrop', () => {
 
 	});
 
+	describe('on disconnect', () => {
+		it('should re-enable body scrolling when disconnected', async() => {
+			const elem = await fixture(backdropFixture);
+			const backdrop = elem.querySelector('d2l-backdrop');
+
+			backdrop.shown = true;
+			await backdrop.updateComplete;
+
+			expect(document.body.style.overflow).to.equal('hidden');
+
+			backdrop.remove();
+			expect(document.body.style.overflow).to.equal('');
+		});
+	});
+
 });

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -485,7 +485,7 @@ export const DialogMixin = superclass => class extends superclass {
 	_removeHandlers() {
 		window.removeEventListener('resize', this._updateSize);
 		this.removeEventListener('touchstart', this._handleTouchStart);
-		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-dialog-content').removeEventListener('scroll', this._updateOverflow);
+		this.shadowRoot?.querySelector('.d2l-dialog-content')?.removeEventListener('scroll', this._updateOverflow);
 	}
 
 	_render(inner, info, iframeTopOverride) {

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -5,6 +5,7 @@ import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { findComposedAncestor, getComposedChildren, isComposedAncestor } from '../../helpers/dom.js';
 import { getComposedActiveElement, getFirstFocusableDescendant, getFirstFocusableRelative, getNextFocusable, isFocusable } from '../../helpers/focus.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { getFlag } from '../../helpers/flags.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -24,6 +25,8 @@ window.D2L.DialogMixin.hasNative = (window.HTMLDialogElement !== undefined);
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const abortAction = 'abort';
 const defaultMargin = { top: 75, right: 30, bottom: 30, left: 30 };
+
+const closeDialogWhenDisconnectedFlag = getFlag('GAUD-10113-close-dialog-when-disconnected', true);
 
 export const DialogMixin = superclass => class extends superclass {
 
@@ -107,6 +110,11 @@ export const DialogMixin = superclass => class extends superclass {
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		window.removeEventListener('d2l-mvc-dialog-open', this._handleMvcDialogOpen);
+
+		// If the dialog is disconnected before the close animation finishes
+		if (this.opened && closeDialogWhenDisconnectedFlag) {
+			this._handleClose();
+		}
 	}
 
 	async updated(changedProperties) {

--- a/components/dialog/test/dialog-mixin.test.js
+++ b/components/dialog/test/dialog-mixin.test.js
@@ -74,4 +74,27 @@ describe('dialog-mixin', () => {
 
 	});
 
+	describe('on disconnect', () => {
+		it('should close dialog and re-enable body scrolling when disconnected', async() => {
+			const elem = await fixture(`<${tagName} opened></${tagName}>`);
+			await oneEvent(elem, 'd2l-dialog-open');
+			expect(document.body.style.overflow).to.equal('hidden');
+
+			elem.remove();
+			expect(elem.opened).to.be.false;
+			expect(document.body.style.overflow).to.equal('');
+		});
+
+		it('should close dialog and re-enable body scrolling when disconnected for native dialogs', async() => {
+			const elem = await fixture(`<${tagName}></${tagName}>`);
+			elem._useNative = true;
+			elem.opened = true;
+			await oneEvent(elem, 'd2l-dialog-open');
+			expect(document.body.style.overflow).to.equal('hidden');
+
+			elem.remove();
+			expect(elem.opened).to.be.false;
+			expect(document.body.style.overflow).to.equal('');
+		});
+	});
 });


### PR DESCRIPTION
This was [reverted this morning](https://github.com/BrightspaceUI/core/pull/7052). Adding the code back, with an extra safety check to handle the case where the dialog is disconnected before it has fully initialized all its internal pieces. That reulted in this error:
```
Error: Uncaught TypeError: Cannot read properties of null (reading 'removeEventListener') (http://localhost:8000/node_modules/@brightspace-ui/core/components/dialog/dialog-mixin.js:488)
```

This issue was seen in tests using `@open-wc/testing`'s `fixture` directly. It doesn't wait for the component to settle before executing the test like our `@brightspace-ui/testing` `fixture` wrapper does.