### PR TITLE
Refactor html-block styles so they can be used to replace Sass styles in BSI

### DIFF
--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -51,11 +51,8 @@ export const _generateHtmlBlockRootStyles = (selector) => {
  * A private helper method that should not be used by general consumers
  */
 export const _generateHtmlBlockContentStyles = (selector) => {
-	if (selector && !_isValidCssSelector(selector)) {
-		return;
-	} else if (!selector) {
-		selector = '';
-	}
+	if (!selector) selector = '';
+	else if (!_isValidCssSelector(selector)) return;
 
 	selector = unsafeCSS(selector);
 	return css`

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -1,6 +1,7 @@
 import '../colors/colors.js';
 import { codeStyles, createHtmlBlockRenderer as createCodeRenderer } from '../../helpers/prism.js';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, unsafeCSS } from 'lit';
+import { _isValidCssSelector } from '../../helpers/internal/css.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { createHtmlBlockRenderer as createMathRenderer } from '../../helpers/mathjax.js';
 import { getFocusRingStyles } from '../../helpers/focus.js';
@@ -9,120 +10,177 @@ import { renderEmbeds } from '../../helpers/embeds.js';
 import { requestInstance } from '../../mixins/provider/provider-mixin.js';
 import { tryGet } from '@brightspace-ui/lms-context-provider/client.js';
 
+/**
+ * A private helper method that should not be used by general consumers
+ */
+export const _generateHtmlBlockContainerStyles = (selector) => {
+	if (!_isValidCssSelector(selector)) return;
+
+	selector = unsafeCSS(selector);
+	return css`
+		${selector} {
+			line-height: 1.47; /* 1.4rem / 0.95rem */
+		}
+		${selector} > :first-child {
+			margin-top: 0;
+		}
+		${selector} > :last-child {
+			margin-bottom: 0;
+		}
+	`;
+};
+
+/**
+ * A private helper method that should not be used by general consumers
+ */
+export const _generateHtmlBlockRootStyles = (selector) => {
+	if (!_isValidCssSelector(selector)) return;
+
+	selector = unsafeCSS(selector);
+	return css`
+		${selector} {
+			overflow-wrap: break-word;
+			overflow-x: auto;
+			overflow-y: hidden;
+			text-align: start;
+		}
+	`;
+};
+
+/**
+ * A private helper method that should not be used by general consumers
+ */
+export const _generateHtmlBlockContentStyles = (selector) => {
+	if (selector && !_isValidCssSelector(selector)) {
+		return;
+	} else if (!selector) {
+		selector = '';
+	}
+
+	selector = unsafeCSS(selector);
+	return css`
+		${selector} h1,
+		${selector} h2,
+		${selector} h3,
+		${selector} h4,
+		${selector} h5,
+		${selector} h6,
+		${selector} b,
+		${selector} strong,
+		${selector} b *,
+		${selector} strong * {
+			font-weight: bold;
+		}
+
+		${selector} h1 {
+			font-size: 2em;
+			line-height: 1;
+			margin: 21px 0;
+		}
+		${selector} h2 {
+			font-size: 1.5em;
+			line-height: 1;
+			margin: 20px 0;
+		}
+		${selector} h3 {
+			font-size: 1.2em;
+			line-height: 1;
+			margin: 19px 0;
+		}
+		${selector} h4 {
+			font-size: 1em;
+			line-height: 1.05;
+			margin: 21px 0;
+		}
+		${selector} h5 {
+			font-size: 0.83em;
+			line-height: 1;
+			margin: 22px 0;
+		}
+		${selector} h6 {
+			font-size: 0.67em;
+			line-height: 1;
+			margin: 25px 0;
+		}
+		${selector} pre {
+			font-family: Monospace;
+			font-size: 13px;
+			margin: 13px 0;
+		}
+		${selector} p {
+			margin: 0.5em 0 1em 0;
+		}
+		${selector} ul,
+		${selector} ol {
+			list-style-position: outside;
+			margin: 1em 0;
+			padding-inline-start: 3em;
+		}
+		${selector} ul,
+		${selector} ul[type="disc"] {
+			list-style-type: disc;
+		}
+		${selector} ul ul,
+		${selector} ul ol,
+		${selector} ol ul,
+		${selector} ol ol {
+			margin-bottom: 0;
+			margin-top: 0;
+		}
+		${selector} ul ul,
+		${selector} ol ul,
+		${selector} ul[type="circle"] {
+			list-style-type: circle;
+		}
+		${selector} ul ul ul,
+		${selector} ul ol ul,
+		${selector} ol ul ul,
+		${selector} ol ol ul,
+		${selector} ul[type="square"] {
+			list-style-type: square;
+		}
+		${selector} a,
+		${selector} a:visited,
+		${selector} a:link,
+		${selector} a:active {
+			color: var(--d2l-color-celestine, #006fbf);
+			cursor: pointer;
+			text-decoration: none;
+		}
+		${selector} a:hover {
+			color: var(--d2l-color-celestine-minus-1, #004489);
+			text-decoration: underline;
+		}
+		${selector} a {
+			--d2l-focus-ring-offset: 1px;
+			--d2l-focus-ring-color: var(--d2l-color-celestine, #006fbf);
+		}
+		${getFocusRingStyles(`${selector} a`, { extraStyles: css`border-radius: 2px; text-decoration: underline;` })}
+		@media print {
+			${selector} a,
+			${selector} a:visited,
+			${selector} a:link,
+			${selector} a:active {
+				color: var(--d2l-color-ferrite, #202122);
+			}
+		}
+		${selector} mjx-assistive-mml math {
+			position: absolute;
+		}
+	`;
+};
+
 export const htmlBlockContentStyles = css`
-	.d2l-html-block-rendered {
-		line-height: 1.47; /* 1.4rem / 0.95rem */
-	}
-	.d2l-html-block-rendered > :first-child {
-		margin-top: 0;
-	}
-	.d2l-html-block-rendered > :last-child {
-		margin-bottom: 0;
-	}
+	${_generateHtmlBlockContainerStyles('.d2l-html-block-rendered')}
 	.d2l-html-block-compact {
 		font-size: 0.8rem;
 		font-weight: 400;
 		line-height: 1.5; /* 1.2rem / 0.8rem */
 	}
-	h1, h2, h3, h4, h5, h6, b, strong, b *, strong * {
-		font-weight: bold;
-	}
-	h1 {
-		font-size: 2em;
-		line-height: 1;
-		margin: 21px 0;
-	}
-	h2 {
-		font-size: 1.5em;
-		line-height: 1;
-		margin: 20px 0;
-	}
-	h3 {
-		font-size: 1.2em;
-		line-height: 1;
-		margin: 19px 0;
-	}
-	h4 {
-		font-size: 1em;
-		line-height: 1.05;
-		margin: 21px 0;
-	}
-	h5 {
-		font-size: 0.83em;
-		line-height: 1;
-		margin: 22px 0;
-	}
-	h6 {
-		font-size: 0.67em;
-		line-height: 1;
-		margin: 25px 0;
-	}
-	pre {
-		font-family: Monospace;
-		font-size: 13px;
-		margin: 13px 0;
-	}
-	p {
-		margin: 0.5em 0 1em 0;
-	}
-	ul, ol {
-		list-style-position: outside;
-		margin: 1em 0;
-		padding-inline-start: 3em;
-	}
+	${_generateHtmlBlockContentStyles()}
 	.d2l-html-block-compact ul,
 	.d2l-html-block-compact ol {
 		padding-inline-start: 1.5em;
-	}
-	ul, ul[type="disc"] {
-		list-style-type: disc;
-	}
-	ul ul,
-	ul ol,
-	ol ul,
-	ol ol {
-		margin-bottom: 0;
-		margin-top: 0;
-	}
-	ul ul,
-	ol ul,
-	ul[type="circle"] {
-		list-style-type: circle;
-	}
-	ul ul ul,
-	ul ol ul,
-	ol ul ul,
-	ol ol ul,
-	ul[type="square"] {
-		list-style-type: square;
-	}
-	a,
-	a:visited,
-	a:link,
-	a:active {
-		color: var(--d2l-color-celestine, #006fbf);
-		cursor: pointer;
-		text-decoration: none;
-	}
-	a:hover {
-		color: var(--d2l-color-celestine-minus-1, #004489);
-		text-decoration: underline;
-	}
-	a {
-		--d2l-focus-ring-offset: 1px;
-		--d2l-focus-ring-color: var(--d2l-color-celestine, #006fbf);
-	}
-	${getFocusRingStyles('a', { extraStyles: css`border-radius: 2px; text-decoration: underline;` })}
-	@media print {
-		a,
-		a:visited,
-		a:link,
-		a:active {
-			color: var(--d2l-color-ferrite, #202122);
-		}
-	}
-	mjx-assistive-mml math {
-		position: absolute;
 	}
 	${codeStyles}
 `;
@@ -174,11 +232,8 @@ class HtmlBlock extends LoadingCompleteMixin(LitElement) {
 		return [ htmlBlockContentStyles, css`
 			:host {
 				display: block;
-				overflow-wrap: break-word;
-				overflow-x: auto;
-				overflow-y: hidden;
-				text-align: start;
 			}
+			${_generateHtmlBlockRootStyles(':host')}
 			:host([inline]),
 			:host([inline]) .d2l-html-block-rendered {
 				display: inline;


### PR DESCRIPTION
[GAUD-6556](https://desire2learn.atlassian.net/browse/GAUD-6556)

This PR refactors the styles from `htmlBlockContentStyles` and `d2l-html-block` so that they can be used to replace the [html-block.scss styles in BSI](https://github.com/Brightspace/brightspace-integration/blob/23f3724f8a924a1ba379b5ea79b877be2af0a46b/sass/html-block.scss#L3). They will also be used to replace the [HtmlBlock styles in MVC](https://github.com/Brightspace/lms/blob/cdfb6f1617e5effdafaad8635e5ce577c615a6b9/lp/framework/web/D2L.LP.Web.UI/Desktop/Controls/HtmlBlock/HtmlBlock.css#L10).

The comparison can be seen in [this Confluence doc](https://desire2learn.atlassian.net/wiki/x/UgDXiAE).

[GAUD-6556]: https://desire2learn.atlassian.net/browse/GAUD-6556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ