### PR TITLE
GAUD-10125: upgrade ifrau

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@brightspace-ui/intl": "^3",
         "@brightspace-ui/lms-context-provider": "^1",
         "@open-wc/dedupe-mixin": "^2",
-        "ifrau": "^0.41",
+        "ifrau": "^0.42",
         "lit": "^3",
         "prismjs": "^1"
       },
@@ -7390,9 +7390,9 @@
       }
     },
     "node_modules/ifrau": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/ifrau/-/ifrau-0.41.4.tgz",
-      "integrity": "sha512-cIcgH8j+fsJ9brsSNKP62lkYA1hTd7F7q9XK2E6RXNBX6p4wJG2XBaJXvlxczgs8zTuAQv8Rc676wqH0MZEIfg==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/ifrau/-/ifrau-0.42.0.tgz",
+      "integrity": "sha512-Q74mjyCbqdej7mVAzdWXWlpFQIsrKWSvaSxzIkHmXHMIy0pyI5YqPfX1do/p+cBLWIA1eBfoNaH4gIv4P1lkIg==",
       "license": "Apache-2.0"
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@brightspace-ui/intl": "^3",
     "@brightspace-ui/lms-context-provider": "^1",
     "@open-wc/dedupe-mixin": "^2",
-    "ifrau": "^0.41",
+    "ifrau": "^0.42",
     "lit": "^3",
     "prismjs": "^1"
   }


### PR DESCRIPTION
I made the mistake of releasing a new "feature" in `ifrau` as a minor "feature" release but because it's still at `0.x` it gets treated as a major version by Dependabot/semver/etc. So I need to manually update everything to `0.42` and coordinate that in BSI.