### PR TITLE
Update PopoverMixin and DropdownPopoverMixin mobile styles to use --d2l-vh

### DIFF
--- a/components/dropdown/dropdown-popover-mixin.js
+++ b/components/dropdown/dropdown-popover-mixin.js
@@ -1,4 +1,5 @@
 import '../button/button.js';
+import '../../helpers/viewport-size.js';
 import '../../helpers/visualReady.js';
 import { css, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
@@ -164,7 +165,7 @@ export const DropdownPopoverMixin = superclass => class extends LocalizeCoreElem
 
 			:host([_mobile][_mobile-tray-location="inline-start"][opened]) .dropdown-content-layout,
 			:host([_mobile][_mobile-tray-location="inline-end"][opened]) .dropdown-content-layout {
-				height: 100vh;
+				height: calc(var(--d2l-vh, 1vh) * 100);
 			}
 		`];
 	}

--- a/components/dropdown/dropdown-popover-mixin.js
+++ b/components/dropdown/dropdown-popover-mixin.js
@@ -166,6 +166,7 @@ export const DropdownPopoverMixin = superclass => class extends LocalizeCoreElem
 			:host([_mobile][_mobile-tray-location="inline-start"][opened]) .dropdown-content-layout,
 			:host([_mobile][_mobile-tray-location="inline-end"][opened]) .dropdown-content-layout {
 				height: calc(var(--d2l-vh, 1vh) * 100);
+				height: 100dvh;
 			}
 		`];
 	}

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -1,6 +1,7 @@
 import '../backdrop/backdrop.js';
 import '../colors/colors.js';
 import '../focus-trap/focus-trap.js';
+import '../../helpers/viewport-size.js';
 import { addResizeNoopEventListener, getComposedParent, isComposedAncestor, removeResizeNoopEventListener } from '../../helpers/dom.js';
 import { clearDismissible, setDismissible } from '../../helpers/dismissible.js';
 import { css, html, nothing } from 'lit';
@@ -241,7 +242,7 @@ export const PopoverMixin = superclass => class extends superclass {
 
 			:host([_mobile][_mobile-tray-location="inline-start"][opened]) .content-container,
 			:host([_mobile][_mobile-tray-location="inline-end"][opened]) .content-container {
-				height: 100vh;
+				height: calc(var(--d2l-vh, 1vh) * 100);
 			}
 
 			:host([_mobile][_mobile-tray-location]) > .pointer {

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -243,6 +243,7 @@ export const PopoverMixin = superclass => class extends superclass {
 			:host([_mobile][_mobile-tray-location="inline-start"][opened]) .content-container,
 			:host([_mobile][_mobile-tray-location="inline-end"][opened]) .content-container {
 				height: calc(var(--d2l-vh, 1vh) * 100);
+				height: 100dvh;
 			}
 
 			:host([_mobile][_mobile-tray-location]) > .pointer {


### PR DESCRIPTION
[GAUD-10140](https://desire2learn.atlassian.net/browse/GAUD-10140)

This PR updates PopoverMixin and DropdownPopoverMixin mobile styles to use `--d2l-vh` instead of `vh` units. This helps to size the dropdown while accounting for space taken by the device's URL footer that otherwise obscures the "Close" button.

iPhone 11 Pro (showing the issue):

<img width="300" alt="image" src="https://github.com/user-attachments/assets/24a01b83-3404-41e9-a6be-abd381fd7b6e" />

[GAUD-10140]: https://desire2learn.atlassian.net/browse/GAUD-10140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ