### PR TITLE
GAUD-9872: Removes auto-show from daylight docs

### DIFF
--- a/components/overflow-group/README.md
+++ b/components/overflow-group/README.md
@@ -78,7 +78,6 @@ Items added to this container element will no longer wrap onto a second line whe
 
 | Property | Type | Description |
 |--|--|--|
-| `auto-show` | Boolean | Automatically determine the min and maximum number of items to show based on which elements have classes `d2l-button-group-show` and `d2l-button-group-no-show`. Please consult the design team when using this attribute. |
 | `min-to-show` | Number | The minimum number of elements to always show. Please consult the design team when using this attribute. |
 | `max-to-show` | Number | The maximum number of elements to show |
 | `opener-style` | String | Set the style of the overflow menu `default` renders a `d2l-button` while `subtle` will render a `d2l-button-subtle`|

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -66,7 +66,6 @@ function createMenuItemSeparator() {
  * A component that can be used to display a set of buttons, links or menus that will be put into a dropdown menu when they no longer fit on the first line of their container
  * @slot - Buttons, dropdown buttons, links or other items to be added to the container
  * @attr {'default'|'icon'} [opener-type="default"] - Set the opener type to 'icon' for a `...` menu icon instead of `More actions` text
- * @attr {boolean} auto-show - Use predefined classes on slot elements to set min and max buttons to show
 */
 class OverflowGroup extends OverflowGroupMixin(LitElement) {
 


### PR DESCRIPTION
## Jira
[GAUD-9872](https://desire2learn.atlassian.net/browse/GAUD-9872)

## Description

The original intention was to actually remove the attribute from the `d2l-overflow-group` component because semantically speaking it is confusing and also its implementation.
Unfortunately it is currently being used in the LMS in a way that is very risky to get rid of it.

### TLDR

There are three different types of buttons that use the 2 dedicated CSS classes (`d2l-button-group-no-show`, `d2l-button-group-show`) that works along the `auto-show` attribute from the `d2l-overflow-group` component
- [ActionButton.cs](https://github.com/Brightspace/lms/blob/75efa9ccd09f209c6e5d9a7542d310bbba5b8b03/lp/framework/web/D2L.Web/ui/ActionButtons/ActionButton.cs#L93)
- [ActionButtonMenu.cs](https://github.com/Brightspace/lms/blob/75efa9ccd09f209c6e5d9a7542d310bbba5b8b03/lp/framework/web/D2L.Web/ui/ActionButtons/ActionButtonMenu.cs#L95)
- [ActionButtonGroup.cs](https://github.com/Brightspace/lms/blob/75efa9ccd09f209c6e5d9a7542d310bbba5b8b03/lp/framework/web/D2L.Web/ui/ActionButtons/ActionButtonGroup.cs#L72)

These 3 classes are being instantiated by the `ActionButtons.cs` that is being instantiated from the d2lPageControl which is being call from 100s of places in the LMS project.

The conclusion that the team came up on this [thread in slack](https://d2l.slack.com/archives/G03Q166G2/p1764785567703669), was to hide this attribute from the [Daylight's documentation](https://daylight.d2l.dev/components/overflow-group/).

This PR addresses that last part

[GAUD-9872]: https://desire2learn.atlassian.net/browse/GAUD-9872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ