### PR TITLE
GAUD-10119: update height of object-property-list demo iframes

### DIFF
--- a/components/object-property-list/README.md
+++ b/components/object-property-list/README.md
@@ -2,7 +2,7 @@
 
 Object property lists are simple dot-separated lists of text, displayed sequentially on a single line. They are used to convey additional information or metadata about an object.
 
-<!-- docs: demo -->
+<!-- docs: demo autoSize:false size:xsmall -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
@@ -40,7 +40,7 @@ Object property lists are simple dot-separated lists of text, displayed sequenti
 
 An object property list can be defined using `d2l-object-property-list` and a combination of items (e.g., `d2l-object-property-list-item`, `d2l-object-property-list-item-link`).
 
-<!-- docs: demo code properties name:d2l-object-property-list sandboxTitle:'Object Property List' -->
+<!-- docs: demo code properties name:d2l-object-property-list sandboxTitle:'Object Property List' autoSize:false size:xsmall -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
@@ -142,7 +142,7 @@ The `d2l-object-property-list-item-link` component is a link item for the object
 
 The `d2l-object-property-list-item-tooltip-help` component is an item for the object property list which is used to also display additional information for users. It displays text as a help tooltip, with an optional leading icon.
 
-<!-- docs: demo code properties name:d2l-object-property-list-item-tooltip-help sandboxTitle:'Object Property List Help Tooltip Item' -->
+<!-- docs: demo code properties name:d2l-object-property-list-item-tooltip-help sandboxTitle:'Object Property List Help Tooltip Item' autoSize:false size:xsmall -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';

--- a/components/object-property-list/README.md
+++ b/components/object-property-list/README.md
@@ -2,7 +2,7 @@
 
 Object property lists are simple dot-separated lists of text, displayed sequentially on a single line. They are used to convey additional information or metadata about an object.
 
-<!-- docs: demo autoSize:false size:xsmall -->
+<!-- docs: demo align:start autoSize:false size:small -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
@@ -40,7 +40,7 @@ Object property lists are simple dot-separated lists of text, displayed sequenti
 
 An object property list can be defined using `d2l-object-property-list` and a combination of items (e.g., `d2l-object-property-list-item`, `d2l-object-property-list-item-link`).
 
-<!-- docs: demo code properties name:d2l-object-property-list sandboxTitle:'Object Property List' autoSize:false size:xsmall -->
+<!-- docs: demo code properties name:d2l-object-property-list sandboxTitle:'Object Property List' align:start autoSize:false size:small -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';
@@ -142,7 +142,7 @@ The `d2l-object-property-list-item-link` component is a link item for the object
 
 The `d2l-object-property-list-item-tooltip-help` component is an item for the object property list which is used to also display additional information for users. It displays text as a help tooltip, with an optional leading icon.
 
-<!-- docs: demo code properties name:d2l-object-property-list-item-tooltip-help sandboxTitle:'Object Property List Help Tooltip Item' autoSize:false size:xsmall -->
+<!-- docs: demo code properties name:d2l-object-property-list-item-tooltip-help sandboxTitle:'Object Property List Help Tooltip Item' align:start autoSize:false size:small -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/object-property-list/object-property-list.js';


### PR DESCRIPTION
Jira: [GAUD-10119](https://desire2learn.atlassian.net/browse/GAUD-10119)

There are 3 iframes with a tooltip-help. We need to set the size and disable autoSize to prevent the iframe from shrinking
<img width="2814" height="1939" alt="Screenshot 2026-06-15 111250" src="https://github.com/user-attachments/assets/b233f91a-774a-4389-a877-0c358e079b7c" />
<img width="2756" height="1168" alt="Screenshot 2026-06-15 115928" src="https://github.com/user-attachments/assets/61eda318-c0d3-40be-9263-1224e8bcab81" />
<img width="2783" height="1199" alt="Screenshot 2026-06-15 115939" src="https://github.com/user-attachments/assets/b51564f0-7c4a-4fe3-bc80-301702de2187" />



[GAUD-10119]: https://desire2learn.atlassian.net/browse/GAUD-10119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ