### PR TITLE
Export new tabs structure flag for re-use

### DIFF
--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -1,6 +1,6 @@
 import { css } from 'lit';
 import { getUniqueId } from '../../helpers/uniqueId.js';
-import { useNewTabsStructureFlag } from './tabs.js';
+import { getUseNewTabsStructureFlag } from './tabs.js';
 
 export const TabPanelMixin = superclass => class extends superclass {
 
@@ -101,6 +101,6 @@ export const TabPanelMixin = superclass => class extends superclass {
 		});
 	}
 
-	#useTabsNewStructure = useNewTabsStructureFlag;
+	#useTabsNewStructure = getUseNewTabsStructureFlag();
 
 };

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -1,5 +1,4 @@
 import { css } from 'lit';
-import { getFlag } from '../../helpers/flags.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { useNewTabsStructureFlag } from './tabs.js';
 

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -1,6 +1,7 @@
 import { css } from 'lit';
 import { getFlag } from '../../helpers/flags.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
+import { useNewTabsStructureFlag } from './tabs.js';
 
 export const TabPanelMixin = superclass => class extends superclass {
 
@@ -101,6 +102,6 @@ export const TabPanelMixin = superclass => class extends superclass {
 		});
 	}
 
-	#useTabsNewStructure = getFlag('GAUD-8299-core-tabs-use-new-structure', false);
+	#useTabsNewStructure = useNewTabsStructureFlag;
 
 };

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -15,7 +15,9 @@ import { repeat } from 'lit/directives/repeat.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-export const useNewTabsStructureFlag = getFlag('GAUD-8299-core-tabs-use-new-structure', false);
+export function getUseNewTabsStructureFlag() {
+	return getFlag('GAUD-8299-core-tabs-use-new-structure', false);
+}
 
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
@@ -429,7 +431,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 
 	#GAUD_9963_FLAG = getFlag('GAUD-9963-dropdown-tabs-not-resizing', false);
 	#checkTabPanelMatchRequested;
-	#newTabsPanelStructure = useNewTabsStructureFlag;
+	#newTabsPanelStructure = getUseNewTabsStructureFlag();
 	#panels;
 	#updateAriaControlsRequested;
 

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -15,6 +15,8 @@ import { repeat } from 'lit/directives/repeat.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
+export const useNewTabsStructureFlag = getFlag('GAUD-8299-core-tabs-use-new-structure', true);
+
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 const scrollButtonWidth = 56;
@@ -427,7 +429,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 
 	#GAUD_9963_FLAG = getFlag('GAUD-9963-dropdown-tabs-not-resizing', false);
 	#checkTabPanelMatchRequested;
-	#newTabsPanelStructure = getFlag('GAUD-8299-core-tabs-use-new-structure', false);
+	#newTabsPanelStructure = useNewTabsStructureFlag;
 	#panels;
 	#updateAriaControlsRequested;
 

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -15,7 +15,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-export const useNewTabsStructureFlag = getFlag('GAUD-8299-core-tabs-use-new-structure', true);
+export const useNewTabsStructureFlag = getFlag('GAUD-8299-core-tabs-use-new-structure', false);
 
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 


### PR DESCRIPTION
[GAUD-10150](https://desire2learn.atlassian.net/browse/GAUD-10150)

This PR updates `tabs.js` and `tab-panel-mixin.js` to get the flag in one place so that the default/fallback is defined in a single spot. It also exports this flag since we need to check it in the labs component.

It leaves the default as `false` for the moment. We will update the default once the labs component has been fixed.


[GAUD-10150]: https://desire2learn.atlassian.net/browse/GAUD-10150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ