### PR TITLE
fix: radio styles fail if container is undefined

### DIFF
--- a/components/inputs/input-radio-styles.js
+++ b/components/inputs/input-radio-styles.js
@@ -50,7 +50,7 @@ function _getRadioStyleSelectors(inputSelectors) {
  * A private helper method that should not be used by general consumers
  */
 export function _generateRadioStyles(selector, containerSelector) {
-	if (!_isValidCssSelector(selector) || !_isValidCssSelector(containerSelector)) return '';
+	if (!_isValidCssSelector(selector) || (containerSelector && !_isValidCssSelector(containerSelector))) return '';
 	const inputSelectors = [selector];
 	if (containerSelector) {
 		inputSelectors.push(`${containerSelector} > input[type="radio"]`);


### PR DESCRIPTION
[GAUD-8849](https://desire2learn.atlassian.net/browse/GAUD-8849)

BSI needs to generate the styles only for the input but leaving the `containerSelector` undefined would make the function fail.

[GAUD-8849]: https://desire2learn.atlassian.net/browse/GAUD-8849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ