### PR TITLE
GAUD-8848:  Remove label.scss

### DIFF
--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -69,7 +69,7 @@ export function _generateInputLabelRequiredStyles(selectorConfigList) {
 const inputLabelSimpleStyles = _generateInputLabelStyles([{ selector: '.d2l-input-label' }]);
 const inputLabelRequiredStyles = _generateInputLabelRequiredStyles([
 	{ container: ':host([required])', selector: '.d2l-input-label', after: true },
-	{ selector: '.d2l-input-label-required', after: false }
+	{ selector: '.d2l-input-label-required', after: true }
 ]);
 
 export const inputLabelStyles = css`

--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -9,7 +9,9 @@ registerSemanticVariableForSvgImageUrl(
 	</svg>`
 );
 
-const _parseSelectors = (selectors) => unsafeCSS(selectors.map(s => s.trim()).join(',\n'));
+function _parseSelectors(selectors) {
+	return unsafeCSS(selectors.map(s => s.trim()).join(',\n'));
+}
 
 function _buildCssSelector({ container, selector, after }) {
 	let cssSelector = `${selector}`;
@@ -22,9 +24,9 @@ function _buildCssSelector({ container, selector, after }) {
 /**
  * A private helper method that should not be used by general consumers
  */
-export function _generateInputLabelStyles(selectors) {
-	if (!selectors.map(s => s.selector).every(_isValidCssSelector)) return;
-	const cssMappedSelectors = selectors.map(_buildCssSelector);
+export function _generateInputLabelStyles(selectorConfigList) {
+	if (!selectorConfigList.map(s => s.selector).every(_isValidCssSelector)) return;
+	const cssMappedSelectors = selectorConfigList.map(_buildCssSelector);
 	const cssSelector = _parseSelectors(cssMappedSelectors);
 
 	return css`
@@ -45,9 +47,9 @@ export function _generateInputLabelStyles(selectors) {
 /**
  * A private helper method that should not be used by general consumers
  */
-export function _generateInputLabelRequiredStyles(selectors) {
-	if (!selectors.map(s => s.selector).every(_isValidCssSelector)) return;
-	const cssMappedSelectors = selectors.map(_buildCssSelector);
+export function _generateInputLabelRequiredStyles(selectorConfigList) {
+	if (!selectorConfigList.map(s => s.selector).every(_isValidCssSelector)) return;
+	const cssMappedSelectors = selectorConfigList.map(_buildCssSelector);
 	const cssSelector = _parseSelectors(cssMappedSelectors);
 
 	return css`

--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -9,25 +9,13 @@ registerSemanticVariableForSvgImageUrl(
 	</svg>`
 );
 
-function _parseSelectors(selectors) {
-	return unsafeCSS(selectors.map(s => s.trim()).join(',\n'));
-}
-
-function _buildCssSelector({ container, selector, after }) {
-	let cssSelector = `${selector}`;
-	if (container) cssSelector = `${container} ${cssSelector}`;
-	if (after) cssSelector = `${cssSelector}::after`;
-
-	return cssSelector;
-}
-
 /**
  * A private helper method that should not be used by general consumers
  */
-export function _generateInputLabelStyles(selectorConfigList) {
-	if (!selectorConfigList.map(s => s.selector).every(_isValidCssSelector)) return;
-	const cssMappedSelectors = selectorConfigList.map(_buildCssSelector);
-	const cssSelector = _parseSelectors(cssMappedSelectors);
+export function _generateInputLabelStyles(selector) {
+	if (!selector || !_isValidCssSelector(selector.trim())) return;
+	const trimmedSelector = selector.trim().split(',').map(s => s.trim()).join(',\n');
+	const cssSelector = unsafeCSS(trimmedSelector);
 
 	return css`
 		${cssSelector} {
@@ -47,10 +35,11 @@ export function _generateInputLabelStyles(selectorConfigList) {
 /**
  * A private helper method that should not be used by general consumers
  */
-export function _generateInputLabelRequiredStyles(selectorConfigList) {
-	if (!selectorConfigList.map(s => s.selector).every(_isValidCssSelector)) return;
-	const cssMappedSelectors = selectorConfigList.map(_buildCssSelector);
-	const cssSelector = _parseSelectors(cssMappedSelectors);
+export function _generateInputLabelRequiredStyles(selector) {
+	if (!selector || !_isValidCssSelector(selector.trim())) return;
+	const selectorList = selector.trim().split(',');
+	const joinedSelector = selectorList.map(s => `${s.trim()}::after`).join(',\n');
+	const cssSelector = unsafeCSS(joinedSelector);
 
 	return css`
 		${cssSelector} {
@@ -66,15 +55,9 @@ export function _generateInputLabelRequiredStyles(selectorConfigList) {
 	`;
 }
 
-const inputLabelSimpleStyles = _generateInputLabelStyles([{ selector: '.d2l-input-label' }]);
-const inputLabelRequiredStyles = _generateInputLabelRequiredStyles([
-	{ container: ':host([required])', selector: '.d2l-input-label', after: true },
-	{ selector: '.d2l-input-label-required', after: true }
-]);
-
 export const inputLabelStyles = css`
-	${inputLabelSimpleStyles}
-	${inputLabelRequiredStyles}
+	${_generateInputLabelStyles('.d2l-input-label')}
+	${_generateInputLabelRequiredStyles(':host([required]) .d2l-input-label,.d2l-input-label-required')}
 	:host([skeleton]) .d2l-input-label.d2l-skeletize::before {
 		bottom: 0.25rem;
 		top: 0.15rem;

--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -66,12 +66,15 @@ export function _generateInputLabelRequiredStyles(selectorConfigList) {
 	`;
 }
 
+const inputLabelSimpleStyles = _generateInputLabelStyles([{ selector: '.d2l-input-label' }]);
+const inputLabelRequiredStyles = _generateInputLabelRequiredStyles([
+	{ container: ':host([required])', selector: '.d2l-input-label', after: true },
+	{ selector: '.d2l-input-label-required', after: false }
+]);
+
 export const inputLabelStyles = css`
-	${_generateInputLabelStyles([{ selector: '.d2l-input-label' }])}
-	${_generateInputLabelRequiredStyles([
-		{ container: ':host([required])', selector: '.d2l-input-label', after: true },
-		{ selector: '.d2l-input-label-required', after: false }
-	])}
+	${inputLabelSimpleStyles}
+	${inputLabelRequiredStyles}
 	:host([skeleton]) .d2l-input-label.d2l-skeletize::before {
 		bottom: 0.25rem;
 		top: 0.15rem;

--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -9,16 +9,24 @@ registerSemanticVariableForSvgImageUrl(
 	</svg>`
 );
 
-function _parseSelectors(selectors) {
-	return unsafeCSS(selectors.map(s => s.trim()).join(',\n'));
+const _parseSelectors = (selectors) => unsafeCSS(selectors.map(s => s.trim()).join(',\n'));
+
+function _buildCssSelector({ container, selector, after }) {
+	let cssSelector = `${selector}`;
+	if (container) cssSelector = `${container} ${cssSelector}`;
+	if (after) cssSelector = `${cssSelector}::after`;
+
+	return cssSelector;
 }
 
 /**
  * A private helper method that should not be used by general consumers
  */
 export function _generateInputLabelStyles(selectors) {
-	if (!selectors.every(_isValidCssSelector)) return;
-	const cssSelector = _parseSelectors(selectors);
+	if (!selectors.map(s => s.selector).every(_isValidCssSelector)) return;
+	const cssMappedSelectors = selectors.map(_buildCssSelector);
+	const cssSelector = _parseSelectors(cssMappedSelectors);
+
 	return css`
 		${cssSelector} {
 			cursor: default;
@@ -38,8 +46,10 @@ export function _generateInputLabelStyles(selectors) {
  * A private helper method that should not be used by general consumers
  */
 export function _generateInputLabelRequiredStyles(selectors) {
-	if (!selectors.every(_isValidCssSelector)) return;
-	const cssSelector = _parseSelectors(selectors);
+	if (!selectors.map(s => s.selector).every(_isValidCssSelector)) return;
+	const cssMappedSelectors = selectors.map(_buildCssSelector);
+	const cssSelector = _parseSelectors(cssMappedSelectors);
+
 	return css`
 		${cssSelector} {
 			background-image: var(--d2l-input-label-required-image);
@@ -55,8 +65,11 @@ export function _generateInputLabelRequiredStyles(selectors) {
 }
 
 export const inputLabelStyles = css`
-	${_generateInputLabelStyles(['.d2l-input-label'])}
-	${_generateInputLabelRequiredStyles([':host([required]) .d2l-input-label::after', '.d2l-input-label-required::after'])}
+	${_generateInputLabelStyles([{ selector: '.d2l-input-label' }])}
+	${_generateInputLabelRequiredStyles([
+		{ container: ':host([required])', selector: '.d2l-input-label', after: true },
+		{ selector: '.d2l-input-label-required', after: false }
+	])}
 	:host([skeleton]) .d2l-input-label.d2l-skeletize::before {
 		bottom: 0.25rem;
 		top: 0.15rem;

--- a/components/inputs/input-label-styles.js
+++ b/components/inputs/input-label-styles.js
@@ -1,4 +1,5 @@
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
+import { _isValidCssSelector } from '../../helpers/internal/css.js';
 import { registerSemanticVariableForSvgImageUrl } from '../colors/colors.js';
 
 registerSemanticVariableForSvgImageUrl(
@@ -8,29 +9,54 @@ registerSemanticVariableForSvgImageUrl(
 	</svg>`
 );
 
+function _parseSelectors(selectors) {
+	return unsafeCSS(selectors.map(s => s.trim()).join(',\n'));
+}
+
+/**
+ * A private helper method that should not be used by general consumers
+ */
+export function _generateInputLabelStyles(selectors) {
+	if (!selectors.every(_isValidCssSelector)) return;
+	const cssSelector = _parseSelectors(selectors);
+	return css`
+		${cssSelector} {
+			cursor: default;
+			display: block;
+			font-size: 0.7rem;
+			font-weight: 700;
+			letter-spacing: 0.2px;
+			line-height: 0.9rem;
+			margin-block: 0 0.4rem;
+			margin-inline: 0;
+			padding: 0;
+		}
+	`;
+}
+
+/**
+ * A private helper method that should not be used by general consumers
+ */
+export function _generateInputLabelRequiredStyles(selectors) {
+	if (!selectors.every(_isValidCssSelector)) return;
+	const cssSelector = _parseSelectors(selectors);
+	return css`
+		${cssSelector} {
+			background-image: var(--d2l-input-label-required-image);
+			bottom: 0.25rem;
+			content: "";
+			display: inline-block;
+			height: 0.3rem;
+			inset-inline-start: 0.15rem;
+			position: relative;
+			width: 0.25rem;
+		}
+	`;
+}
+
 export const inputLabelStyles = css`
-	.d2l-input-label {
-		cursor: default;
-		display: block;
-		font-size: 0.7rem;
-		font-weight: 700;
-		letter-spacing: 0.2px;
-		line-height: 0.9rem;
-		margin-block: 0 0.4rem;
-		margin-inline: 0;
-		padding: 0;
-	}
-	:host([required]) .d2l-input-label::after,
-	.d2l-input-label-required::after {
-		background-image: var(--d2l-input-label-required-image);
-		bottom: 0.25rem;
-		content: "";
-		display: inline-block;
-		height: 0.3rem;
-		inset-inline-start: 0.15rem;
-		position: relative;
-		width: 0.25rem;
-	}
+	${_generateInputLabelStyles(['.d2l-input-label'])}
+	${_generateInputLabelRequiredStyles([':host([required]) .d2l-input-label::after', '.d2l-input-label-required::after'])}
 	:host([skeleton]) .d2l-input-label.d2l-skeletize::before {
 		bottom: 0.25rem;
 		top: 0.15rem;

--- a/helpers/internal/css.js
+++ b/helpers/internal/css.js
@@ -1,6 +1,6 @@
 export function _isValidCssSelector(selector) {
 	const partIsValid = (part) => {
-		const re = /([a-zA-Z0-9-_ >.#]+)(\[[a-zA-Z0-9-_="]+\])?([a-zA-Z0-9-_ >.#]+)?/g;
+		const re = /([:a-zA-Z0-9-_ >.#]+)(\(?\[[a-zA-Z0-9-_="]+\]\)?)?([a-zA-Z0-9-_ >.#]+)?/g;
 		if (part === ':host') return true;
 		const match = part.match(re);
 		const isValid = !!match && match.length === 1 && match[0].length === part.length;

--- a/helpers/test/css.test.js
+++ b/helpers/test/css.test.js
@@ -48,10 +48,10 @@ describe('_isValidCssSelector', () => {
 		expect(_isValidCssSelector('.valid, invalid$')).to.be.false;
 	});
 
-	it('should not support complex :host selectors', () => {
-		expect(_isValidCssSelector(':host p')).to.be.false;
-		expect(_isValidCssSelector(':host([hidden])')).to.be.false;
-		expect(_isValidCssSelector(':host([dir="rtl"])')).to.be.false;
+	it('should support complex :host selectors', () => {
+		expect(_isValidCssSelector(':host p')).to.be.true;
+		expect(_isValidCssSelector(':host([hidden])')).to.be.true;
+		expect(_isValidCssSelector(':host([dir="rtl"])')).to.be.true;
 	});
 
 	it('should not support invalid selectors', () => {

--- a/helpers/test/css.test.js
+++ b/helpers/test/css.test.js
@@ -54,6 +54,12 @@ describe('_isValidCssSelector', () => {
 		expect(_isValidCssSelector(':host([dir="rtl"])')).to.be.true;
 	});
 
+	it('should not support complex :host selectors with pseudo-classes', () => {
+		expect(_isValidCssSelector(':host(:hover)')).to.be.false;
+		expect(_isValidCssSelector(':host(:focus)')).to.be.false;
+		expect(_isValidCssSelector(':host(:active)')).to.be.false;
+	});
+
 	it('should not support invalid selectors', () => {
 		expect(_isValidCssSelector('a[b[c]]')).to.be.false;
 		expect(_isValidCssSelector('abc$')).to.be.false;


### PR DESCRIPTION
This is the first PR of a series to remove the SASS code in core and BSI and only use the CSS styles for input labels.

In this PR I expose 2 new functions that will be used in BSI to generate the CSS there.