### PR TITLE
Set GAUD-9398-make-backdrop-inert default/fallback to true.

### DIFF
--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -182,7 +182,7 @@ function hideAccessible(target) {
 			}
 			child.setAttribute('tabindex', '-1');
 
-			if (getFlag('GAUD-9398-make-backdrop-inert', false)) {
+			if (getFlag('GAUD-9398-make-backdrop-inert', true)) {
 				if (child.hasAttribute('inert')) {
 					child.setAttribute(BACKDROP_INERT, '');
 				}
@@ -222,7 +222,7 @@ function showAccessible(elems) {
 		} else {
 			elem.removeAttribute('tabindex');
 		}
-		if (getFlag('GAUD-9398-make-backdrop-inert', false)) {
+		if (getFlag('GAUD-9398-make-backdrop-inert', true)) {
 			if (elem.hasAttribute(BACKDROP_INERT)) {
 				elem.removeAttribute(BACKDROP_INERT);
 			} else {


### PR DESCRIPTION
[GAUD-10181](https://desire2learn.atlassian.net/browse/GAUD-10181)

The fallback should be true. This flag has been enabled since 20.26.5.

[GAUD-10181]: https://desire2learn.atlassian.net/browse/GAUD-10181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ