### PR TITLE
Set GAUD-9963-dropdown-tabs-not-resizing default/fallback to true.

### DIFF
--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -119,7 +119,7 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 		 * TODO: remove this whole if when removing the GAUD-9963-dropdown-tabs-not-resizing flag
 		 * keep the min max code an place that into the styles above
 		 */
-		if (getFlag('GAUD-9963-dropdown-tabs-not-resizing', false)) {
+		if (getFlag('GAUD-9963-dropdown-tabs-not-resizing', true)) {
 			this.style.setProperty('--d2l-gaud-9963-tab-max-width', 'min(20rem, max(33%, 10rem))');
 		}
 	}

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -430,7 +430,7 @@ class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))
 		return (Object.keys(this._tabIds).length > 1 && !reduceMotion) ? this._animateTabRemoval(tab) : Promise.resolve();
 	}
 
-	#GAUD_9963_FLAG = getFlag('GAUD-9963-dropdown-tabs-not-resizing', false);
+	#GAUD_9963_FLAG = getFlag('GAUD-9963-dropdown-tabs-not-resizing', true);
 	#checkTabPanelMatchRequested;
 	#newTabsPanelStructure = getUseNewTabsStructureFlag();
 	#panels;


### PR DESCRIPTION
[GAUD-10184](https://desire2learn.atlassian.net/browse/GAUD-10184)

The fallback should be true. This flag has been enabled since 20.26.6.

[GAUD-10184]: https://desire2learn.atlassian.net/browse/GAUD-10184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ