### PR TITLE
Set GAUD-9644-prefer-native-confirm-dialogs default/fallback to true.

### DIFF
--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -92,7 +92,7 @@ class DialogConfirm extends LocalizeCoreElement(DialogMixin(LitElement)) {
 	constructor() {
 		super();
 		this.critical = false;
-		this.preferNative = getFlag('GAUD-9644-prefer-native-confirm-dialogs', false);
+		this.preferNative = getFlag('GAUD-9644-prefer-native-confirm-dialogs', true);
 		this._criticalLabelId = getUniqueId();
 		this._textId = getUniqueId();
 		this._titleId = getUniqueId();

--- a/components/dialog/test/dialog-confirm.test.js
+++ b/components/dialog/test/dialog-confirm.test.js
@@ -20,6 +20,11 @@ describe('d2l-dialog-confirm', () => {
 
 	describe('focus management', () => {
 
+		// delete these tests when GAUD-9644-prefer-native-confirm-dialogs is removed
+
+		before(() => mockFlag(preferNativeConfirmDialogsFlag, false));
+		after(() => resetFlag(preferNativeConfirmDialogsFlag));
+
 		it('should focus on first non-primary button', async() => {
 			const el = await fixture(html`
 				<d2l-dialog-confirm opened>
@@ -44,6 +49,8 @@ describe('d2l-dialog-confirm', () => {
 	});
 
 	describe('focus management (prefer-native)', () => {
+
+		// keep these tests when GAUD-9644-prefer-native-confirm-dialogs is removed
 
 		before(() => mockFlag(preferNativeConfirmDialogsFlag, true));
 		after(() => resetFlag(preferNativeConfirmDialogsFlag));


### PR DESCRIPTION
[GAUD-10183](https://desire2learn.atlassian.net/browse/GAUD-10183)

The fallback should be true. This flag has been enabled since 20.26.7.15074.

Note: this flag relates to `GAUD-10113-close-dialog-when-disconnected`, which is required to be on for `GAUD-9644-prefer-native-confirm-dialogs`. Its default is already `true`.

[GAUD-10183]: https://desire2learn.atlassian.net/browse/GAUD-10183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ