### PR TITLE
GAUD-10203 - Add aria-label for supporting panel

### DIFF
--- a/components/page/page.js
+++ b/components/page/page.js
@@ -206,17 +206,25 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 
 	#renderSideNavPanel() {
 		return html`
-			<nav class="side-nav-panel" ?hidden="${!this._slotVisibility['side-nav']}" aria-label="${this.localize('components.page.side-nav-label')}">
+			<nav
+				class="side-nav-panel"
+				?hidden="${!this._slotVisibility['side-nav']}"
+				aria-label="${this.localize('components.page.side-nav-label')}">
 				<slot name="side-nav" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
 			</nav>
-			${this._slotVisibility['side-nav'] ? html`<div class="divider"></div>` : nothing}
+			${!this._slotVisibility['side-nav'] ? nothing :
+				html`<div class="divider"></div>`}
 		`;
 	}
 
 	#renderSupportingPanel() {
 		return html`
-			${this._slotVisibility['supporting'] ? html`<div class="divider"></div>` : nothing}
-			<aside class="supporting-panel" ?hidden="${!this._slotVisibility['supporting']}">
+			${!this._slotVisibility['supporting'] ? nothing :
+				html`<div class="divider"></div>`}
+			<aside
+				class="supporting-panel"
+				?hidden="${!this._slotVisibility['supporting']}"
+				aria-label="${this.localize('components.page.supporting-panel-label')}">
 				<slot name="supporting" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
 			</aside>
 		`;

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "مزيد من الإجراءات",
 	"components.page.header-nav-label": "الرئيسية",
 	"components.page.side-nav-label": "جانبية",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} مادة واحد}

--- a/lang/ca.js
+++ b/lang/ca.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Més accions",
 	"components.page.header-nav-label": "Principal",
 	"components.page.side-nav-label": "Lateral",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} element}

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Rhagor o Gamau Gweithredu",
 	"components.page.header-nav-label": "Prif",
 	"components.page.side-nav-label": "Ochr",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} eitem}

--- a/lang/da.js
+++ b/lang/da.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Flere handlinger",
 	"components.page.header-nav-label": "Hoved",
 	"components.page.side-nav-label": "Side",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} element}

--- a/lang/de.js
+++ b/lang/de.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Weitere Aktionen",
 	"components.page.header-nav-label": "Haupt-",
 	"components.page.side-nav-label": "Seiten-",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} Element}

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "More Actions",
 	"components.page.header-nav-label": "Main",
 	"components.page.side-nav-label": "Side",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/en.js
+++ b/lang/en.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "More Actions",
 	"components.page.header-nav-label": "Main",
 	"components.page.side-nav-label": "Side",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Más acciones",
 	"components.page.header-nav-label": "Principal",
 	"components.page.side-nav-label": "Lateral",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} elemento}

--- a/lang/es.js
+++ b/lang/es.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Más acciones",
 	"components.page.header-nav-label": "Principal",
 	"components.page.side-nav-label": "Lateral",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} elemento}

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Plus d’actions",
 	"components.page.header-nav-label": "Principale",
 	"components.page.side-nav-label": "Côté",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} élément}

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Plus d’actions",
 	"components.page.header-nav-label": "Principal",
 	"components.page.side-nav-label": "Côté",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} élément}

--- a/lang/haw.js
+++ b/lang/haw.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Nā Hana Hou",
 	"components.page.header-nav-label": "Nui",
 	"components.page.side-nav-label": "ʻaoʻao",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} mea}

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "अधिक क्रियाएँ",
 	"components.page.header-nav-label": "मुख्य",
 	"components.page.side-nav-label": "साइड",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} आइटम}

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -149,6 +149,7 @@ export default {
 	"components.overflow-group.moreActions": "その他のアクション",
 	"components.page.header-nav-label": "メイン",
 	"components.page.side-nav-label": "サイド",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 個の項目}

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -149,6 +149,7 @@ export default {
 	"components.overflow-group.moreActions": "추가 작업",
 	"components.page.header-nav-label": "메인",
 	"components.page.side-nav-label": "사이드",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			other {해당 항목 수 {countFormatted}개}

--- a/lang/mi.js
+++ b/lang/mi.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Ētahi atu Hohenga",
 	"components.page.header-nav-label": "Matua",
 	"components.page.side-nav-label": "Taha",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} Tūemi}

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Meer acties",
 	"components.page.header-nav-label": "Hoofdgedeelte",
 	"components.page.side-nav-label": "Zij",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Mais ações",
 	"components.page.header-nav-label": "Principal",
 	"components.page.side-nav-label": "Lateral",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Fler åtgärder",
 	"components.page.header-nav-label": "Huvudsida",
 	"components.page.side-nav-label": "Sida",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} objekt}

--- a/lang/th.js
+++ b/lang/th.js
@@ -150,6 +150,7 @@ export default {
 	"components.overflow-group.moreActions": "การดำเนินการเพิ่มเติม",
 	"components.page.header-nav-label": "หลัก",
 	"components.page.side-nav-label": "ด้านข้าง",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} รายการ}

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -154,6 +154,7 @@ export default {
 	"components.overflow-group.moreActions": "Daha Fazla Eylem",
 	"components.page.header-nav-label": "Ana",
 	"components.page.side-nav-label": "Yan",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} öğe}

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -148,6 +148,7 @@ export default {
 	"components.overflow-group.moreActions": "Thêm các Tác vụ",
 	"components.page.header-nav-label": "Chính",
 	"components.page.side-nav-label": "Bên",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} mục}

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -149,6 +149,7 @@ export default {
 	"components.overflow-group.moreActions": "更多操作",
 	"components.page.header-nav-label": "主要",
 	"components.page.side-nav-label": "侧面",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 项}

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -150,6 +150,7 @@ export default {
 	"components.overflow-group.moreActions": "其他動作",
 	"components.page.header-nav-label": "主要",
 	"components.page.side-nav-label": "側邊",
+	"components.page.supporting-panel-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 個項目}


### PR DESCRIPTION
Simple PR that adjusts the format/order of the html to make the next PR a tad nicer. The only functional change here is adding the `aria-label` for the supporting panel, which I'm not sure why I didn't do in the previous PRs.