### PR TITLE
GAUD-10267: use modern static properties (ignore for now)

### DIFF
--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -38,119 +38,115 @@ let ALERT_HAS_HOVER = false; // if this alert or sibling alert is hovered on
  */
 class AlertToast extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Text that is displayed within the alert's action button. If no text is provided the button is not displayed.
 			 * @type {string}
 			 */
-			buttonText: { type: String, attribute: 'button-text' },
+		buttonText: { type: String, attribute: 'button-text' },
 
-			/**
+		/**
 			 * Hide the close button to prevent users from manually closing the alert
 			 * @type {boolean}
 			 */
-			hideCloseButton: { type: Boolean, attribute: 'hide-close-button' },
+		hideCloseButton: { type: Boolean, attribute: 'hide-close-button' },
 
-			/**
+		/**
 			 * Prevents the alert from automatically closing 4 seconds after opening
 			 * @type {boolean}
 			 */
-			noAutoClose: { type: Boolean, attribute: 'no-auto-close' },
+		noAutoClose: { type: Boolean, attribute: 'no-auto-close' },
 
-			/**
+		/**
 			 * Open or close the toast alert
 			 * @type {boolean}
 			 */
-			open: { type: Boolean, reflect: true },
+		open: { type: Boolean, reflect: true },
 
-			/**
+		/**
 			 * The text that is displayed below the main alert message
 			 * @type {string}
 			 */
-			subtext: { type: String },
+		subtext: { type: String },
 
-			/**
+		/**
 			 * Type of the alert being displayed
 			 * @type {'default'|'critical'|'success'|'warning'}
 			 * @default "default"
 			 */
-			type: { type: String, reflect: true },
-			_closeClicked: { state: true },
-			_numAlertsBelow: { state: true },
-			_smallWidth: { state: true },
-			_state: { type: String },
-			_totalSiblingHeightBelow: { state: true }
-		};
-	}
+		type: { type: String, reflect: true },
+		_closeClicked: { state: true },
+		_numAlertsBelow: { state: true },
+		_smallWidth: { state: true },
+		_state: { type: String },
+		_totalSiblingHeightBelow: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
+	static styles = css`
+		:host {
+			display: block;
+		}
 
+		.d2l-alert-toast-container {
+			border-radius: 0.3rem;
+			box-shadow: 0 0.1rem 0.6rem 0 rgba(0, 0, 0, 0.1);
+			display: none;
+			left: 0;
+			margin: 0 auto 1.5rem;
+			max-width: 600px;
+			position: fixed;
+			right: 0;
+			width: 100%;
+			z-index: 10000;
+		}
+
+		.d2l-alert-toast-container:not([data-state="closed"]) {
+			display: block;
+		}
+
+		.d2l-alert-toast-container[data-state="opening"],
+		.d2l-alert-toast-container.d2l-alert-toast-container-lowest[data-state="closing"] {
+			transition-duration: 600ms;
+			transition-property: opacity, transform;
+			transition-timing-function: ease;
+		}
+		.d2l-alert-toast-container[data-state="closing"] {
+			transition: opacity 200ms ease;
+		}
+
+		.d2l-alert-toast-container.d2l-alert-toast-container-close-clicked[data-state="closing"] {
+			transition-duration: 200ms;
+		}
+
+		.d2l-alert-toast-container[data-state="preopening"],
+		.d2l-alert-toast-container[data-state="closing"] {
+			opacity: 0;
+		}
+		.d2l-alert-toast-container[data-state="preopening"],
+		.d2l-alert-toast-container.d2l-alert-toast-container-lowest[data-state="closing"] {
+			transform: translateY(calc(100% + 1.5rem));
+		}
+
+		.d2l-alert-toast-container[data-state="opening"] {
+			opacity: 1;
+			transform: translateY(0);
+		}
+
+		.d2l-alert-toast-container[data-state="sliding"] {
+			transition: bottom 600ms ease;
+		}
+
+		d2l-alert {
+			animation: none;
+		}
+
+		@media (max-width: 615px) {
 			.d2l-alert-toast-container {
-				border-radius: 0.3rem;
-				box-shadow: 0 0.1rem 0.6rem 0 rgba(0, 0, 0, 0.1);
-				display: none;
-				left: 0;
-				margin: 0 auto 1.5rem;
-				max-width: 600px;
-				position: fixed;
-				right: 0;
-				width: 100%;
-				z-index: 10000;
+				margin-bottom: 12px;
+				width: calc(100% - 16px);
 			}
-
-			.d2l-alert-toast-container:not([data-state="closed"]) {
-				display: block;
-			}
-
-			.d2l-alert-toast-container[data-state="opening"],
-			.d2l-alert-toast-container.d2l-alert-toast-container-lowest[data-state="closing"] {
-				transition-duration: 600ms;
-				transition-property: opacity, transform;
-				transition-timing-function: ease;
-			}
-			.d2l-alert-toast-container[data-state="closing"] {
-				transition: opacity 200ms ease;
-			}
-
-			.d2l-alert-toast-container.d2l-alert-toast-container-close-clicked[data-state="closing"] {
-				transition-duration: 200ms;
-			}
-
-			.d2l-alert-toast-container[data-state="preopening"],
-			.d2l-alert-toast-container[data-state="closing"] {
-				opacity: 0;
-			}
-			.d2l-alert-toast-container[data-state="preopening"],
-			.d2l-alert-toast-container.d2l-alert-toast-container-lowest[data-state="closing"] {
-				transform: translateY(calc(100% + 1.5rem));
-			}
-
-			.d2l-alert-toast-container[data-state="opening"] {
-				opacity: 1;
-				transform: translateY(0);
-			}
-
-			.d2l-alert-toast-container[data-state="sliding"] {
-				transition: bottom 600ms ease;
-			}
-
-			d2l-alert {
-				animation: none;
-			}
-
-			@media (max-width: 615px) {
-				.d2l-alert-toast-container {
-					margin-bottom: 12px;
-					width: calc(100% - 16px);
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/alert/alert.js
+++ b/components/alert/alert.js
@@ -14,134 +14,130 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 class Alert extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Text that is displayed within the alert's action button. If no text is provided the button is not displayed.
 			 * @type {string}
 			 */
-			buttonText: { type: String, attribute: 'button-text' },
+		buttonText: { type: String, attribute: 'button-text' },
 
-			/**
+		/**
 			 * Gives the alert a close button that will close the alert when clicked
 			 * @type {boolean}
 			 */
-			hasCloseButton: { type: Boolean, attribute: 'has-close-button' },
+		hasCloseButton: { type: Boolean, attribute: 'has-close-button' },
 
-			/**
+		/**
 			 * Opt out of default padding/whitespace around the alert
 			 * @type {boolean}
 			 */
-			noPadding: { type: Boolean, attribute: 'no-padding', reflect: true },
+		noPadding: { type: Boolean, attribute: 'no-padding', reflect: true },
 
-			/**
+		/**
 			 * The text that is displayed below the main alert message
 			 * @type {string}
 			 */
-			subtext: { type: String },
+		subtext: { type: String },
 
-			/**
+		/**
 			 * Type of the alert being displayed
 			 * @type {'default'|'critical'|'success'|'warning'}
 			 */
-			type: { type: String, reflect: true }
-		};
-	}
-	static get styles() {
-		return [bodyCompactStyles, bodyStandardStyles, css`
+		type: { type: String, reflect: true }
+	};
+	static styles = [bodyCompactStyles, bodyStandardStyles, css`
 
-			:host {
-				animation: 600ms ease drop-in;
-				background: var(--d2l-theme-background-color-base);
-				border: 1px solid var(--d2l-theme-border-color-standard);
-				border-inline-start-width: 0.3rem;
-				border-radius: 0.3rem;
-				box-sizing: border-box;
-				display: flex;
-				flex: 1;
-				max-width: 710px;
-				position: relative;
-				width: 100%;
-			}
+		:host {
+			animation: 600ms ease drop-in;
+			background: var(--d2l-theme-background-color-base);
+			border: 1px solid var(--d2l-theme-border-color-standard);
+			border-inline-start-width: 0.3rem;
+			border-radius: 0.3rem;
+			box-sizing: border-box;
+			display: flex;
+			flex: 1;
+			max-width: 710px;
+			position: relative;
+			width: 100%;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
-			:host([type="critical"]),
-			:host([type="error"]) {
-				border-inline-start-color: var(--d2l-theme-status-color-error);
-			}
-			:host([type="warning"]) {
-				border-inline-start-color: var(--d2l-theme-status-color-warning);
-			}
-			:host([type="default"]),
-			:host([type="call-to-action"]) {
-				border-inline-start-color: var(--d2l-theme-status-color-default);
-			}
-			:host([type="success"]) {
-				border-inline-start-color: var(--d2l-theme-status-color-success);
-			}
+		:host([type="critical"]),
+		:host([type="error"]) {
+			border-inline-start-color: var(--d2l-theme-status-color-error);
+		}
+		:host([type="warning"]) {
+			border-inline-start-color: var(--d2l-theme-status-color-warning);
+		}
+		:host([type="default"]),
+		:host([type="call-to-action"]) {
+			border-inline-start-color: var(--d2l-theme-status-color-default);
+		}
+		:host([type="success"]) {
+			border-inline-start-color: var(--d2l-theme-status-color-success);
+		}
 
+		.d2l-alert-text {
+			flex: 1;
+			padding-block: 0.9rem;
+			padding-inline-end: 1.5rem;
+			padding-inline-start: 1.2rem;
+			position: relative;
+		}
+		.d2l-alert-text-with-actions {
+			padding-inline-end: 0.9rem;
+		}
+
+		:host([no-padding]) .d2l-alert-text,
+		:host([no-padding]) .d2l-alert-text-with-actions {
+			padding-block: 0;
+			padding-inline-end: 0;
+			padding-inline-start: 0;
+		}
+
+		.d2l-alert-subtext {
+			margin: 0.5rem 0 0;
+		}
+
+		.d2l-alert-action {
+			margin-block: 0.6rem;
+			margin-inline-end: 0.6rem;
+			margin-inline-start: 0;
+		}
+		:host([no-padding]) .d2l-alert-action {
+			margin: 0;
+		}
+
+		@media (max-width: 615px) {
 			.d2l-alert-text {
 				flex: 1;
-				padding-block: 0.9rem;
-				padding-inline-end: 1.5rem;
-				padding-inline-start: 1.2rem;
 				position: relative;
 			}
-			.d2l-alert-text-with-actions {
-				padding-inline-end: 0.9rem;
-			}
-
-			:host([no-padding]) .d2l-alert-text,
-			:host([no-padding]) .d2l-alert-text-with-actions {
-				padding-block: 0;
-				padding-inline-end: 0;
-				padding-inline-start: 0;
-			}
-
-			.d2l-alert-subtext {
-				margin: 0.5rem 0 0;
-			}
-
 			.d2l-alert-action {
-				margin-block: 0.6rem;
-				margin-inline-end: 0.6rem;
-				margin-inline-start: 0;
+				margin: 0.45rem;
 			}
-			:host([no-padding]) .d2l-alert-action {
-				margin: 0;
-			}
+		}
 
-			@media (max-width: 615px) {
-				.d2l-alert-text {
-					flex: 1;
-					position: relative;
-				}
-				.d2l-alert-action {
-					margin: 0.45rem;
-				}
+		@keyframes drop-in {
+			from {
+				opacity: 0;
+				transform: translate(0, -10px);
 			}
+			to {
+				opacity: 1;
+				transform: translate(0, 0);
+			}
+		}
 
-			@keyframes drop-in {
-				from {
-					opacity: 0;
-					transform: translate(0, -10px);
-				}
-				to {
-					opacity: 1;
-					transform: translate(0, 0);
-				}
+		@media (prefers-reduced-motion: reduce) {
+			:host {
+				animation: none;
 			}
-
-			@media (prefers-reduced-motion: reduce) {
-				:host {
-					animation: none;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/backdrop/backdrop-dirty-overlay.js
+++ b/components/backdrop/backdrop-dirty-overlay.js
@@ -34,25 +34,21 @@ const overlayStyles = css`
  */
 class BackdropDirtyOverlay extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * The text displayed on the dirty state overlay.
 			 * @type {string}
 			 */
-			description: { type: String, required: true },
+		description: { type: String, required: true },
 
-			/**
+		/**
 			 * The text displayed on the button of the dirty state overlay when the 'dirty' dataState is set.
 			 * @type {string}
 			 */
-			action: { type: String, required: true }
-		};
-	}
+		action: { type: String, required: true }
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, overlayStyles, getFocusRingStyles('.d2l-backdrop-dirty-overlay')];
-	}
+	static styles = [bodyCompactStyles, overlayStyles, getFocusRingStyles('.d2l-backdrop-dirty-overlay')];
 
 	render() {
 		return html`

--- a/components/backdrop/backdrop-loading.js
+++ b/components/backdrop/backdrop-loading.js
@@ -22,120 +22,116 @@ const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
  */
 class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * The state of data in the element being overlaid. Set to 'clean' when the data represents the user's latest selections, 'dirty' when the data does not represent the user's latest selections, and 'loading' if the data is being actively refreshed
-			 * @type {'clean'|'dirty'|'loading'}
-			 */
-			dataState: {
-				reflect: true,
-				type: String
-			},
-			/**
-			 * Used to identify content that the backdrop should make inert
-			 * @type {string}
-			 */
-			for: { type: String, required: true },
-			/**
-			 * The text displayed on the dirty state overlay when the 'dirty' dataState is set.
-			 * @type {string}
-			 */
-			dirtyText: {
-				reflect: true,
-				attribute: 'dirty-text',
-				type: String
-			},
-			/**
-			 * The text displayed on the button of the dirty state overlay when the 'dirty' dataState is set.
-			 * @type {string}
-			 */
-			dirtyButtonText: {
-				reflect: true,
-				attribute: 'dirty-button-text',
-				type: String
-			},
-			_state: { type: String, reflect: true },
-			_spinnerTop: { state: true },
-			_ariaContent: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * The state of data in the element being overlaid. Set to 'clean' when the data represents the user's latest selections, 'dirty' when the data does not represent the user's latest selections, and 'loading' if the data is being actively refreshed
+		 * @type {'clean'|'dirty'|'loading'}
+		 */
+		dataState: {
+			reflect: true,
+			type: String
+		},
+		/**
+		 * Used to identify content that the backdrop should make inert
+		 * @type {string}
+		 */
+		for: { type: String, required: true },
+		/**
+		 * The text displayed on the dirty state overlay when the 'dirty' dataState is set.
+		 * @type {string}
+		 */
+		dirtyText: {
+			reflect: true,
+			attribute: 'dirty-text',
+			type: String
+		},
+		/**
+		 * The text displayed on the button of the dirty state overlay when the 'dirty' dataState is set.
+		 * @type {string}
+		 */
+		dirtyButtonText: {
+			reflect: true,
+			attribute: 'dirty-button-text',
+			type: String
+		},
+		_state: { type: String, reflect: true },
+		_spinnerTop: { state: true },
+		_ariaContent: { state: true }
+	};
 
-	static get styles() {
-		return [css`
-			#visible {
-				display: none;
-			}
+	static styles = [css`
+		#visible {
+			display: none;
+		}
 
-			:host([_state="showing"]),
-			:host([_state="shown"]),
-			:host([_state="hiding"]),
-			:host([_state="showing"]) #visible,
-			:host([_state="shown"]) #visible,
-			:host([_state="hiding"]) #visible {
-				display: flex;
-				height: 100%;
-				justify-content: center;
-				position: absolute;
-				top: 0;
-				width: 100%;
-				z-index: 999;
-			}
+		:host([_state="showing"]),
+		:host([_state="shown"]),
+		:host([_state="hiding"]),
+		:host([_state="showing"]) #visible,
+		:host([_state="shown"]) #visible,
+		:host([_state="hiding"]) #visible {
+			display: flex;
+			height: 100%;
+			justify-content: center;
+			position: absolute;
+			top: 0;
+			width: 100%;
+			z-index: 999;
+		}
 
-			.backdrop {
-				background-color: var(--d2l-theme-backdrop-background-color);
-				height: 100%;
-				opacity: 0;
-				position: absolute;
-				top: 0;
-				width: 100%;
-			}
-			:host([_state="shown"]) .backdrop {
-				opacity: var(--d2l-theme-backdrop-opacity);
-				transition: opacity ${FADE_DURATION_MS}ms ease-in;
-			}
-			:host([_state="hiding"]) .backdrop {
-				transition: opacity ${FADE_DURATION_MS}ms ease-out;
-			}
+		.backdrop {
+			background-color: var(--d2l-theme-backdrop-background-color);
+			height: 100%;
+			opacity: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
+		:host([_state="shown"]) .backdrop {
+			opacity: var(--d2l-theme-backdrop-opacity);
+			transition: opacity ${FADE_DURATION_MS}ms ease-in;
+		}
+		:host([_state="hiding"]) .backdrop {
+			transition: opacity ${FADE_DURATION_MS}ms ease-out;
+		}
 
-			d2l-loading-spinner {
-				opacity: 0;
-				position: absolute;
-			}
-			:host([_state="shown"]) d2l-loading-spinner {
-				opacity: 1;
-				transition: opacity ${FADE_DURATION_MS}ms ease-in ${SPINNER_DELAY_MS}ms;
-			}
-			:host([_state="shown"][dataState="dirty"]) d2l-loading-spinner,
-			:host([_state="hiding"]) d2l-loading-spinner {
-				opacity: 0;
-				transition: opacity ${FADE_DURATION_MS}ms ease-out;
-			}
+		d2l-loading-spinner {
+			opacity: 0;
+			position: absolute;
+		}
+		:host([_state="shown"]) d2l-loading-spinner {
+			opacity: 1;
+			transition: opacity ${FADE_DURATION_MS}ms ease-in ${SPINNER_DELAY_MS}ms;
+		}
+		:host([_state="shown"][dataState="dirty"]) d2l-loading-spinner,
+		:host([_state="hiding"]) d2l-loading-spinner {
+			opacity: 0;
+			transition: opacity ${FADE_DURATION_MS}ms ease-out;
+		}
 
-			d2l-backdrop-dirty-overlay {
-				background-color: var(--d2l-theme-backdrop-dialog-color);
-				height: fit-content;
-				justify-content: center;
-				opacity: 0;
-				position: relative;
-				top: 0;
-				z-index: 1000;
-			}
-			:host([_state="shown"]) d2l-backdrop-dirty-overlay {
-				opacity: 1;
-				transition: opacity ${FADE_DURATION_MS}ms ease-in;
-			}
-			:host([_state="shown"][dataState="loading"]) d2l-backdrop-dirty-overlay,
-			:host([_state="hiding"]) d2l-backdrop-dirty-overlay {
-				opacity: 0;
-				transition: opacity ${FADE_DURATION_MS}ms ease-out;
-			}
+		d2l-backdrop-dirty-overlay {
+			background-color: var(--d2l-theme-backdrop-dialog-color);
+			height: fit-content;
+			justify-content: center;
+			opacity: 0;
+			position: relative;
+			top: 0;
+			z-index: 1000;
+		}
+		:host([_state="shown"]) d2l-backdrop-dirty-overlay {
+			opacity: 1;
+			transition: opacity ${FADE_DURATION_MS}ms ease-in;
+		}
+		:host([_state="shown"][dataState="loading"]) d2l-backdrop-dirty-overlay,
+		:host([_state="hiding"]) d2l-backdrop-dirty-overlay {
+			opacity: 0;
+			transition: opacity ${FADE_DURATION_MS}ms ease-out;
+		}
 
-			@media (prefers-reduced-motion: reduce) {
-				* { transition: none; }
-			}
-		`];
-	}
+		@media (prefers-reduced-motion: reduce) {
+			* { transition: none; }
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -20,64 +20,60 @@ let scrollOverflow = null;
  */
 class Backdrop extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: id of the target element to display backdrop behind
-			 * @type {string}
-			 */
-			forTarget: { type: String, attribute: 'for-target' },
+	static properties = {
+		/**
+		 * REQUIRED: id of the target element to display backdrop behind
+		 * @type {string}
+		 */
+		forTarget: { type: String, attribute: 'for-target' },
 
-			/**
-			 * Disables the fade-out transition while the backdrop is being hidden
-			 * @type {boolean}
-			 */
-			noAnimateHide: { type: Boolean, attribute: 'no-animate-hide' },
+		/**
+		 * Disables the fade-out transition while the backdrop is being hidden
+		 * @type {boolean}
+		 */
+		noAnimateHide: { type: Boolean, attribute: 'no-animate-hide' },
 
-			/**
-			 * Used to control whether the backdrop is shown
-			 * @type {boolean}
-			 */
-			shown: { type: Boolean },
-			_state: { type: String, reflect: true }
-		};
-	}
+		/**
+		 * Used to control whether the backdrop is shown
+		 * @type {boolean}
+		 */
+		shown: { type: Boolean },
+		_state: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [ css`
-			:host {
-				background-color: var(--d2l-theme-backdrop-background-color);
-				height: 0;
-				left: 0;
-				opacity: 0;
-				position: fixed;
-				top: 0;
-				transition: opacity ${TRANSITION_DURATION}ms ease-in;
-				width: 0;
-				z-index: 999;
-			}
+	static styles = [ css`
+		:host {
+			background-color: var(--d2l-theme-backdrop-background-color);
+			height: 0;
+			left: 0;
+			opacity: 0;
+			position: fixed;
+			top: 0;
+			transition: opacity ${TRANSITION_DURATION}ms ease-in;
+			width: 0;
+			z-index: 999;
+		}
+		:host([slow-transition]) {
+			transition: opacity 1200ms ease-in;
+		}
+		:host([_state="showing"]) {
+			opacity: var(--d2l-theme-backdrop-opacity);
+		}
+		:host([_state="showing"]),
+		:host([_state="hiding"]) {
+			height: 100%;
+			width: 100%;
+		}
+		:host([_state=null][no-animate-hide]) {
+			transition: none;
+		}
+		@media (prefers-reduced-motion: reduce) {
+			:host,
 			:host([slow-transition]) {
-				transition: opacity 1200ms ease-in;
-			}
-			:host([_state="showing"]) {
-				opacity: var(--d2l-theme-backdrop-opacity);
-			}
-			:host([_state="showing"]),
-			:host([_state="hiding"]) {
-				height: 100%;
-				width: 100%;
-			}
-			:host([_state=null][no-animate-hide]) {
 				transition: none;
 			}
-			@media (prefers-reduced-motion: reduce) {
-				:host,
-				:host([slow-transition]) {
-					transition: none;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/breadcrumbs/breadcrumb-current-page.js
+++ b/components/breadcrumbs/breadcrumb-current-page.js
@@ -5,30 +5,26 @@ import { css, html, LitElement } from 'lit';
  */
 class BreadcrumbCurrentPage extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			_role: { type: 'string', attribute: 'role', reflect: true },
-			/**
+		_role: { type: 'string', attribute: 'role', reflect: true },
+		/**
 			 * REQUIRED: The title of the current page
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true }
-		};
-	}
+		text: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/breadcrumbs/breadcrumb.js
+++ b/components/breadcrumbs/breadcrumb.js
@@ -10,61 +10,57 @@ import { linkStyles } from '../link/link.js';
  */
 class Breadcrumb extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			_compact: { attribute: 'data-compact', reflect: true, type: Boolean },
-			/**
+		_compact: { attribute: 'data-compact', reflect: true, type: Boolean },
+		/**
 			 * @ignore
 			 */
-			_role: { type: 'string', attribute: 'role', reflect: true },
-			/**
+		_role: { type: 'string', attribute: 'role', reflect: true },
+		/**
 			 * The Url that breadcrumb is pointing to
 			 * @type {string}
 			 */
-			href: { type: String, reflect: true },
-			/**
+		href: { type: String, reflect: true },
+		/**
 			 * The target of breadcrumb link
 			 * @type {string}
 			 */
-			target: { type: String, reflect: true },
-			/**
+		target: { type: String, reflect: true },
+		/**
 			 * REQUIRED: The text of the breadcrumb link
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true },
-			/**
+		text: { type: String, reflect: true },
+		/**
 			 * ACCESSIBILITY: ARIA label for the breadcrumb, used if `text` does not provide enough context for screen reader users
 			 * @type {string}
 			 */
-			ariaLabel: { attribute: 'aria-label', type: String, reflect: true }
-		};
-	}
+		ariaLabel: { attribute: 'aria-label', type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [linkStyles, css`
-			:host {
-				align-items: center;
-				display: inline-flex;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([data-compact]) {
-				flex-direction: row-reverse;
-			}
-			d2l-icon {
-				height: 8px;
-				padding-inline: 8px 3px;
-				width: 8px;
-			}
-			d2l-icon[icon="tier1:chevron-left"] {
-				padding-inline: 0 8px;
-			}
-		`];
-	}
+	static styles = [linkStyles, css`
+		:host {
+			align-items: center;
+			display: inline-flex;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([data-compact]) {
+			flex-direction: row-reverse;
+		}
+		d2l-icon {
+			height: 8px;
+			padding-inline: 8px 3px;
+			width: 8px;
+		}
+		d2l-icon[icon="tier1:chevron-left"] {
+			padding-inline: 0 8px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/breadcrumbs/breadcrumbs.js
+++ b/components/breadcrumbs/breadcrumbs.js
@@ -9,45 +9,41 @@ import { overflowEllipsisDeclarations } from '../../helpers/overflow.js';
  */
 class Breadcrumbs extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Renders in compact mode, displaying only the last item
 			 * @type {boolean}
 			 */
-			compact: { type: Boolean, reflect: true }
-		};
-	}
+		compact: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				clip-path: rect(-1em 100% calc(100% + 1em) -1em);
-				display: block;
-				font-size: 0.7rem;
-				line-height: 1.05rem;
-				${overflowEllipsisDeclarations}
-				overflow-y: clip;
-				position: relative;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host::after {
-				background: linear-gradient(to var(--d2l-inline-end, right), rgba(255, 255, 255, 0), rgb(251, 252, 252));
-				content: "";
-				inset-block: 0;
-				inset-inline-end: 0;
-				pointer-events: none;
-				position: absolute;
-				width: 10px;
-			}
-			:host([compact]) ::slotted(d2l-breadcrumb:not(:last-of-type)),
-			:host([compact]) ::slotted(d2l-breadcrumb-current-page) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			clip-path: rect(-1em 100% calc(100% + 1em) -1em);
+			display: block;
+			font-size: 0.7rem;
+			line-height: 1.05rem;
+			${overflowEllipsisDeclarations}
+			overflow-y: clip;
+			position: relative;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host::after {
+			background: linear-gradient(to var(--d2l-inline-end, right), rgba(255, 255, 255, 0), rgb(251, 252, 252));
+			content: "";
+			inset-block: 0;
+			inset-inline-end: 0;
+			pointer-events: none;
+			position: absolute;
+			width: 10px;
+		}
+		:host([compact]) ::slotted(d2l-breadcrumb:not(:last-of-type)),
+		:host([compact]) ::slotted(d2l-breadcrumb-current-page) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/button/button-add.js
+++ b/components/button/button-add.js
@@ -19,138 +19,134 @@ const MODE = {
  * A component for quickly adding items to a specific locaiton.
  */
 class ButtonAdd extends PropertyRequiredMixin(FocusMixin(LocalizeCoreElement(LitElement))) {
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Display mode of the component. Defaults to `icon` (plus icon is always visible). Other options are `icon-and-text` (plus icon and text are always visible), and `icon-when-interacted` (plus icon is only visible when hover or focus).
 			 * @type {'icon'|'icon-and-text'|'icon-when-interacted'}
 			 */
-			mode: { type: String, reflect: true },
-			/**
+		mode: { type: String, reflect: true },
+		/**
 			 * ACCESSIBILITY: The text associated with the button. When mode is `icon-and-text` this text is displayed next to the icon, otherwise this text is in a tooltip.
 			 * @type {string}
 			 */
-			text: { type: String, required: true }
-		};
-	}
+		text: { type: String, required: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				--d2l-button-add-animation-delay: 0ms;
-				--d2l-button-add-animation-duration: 200ms;
-				--d2l-button-add-hover-focus-color: var(--d2l-color-celestine-minus-1);
-				--d2l-button-add-line-color: var(--d2l-color-mica);
-				--d2l-button-add-line-height: 1px;
-				--d2l-button-add-hover-focus-line-height: 2px;
-			}
-			:host([mode="icon-when-interacted"]) {
-				--d2l-button-add-animation-delay: 50ms;
-			}
-			button {
-				align-items: center;
-				background-color: transparent;
-				border: 0;
-				box-shadow: none;
-				cursor: pointer;
-				display: flex;
-				font-family: inherit;
-				height: 11px;
-				justify-content: center;
-				margin: 6.5px 0; /* (d2l-button-add-icon-text height - line height) / 2 */
-				outline: none;
-				padding: 0;
-				position: relative;
-				user-select: none;
-				white-space: nowrap;
-				width: 100%;
-				z-index: 1; /* needed for button-add to have expected hover behaviour in list (hover from below, tooltip position) */
-			}
-			:host([mode="icon-and-text"]) button {
-				margin: calc((1.5rem - 11px) / 2) 0; /* (d2l-button-add-icon-text height - line height) / 2 */
-			}
+	static styles = css`
+		:host {
+			--d2l-button-add-animation-delay: 0ms;
+			--d2l-button-add-animation-duration: 200ms;
+			--d2l-button-add-hover-focus-color: var(--d2l-color-celestine-minus-1);
+			--d2l-button-add-line-color: var(--d2l-color-mica);
+			--d2l-button-add-line-height: 1px;
+			--d2l-button-add-hover-focus-line-height: 2px;
+		}
+		:host([mode="icon-when-interacted"]) {
+			--d2l-button-add-animation-delay: 50ms;
+		}
+		button {
+			align-items: center;
+			background-color: transparent;
+			border: 0;
+			box-shadow: none;
+			cursor: pointer;
+			display: flex;
+			font-family: inherit;
+			height: 11px;
+			justify-content: center;
+			margin: 6.5px 0; /* (d2l-button-add-icon-text height - line height) / 2 */
+			outline: none;
+			padding: 0;
+			position: relative;
+			user-select: none;
+			white-space: nowrap;
+			width: 100%;
+			z-index: 1; /* needed for button-add to have expected hover behaviour in list (hover from below, tooltip position) */
+		}
+		:host([mode="icon-and-text"]) button {
+			margin: calc((1.5rem - 11px) / 2) 0; /* (d2l-button-add-icon-text height - line height) / 2 */
+		}
 
-			.line {
-				background: var(--d2l-button-add-line-color);
-				height: var(--d2l-button-add-line-height);
-				margin: 5px 0;
-				width: 100%;
-			}
+		.line {
+			background: var(--d2l-button-add-line-color);
+			height: var(--d2l-button-add-line-height);
+			margin: 5px 0;
+			width: 100%;
+		}
 
+		button:hover .line,
+		button:focus .line {
+			background: var(--d2l-button-add-hover-focus-color);
+			height: var(--d2l-button-add-hover-focus-line-height);
+		}
+		button:hover d2l-button-add-icon-text,
+		button:focus d2l-button-add-icon-text {
+			--d2l-button-add-icon-text-color: var(--d2l-button-add-hover-focus-color);
+		}
+		:host([mode="icon-when-interacted"]) button:hover .line {
+			transition-delay: var(--d2l-button-add-animation-delay);
+		}
+
+		:host([mode="icon-when-interacted"]) button:not(:focus):not(:hover) d2l-button-add-icon-text {
+			position: absolute;
+		}
+		:host([mode="icon-when-interacted"]) button:hover d2l-button-add-icon-text,
+		:host([mode="icon-when-interacted"]) button:focus d2l-button-add-icon-text {
+			animation: position-change-animation var(--d2l-button-add-animation-delay); /* add delay in changing position to avoid flash of missing icon space */
+		}
+		@keyframes position-change-animation {
+			0% { position: absolute; }
+			100% { position: static; }
+		}
+		${getFocusRingStyles(pseudoClass => `button:${pseudoClass} d2l-button-add-icon-text`, { extraStyles: css`background-color: white; border-radius: 0.3rem;` })}
+		:host([mode="icon-when-interacted"]) button:${unsafeCSS(getFocusPseudoClass())} d2l-button-add-icon-text,
+		:host([mode="icon"]) button:${unsafeCSS(getFocusPseudoClass())} d2l-button-add-icon-text {
+			border-radius: 0.2rem;
+			padding: 0.15rem;
+		}
+
+		@media (prefers-reduced-motion: no-preference) {
 			button:hover .line,
 			button:focus .line {
-				background: var(--d2l-button-add-hover-focus-color);
-				height: var(--d2l-button-add-hover-focus-line-height);
+				animation: line-start-animation var(--d2l-button-add-animation-duration) ease-in var(--d2l-button-add-animation-delay) 1 forwards;
+				transition: all var(--d2l-button-add-animation-duration) ease-in var(--d2l-button-add-animation-delay);
 			}
-			button:hover d2l-button-add-icon-text,
-			button:focus d2l-button-add-icon-text {
-				--d2l-button-add-icon-text-color: var(--d2l-button-add-hover-focus-color);
-			}
-			:host([mode="icon-when-interacted"]) button:hover .line {
-				transition-delay: var(--d2l-button-add-animation-delay);
+			button:hover .line-end,
+			button:focus .line-end {
+				animation-name: line-end-animation;
 			}
 
-			:host([mode="icon-when-interacted"]) button:not(:focus):not(:hover) d2l-button-add-icon-text {
-				position: absolute;
-			}
-			:host([mode="icon-when-interacted"]) button:hover d2l-button-add-icon-text,
-			:host([mode="icon-when-interacted"]) button:focus d2l-button-add-icon-text {
-				animation: position-change-animation var(--d2l-button-add-animation-delay); /* add delay in changing position to avoid flash of missing icon space */
-			}
-			@keyframes position-change-animation {
-				0% { position: absolute; }
-				100% { position: static; }
-			}
-			${getFocusRingStyles(pseudoClass => `button:${pseudoClass} d2l-button-add-icon-text`, { extraStyles: css`background-color: white; border-radius: 0.3rem;` })}
-			:host([mode="icon-when-interacted"]) button:${unsafeCSS(getFocusPseudoClass())} d2l-button-add-icon-text,
-			:host([mode="icon"]) button:${unsafeCSS(getFocusPseudoClass())} d2l-button-add-icon-text {
-				border-radius: 0.2rem;
-				padding: 0.15rem;
-			}
-
-			@media (prefers-reduced-motion: no-preference) {
-				button:hover .line,
-				button:focus .line {
-					animation: line-start-animation var(--d2l-button-add-animation-duration) ease-in var(--d2l-button-add-animation-delay) 1 forwards;
-					transition: all var(--d2l-button-add-animation-duration) ease-in var(--d2l-button-add-animation-delay);
+			@keyframes line-start-animation {
+				0% {
+					background: linear-gradient(to var(--d2l-inline-end, right), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-start, left) center / 113%;
+					opacity: 10%;
 				}
-				button:hover .line-end,
-				button:focus .line-end {
-					animation-name: line-end-animation;
-				}
-
-				@keyframes line-start-animation {
-					0% {
-						background: linear-gradient(to var(--d2l-inline-end, right), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-start, left) center / 113%;
-						opacity: 10%;
-					}
-					100% {
-						background: linear-gradient(to var(--d2l-inline-end, right), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-start, left) center / 113%; /* safari */
-						background-position: var(--d2l-inline-end, right);
-					}
-				}
-				@keyframes line-end-animation {
-					0% {
-						background: linear-gradient(to var(--d2l-inline-start, left), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-end, right) center / 113%;
-						opacity: 10%;
-					}
-					100% {
-						background: linear-gradient(to var(--d2l-inline-start, left), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-end, right) center / 113%; /* safari */
-						background-position: var(--d2l-inline-start, left);
-					}
+				100% {
+					background: linear-gradient(to var(--d2l-inline-end, right), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-start, left) center / 113%; /* safari */
+					background-position: var(--d2l-inline-end, right);
 				}
 			}
-			@media (prefers-contrast: more) {
-				.line {
-					background-color: ButtonBorder;
+			@keyframes line-end-animation {
+				0% {
+					background: linear-gradient(to var(--d2l-inline-start, left), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-end, right) center / 113%;
+					opacity: 10%;
 				}
-				button:hover .line,
-				button:focus .line {
-					background-color: Highlight !important;
+				100% {
+					background: linear-gradient(to var(--d2l-inline-start, left), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-end, right) center / 113%; /* safari */
+					background-position: var(--d2l-inline-start, left);
 				}
 			}
-		`;
-	}
+		}
+		@media (prefers-contrast: more) {
+			.line {
+				background-color: ButtonBorder;
+			}
+			button:hover .line,
+			button:focus .line {
+				background-color: Highlight !important;
+			}
+		}
+	`;
 
 	constructor() {
 		super();
@@ -194,49 +190,45 @@ customElements.define('d2l-button-add', ButtonAdd);
  * @ignore
  */
 class ButtonAddIconText extends VisibleOnAncestorMixin(LitElement) {
-	static get properties() {
-		return {
-			text: { type: String }
-		};
-	}
+	static properties = {
+		text: { type: String }
+	};
 
-	static get styles() {
-		return [visibleOnAncestorStyles, css`
-			:host {
-				--d2l-focus-ring-offset: 0;
-				--d2l-focus-ring-color: var(--d2l-button-add-hover-focus-color);
-				--d2l-button-add-icon-text-color: var(--d2l-color-galena);
-				align-items: center;
-				display: flex;
-				stroke: var(--d2l-button-add-icon-text-color);
-				stroke-width: 2;
-			}
-			:host([visible-on-ancestor]),
-			:host([text]) {
-				--d2l-button-add-icon-text-color: var(--d2l-color-celestine);
-			}
-			:host([text]) {
-				color: var(--d2l-button-add-icon-text-color);
-				height: 1.5rem;
-				padding: 0 0.3rem;
-			}
+	static styles = [visibleOnAncestorStyles, css`
+		:host {
+			--d2l-focus-ring-offset: 0;
+			--d2l-focus-ring-color: var(--d2l-button-add-hover-focus-color);
+			--d2l-button-add-icon-text-color: var(--d2l-color-galena);
+			align-items: center;
+			display: flex;
+			stroke: var(--d2l-button-add-icon-text-color);
+			stroke-width: 2;
+		}
+		:host([visible-on-ancestor]),
+		:host([text]) {
+			--d2l-button-add-icon-text-color: var(--d2l-color-celestine);
+		}
+		:host([text]) {
+			color: var(--d2l-button-add-icon-text-color);
+			height: 1.5rem;
+			padding: 0 0.3rem;
+		}
 
-			:host([text]) svg {
-				padding-inline-end: 0.2rem;
-			}
-			:host(:not([text])) svg {
-				margin: -0.15rem; /** hover/click target */
-				padding: 0.15rem; /** hover/click target */
-			}
+		:host([text]) svg {
+			padding-inline-end: 0.2rem;
+		}
+		:host(:not([text])) svg {
+			margin: -0.15rem; /** hover/click target */
+			padding: 0.15rem; /** hover/click target */
+		}
 
-			span {
-				font-size: 0.7rem;
-				font-weight: 700;
-				letter-spacing: 0.2px;
-				line-height: 1rem;
-			}`
-		];
-	}
+		span {
+			font-size: 0.7rem;
+			font-weight: 700;
+			letter-spacing: 0.2px;
+			line-height: 1rem;
+		}`
+	];
 
 	render() {
 		return html`

--- a/components/button/button-copy-mixin.js
+++ b/components/button/button-copy-mixin.js
@@ -4,17 +4,15 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 
 export const ButtonCopyMixin = (superclass) => class extends LocalizeCoreElement(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Disables the button
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			_recentCopySuccessful: { state: true },
-			_toastState: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the button
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		_recentCopySuccessful: { state: true },
+		_toastState: { state: true }
+	};
 
 	constructor() {
 		super();

--- a/components/button/button-copy.js
+++ b/components/button/button-copy.js
@@ -8,26 +8,22 @@ import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
  */
 class ButtonCopy extends FocusMixin(ButtonCopyMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Description of the content being copied to clipboard
 			 * @type {string}
 			 */
-			text: { type: String },
-		};
-	}
+		text: { type: String },
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	static get focusElementSelector() {
 		return 'd2l-button-icon';

--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -17,122 +17,118 @@ import { ThemeMixin } from '../../mixins/theme/theme-mixin.js';
  */
 class ButtonIcon extends SlottedIconMixin(PropertyRequiredMixin(ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
-			description: { type: String },
+		description: { type: String },
 
-			/**
+		/**
 			 * Aligns the leading edge of text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
 			 * @type {'text'|'text-end'|''}
 			 */
-			hAlign: { type: String, reflect: true, attribute: 'h-align' },
+		hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
-			/**
+		/**
 			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true, required: true },
+		text: { type: String, reflect: true, required: true },
 
-			/**
+		/**
 			 * Indicates to display translucent (e.g., on rich backgrounds)
 			 * @type {boolean}
 			 */
-			translucent: { type: Boolean, reflect: true }
-		};
-	}
+		translucent: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return [super.styles, buttonStyles, visibleOnAncestorStyles,
-			css`
-				:host {
-					--d2l-button-icon-background-color-default: var(--d2l-theme-background-color-interactive-tertiary-default);
-					--d2l-button-icon-background-color-hover-default: var(--d2l-theme-background-color-interactive-tertiary-hover);
-					--d2l-button-icon-border-radius-default: 0.3rem;
-					--d2l-button-icon-min-height-default: calc(2rem + 2px);
-					--d2l-button-icon-min-width-default: calc(2rem + 2px);
-					--d2l-button-icon-h-align: calc(((2rem + 2px - 0.9rem) / 2) * -1);
-					display: inline-block;
-					line-height: 0;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([translucent]) {
-					--d2l-button-icon-background-color-default: var(--d2l-theme-background-color-interactive-translucent-default);
-					--d2l-button-icon-background-color-hover-default: var(--d2l-theme-background-color-interactive-translucent-hover);
-					--d2l-focus-ring-color: var(--d2l-theme-icon-color-inverted);
-					--d2l-focus-ring-offset: -4px;
-					--d2l-button-icon-fill-color: var(--d2l-theme-icon-color-inverted);
-					--d2l-button-icon-fill-color-hover: var(--d2l-theme-icon-color-inverted);
-				}
-				:host([theme="dark"]) {
-					--d2l-button-icon-background-color-default: transparent;
-					--d2l-button-icon-background-color-hover-default: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
-					--d2l-button-icon-fill-color: var(--d2l-color-sylvite);
-					--d2l-button-icon-fill-color-hover: var(--d2l-color-sylvite);
-					--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
-				}
+	static styles = [super.styles, buttonStyles, visibleOnAncestorStyles,
+		css`
+			:host {
+				--d2l-button-icon-background-color-default: var(--d2l-theme-background-color-interactive-tertiary-default);
+				--d2l-button-icon-background-color-hover-default: var(--d2l-theme-background-color-interactive-tertiary-hover);
+				--d2l-button-icon-border-radius-default: 0.3rem;
+				--d2l-button-icon-min-height-default: calc(2rem + 2px);
+				--d2l-button-icon-min-width-default: calc(2rem + 2px);
+				--d2l-button-icon-h-align: calc(((2rem + 2px - 0.9rem) / 2) * -1);
+				display: inline-block;
+				line-height: 0;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([translucent]) {
+				--d2l-button-icon-background-color-default: var(--d2l-theme-background-color-interactive-translucent-default);
+				--d2l-button-icon-background-color-hover-default: var(--d2l-theme-background-color-interactive-translucent-hover);
+				--d2l-focus-ring-color: var(--d2l-theme-icon-color-inverted);
+				--d2l-focus-ring-offset: -4px;
+				--d2l-button-icon-fill-color: var(--d2l-theme-icon-color-inverted);
+				--d2l-button-icon-fill-color-hover: var(--d2l-theme-icon-color-inverted);
+			}
+			:host([theme="dark"]) {
+				--d2l-button-icon-background-color-default: transparent;
+				--d2l-button-icon-background-color-hover-default: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
+				--d2l-button-icon-fill-color: var(--d2l-color-sylvite);
+				--d2l-button-icon-fill-color-hover: var(--d2l-color-sylvite);
+				--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
+			}
 
-				button {
-					background-color: var(--d2l-button-icon-background-color, var(--d2l-button-icon-background-color-default));
-					border-color: transparent;
-					border-radius: var(--d2l-button-icon-border-radius, var(--d2l-button-icon-border-radius-default));
-					font-family: inherit;
-					min-height: var(--d2l-button-icon-min-height, var(--d2l-button-icon-min-height-default));
-					min-width: var(--d2l-button-icon-min-width, var(--d2l-button-icon-min-width-default));
-					padding: 0;
-					position: relative;
-				}
+			button {
+				background-color: var(--d2l-button-icon-background-color, var(--d2l-button-icon-background-color-default));
+				border-color: transparent;
+				border-radius: var(--d2l-button-icon-border-radius, var(--d2l-button-icon-border-radius-default));
+				font-family: inherit;
+				min-height: var(--d2l-button-icon-min-height, var(--d2l-button-icon-min-height-default));
+				min-width: var(--d2l-button-icon-min-width, var(--d2l-button-icon-min-width-default));
+				padding: 0;
+				position: relative;
+			}
 
-				:host([h-align="text"]) button {
-					inset-inline-start: var(--d2l-button-icon-h-align);
-				}
-				:host([h-align="text-end"]) button {
-					inset-inline-end: var(--d2l-button-icon-h-align);
-				}
+			:host([h-align="text"]) button {
+				inset-inline-start: var(--d2l-button-icon-h-align);
+			}
+			:host([h-align="text-end"]) button {
+				inset-inline-end: var(--d2l-button-icon-h-align);
+			}
 
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
+			/* Firefox includes a hidden border which messes up button dimensions */
+			button::-moz-focus-inner {
+				border: 0;
+			}
 
-				button:hover:not([disabled]),
-				button:focus:not([disabled]),
-				:host([active]) button:not([disabled]) {
-					--d2l-button-icon-fill-color: var(--d2l-button-icon-fill-color-hover, var(--d2l-theme-icon-color-standard));
-					background-color: var(--d2l-button-icon-background-color-hover, var(--d2l-button-icon-background-color-hover-default));
-				}
+			button:hover:not([disabled]),
+			button:focus:not([disabled]),
+			:host([active]) button:not([disabled]) {
+				--d2l-button-icon-fill-color: var(--d2l-button-icon-fill-color-hover, var(--d2l-theme-icon-color-standard));
+				background-color: var(--d2l-button-icon-background-color-hover, var(--d2l-button-icon-background-color-hover-default));
+			}
 
-				d2l-icon,
-				slot[name="icon"]::slotted(d2l-icon-custom) {
-					color: var(--d2l-button-icon-fill-color, var(--d2l-theme-icon-color-standard));
-				}
+			d2l-icon,
+			slot[name="icon"]::slotted(d2l-icon-custom) {
+				color: var(--d2l-button-icon-fill-color, var(--d2l-theme-icon-color-standard));
+			}
 
+			:host([translucent]) button {
+				transition-duration: 0.2s, 0.2s;
+				transition-property: background-color, box-shadow;
+			}
+			:host([translucent][visible-on-ancestor]) button {
+				transition-duration: 0.4s, 0.4s;
+			}
+
+			:host([disabled]) button {
+				cursor: default;
+				opacity: var(--d2l-theme-opacity-disabled-control);
+			}
+
+			@media (prefers-reduced-motion: reduce) {
 				:host([translucent]) button {
-					transition-duration: 0.2s, 0.2s;
-					transition-property: background-color, box-shadow;
+					transition: none;
 				}
-				:host([translucent][visible-on-ancestor]) button {
-					transition-duration: 0.4s, 0.4s;
-				}
-
-				:host([disabled]) button {
-					cursor: default;
-					opacity: var(--d2l-theme-opacity-disabled-control);
-				}
-
-				@media (prefers-reduced-motion: reduce) {
-					:host([translucent]) button {
-						transition: none;
-					}
-				}
-			`
-		];
-	}
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -2,74 +2,72 @@ import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 
 export const ButtonMixin = superclass => class extends FocusMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			ariaExpanded: { type: String, reflect: true, attribute: 'aria-expanded' },
-			/**
+		ariaExpanded: { type: String, reflect: true, attribute: 'aria-expanded' },
+		/**
 			 * @ignore
 			 */
-			ariaHaspopup: { type: String, reflect: true, attribute: 'aria-haspopup' },
-			/**
+		ariaHaspopup: { type: String, reflect: true, attribute: 'aria-haspopup' },
+		/**
 			 * @ignore
 			 */
-			ariaLabel: { type: String, reflect: true, attribute: 'aria-label' },
-			/**
+		ariaLabel: { type: String, reflect: true, attribute: 'aria-label' },
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean, reflect: true },
-			/**
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean, reflect: true },
+		/**
 			 * Wether the controlled element is expanded. Replaces 'aria-expanded'
 			 * @type {'true' | 'false'}
 			 */
-			expanded: { type: String, reflect: true, attribute: 'expanded' },
-			/**
+		expanded: { type: String, reflect: true, attribute: 'expanded' },
+		/**
 			 * Disables the button
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * Tooltip text when disabled
 			 * @type {string}
 			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			/**
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		/**
 			 * @ignore
 			 */
-			form: { type: String, reflect: true },
-			/**
+		form: { type: String, reflect: true },
+		/**
 			 * @ignore
 			 */
-			formaction: { type: String, reflect: true },
-			/**
+		formaction: { type: String, reflect: true },
+		/**
 			 * @ignore
 			 */
-			formenctype: { type: String, reflect: true },
-			/**
+		formenctype: { type: String, reflect: true },
+		/**
 			 * @ignore
 			 */
-			formmethod: { type: String, reflect: true },
-			/**
+		formmethod: { type: String, reflect: true },
+		/**
 			 * @ignore
 			 */
-			formnovalidate: { type: String, reflect: true },
-			/**
+		formnovalidate: { type: String, reflect: true },
+		/**
 			 * @ignore
 			 */
-			formtarget: { type: String, reflect: true },
-			/**
+		formtarget: { type: String, reflect: true },
+		/**
 			 * @ignore
 			 */
-			name: { type: String, reflect: true },
-			/**
+		name: { type: String, reflect: true },
+		/**
 			 * @ignore
 			 */
-			type: { type: String, reflect: true }
-		};
-	}
+		type: { type: String, reflect: true }
+	};
 
 	constructor() {
 		super();

--- a/components/button/button-move.js
+++ b/components/button/button-move.js
@@ -34,168 +34,164 @@ export const moveActions = Object.freeze({
  */
 class ButtonMove extends ThemeMixin(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean, reflect: true },
-			/**
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
-			description: { type: String },
-			/**
+		description: { type: String },
+		/**
 			 * Disables the down interaction
 			 * @type {boolean}
 			 */
-			disabledDown: { type: Boolean, attribute: 'disabled-down', reflect: true },
-			/**
+		disabledDown: { type: Boolean, attribute: 'disabled-down', reflect: true },
+		/**
 			 * Disables the end interaction
 			 * @type {boolean}
 			 */
-			disabledEnd: { type: Boolean, attribute: 'disabled-end', reflect: true },
-			/**
+		disabledEnd: { type: Boolean, attribute: 'disabled-end', reflect: true },
+		/**
 			 * Disables the home interaction
 			 * @type {boolean}
 			 */
-			disabledHome: { type: Boolean, attribute: 'disabled-home', reflect: true },
-			/**
+		disabledHome: { type: Boolean, attribute: 'disabled-home', reflect: true },
+		/**
 			 * Disables the left interaction
 			 * @type {boolean}
 			 */
-			disabledLeft: { type: Boolean, attribute: 'disabled-left', reflect: true },
-			/**
+		disabledLeft: { type: Boolean, attribute: 'disabled-left', reflect: true },
+		/**
 			 * Disables the right interaction
 			 * @type {boolean}
 			 */
-			disabledRight: { type: Boolean, attribute: 'disabled-right', reflect: true },
-			/**
+		disabledRight: { type: Boolean, attribute: 'disabled-right', reflect: true },
+		/**
 			 * Disables the up interaction
 			 * @type {boolean}
 			 */
-			disabledUp: { type: Boolean, attribute: 'disabled-up', reflect: true },
-			/**
+		disabledUp: { type: Boolean, attribute: 'disabled-up', reflect: true },
+		/**
 			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true },
-			/**
+		text: { type: String, reflect: true },
+		/**
 			 * Renders the buttons in a side by side orientation
 			 * @type {boolean}
 			 */
-			sideToSide: { type: Boolean, attribute: 'side-to-side', reflect: true }
-		};
-	}
+		sideToSide: { type: Boolean, attribute: 'side-to-side', reflect: true }
+	};
 
-	static get styles() {
-		return [ buttonStyles,
-			css`
-				:host {
-					--d2l-button-move-background-color-focus: #ffffff;
-					--d2l-button-move-icon-background-color-hover: var(--d2l-color-mica);
-					--d2l-icon-fill-color: var(--d2l-color-tungsten);
-					display: inline-block;
-					line-height: 0;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([theme="dark"]) {
-					--d2l-button-move-background-color-focus: #000000;
-					--d2l-button-move-icon-background-color-hover: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
-					--d2l-icon-fill-color: var(--d2l-color-sylvite);
-					--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
-				}
-				button {
-					background-color: transparent;
-					display: flex;
-					flex-direction: column;
-					gap: 2px;
-					margin: 0;
-					min-height: auto;
-					padding: 0;
-					position: relative;
-					width: 0.9rem;
-				}
-				d2l-icon {
-					border-radius: 0.1rem;
-					height: 0.85rem;
-					width: 0.9rem;
-				}
-				button:focus {
-					background-color: var(--d2l-button-move-background-color-focus);
-				}
-				button:hover > d2l-icon,
-				button:focus > d2l-icon {
-					background-color: var(--d2l-button-move-icon-background-color-hover);
-				}
-				.up-icon {
-					border-top-left-radius: 0.3rem;
-					border-top-right-radius: 0.3rem;
-				}
-				.down-icon {
-					border-bottom-left-radius: 0.3rem;
-					border-bottom-right-radius: 0.3rem;
-				}
-				.layer {
-					display: flex;
-					flex-direction: column;
-					height: calc(1.2rem * 2);
-					inset-inline-start: -0.2rem;
-					position: absolute;
-					top: -0.35rem;
-					width: 1.3rem;
-				}
-				.up-layer,
-				.down-layer {
-					height: 1.2rem;
-					position: relative;
-					width: 1.25rem;
-				}
+	static styles = [ buttonStyles,
+		css`
+			:host {
+				--d2l-button-move-background-color-focus: #ffffff;
+				--d2l-button-move-icon-background-color-hover: var(--d2l-color-mica);
+				--d2l-icon-fill-color: var(--d2l-color-tungsten);
+				display: inline-block;
+				line-height: 0;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([theme="dark"]) {
+				--d2l-button-move-background-color-focus: #000000;
+				--d2l-button-move-icon-background-color-hover: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
+				--d2l-icon-fill-color: var(--d2l-color-sylvite);
+				--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
+			}
+			button {
+				background-color: transparent;
+				display: flex;
+				flex-direction: column;
+				gap: 2px;
+				margin: 0;
+				min-height: auto;
+				padding: 0;
+				position: relative;
+				width: 0.9rem;
+			}
+			d2l-icon {
+				border-radius: 0.1rem;
+				height: 0.85rem;
+				width: 0.9rem;
+			}
+			button:focus {
+				background-color: var(--d2l-button-move-background-color-focus);
+			}
+			button:hover > d2l-icon,
+			button:focus > d2l-icon {
+				background-color: var(--d2l-button-move-icon-background-color-hover);
+			}
+			.up-icon {
+				border-top-left-radius: 0.3rem;
+				border-top-right-radius: 0.3rem;
+			}
+			.down-icon {
+				border-bottom-left-radius: 0.3rem;
+				border-bottom-right-radius: 0.3rem;
+			}
+			.layer {
+				display: flex;
+				flex-direction: column;
+				height: calc(1.2rem * 2);
+				inset-inline-start: -0.2rem;
+				position: absolute;
+				top: -0.35rem;
+				width: 1.3rem;
+			}
+			.up-layer,
+			.down-layer {
+				height: 1.2rem;
+				position: relative;
+				width: 1.25rem;
+			}
 
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
-				button[disabled]:hover > d2l-icon {
-					background-color: transparent;
-				}
-				:host([disabled-up]) .up-icon,
-				:host([disabled-down]) .down-icon {
-					opacity: 0.5;
-				}
-				:host([disabled-up]) .up-layer,
-				:host([disabled-down]) .down-layer {
-					cursor: default;
-				}
+			/* Firefox includes a hidden border which messes up button dimensions */
+			button::-moz-focus-inner {
+				border: 0;
+			}
+			button[disabled]:hover > d2l-icon {
+				background-color: transparent;
+			}
+			:host([disabled-up]) .up-icon,
+			:host([disabled-down]) .down-icon {
+				opacity: 0.5;
+			}
+			:host([disabled-up]) .up-layer,
+			:host([disabled-down]) .down-layer {
+				cursor: default;
+			}
 
-				:host([side-to-side]) button {
-					align-items: center;
-					flex-direction: row;
-					height: 1.2rem;
-					width: calc(calc(1.2rem + 1px) * 2);
-				}
+			:host([side-to-side]) button {
+				align-items: center;
+				flex-direction: row;
+				height: 1.2rem;
+				width: calc(calc(1.2rem + 1px) * 2);
+			}
 
-				:host([side-to-side]) .layer {
-					flex-direction: row;
-					gap: 2px;
-					height: 1.2rem;
-					inset-inline-start: 0;
-					top: 0;
-					width: calc(calc(1.2rem + 1px) * 2);
-				}
+			:host([side-to-side]) .layer {
+				flex-direction: row;
+				gap: 2px;
+				height: 1.2rem;
+				inset-inline-start: 0;
+				top: 0;
+				width: calc(calc(1.2rem + 1px) * 2);
+			}
 
-				:host([side-to-side]) d2l-icon {
-					height: 1.2rem;
-					/* Arrows need to be rotated in opposite direction for RTL */
-					transform: rotate(calc(-90deg * var(--d2l-length-factor)));
-					width: 1.2rem;
-				}
-			`
-		];
-	}
+			:host([side-to-side]) d2l-icon {
+				height: 1.2rem;
+				/* Arrows need to be rotated in opposite direction for RTL */
+				transform: rotate(calc(-90deg * var(--d2l-length-factor)));
+				width: 1.2rem;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/button/button-split-item.js
+++ b/components/button/button-split-item.js
@@ -8,27 +8,23 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class ButtonSplitItem extends PropertyRequiredMixin(MenuItemMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Key of the action
 			 * @type {string}
 			 */
-			key: { type: String, required: true }
-		};
-	}
+		key: { type: String, required: true }
+	};
 
-	static get styles() {
-		return [ menuItemStyles,
-			css`
+	static styles = [ menuItemStyles,
+		css`
 				:host {
 					align-items: center;
 					display: flex;
 					padding: 0.75rem 1rem;
 				}
 			`
-		];
-	}
+	];
 
 	render() {
 		return html`

--- a/components/button/button-split.js
+++ b/components/button/button-split.js
@@ -16,80 +16,76 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class ButtonSplit extends FocusMixin(PropertyRequiredMixin(LocalizeCoreElement(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: A description to be added to the main action button for accessibility when text does not provide enough context
 			 * @type {string}
 			 */
-			description: { type: String },
-			/**
+		description: { type: String },
+		/**
 			 * Disables the main action and dropdown opener buttons
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * Tooltip text when disabled
 			 * @type {string}
 			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			/**
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		/**
 			 * REQUIRED: Key of the main action
 			 * @type {string}
 			 */
-			key: { type: String, required: true },
-			/**
+		key: { type: String, required: true },
+		/**
 			 * Styles the buttons as a primary buttons
 			 * @type {boolean}
 			 */
-			primary: { type: Boolean, reflect: true },
-			/**
+		primary: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: REQUIRED: Accessible text for the main action button
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true, required: true },
-			_focusVisibleElem: { state: true }
-		};
-	}
+		text: { type: String, reflect: true, required: true },
+		_focusVisibleElem: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.container {
-				display: flex;
-				gap: 2px;
-			}
-			.main-action {
-				--d2l-button-start-end-radius: 0;
-				--d2l-button-end-end-radius: 0;
-			}
-			.d2l-dropdown-opener {
-				--d2l-button-start-start-radius: 0;
-				--d2l-button-end-start-radius: 0;
-				--d2l-button-padding-inline-end: 0.6rem;
-				--d2l-button-padding-inline-start: 0.6rem;
-			}
-			.d2l-dropdown-opener[primary] > d2l-icon {
-				color: #ffffff;
-			}
-			::slotted(:not(d2l-button-split-item)) {
-				display: none;
-			}
-			.main-action-focus-visible .d2l-dropdown-opener {
-				--d2l-button-padding-inline-start: calc(0.6rem - 4px);
-				margin-inline-start: 4px;
-			}
-			.menu-opener-focus-visible .main-action {
-				--d2l-button-padding-inline-end: calc(1.5rem - 4px);
-				margin-inline-end: 4px;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.container {
+			display: flex;
+			gap: 2px;
+		}
+		.main-action {
+			--d2l-button-start-end-radius: 0;
+			--d2l-button-end-end-radius: 0;
+		}
+		.d2l-dropdown-opener {
+			--d2l-button-start-start-radius: 0;
+			--d2l-button-end-start-radius: 0;
+			--d2l-button-padding-inline-end: 0.6rem;
+			--d2l-button-padding-inline-start: 0.6rem;
+		}
+		.d2l-dropdown-opener[primary] > d2l-icon {
+			color: #ffffff;
+		}
+		::slotted(:not(d2l-button-split-item)) {
+			display: none;
+		}
+		.main-action-focus-visible .d2l-dropdown-opener {
+			--d2l-button-padding-inline-start: calc(0.6rem - 4px);
+			margin-inline-start: 4px;
+		}
+		.menu-opener-focus-visible .main-action {
+			--d2l-button-padding-inline-end: calc(1.5rem - 4px);
+			margin-inline-end: 4px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/button/button-subtle-copy.js
+++ b/components/button/button-subtle-copy.js
@@ -7,25 +7,23 @@ import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
  * A button component that copies to the clipboard, using the "subtle" button style.
  */
 class ButtonSubtleCopy extends FocusMixin(ButtonCopyMixin(LitElement)) {
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
-			description: { type: String },
-			/**
+		description: { type: String },
+		/**
 			 * ACCESSIBILITY: REQUIRED: Text for the button
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true },
-			/**
+		text: { type: String, reflect: true },
+		/**
 			 * Whether to render the slimmer version of the button
 			 * @type {boolean}
 			 */
-			slim: { type: Boolean, reflect: true },
-		};
-	}
+		slim: { type: Boolean, reflect: true },
+	};
 
 	static get focusElementSelector() {
 		return 'd2l-button-subtle';

--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -16,155 +16,151 @@ import { SlottedIconMixin } from '../icons/slotted-icon-mixin.js';
  */
 class ButtonSubtle extends SlottedIconMixin(ButtonMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
-			description: { type: String },
+		description: { type: String },
 
-			/**
+		/**
 			 * Aligns the leading edge of text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
 			 * @type {'text'|'text-end'|''}
 			 */
-			hAlign: { type: String, reflect: true, attribute: 'h-align' },
+		hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
-			/**
+		/**
 			 * Indicates that the icon should be rendered on right
 			 * @type {boolean}
 			 */
-			iconRight: { type: Boolean, reflect: true, attribute: 'icon-right' },
+		iconRight: { type: Boolean, reflect: true, attribute: 'icon-right' },
 
-			/**
+		/**
 			 * Whether to render the slimmer version of the button
 			 * @type {boolean}
 			 */
-			slim: { type: Boolean, reflect: true },
+		slim: { type: Boolean, reflect: true },
 
-			/**
+		/**
 			 * ACCESSIBILITY: REQUIRED: Text for the button
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true }
-		};
-	}
+		text: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [super.styles, labelStyles, buttonStyles,
-			css`
-				:host {
-					--d2l-count-badge-background-color: var(--d2l-theme-background-color-interactive-primary-default);
-					--d2l-count-badge-foreground-color: var(--d2l-theme-text-color-static-inverted);
-					display: inline-block;
-				}
+	static styles = [super.styles, labelStyles, buttonStyles,
+		css`
+			:host {
+				--d2l-count-badge-background-color: var(--d2l-theme-background-color-interactive-primary-default);
+				--d2l-count-badge-foreground-color: var(--d2l-theme-text-color-static-inverted);
+				display: inline-block;
+			}
 
-				:host([hidden]) {
-					display: none;
-				}
+			:host([hidden]) {
+				display: none;
+			}
 
-				button {
-					--d2l-button-subtle-padding-inline-start: 0.6rem;
-					--d2l-button-subtle-padding-inline-end: 0.6rem;
-					align-items: center;
-					background-color: var(--d2l-theme-background-color-interactive-tertiary-default);
-					border-color: transparent;
-					column-gap: 0.3rem;
-					display: inline-flex;
-					font-family: inherit;
-					padding-block-end: 0;
-					padding-block-start: 0;
-					padding-inline-end: var(--d2l-button-subtle-padding-inline-end);
-					padding-inline-start: var(--d2l-button-subtle-padding-inline-start);
-					position: relative;
-				}
+			button {
+				--d2l-button-subtle-padding-inline-start: 0.6rem;
+				--d2l-button-subtle-padding-inline-end: 0.6rem;
+				align-items: center;
+				background-color: var(--d2l-theme-background-color-interactive-tertiary-default);
+				border-color: transparent;
+				column-gap: 0.3rem;
+				display: inline-flex;
+				font-family: inherit;
+				padding-block-end: 0;
+				padding-block-start: 0;
+				padding-inline-end: var(--d2l-button-subtle-padding-inline-end);
+				padding-inline-start: var(--d2l-button-subtle-padding-inline-start);
+				position: relative;
+			}
 
-				:host([slim]) button {
-					--d2l-button-subtle-padding-inline-start: 0.5rem;
-					--d2l-button-subtle-padding-inline-end: 0.5rem;
-					min-height: 1.5rem;
-				}
+			:host([slim]) button {
+				--d2l-button-subtle-padding-inline-start: 0.5rem;
+				--d2l-button-subtle-padding-inline-end: 0.5rem;
+				min-height: 1.5rem;
+			}
 
-				:host([slim]) button.d2l-button-subtle-has-icon {
-					--d2l-button-subtle-padding-inline-start: 0.4rem;
-					--d2l-button-subtle-padding-inline-end: 0.5rem;
-				}
+			:host([slim]) button.d2l-button-subtle-has-icon {
+				--d2l-button-subtle-padding-inline-start: 0.4rem;
+				--d2l-button-subtle-padding-inline-end: 0.5rem;
+			}
 
-				:host([slim][icon-right]) button.d2l-button-subtle-has-icon {
-					--d2l-button-subtle-padding-inline-start: 0.5rem;
-					--d2l-button-subtle-padding-inline-end: 0.4rem;
-				}
+			:host([slim][icon-right]) button.d2l-button-subtle-has-icon {
+				--d2l-button-subtle-padding-inline-start: 0.5rem;
+				--d2l-button-subtle-padding-inline-end: 0.4rem;
+			}
 
-				:host([h-align="text"]) button {
-					inset-inline-start: calc(var(--d2l-button-subtle-padding-inline-start) * -1);
-				}
-				:host([h-align="text-end"]) button {
-					inset-inline-end: calc(var(--d2l-button-subtle-padding-inline-end) * -1);
-				}
+			:host([h-align="text"]) button {
+				inset-inline-start: calc(var(--d2l-button-subtle-padding-inline-start) * -1);
+			}
+			:host([h-align="text-end"]) button {
+				inset-inline-end: calc(var(--d2l-button-subtle-padding-inline-end) * -1);
+			}
 
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
+			/* Firefox includes a hidden border which messes up button dimensions */
+			button::-moz-focus-inner {
+				border: 0;
+			}
 
-				button[disabled]:hover,
-				button[disabled]:focus,
-				:host([active]) button[disabled] {
-					background-color: var(--d2l-theme-background-color-interactive-tertiary-default);
-				}
+			button[disabled]:hover,
+			button[disabled]:focus,
+			:host([active]) button[disabled] {
+				background-color: var(--d2l-theme-background-color-interactive-tertiary-default);
+			}
 
-				button:hover,
-				button:focus,
-				:host([active]) button {
-					background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
-				}
+			button:hover,
+			button:focus,
+			:host([active]) button {
+				background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
+			}
 
-				.d2l-button-subtle-content {
-					color: var(--d2l-theme-text-color-interactive-default);
-				}
+			.d2l-button-subtle-content {
+				color: var(--d2l-theme-text-color-interactive-default);
+			}
 
-				button:hover:not([disabled]) .d2l-button-subtle-content,
-				button:focus:not([disabled]) .d2l-button-subtle-content,
-				:host([active]:not([disabled])) button .d2l-button-subtle-content {
-					color: var(--d2l-theme-text-color-interactive-hover);
-				}
+			button:hover:not([disabled]) .d2l-button-subtle-content,
+			button:focus:not([disabled]) .d2l-button-subtle-content,
+			:host([active]:not([disabled])) button .d2l-button-subtle-content {
+				color: var(--d2l-theme-text-color-interactive-hover);
+			}
 
-				button:hover:not([disabled]),
-				button:focus:not([disabled]),
-				:host([active]:not([disabled])) {
-					--d2l-count-badge-background-color: var(--d2l-theme-text-color-interactive-hover);
-				}
+			button:hover:not([disabled]),
+			button:focus:not([disabled]),
+			:host([active]:not([disabled])) {
+				--d2l-count-badge-background-color: var(--d2l-theme-text-color-interactive-hover);
+			}
 
-				.property-icon,
-				slot[name="icon"]::slotted(d2l-icon-custom) {
-					color: var(--d2l-theme-text-color-interactive-default);
-				}
+			.property-icon,
+			slot[name="icon"]::slotted(d2l-icon-custom) {
+				color: var(--d2l-theme-text-color-interactive-default);
+			}
 
-				button:hover:not([disabled]) .property-icon,
-				button:focus:not([disabled]) .property-icon,
-				:host([active]:not([disabled])) button .property-icon,
-				button:hover:not([disabled]) slot[name="icon"]::slotted(d2l-icon-custom),
-				button:focus:not([disabled]) slot[name="icon"]::slotted(d2l-icon-custom),
-				:host([active]:not([disabled])) slot[name="icon"]::slotted(d2l-icon-custom) {
-					color: var(--d2l-theme-text-color-interactive-hover);
-				}
+			button:hover:not([disabled]) .property-icon,
+			button:focus:not([disabled]) .property-icon,
+			:host([active]:not([disabled])) button .property-icon,
+			button:hover:not([disabled]) slot[name="icon"]::slotted(d2l-icon-custom),
+			button:focus:not([disabled]) slot[name="icon"]::slotted(d2l-icon-custom),
+			:host([active]:not([disabled])) slot[name="icon"]::slotted(d2l-icon-custom) {
+				color: var(--d2l-theme-text-color-interactive-hover);
+			}
 
-				:host([icon-right]) .property-icon,
-				:host([icon-right]) slot[name="icon"]::slotted(d2l-icon-custom) {
-					order: 1;
-				}
+			:host([icon-right]) .property-icon,
+			:host([icon-right]) slot[name="icon"]::slotted(d2l-icon-custom) {
+				order: 1;
+			}
 
-				.d2l-button-subtle-content-wrapper slot {
-					color: var(--d2l-theme-text-color-static-standard);
-				}
+			.d2l-button-subtle-content-wrapper slot {
+				color: var(--d2l-theme-text-color-static-standard);
+			}
 
-				:host([disabled]) button {
-					cursor: default;
-					opacity: var(--d2l-theme-opacity-disabled-control);
-				}
-			`
-		];
-	}
+			:host([disabled]) button {
+				cursor: default;
+				opacity: var(--d2l-theme-opacity-disabled-control);
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/button/button-toggle.js
+++ b/components/button/button-toggle.js
@@ -6,35 +6,31 @@ import { css, html, LitElement } from 'lit';
  */
 class ButtonToggle extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Pressed state
 			 * @type {boolean}
 			 */
-			pressed: { type: Boolean, reflect: true }
-		};
-	}
+		pressed: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			::slotted(:not(d2l-button-icon, d2l-button-subtle)),
-			:host slot[name="pressed"],
-			:host([pressed]) slot[name="not-pressed"] {
-				display: none;
-			}
-			:host slot[name="not-pressed"],
-			:host([pressed]) slot[name="pressed"] {
-				display: contents;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		::slotted(:not(d2l-button-icon, d2l-button-subtle)),
+		:host slot[name="pressed"],
+		:host([pressed]) slot[name="not-pressed"] {
+			display: none;
+		}
+		:host slot[name="not-pressed"],
+		:host([pressed]) slot[name="pressed"] {
+			display: contents;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -13,88 +13,84 @@ import { labelStyles } from '../typography/styles.js';
  */
 class Button extends ButtonMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
-			description: { type: String },
+		description: { type: String },
 
-			/**
+		/**
 			 * Styles the button as a primary button
 			 * @type {boolean}
 			 */
-			primary: { type: Boolean, reflect: true }
-		};
-	}
+		primary: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return [ labelStyles, buttonStyles,
-			css`
-				:host {
-					display: inline-block;
-				}
-				:host([hidden]) {
-					display: none;
-				}
+	static styles = [ labelStyles, buttonStyles,
+		css`
+			:host {
+				display: inline-block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
 
-				button {
-					font-family: inherit;
-					padding-block-end: 0;
-					padding-block-start: 0;
-					padding-inline-end: var(--d2l-button-padding-inline-end, 1.5rem);
-					padding-inline-start: var(--d2l-button-padding-inline-start, 1.5rem);
-					width: 100%;
-				}
+			button {
+				font-family: inherit;
+				padding-block-end: 0;
+				padding-block-start: 0;
+				padding-inline-end: var(--d2l-button-padding-inline-end, 1.5rem);
+				padding-inline-start: var(--d2l-button-padding-inline-start, 1.5rem);
+				width: 100%;
+			}
 
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
+			/* Firefox includes a hidden border which messes up button dimensions */
+			button::-moz-focus-inner {
+				border: 0;
+			}
 
-				button,
-				button[disabled]:hover,
-				button[disabled]:focus,
-				:host([active]) button[disabled] {
-					background-color: var(--d2l-theme-background-color-interactive-secondary-default);
-					color: var(--d2l-theme-text-color-static-standard);
-				}
+			button,
+			button[disabled]:hover,
+			button[disabled]:focus,
+			:host([active]) button[disabled] {
+				background-color: var(--d2l-theme-background-color-interactive-secondary-default);
+				color: var(--d2l-theme-text-color-static-standard);
+			}
 
-				button:hover,
-				button:focus,
-				:host([active]) button {
-					background-color: var(--d2l-theme-background-color-interactive-secondary-hover);
-				}
+			button:hover,
+			button:focus,
+			:host([active]) button {
+				background-color: var(--d2l-theme-background-color-interactive-secondary-hover);
+			}
 
-				:host([disabled]) button {
-					cursor: default;
-					position: relative;
-				}
-				:host([disabled]) button::before {
-					background-color: var(--d2l-theme-background-color-base);
-					border-radius: inherit;
-					content: "";
-					inset: 0;
-					opacity: var(--d2l-theme-opacity-disabled-control);
-					position: absolute;
-				}
+			:host([disabled]) button {
+				cursor: default;
+				position: relative;
+			}
+			:host([disabled]) button::before {
+				background-color: var(--d2l-theme-background-color-base);
+				border-radius: inherit;
+				content: "";
+				inset: 0;
+				opacity: var(--d2l-theme-opacity-disabled-control);
+				position: absolute;
+			}
 
-				:host([primary]) button,
-				:host([primary]) button[disabled]:hover,
-				:host([primary]) button[disabled]:focus,
-				:host([primary][active]) button[disabled] {
-					background-color: var(--d2l-theme-background-color-interactive-primary-default);
-					color: var(--d2l-theme-text-color-static-inverted);
-				}
-				:host([primary]) button:hover,
-				:host([primary]) button:focus,
-				:host([primary][active]) button {
-					background-color: var(--d2l-theme-background-color-interactive-primary-hover);
-				}
-			`
-		];
-	}
+			:host([primary]) button,
+			:host([primary]) button[disabled]:hover,
+			:host([primary]) button[disabled]:focus,
+			:host([primary][active]) button[disabled] {
+				background-color: var(--d2l-theme-background-color-interactive-primary-default);
+				color: var(--d2l-theme-text-color-static-inverted);
+			}
+			:host([primary]) button:hover,
+			:host([primary]) button:focus,
+			:host([primary][active]) button {
+				background-color: var(--d2l-theme-background-color-interactive-primary-hover);
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -16,84 +16,80 @@ const MINIMUM_TARGET_SIZE = 24;
  */
 class FloatingButtons extends LoadingCompleteMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Indicates to display buttons as always floating
 			 * @type {boolean}
 			 */
-			alwaysFloat: { type: Boolean, attribute: 'always-float', reflect: true },
-			_containerMarginLeft: { attribute: false, type: String },
-			_containerMarginRight: { attribute: false, type: String },
-			_floating: { type: Boolean, reflect: true },
-			_innerContainerLeft: { attribute: false, type: String }
-		};
-	}
+		alwaysFloat: { type: Boolean, attribute: 'always-float', reflect: true },
+		_containerMarginLeft: { attribute: false, type: String },
+		_containerMarginRight: { attribute: false, type: String },
+		_floating: { type: Boolean, reflect: true },
+		_innerContainerLeft: { attribute: false, type: String }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				box-sizing: border-box;
-				display: block;
-			}
+	static styles = css`
+		:host {
+			box-sizing: border-box;
+			display: block;
+		}
 
-			:host([_floating]) {
-				bottom: -10px;
-				left: 0;
-				position: -webkit-sticky;
-				position: sticky;
-				right: 0;
-				z-index: 997;
-			}
+		:host([_floating]) {
+			bottom: -10px;
+			left: 0;
+			position: -webkit-sticky;
+			position: sticky;
+			right: 0;
+			z-index: 997;
+		}
 
-			:host([_floating][always-float]) {
-				bottom: 0;
-			}
+		:host([_floating][always-float]) {
+			bottom: 0;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
-			.d2l-floating-buttons-container {
-				border-top: 1px solid transparent;
-				display: block;
-			}
+		.d2l-floating-buttons-container {
+			border-top: 1px solid transparent;
+			display: block;
+		}
 
-			:host([_floating]) .d2l-floating-buttons-container {
-				background-color: #ffffff;
-				background-color: rgba(255, 255, 255, 0.88);
-				border-top-color: var(--d2l-color-mica);
-				box-shadow: 0 -2px 4px rgba(32, 33, 34, 0.2); /* ferrite */
-			}
+		:host([_floating]) .d2l-floating-buttons-container {
+			background-color: #ffffff;
+			background-color: rgba(255, 255, 255, 0.88);
+			border-top-color: var(--d2l-color-mica);
+			box-shadow: 0 -2px 4px rgba(32, 33, 34, 0.2); /* ferrite */
+		}
 
+		:host([_floating]:not([always-float])) .d2l-floating-buttons-container {
+			transform: translate(0, -10px);
+			transition: transform 500ms, border-top-color 500ms, background-color 500ms;
+		}
+
+		.d2l-floating-buttons-inner-container {
+			padding: 0.75rem 0 0 0;
+			position: relative;
+		}
+
+		.d2l-floating-buttons-inner-container ::slotted(d2l-button),
+		.d2l-floating-buttons-inner-container ::slotted(button),
+		.d2l-floating-buttons-inner-container ::slotted(.d2l-button) {
+			margin-inline-end: 0.75rem !important;
+			margin-bottom: 0.75rem !important;
+		}
+
+		.d2l-floating-buttons-inner-container ::slotted(d2l-overflow-group) {
+			padding-bottom: 0.75rem !important;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
 			:host([_floating]:not([always-float])) .d2l-floating-buttons-container {
-				transform: translate(0, -10px);
-				transition: transform 500ms, border-top-color 500ms, background-color 500ms;
+				transition: none;
 			}
-
-			.d2l-floating-buttons-inner-container {
-				padding: 0.75rem 0 0 0;
-				position: relative;
-			}
-
-			.d2l-floating-buttons-inner-container ::slotted(d2l-button),
-			.d2l-floating-buttons-inner-container ::slotted(button),
-			.d2l-floating-buttons-inner-container ::slotted(.d2l-button) {
-				margin-inline-end: 0.75rem !important;
-				margin-bottom: 0.75rem !important;
-			}
-
-			.d2l-floating-buttons-inner-container ::slotted(d2l-overflow-group) {
-				padding-bottom: 0.75rem !important;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				:host([_floating]:not([always-float])) .d2l-floating-buttons-container {
-					transition: none;
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -149,304 +149,300 @@ export function getPrevMonth(month) {
  */
 class Calendar extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Additional info for each day (ex. events on [{"date": "2024-09-19"}])
 			 * @type {Array}
 			 */
-			dayInfos: { type: Array, attribute: 'day-infos' },
-			/**
+		dayInfos: { type: Array, attribute: 'day-infos' },
+		/**
 			 * Unique label text for calendar (necessary if multiple calendars on page)
 			 * @type {string}
 			 */
-			label: { attribute: 'label', reflect: true, type: String },
-			/**
+		label: { attribute: 'label', reflect: true, type: String },
+		/**
 			 * ADVANCED: Initial date to override the logic for determining default date to initially show
 			 * @type {string}
 			 */
-			initialValue: { attribute: 'initial-value', type: String },
-			/**
+		initialValue: { attribute: 'initial-value', type: String },
+		/**
 			 * Maximum valid date that could be selected by a user
 			 * @type {string}
 			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
 			 * Minimum valid date that could be selected by a user
 			 * @type {string}
 			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
 			 * Currently selected date
 			 * @type {string}
 			 */
-			selectedValue: { type: String, attribute: 'selected-value' },
-			/**
+		selectedValue: { type: String, attribute: 'selected-value' },
+		/**
 			 * ACCESSIBILITY: Summary of the calendar used by screen reader users for identifying the calendar and/or summarizing its purpose
 			 * @type {string}
 			 */
-			summary: { type: String },
-			_dialog: { type: Boolean },
-			_focusDate: { type: Object },
-			_isInitialFocusDate: { type: Boolean },
-			_monthNav: { type: String },
-			_shownMonth: { type: Number },
-			_shownYear: { type: Number }
-		};
-	}
+		summary: { type: String },
+		_dialog: { type: Boolean },
+		_focusDate: { type: Object },
+		_isInitialFocusDate: { type: Boolean },
+		_monthNav: { type: String },
+		_shownMonth: { type: Number },
+		_shownYear: { type: Number }
+	};
 
-	static get styles() {
-		return [bodySmallStyles, heading4Styles, offscreenStyles, css`
-			:host {
-				display: block;
-				min-width: 14rem;
-			}
+	static styles = [bodySmallStyles, heading4Styles, offscreenStyles, css`
+		:host {
+			display: block;
+			min-width: 14rem;
+		}
 
-			table {
-				border-collapse: collapse;
-				border-spacing: 0;
-				table-layout: fixed;
-				width: 100%;
-			}
+		table {
+			border-collapse: collapse;
+			border-spacing: 0;
+			table-layout: fixed;
+			width: 100%;
+		}
 
-			th {
-				border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
-				padding-bottom: 0.6rem;
-				padding-top: 0.3rem;
-				text-align: center;
-			}
+		th {
+			border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
+			padding-bottom: 0.6rem;
+			padding-top: 0.3rem;
+			text-align: center;
+		}
 
-			abbr {
-				text-decoration: none;
-			}
+		abbr {
+			text-decoration: none;
+		}
 
-			tbody > tr:first-child button {
-				margin-top: 0.3rem;
-			}
+		tbody > tr:first-child button {
+			margin-top: 0.3rem;
+		}
 
-			.d2l-calendar {
-				border-radius: 4px;
-			}
+		.d2l-calendar {
+			border-radius: 4px;
+		}
 
-			.d2l-calendar-title {
-				align-items: center;
-				display: flex;
-				justify-content: space-between;
-			}
+		.d2l-calendar-title {
+			align-items: center;
+			display: flex;
+			justify-content: space-between;
+		}
 
-			.d2l-calendar-title .d2l-heading-4 {
-				height: 100%;
-				margin: 0;
-				opacity: 0;
-			}
+		.d2l-calendar-title .d2l-heading-4 {
+			height: 100%;
+			margin: 0;
+			opacity: 0;
+		}
 
-			.d2l-calendar-next .d2l-calendar-title .d2l-heading-4 {
-				padding-left: 20px;
-				padding-right: 0;
-			}
+		.d2l-calendar-next .d2l-calendar-title .d2l-heading-4 {
+			padding-left: 20px;
+			padding-right: 0;
+		}
 
-			.d2l-calendar-prev .d2l-calendar-title .d2l-heading-4 {
-				padding-left: 0;
-				padding-right: 20px;
-			}
+		.d2l-calendar-prev .d2l-calendar-title .d2l-heading-4 {
+			padding-left: 0;
+			padding-right: 20px;
+		}
 
-			.d2l-calendar-next-updown .d2l-calendar-title .d2l-heading-4 {
-				padding-bottom: 0;
-				padding-top: 20px;
-			}
+		.d2l-calendar-next-updown .d2l-calendar-title .d2l-heading-4 {
+			padding-bottom: 0;
+			padding-top: 20px;
+		}
 
-			.d2l-calendar-prev-updown .d2l-calendar-title .d2l-heading-4 {
-				padding-bottom: 20px;
-				padding-top: 0;
-			}
+		.d2l-calendar-prev-updown .d2l-calendar-title .d2l-heading-4 {
+			padding-bottom: 20px;
+			padding-top: 0;
+		}
 
+		.d2l-calendar-date {
+			align-items: center;
+			background-color: var(--d2l-theme-background-color-base);
+			border-radius: 0.3rem;
+			border-style: none;
+			box-sizing: content-box;
+			color: var(--d2l-theme-text-color-static-standard);
+			cursor: pointer;
+			display: flex;
+			font-family: inherit;
+			font-size: 0.8rem;
+			height: calc(2rem - 6px);
+			justify-content: center;
+			letter-spacing: inherit;
+			line-height: inherit;
+			margin-left: auto;
+			margin-right: auto;
+			opacity: 0;
+			outline-offset: -1px;
+			padding: 3px;
+			position: relative;
+			text-align: center;
+			-webkit-user-select: none;
+			-moz-user-select: none;
+			-ms-user-select: none;
+			user-select: none;
+			width: calc(2rem - 6px);
+		}
+
+		.d2l-calendar-date::-moz-focus-inner {
+			border: 0;
+		}
+
+		.d2l-calendar-date:disabled {
+			cursor: not-allowed;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			.d2l-calendar-title .d2l-heading-4,
 			.d2l-calendar-date {
-				align-items: center;
-				background-color: var(--d2l-theme-background-color-base);
-				border-radius: 0.3rem;
-				border-style: none;
-				box-sizing: content-box;
-				color: var(--d2l-theme-text-color-static-standard);
-				cursor: pointer;
-				display: flex;
-				font-family: inherit;
-				font-size: 0.8rem;
-				height: calc(2rem - 6px);
-				justify-content: center;
-				letter-spacing: inherit;
-				line-height: inherit;
-				margin-left: auto;
-				margin-right: auto;
-				opacity: 0;
-				outline-offset: -1px;
-				padding: 3px;
-				position: relative;
-				text-align: center;
-				-webkit-user-select: none;
-				-moz-user-select: none;
-				-ms-user-select: none;
-				user-select: none;
-				width: calc(2rem - 6px);
-			}
-
-			.d2l-calendar-date::-moz-focus-inner {
-				border: 0;
+				opacity: 1;
 			}
 
 			.d2l-calendar-date:disabled {
-				cursor: not-allowed;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				.d2l-calendar-title .d2l-heading-4,
-				.d2l-calendar-date {
-					opacity: 1;
-				}
-
-				.d2l-calendar-date:disabled {
-					opacity: var(--d2l-theme-opacity-disabled-control);
-				}
-			}
-
-			.d2l-calendar-next .d2l-calendar-date {
-				left: 10px;
-			}
-
-			.d2l-calendar-next-updown .d2l-calendar-date {
-				top: 10px;
-			}
-
-			.d2l-calendar-prev .d2l-calendar-date {
-				left: -10px;
-			}
-
-			.d2l-calendar-prev-updown .d2l-calendar-date {
-				top: -10px;
-			}
-
-			.d2l-calendar-animating .d2l-calendar-title .d2l-heading-4,
-			.d2l-calendar-animating .d2l-calendar-date {
-				opacity: 1;
-				transition-duration: 200ms;
-				transition-property: opacity, transform;
-				transition-timing-function: ease-out;
-			}
-
-			.d2l-calendar-animating .d2l-calendar-date:disabled {
 				opacity: var(--d2l-theme-opacity-disabled-control);
 			}
+		}
 
-			.d2l-calendar-next .d2l-heading-4,
-			.d2l-calendar-next .d2l-calendar-date {
-				transform: translateX(-10px);
+		.d2l-calendar-next .d2l-calendar-date {
+			left: 10px;
+		}
+
+		.d2l-calendar-next-updown .d2l-calendar-date {
+			top: 10px;
+		}
+
+		.d2l-calendar-prev .d2l-calendar-date {
+			left: -10px;
+		}
+
+		.d2l-calendar-prev-updown .d2l-calendar-date {
+			top: -10px;
+		}
+
+		.d2l-calendar-animating .d2l-calendar-title .d2l-heading-4,
+		.d2l-calendar-animating .d2l-calendar-date {
+			opacity: 1;
+			transition-duration: 200ms;
+			transition-property: opacity, transform;
+			transition-timing-function: ease-out;
+		}
+
+		.d2l-calendar-animating .d2l-calendar-date:disabled {
+			opacity: var(--d2l-theme-opacity-disabled-control);
+		}
+
+		.d2l-calendar-next .d2l-heading-4,
+		.d2l-calendar-next .d2l-calendar-date {
+			transform: translateX(-10px);
+		}
+
+		.d2l-calendar-next-updown .d2l-heading-4,
+		.d2l-calendar-next-updown .d2l-calendar-date {
+			transform: translateY(-10px);
+		}
+
+		.d2l-calendar-prev .d2l-heading-4,
+		.d2l-calendar-prev .d2l-calendar-date {
+			transform: translateX(10px);
+		}
+
+		.d2l-calendar-prev-updown .d2l-heading-4,
+		.d2l-calendar-prev-updown .d2l-calendar-date {
+			transform: translateY(10px);
+		}
+
+		.d2l-calendar-date:enabled:not(.d2l-calendar-date-selected):hover,
+		.d2l-calendar-date:enabled:not(.d2l-calendar-date-selected).d2l-calendar-date-hover {
+			background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
+		}
+
+		td, .d2l-calendar-date:${unsafeCSS(getFocusPseudoClass())} {
+			outline: none;
+		}
+
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date:not(:disabled) {
+			outline: 2px solid var(--d2l-theme-border-color-focus);
+		}
+
+		@keyframes initial-focus {
+			from {
+				outline: 0 solid var(--d2l-theme-border-color-focus);
+				padding: 0;
 			}
+		}
 
-			.d2l-calendar-next-updown .d2l-heading-4,
-			.d2l-calendar-next-updown .d2l-calendar-date {
-				transform: translateY(-10px);
-			}
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-initial {
+			animation: 200ms ease-in initial-focus;
+		}
 
-			.d2l-calendar-prev .d2l-heading-4,
-			.d2l-calendar-prev .d2l-calendar-date {
-				transform: translateX(10px);
-			}
-
-			.d2l-calendar-prev-updown .d2l-heading-4,
-			.d2l-calendar-prev-updown .d2l-calendar-date {
-				transform: translateY(10px);
-			}
-
-			.d2l-calendar-date:enabled:not(.d2l-calendar-date-selected):hover,
-			.d2l-calendar-date:enabled:not(.d2l-calendar-date-selected).d2l-calendar-date-hover {
-				background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
-			}
-
-			td, .d2l-calendar-date:${unsafeCSS(getFocusPseudoClass())} {
-				outline: none;
-			}
-
-			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date:not(:disabled) {
-				outline: 2px solid var(--d2l-theme-border-color-focus);
-			}
-
-			@keyframes initial-focus {
-				from {
-					outline: 0 solid var(--d2l-theme-border-color-focus);
-					padding: 0;
-				}
-			}
-
-			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-initial {
-				animation: 200ms ease-in initial-focus;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-initial,
-				td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-initial.d2l-calendar-date-day-info::after {
-					animation: none;
-				}
-			}
-
-			.d2l-calendar-date.d2l-calendar-date-selected {
-				background-color: var(--d2l-theme-background-color-interactive-highlighted);
-				outline: 1px solid var(--d2l-theme-border-color-focus);
-			}
-
-			.d2l-calendar-date.d2l-calendar-date-selected:disabled {
-				background-color: var(--d2l-theme-background-color-base);
-				color: var(--d2l-theme-text-color-static-disabled);
-				opacity: 1;
-				outline: none;
-			}
-
-			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-selected:disabled {
-				outline: 2px solid var(--d2l-theme-border-color-focus);
-			}
-
-			.d2l-calendar-date.d2l-calendar-date-today,
-			.d2l-calendar-date.d2l-calendar-date-selected:enabled {
-				font-size: 1rem;
-				font-weight: 700;
-			}
-
-			@keyframes initial-focus-day-info {
-				from {
-					bottom: 1px;
-				}
-			}
-
+		@media (prefers-reduced-motion: reduce) {
+			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-initial,
 			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-initial.d2l-calendar-date-day-info::after {
-				animation: 200ms ease-in initial-focus-day-info;
+				animation: none;
 			}
+		}
 
+		.d2l-calendar-date.d2l-calendar-date-selected {
+			background-color: var(--d2l-theme-background-color-interactive-highlighted);
+			outline: 1px solid var(--d2l-theme-border-color-focus);
+		}
+
+		.d2l-calendar-date.d2l-calendar-date-selected:disabled {
+			background-color: var(--d2l-theme-background-color-base);
+			color: var(--d2l-theme-text-color-static-disabled);
+			opacity: 1;
+			outline: none;
+		}
+
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-selected:disabled {
+			outline: 2px solid var(--d2l-theme-border-color-focus);
+		}
+
+		.d2l-calendar-date.d2l-calendar-date-today,
+		.d2l-calendar-date.d2l-calendar-date-selected:enabled {
+			font-size: 1rem;
+			font-weight: 700;
+		}
+
+		@keyframes initial-focus-day-info {
+			from {
+				bottom: 1px;
+			}
+		}
+
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-initial.d2l-calendar-date-day-info::after {
+			animation: 200ms ease-in initial-focus-day-info;
+		}
+
+		.d2l-calendar-date-day-info::after {
+			background-color: var(--d2l-theme-brand-color-primary-default);
+			border-radius: 3px;
+			bottom: 4px;
+			content: "";
+			display: inline-block;
+			height: 6px;
+			position: absolute;
+			width: 6px;
+		}
+
+		.d2l-calendar-date-selected.d2l-calendar-date-day-info::after,
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-day-info::after {
+			bottom: 3px;
+		}
+		@media (prefers-contrast: more) {
 			.d2l-calendar-date-day-info::after {
-				background-color: var(--d2l-theme-brand-color-primary-default);
-				border-radius: 3px;
-				bottom: 4px;
-				content: "";
-				display: inline-block;
-				height: 6px;
-				position: absolute;
-				width: 6px;
+				background-color: FieldText;
+				forced-color-adjust: none;
 			}
 
-			.d2l-calendar-date-selected.d2l-calendar-date-day-info::after,
-			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-day-info::after {
-				bottom: 3px;
+			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date {
+				outline-color: Highlight !important;
 			}
-			@media (prefers-contrast: more) {
-				.d2l-calendar-date-day-info::after {
-					background-color: FieldText;
-					forced-color-adjust: none;
-				}
+		}
 
-				td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date {
-					outline-color: Highlight !important;
-				}
-			}
-
-		`];
-	}
+	`];
 
 	constructor() {
 		super();

--- a/components/card/card-content-meta.js
+++ b/components/card/card-content-meta.js
@@ -7,21 +7,19 @@ import { css, html, LitElement } from 'lit';
  */
 class CardContentMeta extends LitElement {
 
-	static get styles() {
-		return css`
-			:host {
-				box-sizing: border-box;
-				color: var(--d2l-color-tungsten);
-				display: inline-block;
-				font-size: 0.7rem;
-				font-weight: 400;
-				line-height: 1rem;
-			}
-			:host span {
-				display: inline-block; /* extra inline-block helps reset display context to opt-out of underline */
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			box-sizing: border-box;
+			color: var(--d2l-color-tungsten);
+			display: inline-block;
+			font-size: 0.7rem;
+			font-weight: 400;
+			line-height: 1rem;
+		}
+		:host span {
+			display: inline-block; /* extra inline-block helps reset display context to opt-out of underline */
+		}
+	`;
 
 	render() {
 		return html`<span><slot></slot></span>`;

--- a/components/card/card-content-title.js
+++ b/components/card/card-content-title.js
@@ -6,8 +6,7 @@ import { css, html, LitElement } from 'lit';
  */
 class CardContentTitle extends LitElement {
 
-	static get styles() {
-		return css`
+	static styles = css`
 			:host {
 				box-sizing: border-box;
 				display: block;
@@ -16,7 +15,6 @@ class CardContentTitle extends LitElement {
 				line-height: 1.4rem;
 			}
 		`;
-	}
 
 	render() {
 		return html`<slot></slot>`;

--- a/components/card/card-footer-link.js
+++ b/components/card/card-footer-link.js
@@ -12,68 +12,65 @@ import { offscreenStyles } from '../offscreen/offscreen.js';
  */
 class CardFooterLink extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Download a URL instead of navigating to it
 			 * @type {boolean}
 			 */
-			download: { type: Boolean, reflect: true },
-			/**
+		download: { type: Boolean, reflect: true },
+		/**
 			 * URL or URL fragment of the link
 			 * @type {string}
 			 */
-			href: { type: String, reflect: true },
-			/**
+		href: { type: String, reflect: true },
+		/**
 			 * Indicates the human language of the linked resource; purely advisory, with no built-in functionality
 			 * @type {string}
 			 */
-			hreflang: { type: String, reflect: true },
-			/**
+		hreflang: { type: String, reflect: true },
+		/**
 			 * REQUIRED: Preset icon key (e.g. "tier1:gear"). Must be a tier 1 icon.
 			 * @type {string}
 			 */
-			icon: { type: String, reflect: true },
-			/**
+		icon: { type: String, reflect: true },
+		/**
 			 * Specifies the relationship of the target object to the link object
 			 * @type {string}
 			 */
-			rel: { type: String, reflect: true },
-			/**
+		rel: { type: String, reflect: true },
+		/**
 			 * Secondary count to display as a count bubble on the icon
 			 * @type {number}
 			 */
-			secondaryCount: { type: Number, attribute: 'secondary-count', reflect: true },
-			/**
+		secondaryCount: { type: Number, attribute: 'secondary-count', reflect: true },
+		/**
 			 * Maximum digits to display in the secondary count. Defaults to no limit
 			 * @type {number}
 			 */
-			secondaryCountMaxDigits: { type: Number, attribute: 'secondary-count-max-digits' },
-			/**
+		secondaryCountMaxDigits: { type: Number, attribute: 'secondary-count-max-digits' },
+		/**
 			 * Controls the style of the secondary count bubble
 			 * @type {'count'|'notification'}
 			 */
-			secondaryCountType: { type: String, attribute: 'secondary-count-type', reflect: true },
-			/**
+		secondaryCountType: { type: String, attribute: 'secondary-count-type', reflect: true },
+		/**
 			 * Where to display the linked URL
 			 * @type {string}
 			 */
-			target: { type: String, reflect: true },
-			/**
+		target: { type: String, reflect: true },
+		/**
 			 * ACCESSIBILITY: REQUIRED: Accessible text for the link
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true },
-			/**
+		text: { type: String, reflect: true },
+		/**
 			 * Specifies the media type in the form of a MIME type for the linked URL; purely advisory, with no built-in functionality
 			 * @type {string}
 			 */
-			type: { type: String, reflect: true }
-		};
-	}
+		type: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [offscreenStyles, css`
+	static styles = [offscreenStyles, css`
 			:host {
 				display: inline-block;
 				position: relative;
@@ -92,7 +89,6 @@ class CardFooterLink extends FocusMixin(LitElement) {
 				text-align: initial;
 			}
 		`];
-	}
 
 	constructor() {
 		super();

--- a/components/card/card-loading-shimmer.js
+++ b/components/card/card-loading-shimmer.js
@@ -7,49 +7,45 @@ import { css, html, LitElement } from 'lit';
  */
 class CardLoadingShimmer extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether the header content is being loaded
 			 * @type {boolean}
 			 */
-			loading: { type: Boolean }
-		};
-	}
+		loading: { type: Boolean }
+	};
 
-	static get styles() {
-		return css`
-			:host([hidden]) {
-				display: none;
-			}
+	static styles = css`
+		:host([hidden]) {
+			display: none;
+		}
 
-			.d2l-card-loading-indicator {
-				background-color: var(--d2l-color-regolith);
-				border-radius: 7px 7px 0 0;
-				box-shadow: inset 0 -1px 0 0 var(--d2l-color-gypsum);
-				height: inherit;
-				overflow: hidden;
-				position: relative;
-			}
+		.d2l-card-loading-indicator {
+			background-color: var(--d2l-color-regolith);
+			border-radius: 7px 7px 0 0;
+			box-shadow: inset 0 -1px 0 0 var(--d2l-color-gypsum);
+			height: inherit;
+			overflow: hidden;
+			position: relative;
+		}
 
-			.d2l-card-loading-indicator::after {
-				animation: loadingShimmer 1.5s ease-in-out infinite;
-				background: linear-gradient(90deg, rgba(249, 250, 251, 0.1), rgba(114, 119, 122, 0.1), rgba(249, 250, 251, 0.1));
-				background-color: var(--d2l-color-regolith);
-				content: "";
-				height: 100%;
-				left: 0;
-				position: absolute;
-				top: 0;
-				width: 100%;
-			}
+		.d2l-card-loading-indicator::after {
+			animation: loadingShimmer 1.5s ease-in-out infinite;
+			background: linear-gradient(90deg, rgba(249, 250, 251, 0.1), rgba(114, 119, 122, 0.1), rgba(249, 250, 251, 0.1));
+			background-color: var(--d2l-color-regolith);
+			content: "";
+			height: 100%;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
 
-			@keyframes loadingShimmer {
-				0% { transform: translate3d(-100%, 0, 0); }
-				100% { transform: translate3d(100%, 0, 0); }
-			}
-		`;
-	}
+		@keyframes loadingShimmer {
+			0% { transform: translate3d(-100%, 0, 0); }
+			100% { transform: translate3d(100%, 0, 0); }
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -16,209 +16,205 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class Card extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Style the card's content and footer as centered horizontally
 			 * @type {boolean}
 			 */
-			alignCenter: { type: Boolean, attribute: 'align-center', reflect: true },
-			/**
+		alignCenter: { type: Boolean, attribute: 'align-center', reflect: true },
+		/**
 			 * Download a URL instead of navigating to it
 			 * @type {boolean}
 			 */
-			download: { type: Boolean, reflect: true },
-			/**
+		download: { type: Boolean, reflect: true },
+		/**
 			 * Location for the primary action/navigation
 			 * @type {string}
 			 */
-			href: { type: String, reflect: true },
-			/**
+		href: { type: String, reflect: true },
+		/**
 			 * Indicates the human language of the linked resource; purely advisory, with no built-in functionality
 			 * @type {string}
 			 */
-			hreflang: { type: String, reflect: true },
-			/**
+		hreflang: { type: String, reflect: true },
+		/**
 			 * Specifies the relationship of the target object to the link object
 			 * @type {string}
 			 */
-			rel: { type: String, reflect: true },
-			/**
+		rel: { type: String, reflect: true },
+		/**
 			 * Subtle aesthetic on non-white backgrounds
 			 * @type {boolean}
 			 */
-			subtle: { type: Boolean, reflect: true },
-			/**
+		subtle: { type: Boolean, reflect: true },
+		/**
 			 * Where to display the linked URL
 			 * @type {string}
 			 */
-			target: { type: String, reflect: true },
-			/**
+		target: { type: String, reflect: true },
+		/**
 			 * ACCESSIBILITY: Accessible text for the card; required if `href` is set
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true },
-			/**
+		text: { type: String, reflect: true },
+		/**
 			 * Specifies the media type in the form of a MIME type for the linked URL; purely advisory, with no built-in functionality
 			 * @type {string}
 			 */
-			type: { type: String, reflect: true },
-			_active: { type: Boolean, reflect: true },
-			_dropdownActionOpen: { type: Boolean, attribute: '_dropdown-action-open', reflect: true },
-			_hover: { type: Boolean },
-			_badgeMarginTop: { type: String },
-			_footerHidden: { type: Boolean },
-			_tooltipShowing: { type: Boolean, attribute: '_tooltip_showing', reflect: true }
-		};
-	}
+		type: { type: String, reflect: true },
+		_active: { type: Boolean, reflect: true },
+		_dropdownActionOpen: { type: Boolean, attribute: '_dropdown-action-open', reflect: true },
+		_hover: { type: Boolean },
+		_badgeMarginTop: { type: String },
+		_footerHidden: { type: Boolean },
+		_tooltipShowing: { type: Boolean, attribute: '_tooltip_showing', reflect: true }
+	};
 
-	static get styles() {
-		return [offscreenStyles, css`
+	static styles = [offscreenStyles, css`
+		:host {
+			background-color: #ffffff;
+			border: 1px solid var(--d2l-color-gypsum);
+			border-radius: 6px;
+			box-sizing: border-box;
+			display: inline-block;
+			position: relative;
+			z-index: 0;
+		}
+		.d2l-card-container {
+			align-items: flex-start; /* required so that footer will not stretch to 100% width */
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			position: relative;
+		}
+		.d2l-card-link-container {
+			flex-basis: auto;
+			flex-grow: 1;
+			flex-shrink: 1;
+			width: 100%; /* required for Legacy-Edge and FF when align-items: flex-start is specified */
+		}
+		.d2l-card-link-text {
+			display: inline-block;
+		}
+		.d2l-card-header {
+			border-start-end-radius: 6px;
+			border-start-start-radius: 6px;
+			overflow: hidden;
+		}
+
+		a {
+			bottom: -1px;
+			display: block;
+			left: -1px;
+			outline: none;
+			position: absolute;
+			right: -1px;
+			top: -1px;
+			z-index: 1;
+		}
+		:host([subtle]) a {
+			bottom: 0;
+			left: 0;
+			right: 0;
+			top: 0;
+		}
+
+		:host(:hover) a {
+			bottom: -5px;
+		}
+		:host([subtle]:hover) a {
+			bottom: -4px;
+		}
+
+		.d2l-card-content {
+			padding: 1.2rem 0.8rem 0 0.8rem;
+		}
+		:host([align-center]) .d2l-card-content {
+			text-align: center;
+		}
+
+		:host([align-center]) .d2l-card-badge {
+			display: flex;
+			justify-content: center;
+		}
+
+		.d2l-card-footer-hidden .d2l-card-content {
+			padding-bottom: 1.2rem;
+		}
+		.d2l-card-actions {
+			inset-inline-end: 0.6rem;
+			position: absolute;
+			top: 0.6rem;
+			/* this must be higher than footer z-index so dropdowns will be on top */
+			z-index: 3;
+		}
+		.d2l-card-actions ::slotted(*) {
+			margin-inline-start: 0.3rem;
+		}
+		.d2l-card-badge {
+			line-height: 0;
+			padding: 0 0.8rem;
+		}
+		.d2l-card-footer {
+			box-sizing: border-box;
+			flex: none;
+			padding: 1.2rem 0.8rem 0.6rem 0.8rem;
+			pointer-events: none;
+			width: 100%;
+			z-index: 2;
+		}
+		:host([align-center]) .d2l-card-footer {
+			text-align: center;
+		}
+
+		.d2l-card-footer ::slotted([slot="footer"]) {
+			pointer-events: all;
+		}
+
+		.d2l-card-footer-hidden .d2l-card-footer {
+			box-sizing: content-box;
+			height: auto;
+		}
+
+		:host([subtle]) {
+			border: none;
+		}
+		:host([subtle][href]) {
+			box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.03);
+		}
+		:host([href]:not([_active]):hover) {
+			box-shadow: 0 2px 14px 1px rgba(0, 0, 0, 0.06);
+		}
+		:host([subtle][href]:not([_active]):hover) {
+			box-shadow: 0 4px 18px 2px rgba(0, 0, 0, 0.06);
+		}
+		${getFocusRingStyles(() => ':host([_active])', { 'extraStyles': css`border-color: transparent;` })}
+		/* .d2l-card-link-container-hover is used to only color/underline when
+		hovering the anchor; these styles are not applied when hovering actions */
+		:host([href]) .d2l-card-link-container-hover,
+		:host([href][_active]) .d2l-card-content {
+			color: var(--d2l-color-celestine);
+			text-decoration: underline;
+		}
+		/* this is needed to ensure tooltip is not be clipped by adjacent cards */
+		:host([_tooltip_showing]) {
+			z-index: 1;
+		}
+		/* this is needed to ensure open menu will be ontop of adjacent cards */
+		:host([_dropdown-action-open]) {
+			z-index: 2;
+		}
+		@media (prefers-reduced-motion: no-preference) {
 			:host {
-				background-color: #ffffff;
-				border: 1px solid var(--d2l-color-gypsum);
-				border-radius: 6px;
-				box-sizing: border-box;
-				display: inline-block;
-				position: relative;
-				z-index: 0;
+				transition: box-shadow 0.2s;
 			}
-			.d2l-card-container {
-				align-items: flex-start; /* required so that footer will not stretch to 100% width */
-				display: flex;
-				flex-direction: column;
-				height: 100%;
-				position: relative;
-			}
-			.d2l-card-link-container {
-				flex-basis: auto;
-				flex-grow: 1;
-				flex-shrink: 1;
-				width: 100%; /* required for Legacy-Edge and FF when align-items: flex-start is specified */
-			}
-			.d2l-card-link-text {
-				display: inline-block;
-			}
-			.d2l-card-header {
-				border-start-end-radius: 6px;
-				border-start-start-radius: 6px;
-				overflow: hidden;
-			}
-
-			a {
-				bottom: -1px;
-				display: block;
-				left: -1px;
-				outline: none;
-				position: absolute;
-				right: -1px;
-				top: -1px;
-				z-index: 1;
-			}
-			:host([subtle]) a {
-				bottom: 0;
-				left: 0;
-				right: 0;
-				top: 0;
-			}
-
-			:host(:hover) a {
-				bottom: -5px;
-			}
-			:host([subtle]:hover) a {
-				bottom: -4px;
-			}
-
-			.d2l-card-content {
-				padding: 1.2rem 0.8rem 0 0.8rem;
-			}
-			:host([align-center]) .d2l-card-content {
-				text-align: center;
-			}
-
-			:host([align-center]) .d2l-card-badge {
-				display: flex;
-				justify-content: center;
-			}
-
-			.d2l-card-footer-hidden .d2l-card-content {
-				padding-bottom: 1.2rem;
-			}
-			.d2l-card-actions {
-				inset-inline-end: 0.6rem;
-				position: absolute;
-				top: 0.6rem;
-				/* this must be higher than footer z-index so dropdowns will be on top */
-				z-index: 3;
-			}
-			.d2l-card-actions ::slotted(*) {
-				margin-inline-start: 0.3rem;
-			}
-			.d2l-card-badge {
-				line-height: 0;
-				padding: 0 0.8rem;
-			}
-			.d2l-card-footer {
-				box-sizing: border-box;
-				flex: none;
-				padding: 1.2rem 0.8rem 0.6rem 0.8rem;
-				pointer-events: none;
-				width: 100%;
-				z-index: 2;
-			}
-			:host([align-center]) .d2l-card-footer {
-				text-align: center;
-			}
-
-			.d2l-card-footer ::slotted([slot="footer"]) {
-				pointer-events: all;
-			}
-
-			.d2l-card-footer-hidden .d2l-card-footer {
-				box-sizing: content-box;
-				height: auto;
-			}
-
+		}
+		@media (prefers-contrast: more) {
 			:host([subtle]) {
-				border: none;
+				border: 1px solid var(--d2l-color-gypsum);
 			}
-			:host([subtle][href]) {
-				box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.03);
-			}
-			:host([href]:not([_active]):hover) {
-				box-shadow: 0 2px 14px 1px rgba(0, 0, 0, 0.06);
-			}
-			:host([subtle][href]:not([_active]):hover) {
-				box-shadow: 0 4px 18px 2px rgba(0, 0, 0, 0.06);
-			}
-			${getFocusRingStyles(() => ':host([_active])', { 'extraStyles': css`border-color: transparent;` })}
-			/* .d2l-card-link-container-hover is used to only color/underline when
-			hovering the anchor; these styles are not applied when hovering actions */
-			:host([href]) .d2l-card-link-container-hover,
-			:host([href][_active]) .d2l-card-content {
-				color: var(--d2l-color-celestine);
-				text-decoration: underline;
-			}
-			/* this is needed to ensure tooltip is not be clipped by adjacent cards */
-			:host([_tooltip_showing]) {
-				z-index: 1;
-			}
-			/* this is needed to ensure open menu will be ontop of adjacent cards */
-			:host([_dropdown-action-open]) {
-				z-index: 2;
-			}
-			@media (prefers-reduced-motion: no-preference) {
-				:host {
-					transition: box-shadow 0.2s;
-				}
-			}
-			@media (prefers-contrast: more) {
-				:host([subtle]) {
-					border: 1px solid var(--d2l-color-gypsum);
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/collapsible-panel/README.md
+++ b/components/collapsible-panel/README.md
@@ -219,21 +219,19 @@ import { selectStyles } from '@brightspace-ui/core/components/inputs/input-selec
 
 class CollapsiblePanelDaylightDemo extends LitElement {
 
-	static get properties() {
-		return {
-      _addons: { state: true },
-			_icingType: { state: true },
-			_icingTypes: { state: true },
-		};
-	}
+	static properties = {
+		_addons: { state: true },
+		_icingType: { state: true },
+		_icingTypes: { state: true },
+	};
 
-	static get styles() {
-		return [labelStyles, selectStyles, css`
-			d2l-collapsible-panel {
-				width: 500px;
-			}
-		`];
-	}
+	static styles = [
+		labelStyles,
+		selectStyles, css`
+		d2l-collapsible-panel {
+			width: 500px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/collapsible-panel/collapsible-panel-group.js
+++ b/components/collapsible-panel/collapsible-panel-group.js
@@ -9,27 +9,23 @@ import { SubscriberRegistryController } from '../../controllers/subscriber/subsc
  */
 class CollapsiblePanelGroup extends SkeletonGroupMixin(LitElement) {
 
-	static get properties() {
-		return {
-			_spaced: { state: true }
-		};
-	}
+	static properties = {
+		_spaced: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host ::slotted(*) {
-				display: none;
-			}
-			:host ::slotted(d2l-collapsible-panel) {
-				display: unset;
-			}
-			.spaced {
-				display: flex;
-				flex-direction: column;
-				row-gap: 0.5rem;
-			}
-		`;
-	}
+	static styles = css`
+		:host ::slotted(*) {
+			display: none;
+		}
+		:host ::slotted(d2l-collapsible-panel) {
+			display: unset;
+		}
+		.spaced {
+			display: flex;
+			flex-direction: column;
+			row-gap: 0.5rem;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/collapsible-panel/collapsible-panel-summary-item.js
+++ b/components/collapsible-panel/collapsible-panel-summary-item.js
@@ -11,38 +11,34 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class CollapsiblePanelSummaryItem extends SkeletonMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * The number of lines to display before truncating text with an ellipsis. The text will not be truncated unless a value is specified.
 			 * @type {number}
 			 */
-			lines: { type: Number },
-			/**
+		lines: { type: Number },
+		/**
 			 * REQUIRED: Text that is displayed
 			 * @type {string}
 			 */
-			text: { type: String },
-		};
-	}
+		text: { type: String },
+	};
 
-	static get styles() {
-		return [super.styles, bodySmallStyles, css`
-			:host {
-				color: var(--d2l-theme-text-color-static-faint);
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-body-small {
-				line-height: 1.2rem;
-			}
-			p.truncate {
-				${getOverflowDeclarations({ lines: 1 })}
-			}
-		`];
-	}
+	static styles = [super.styles, bodySmallStyles, css`
+		:host {
+			color: var(--d2l-theme-text-color-static-faint);
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-body-small {
+			line-height: 1.2rem;
+		}
+		p.truncate {
+			${getOverflowDeclarations({ lines: 1 })}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -54,278 +54,274 @@ function addTabListener() {
  */
 class CollapsiblePanel extends SkeletonMixin(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: The title of the panel
 			 * @type {string}
 			 */
-			panelTitle: { attribute: 'panel-title', type: String, reflect: true },
-			/**
+		panelTitle: { attribute: 'panel-title', type: String, reflect: true },
+		/**
 			 * The semantic heading level (h1-h6)
 			 * @type {'1'|'2'|'3'|'4'|'5'|'6'}
 			 * @default "3"
 			 */
-			headingLevel: { attribute: 'heading-level', type: String, reflect: true },
-			/**
+		headingLevel: { attribute: 'heading-level', type: String, reflect: true },
+		/**
 			 * The heading style to use
 			 * @type {'1'|'2'|'3'|'4'}
 			 * @default "3"
 			 */
-			headingStyle: { attribute: 'heading-style', type: String, reflect: true },
-			/**
+		headingStyle: { attribute: 'heading-style', type: String, reflect: true },
+		/**
 			 * Whether or not the panel is expanded
 			 * @type {boolean}
 			 */
-			expanded: { type: Boolean, reflect: true },
-			/**
+		expanded: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: Label describing the contents of the header for screen reader users
 			 * @type {string}
 			 */
-			expandCollapseLabel: { attribute: 'expand-collapse-label', type: String, reflect: true },
-			/**
+		expandCollapseLabel: { attribute: 'expand-collapse-label', type: String, reflect: true },
+		/**
 			 * Type of collapsible panel
 			 * @type {'default'|'subtle'|'inline'}
 			 * @default "default"
 			 */
-			type: { type: String, reflect: true },
-			/**
+		type: { type: String, reflect: true },
+		/**
 			 * Horizontal padding of the panel
 			 * @type {'default'|'large'}
 			 * @default "default"
 			 */
-			paddingType: { attribute: 'padding-type', type: String, reflect: true },
-			/**
+		paddingType: { attribute: 'padding-type', type: String, reflect: true },
+		/**
 			 * Disables sticky positioning for the header
 			 * @type {boolean}
 			 */
-			noSticky: { attribute: 'no-sticky', type: Boolean },
-			_focused: { state: true },
-			_hasBefore: { state: true },
-			_hasSummary: { state: true },
-			_isLastPanelInGroup: { state: true },
-			_scrolled: { state: true },
-		};
-	}
+		noSticky: { attribute: 'no-sticky', type: Boolean },
+		_focused: { state: true },
+		_hasBefore: { state: true },
+		_hasSummary: { state: true },
+		_isLastPanelInGroup: { state: true },
+		_scrolled: { state: true },
+	};
 
-	static get styles() {
-		return [super.styles, heading1Styles, heading2Styles, heading3Styles, heading4Styles, css`
-			:host {
-				--d2l-collapsible-panel-focus-outline: solid 2px var(--d2l-theme-border-color-focus);
-				--d2l-collapsible-panel-spacing-inline: 0.9rem;
-				--d2l-collapsible-panel-header-spacing: 0.6rem;
-				--d2l-collapsible-panel-transition-time: 0.2s;
-				--d2l-collapsible-panel-arrow-time: 0.5s;
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([padding-type="large"][type="inline"]) {
-				--d2l-collapsible-panel-spacing-inline: 2rem;
-			}
-			.d2l-collapsible-panel {
-				border: 1px solid var(--d2l-theme-border-color-standard);
-				border-radius: 0.4rem;
-			}
-			:host(:not([expanded]):not([skeleton])) .d2l-collapsible-panel {
-				cursor: pointer;
-			}
-			:host([type="subtle"]) .d2l-collapsible-panel {
-				background-color: var(--d2l-theme-background-color-base);
-				border: none;
-				box-shadow: var(--d2l-theme-shadow-attached);
-			}
-			:host([type="inline"]) .d2l-collapsible-panel {
-				border-left: none;
-				border-radius: 0;
-				border-right: none;
-				outline-offset: -2px;
-			}
-			:host([type="inline"]) .d2l-collapsible-panel.no-bottom-border {
-				border-bottom: none;
-			}
-			:host([heading-style="1"]) {
-				--d2l-collapsible-panel-header-spacing: 1.2rem;
-			}
-			:host([heading-style="4"]) {
-				--d2l-collapsible-panel-header-spacing: 0.3rem;
-			}
-			.d2l-collapsible-panel-before {
-				grid-row: 1/-1;
-			}
-			.d2l-collapsible-panel.has-before .d2l-collapsible-panel-before {
-				margin: 0.3rem 0;
-				margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
-			}
-			.d2l-collapsible-panel-header {
-				border-radius: 0.4rem;
-				cursor: pointer;
-				display: grid;
-				grid-template-columns: auto 1fr;
-				grid-template-rows: auto auto;
-				padding: var(--d2l-collapsible-panel-header-spacing) 0;
-			}
-			:host(:not([skeleton])) .d2l-collapsible-panel-header {
-				cursor: pointer;
-			}
-			:host([type="inline"]) .d2l-collapsible-panel-header {
-				border-radius: 0;
-				outline-offset: -2px;
-			}
-			.d2l-collapsible-panel.scrolled .d2l-collapsible-panel-header {
-				background-color: var(--d2l-theme-background-color-base);
-				box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
-				position: sticky;
-				top: 0;
-				z-index: 11; /* must be greater greater than list-items with open dropdowns or tooltips */
-			}
-			.d2l-collapsible-panel.focused.scrolled .d2l-collapsible-panel-header {
-				top: 2px;
-			}
-			.d2l-collapsible-panel-title {
-				flex: 1;
-				margin: 0.3rem;
-				margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
-				overflow-wrap: anywhere;
-				user-select: none;
-			}
-			.d2l-collapsible-panel.has-before .d2l-collapsible-panel-title {
-				margin-inline-start: 0.75rem;
-			}
+	static styles = [super.styles, heading1Styles, heading2Styles, heading3Styles, heading4Styles, css`
+		:host {
+			--d2l-collapsible-panel-focus-outline: solid 2px var(--d2l-theme-border-color-focus);
+			--d2l-collapsible-panel-spacing-inline: 0.9rem;
+			--d2l-collapsible-panel-header-spacing: 0.6rem;
+			--d2l-collapsible-panel-transition-time: 0.2s;
+			--d2l-collapsible-panel-arrow-time: 0.5s;
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([padding-type="large"][type="inline"]) {
+			--d2l-collapsible-panel-spacing-inline: 2rem;
+		}
+		.d2l-collapsible-panel {
+			border: 1px solid var(--d2l-theme-border-color-standard);
+			border-radius: 0.4rem;
+		}
+		:host(:not([expanded]):not([skeleton])) .d2l-collapsible-panel {
+			cursor: pointer;
+		}
+		:host([type="subtle"]) .d2l-collapsible-panel {
+			background-color: var(--d2l-theme-background-color-base);
+			border: none;
+			box-shadow: var(--d2l-theme-shadow-attached);
+		}
+		:host([type="inline"]) .d2l-collapsible-panel {
+			border-left: none;
+			border-radius: 0;
+			border-right: none;
+			outline-offset: -2px;
+		}
+		:host([type="inline"]) .d2l-collapsible-panel.no-bottom-border {
+			border-bottom: none;
+		}
+		:host([heading-style="1"]) {
+			--d2l-collapsible-panel-header-spacing: 1.2rem;
+		}
+		:host([heading-style="4"]) {
+			--d2l-collapsible-panel-header-spacing: 0.3rem;
+		}
+		.d2l-collapsible-panel-before {
+			grid-row: 1/-1;
+		}
+		.d2l-collapsible-panel.has-before .d2l-collapsible-panel-before {
+			margin: 0.3rem 0;
+			margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
+		}
+		.d2l-collapsible-panel-header {
+			border-radius: 0.4rem;
+			cursor: pointer;
+			display: grid;
+			grid-template-columns: auto 1fr;
+			grid-template-rows: auto auto;
+			padding: var(--d2l-collapsible-panel-header-spacing) 0;
+		}
+		:host(:not([skeleton])) .d2l-collapsible-panel-header {
+			cursor: pointer;
+		}
+		:host([type="inline"]) .d2l-collapsible-panel-header {
+			border-radius: 0;
+			outline-offset: -2px;
+		}
+		.d2l-collapsible-panel.scrolled .d2l-collapsible-panel-header {
+			background-color: var(--d2l-theme-background-color-base);
+			box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
+			position: sticky;
+			top: 0;
+			z-index: 11; /* must be greater greater than list-items with open dropdowns or tooltips */
+		}
+		.d2l-collapsible-panel.focused.scrolled .d2l-collapsible-panel-header {
+			top: 2px;
+		}
+		.d2l-collapsible-panel-title {
+			flex: 1;
+			margin: 0.3rem;
+			margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
+			overflow-wrap: anywhere;
+			user-select: none;
+		}
+		.d2l-collapsible-panel.has-before .d2l-collapsible-panel-title {
+			margin-inline-start: 0.75rem;
+		}
 
+		.d2l-collapsible-panel.focused,
+		:host([expanded]) .d2l-collapsible-panel.focused .d2l-collapsible-panel-header {
+			outline: var(--d2l-collapsible-panel-focus-outline);
+		}
+		@supports selector(:has(a, b)) {
 			.d2l-collapsible-panel.focused,
 			:host([expanded]) .d2l-collapsible-panel.focused .d2l-collapsible-panel-header {
+				outline: none;
+			}
+			.d2l-collapsible-panel.focused:has(:focus-visible),
+			:host([expanded]) .d2l-collapsible-panel.focused:has(:focus-visible) .d2l-collapsible-panel-header {
 				outline: var(--d2l-collapsible-panel-focus-outline);
 			}
-			@supports selector(:has(a, b)) {
-				.d2l-collapsible-panel.focused,
-				:host([expanded]) .d2l-collapsible-panel.focused .d2l-collapsible-panel-header {
-					outline: none;
-				}
-				.d2l-collapsible-panel.focused:has(:focus-visible),
-				:host([expanded]) .d2l-collapsible-panel.focused:has(:focus-visible) .d2l-collapsible-panel-header {
-					outline: var(--d2l-collapsible-panel-focus-outline);
-				}
-			}
-			:host([expanded]) .d2l-collapsible-panel {
-				outline: none;
-			}
+		}
+		:host([expanded]) .d2l-collapsible-panel {
+			outline: none;
+		}
 
-			.d2l-collapsible-panel-header-primary {
-				align-items: center;
-				display: flex;
-				justify-content: space-between;
-			}
-			.d2l-collapsible-panel-header-secondary {
-				display: flex;
-				margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
-				margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
-			}
-			.d2l-collapsible-panel.has-before .d2l-collapsible-panel-header-secondary {
-				margin-inline-start: 0.75rem;
-			}
-			.d2l-collapsible-panel-header-secondary ::slotted(*) {
-				cursor: default;
-			}
-			.d2l-collapsible-panel-header-actions {
-				align-self: self-start;
-				display: flex;
-				gap: 0.3rem;
-			}
-			.d2l-collapsible-panel-header-actions::after {
-				border-inline-end: 1px solid var(--d2l-theme-border-color-standard);
-				content: "";
-				display: flex;
-				margin: 0.3rem;
-			}
-			.d2l-collapsible-panel-opener {
-				background-color: transparent;
-				border: none;
-				color: inherit;
-				cursor: pointer;
-				font-family: inherit;
-				font-size: inherit;
-				font-weight: inherit;
-				letter-spacing: inherit;
-				line-height: inherit;
-				outline: none;
-				padding-block: 0;
-				padding-inline: 0;
-				text-align: inherit;
-			}
-			d2l-icon-custom {
-				align-self: self-start;
-				height: 0.9rem;
-				margin: 0.6rem;
-				margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
-				position: relative;
-				transform: var(--d2l-mirror-transform, ${document.dir === 'rtl' ? css`scale(-1, 1)` : css`none`}); /* stylelint-disable-line @stylistic/string-quotes, @stylistic/function-whitespace-after */
-				transform-origin: center;
-				width: 0.9rem;
+		.d2l-collapsible-panel-header-primary {
+			align-items: center;
+			display: flex;
+			justify-content: space-between;
+		}
+		.d2l-collapsible-panel-header-secondary {
+			display: flex;
+			margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
+			margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
+		}
+		.d2l-collapsible-panel.has-before .d2l-collapsible-panel-header-secondary {
+			margin-inline-start: 0.75rem;
+		}
+		.d2l-collapsible-panel-header-secondary ::slotted(*) {
+			cursor: default;
+		}
+		.d2l-collapsible-panel-header-actions {
+			align-self: self-start;
+			display: flex;
+			gap: 0.3rem;
+		}
+		.d2l-collapsible-panel-header-actions::after {
+			border-inline-end: 1px solid var(--d2l-theme-border-color-standard);
+			content: "";
+			display: flex;
+			margin: 0.3rem;
+		}
+		.d2l-collapsible-panel-opener {
+			background-color: transparent;
+			border: none;
+			color: inherit;
+			cursor: pointer;
+			font-family: inherit;
+			font-size: inherit;
+			font-weight: inherit;
+			letter-spacing: inherit;
+			line-height: inherit;
+			outline: none;
+			padding-block: 0;
+			padding-inline: 0;
+			text-align: inherit;
+		}
+		d2l-icon-custom {
+			align-self: self-start;
+			height: 0.9rem;
+			margin: 0.6rem;
+			margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
+			position: relative;
+			transform: var(--d2l-mirror-transform, ${document.dir === 'rtl' ? css`scale(-1, 1)` : css`none`}); /* stylelint-disable-line @stylistic/string-quotes, @stylistic/function-whitespace-after */
+			transform-origin: center;
+			width: 0.9rem;
+		}
+		d2l-icon-custom svg {
+			position: absolute;
+			transform-origin: 0.4rem;
+		}
+		:host([expanded]) d2l-icon-custom svg {
+			fill: currentColor;
+			transform: rotate(90deg);
+		}
+		@media (prefers-reduced-motion: no-preference) {
+			.d2l-collapsible-panel-divider {
+				transition: opacity var(--d2l-collapsible-panel-transition-time) ease-in-out;
 			}
 			d2l-icon-custom svg {
-				position: absolute;
-				transform-origin: 0.4rem;
+				animation: d2l-collapsible-panel-opener-close var(--d2l-collapsible-panel-arrow-time) ease-in-out;
 			}
 			:host([expanded]) d2l-icon-custom svg {
-				fill: currentColor;
-				transform: rotate(90deg);
+				animation: d2l-collapsible-panel-opener-open var(--d2l-collapsible-panel-arrow-time) ease-in-out;
 			}
-			@media (prefers-reduced-motion: no-preference) {
-				.d2l-collapsible-panel-divider {
-					transition: opacity var(--d2l-collapsible-panel-transition-time) ease-in-out;
-				}
-				d2l-icon-custom svg {
-					animation: d2l-collapsible-panel-opener-close var(--d2l-collapsible-panel-arrow-time) ease-in-out;
-				}
-				:host([expanded]) d2l-icon-custom svg {
-					animation: d2l-collapsible-panel-opener-open var(--d2l-collapsible-panel-arrow-time) ease-in-out;
-				}
-				/* stylelint-disable order/properties-alphabetical-order */
-				@keyframes d2l-collapsible-panel-opener-open {
-					0% { transform: rotate(0deg); }
-					25% { transform: rotate(105deg); animation-timing-function: ease-in-out; }
-					50% { transform: rotate(82deg); animation-timing-function: ease-in-out; }
-					75% { transform: rotate(93deg); animation-timing-function: ease-in-out; }
-					100% { transform: rotate(90deg); animation-timing-function: ease-in-out; }
-				}
-				@keyframes d2l-collapsible-panel-opener-close {
-					0% { transform: rotate(90deg); }
-					25% { transform: rotate(-15deg); animation-timing-function: ease-in-out; }
-					50% { transform: rotate(8deg); animation-timing-function: ease-in-out; }
-					75% { transform: rotate(-3deg); animation-timing-function: ease-in-out; }
-					100% { transform: rotate(0deg); animation-timing-function: ease-in-out; }
-				}
-				/* stylelint-enable */
+			/* stylelint-disable order/properties-alphabetical-order */
+			@keyframes d2l-collapsible-panel-opener-open {
+				0% { transform: rotate(0deg); }
+				25% { transform: rotate(105deg); animation-timing-function: ease-in-out; }
+				50% { transform: rotate(82deg); animation-timing-function: ease-in-out; }
+				75% { transform: rotate(93deg); animation-timing-function: ease-in-out; }
+				100% { transform: rotate(90deg); animation-timing-function: ease-in-out; }
 			}
-			.d2l-collapsible-panel-divider {
-				border-bottom: 1px solid var(--d2l-theme-border-color-standard);
-				margin-inline: var(--d2l-collapsible-panel-spacing-inline);
-				opacity: 1;
+			@keyframes d2l-collapsible-panel-opener-close {
+				0% { transform: rotate(90deg); }
+				25% { transform: rotate(-15deg); animation-timing-function: ease-in-out; }
+				50% { transform: rotate(8deg); animation-timing-function: ease-in-out; }
+				75% { transform: rotate(-3deg); animation-timing-function: ease-in-out; }
+				100% { transform: rotate(0deg); animation-timing-function: ease-in-out; }
 			}
-			:host([type=inline]) .d2l-collapsible-panel-divider {
-				opacity: 0;
-			}
-			:host(:not([expanded])) .d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-divider {
-				opacity: 0;
-			}
-			.d2l-collapsible-panel-summary,
-			.d2l-collapsible-panel-content {
-				padding: 0.9rem var(--d2l-collapsible-panel-spacing-inline);
-			}
-			:host([type=inline]) .d2l-collapsible-panel-summary,
-			:host([type=inline]) .d2l-collapsible-panel-content {
-				padding-top: 0;
-			}
-			:host([type="inline"]) .d2l-collapsible-panel-summary {
-				margin-top: -0.3rem;
-			}
-			.d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-summary {
-				display: none;
-			}
-		`];
-	}
+			/* stylelint-enable */
+		}
+		.d2l-collapsible-panel-divider {
+			border-bottom: 1px solid var(--d2l-theme-border-color-standard);
+			margin-inline: var(--d2l-collapsible-panel-spacing-inline);
+			opacity: 1;
+		}
+		:host([type=inline]) .d2l-collapsible-panel-divider {
+			opacity: 0;
+		}
+		:host(:not([expanded])) .d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-divider {
+			opacity: 0;
+		}
+		.d2l-collapsible-panel-summary,
+		.d2l-collapsible-panel-content {
+			padding: 0.9rem var(--d2l-collapsible-panel-spacing-inline);
+		}
+		:host([type=inline]) .d2l-collapsible-panel-summary,
+		:host([type=inline]) .d2l-collapsible-panel-content {
+			padding-top: 0;
+		}
+		:host([type="inline"]) .d2l-collapsible-panel-summary {
+			margin-top: -0.3rem;
+		}
+		.d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-summary {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/colors/demo/color-swatch.js
+++ b/components/colors/demo/color-swatch.js
@@ -2,232 +2,228 @@ import { css, html, LitElement } from 'lit';
 
 class ColorSwatch extends LitElement {
 
-	static get properties() {
-		return {
-			name: { type: String, reflect: true }
-		};
-	}
+	static properties = {
+		name: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				border-radius: 8px;
-				box-sizing: border-box;
-				color: #ffffff;
-				display: block;
-				font-size: 0.7rem;
-				font-weight: 400;
-				margin: 0.3rem;
-				padding: 0.3rem;
-				width: 300px;
-			}
-			:host([name="regolith"]) {
-				background-color: var(--d2l-color-regolith);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="sylvite"]) {
-				background-color: var(--d2l-color-sylvite);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="gypsum"]) {
-				background-color: var(--d2l-color-gypsum);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="mica"]) {
-				background-color: var(--d2l-color-mica);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="corundum"]) {
-				background-color: var(--d2l-color-corundum);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="chromite"]) {
-				background-color: var(--d2l-color-chromite);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="galena"]) {
-				background-color: var(--d2l-color-galena);
-			}
-			:host([name="tungsten"]) {
-				background-color: var(--d2l-color-tungsten);
-			}
-			:host([name="ferrite"]) {
-				background-color: var(--d2l-color-ferrite);
-			}
-			:host([name="primary-accent-action"]) {
-				background-color: var(--d2l-color-primary-accent-action);
-			}
-			:host([name="primary-accent-indicator"]) {
-				background-color: var(--d2l-color-primary-accent-indicator);
-			}
-			:host([name="feedback-error"]) {
-				background-color: var(--d2l-color-feedback-error);
-			}
-			:host([name="feedback-warning"]) {
-				background-color: var(--d2l-color-feedback-warning);
-			}
-			:host([name="feedback-success"]) {
-				background-color: var(--d2l-color-feedback-success);
-			}
-			:host([name="feedback-action"]) {
-				background-color: var(--d2l-color-feedback-action);
-			}
-			:host([name="zircon-plus-2"]) {
-				background-color: var(--d2l-color-zircon-plus-2);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="zircon-plus-1"]) {
-				background-color: var(--d2l-color-zircon-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="zircon"]) {
-				background-color: var(--d2l-color-zircon);
-			}
-			:host([name="zircon-minus-1"]) {
-				background-color: var(--d2l-color-zircon-minus-1);
-			}
-			:host([name="celestine-plus-2"]) {
-				background-color: var(--d2l-color-celestine-plus-2);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="celestine-plus-1"]) {
-				background-color: var(--d2l-color-celestine-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="celestine"]) {
-				background-color: var(--d2l-color-celestine);
-			}
-			:host([name="celestine-minus-1"]) {
-				background-color: var(--d2l-color-celestine-minus-1);
-			}
-			:host([name="amethyst-plus-2"]) {
-				background-color: var(--d2l-color-amethyst-plus-2);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="amethyst-plus-1"]) {
-				background-color: var(--d2l-color-amethyst-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="amethyst"]) {
-				background-color: var(--d2l-color-amethyst);
-			}
-			:host([name="amethyst-minus-1"]) {
-				background-color: var(--d2l-color-amethyst-minus-1);
-			}
-			:host([name="fluorite-plus-2"]) {
-				background-color: var(--d2l-color-fluorite-plus-2);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="fluorite-plus-1"]) {
-				background-color: var(--d2l-color-fluorite-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="fluorite"]) {
-				background-color: var(--d2l-color-fluorite);
-			}
-			:host([name="fluorite-minus-1"]) {
-				background-color: var(--d2l-color-fluorite-minus-1);
-			}
-			:host([name="tourmaline-plus-2"]) {
-				background-color: var(--d2l-color-tourmaline-plus-2);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="tourmaline-plus-1"]) {
-				background-color: var(--d2l-color-tourmaline-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="tourmaline"]) {
-				background-color: var(--d2l-color-tourmaline);
-			}
-			:host([name="tourmaline-minus-1"]) {
-				background-color: var(--d2l-color-tourmaline-minus-1);
-			}
-			:host([name="cinnabar-plus-2"]) {
-				background-color: var(--d2l-color-cinnabar-plus-2);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="cinnabar-plus-1"]) {
-				background-color: var(--d2l-color-cinnabar-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="cinnabar"]) {
-				background-color: var(--d2l-color-cinnabar);
-			}
-			:host([name="cinnabar-minus-1"]) {
-				background-color: var(--d2l-color-cinnabar-minus-1);
-			}
-			:host([name="carnelian-plus-1"]) {
-				background-color: var(--d2l-color-carnelian-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="carnelian"]) {
-				background-color: var(--d2l-color-carnelian);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="carnelian-minus-1"]) {
-				background-color: var(--d2l-color-carnelian-minus-1);
-			}
-			:host([name="carnelian-minus-2"]) {
-				background-color: var(--d2l-color-carnelian-minus-2);
-			}
-			:host([name="citrine-plus-1"]) {
-				background-color: var(--d2l-color-citrine-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="citrine"]) {
-				background-color: var(--d2l-color-citrine);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="citrine-minus-1"]) {
-				background-color: var(--d2l-color-citrine-minus-1);
-			}
-			:host([name="citrine-minus-2"]) {
-				background-color: var(--d2l-color-citrine-minus-2);
-			}
-			:host([name="peridot-plus-1"]) {
-				background-color: var(--d2l-color-peridot-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="peridot"]) {
-				background-color: var(--d2l-color-peridot);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="peridot-minus-1"]) {
-				background-color: var(--d2l-color-peridot-minus-1);
-			}
-			:host([name="peridot-minus-2"]) {
-				background-color: var(--d2l-color-peridot-minus-2);
-			}
-			:host([name="olivine-plus-1"]) {
-				background-color: var(--d2l-color-olivine-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="olivine"]) {
-				background-color: var(--d2l-color-olivine);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="olivine-minus-1"]) {
-				background-color: var(--d2l-color-olivine-minus-1);
-			}
-			:host([name="olivine-minus-2"]) {
-				background-color: var(--d2l-color-olivine-minus-2);
-			}
-			:host([name="malachite-plus-1"]) {
-				background-color: var(--d2l-color-malachite-plus-1);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="malachite"]) {
-				background-color: var(--d2l-color-malachite);
-				color: var(--d2l-color-ferrite);
-			}
-			:host([name="malachite-minus-1"]) {
-				background-color: var(--d2l-color-malachite-minus-1);
-			}
-			:host([name="malachite-minus-2"]) {
-				background-color: var(--d2l-color-malachite-minus-2);
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			border-radius: 8px;
+			box-sizing: border-box;
+			color: #ffffff;
+			display: block;
+			font-size: 0.7rem;
+			font-weight: 400;
+			margin: 0.3rem;
+			padding: 0.3rem;
+			width: 300px;
+		}
+		:host([name="regolith"]) {
+			background-color: var(--d2l-color-regolith);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="sylvite"]) {
+			background-color: var(--d2l-color-sylvite);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="gypsum"]) {
+			background-color: var(--d2l-color-gypsum);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="mica"]) {
+			background-color: var(--d2l-color-mica);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="corundum"]) {
+			background-color: var(--d2l-color-corundum);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="chromite"]) {
+			background-color: var(--d2l-color-chromite);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="galena"]) {
+			background-color: var(--d2l-color-galena);
+		}
+		:host([name="tungsten"]) {
+			background-color: var(--d2l-color-tungsten);
+		}
+		:host([name="ferrite"]) {
+			background-color: var(--d2l-color-ferrite);
+		}
+		:host([name="primary-accent-action"]) {
+			background-color: var(--d2l-color-primary-accent-action);
+		}
+		:host([name="primary-accent-indicator"]) {
+			background-color: var(--d2l-color-primary-accent-indicator);
+		}
+		:host([name="feedback-error"]) {
+			background-color: var(--d2l-color-feedback-error);
+		}
+		:host([name="feedback-warning"]) {
+			background-color: var(--d2l-color-feedback-warning);
+		}
+		:host([name="feedback-success"]) {
+			background-color: var(--d2l-color-feedback-success);
+		}
+		:host([name="feedback-action"]) {
+			background-color: var(--d2l-color-feedback-action);
+		}
+		:host([name="zircon-plus-2"]) {
+			background-color: var(--d2l-color-zircon-plus-2);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="zircon-plus-1"]) {
+			background-color: var(--d2l-color-zircon-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="zircon"]) {
+			background-color: var(--d2l-color-zircon);
+		}
+		:host([name="zircon-minus-1"]) {
+			background-color: var(--d2l-color-zircon-minus-1);
+		}
+		:host([name="celestine-plus-2"]) {
+			background-color: var(--d2l-color-celestine-plus-2);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="celestine-plus-1"]) {
+			background-color: var(--d2l-color-celestine-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="celestine"]) {
+			background-color: var(--d2l-color-celestine);
+		}
+		:host([name="celestine-minus-1"]) {
+			background-color: var(--d2l-color-celestine-minus-1);
+		}
+		:host([name="amethyst-plus-2"]) {
+			background-color: var(--d2l-color-amethyst-plus-2);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="amethyst-plus-1"]) {
+			background-color: var(--d2l-color-amethyst-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="amethyst"]) {
+			background-color: var(--d2l-color-amethyst);
+		}
+		:host([name="amethyst-minus-1"]) {
+			background-color: var(--d2l-color-amethyst-minus-1);
+		}
+		:host([name="fluorite-plus-2"]) {
+			background-color: var(--d2l-color-fluorite-plus-2);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="fluorite-plus-1"]) {
+			background-color: var(--d2l-color-fluorite-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="fluorite"]) {
+			background-color: var(--d2l-color-fluorite);
+		}
+		:host([name="fluorite-minus-1"]) {
+			background-color: var(--d2l-color-fluorite-minus-1);
+		}
+		:host([name="tourmaline-plus-2"]) {
+			background-color: var(--d2l-color-tourmaline-plus-2);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="tourmaline-plus-1"]) {
+			background-color: var(--d2l-color-tourmaline-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="tourmaline"]) {
+			background-color: var(--d2l-color-tourmaline);
+		}
+		:host([name="tourmaline-minus-1"]) {
+			background-color: var(--d2l-color-tourmaline-minus-1);
+		}
+		:host([name="cinnabar-plus-2"]) {
+			background-color: var(--d2l-color-cinnabar-plus-2);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="cinnabar-plus-1"]) {
+			background-color: var(--d2l-color-cinnabar-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="cinnabar"]) {
+			background-color: var(--d2l-color-cinnabar);
+		}
+		:host([name="cinnabar-minus-1"]) {
+			background-color: var(--d2l-color-cinnabar-minus-1);
+		}
+		:host([name="carnelian-plus-1"]) {
+			background-color: var(--d2l-color-carnelian-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="carnelian"]) {
+			background-color: var(--d2l-color-carnelian);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="carnelian-minus-1"]) {
+			background-color: var(--d2l-color-carnelian-minus-1);
+		}
+		:host([name="carnelian-minus-2"]) {
+			background-color: var(--d2l-color-carnelian-minus-2);
+		}
+		:host([name="citrine-plus-1"]) {
+			background-color: var(--d2l-color-citrine-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="citrine"]) {
+			background-color: var(--d2l-color-citrine);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="citrine-minus-1"]) {
+			background-color: var(--d2l-color-citrine-minus-1);
+		}
+		:host([name="citrine-minus-2"]) {
+			background-color: var(--d2l-color-citrine-minus-2);
+		}
+		:host([name="peridot-plus-1"]) {
+			background-color: var(--d2l-color-peridot-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="peridot"]) {
+			background-color: var(--d2l-color-peridot);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="peridot-minus-1"]) {
+			background-color: var(--d2l-color-peridot-minus-1);
+		}
+		:host([name="peridot-minus-2"]) {
+			background-color: var(--d2l-color-peridot-minus-2);
+		}
+		:host([name="olivine-plus-1"]) {
+			background-color: var(--d2l-color-olivine-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="olivine"]) {
+			background-color: var(--d2l-color-olivine);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="olivine-minus-1"]) {
+			background-color: var(--d2l-color-olivine-minus-1);
+		}
+		:host([name="olivine-minus-2"]) {
+			background-color: var(--d2l-color-olivine-minus-2);
+		}
+		:host([name="malachite-plus-1"]) {
+			background-color: var(--d2l-color-malachite-plus-1);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="malachite"]) {
+			background-color: var(--d2l-color-malachite);
+			color: var(--d2l-color-ferrite);
+		}
+		:host([name="malachite-minus-1"]) {
+			background-color: var(--d2l-color-malachite-minus-1);
+		}
+		:host([name="malachite-minus-2"]) {
+			background-color: var(--d2l-color-malachite-minus-2);
+		}
+	`;
 
 	render() {
 		return html`

--- a/components/count-badge/count-badge-icon.js
+++ b/components/count-badge/count-badge-icon.js
@@ -9,51 +9,47 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 class CountBadgeIcon extends FocusMixin(CountBadgeMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Preset icon key (e.g. "tier1:gear")
 			 * @type {string}
 			 */
-			icon: {
-				type: String,
-				reflect: true
-			}
-		};
+		icon: {
+			type: String,
+			reflect: true
+		}
+	};
+
+	static styles = [super.styles, css`
+	${getFocusRingStyles(pseudoClass => `:host([focus-ring]) d2l-icon, d2l-icon:${pseudoClass}`)}
+	:host {
+		display: inline-block;
+		/* symmetrical padding to prevent overflows for most numbers */
+		padding-left: 0.5rem;
+		padding-right: 0.5rem;
+		position: relative;
 	}
 
-	static get styles() {
-		return [super.styles, css`
-		${getFocusRingStyles(pseudoClass => `:host([focus-ring]) d2l-icon, d2l-icon:${pseudoClass}`)}
-		:host {
-			display: inline-block;
-			/* symmetrical padding to prevent overflows for most numbers */
-			padding-left: 0.5rem;
-			padding-right: 0.5rem;
-			position: relative;
-		}
-
-		:host([size="large"]) {
-			--d2l-count-badge-icon-padding-top: 0.7rem;
-			padding-top: var(--d2l-count-badge-icon-padding-top);
-		}
-
-		:host([size="small"]) {
-			--d2l-count-badge-icon-padding-top: 0.55rem;
-			padding-top: var(--d2l-count-badge-icon-padding-top);
-		}
-
-		d2l-tooltip[_open-dir="top"] {
-			margin-top: calc(0px - var(--d2l-count-badge-icon-padding-top));
-		}
-
-		d2l-icon {
-			--d2l-focus-ring-offset: 0;
-			border: 2px solid transparent;
-			border-radius: 6px;
-		}
-		`];
+	:host([size="large"]) {
+		--d2l-count-badge-icon-padding-top: 0.7rem;
+		padding-top: var(--d2l-count-badge-icon-padding-top);
 	}
+
+	:host([size="small"]) {
+		--d2l-count-badge-icon-padding-top: 0.55rem;
+		padding-top: var(--d2l-count-badge-icon-padding-top);
+	}
+
+	d2l-tooltip[_open-dir="top"] {
+		margin-top: calc(0px - var(--d2l-count-badge-icon-padding-top));
+	}
+
+	d2l-icon {
+		--d2l-focus-ring-offset: 0;
+		border: 2px solid transparent;
+		border-radius: 6px;
+	}
+	`];
 
 	constructor() {
 		super();

--- a/components/count-badge/count-badge-mixin.js
+++ b/components/count-badge/count-badge-mixin.js
@@ -12,135 +12,131 @@ const maxBadgeDigits = 5;
 
 export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(SkeletonMixin(superclass)) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: When `true`, changes to the badge will be announced to screen reader users
-			 * @type {boolean}
-			 */
-			announceChanges: {
-				type: Boolean,
-				attribute: 'announce-changes'
-			},
-			/**
-			 * Forces the focus ring around the badge
-			 * @type {boolean}
-			 */
-			forceFocusRing: {
-				type: Boolean,
-				attribute: 'focus-ring',
-				reflect: true
-			},
-			/**
-			 * ACCESSIBILITY: Adds a tooltip on the badge, which will be visible on hover and keyboard interaction
-			 * @type {boolean}
-			 */
-			hasTooltip: {
-				type: Boolean,
-				attribute: 'has-tooltip'
-			},
-			/**
-			 * Hides the count badge when `number` is zero
-			 * @type {boolean}
-			 */
-			hideZero: {
-				type: Boolean,
-				attribute: 'hide-zero'
-			},
-			/**
-			 * Specifies a digit limit, after which numbers are truncated. Defaults to two for "notification" type and five for "count" type.
-			 * @type {number}
-			 */
-			maxDigits: {
-				type: Number,
-				attribute: 'max-digits'
-			},
-			/**
-			 * REQUIRED: The number to be displayed on the badge; must be a positive integer
-			 * @type {number}
-			 */
-			number: {
-				type: Number,
-				attribute: 'number'
-			},
-			/**
-			 * The size of the badge
-			 * @type {'small'|'large'}
-			 */
-			size: {
-				type: String,
-				reflect: true,
-				attribute: 'size'
-			},
-			/**
-			 * ACCESSIBILITY: Adds a tab stop to the badge, which allows screen reader and keyboard users to easily tab to the badge
-			 * @type {boolean}
-			 */
-			tabStop: {
-				type: Boolean,
-				attribute: 'tab-stop'
-			},
-			/**
-			 * ACCESSIBILITY: REQUIRED: Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled
-			 * @type {string}
-			 */
-			text: {
-				type: String
-			},
-			/**
-			 * The type of the badge
-			 * @type {'count'|'notification'}
-			 */
-			type: {
-				type: String,
-				reflect: true,
-				attribute: 'type'
-			}
-		};
-	}
+	static properties = {
+		/**
+		 * ACCESSIBILITY: When `true`, changes to the badge will be announced to screen reader users
+		 * @type {boolean}
+		 */
+		announceChanges: {
+			type: Boolean,
+			attribute: 'announce-changes'
+		},
+		/**
+		 * Forces the focus ring around the badge
+		 * @type {boolean}
+		 */
+		forceFocusRing: {
+			type: Boolean,
+			attribute: 'focus-ring',
+			reflect: true
+		},
+		/**
+		 * ACCESSIBILITY: Adds a tooltip on the badge, which will be visible on hover and keyboard interaction
+		 * @type {boolean}
+		 */
+		hasTooltip: {
+			type: Boolean,
+			attribute: 'has-tooltip'
+		},
+		/**
+		 * Hides the count badge when `number` is zero
+		 * @type {boolean}
+		 */
+		hideZero: {
+			type: Boolean,
+			attribute: 'hide-zero'
+		},
+		/**
+		 * Specifies a digit limit, after which numbers are truncated. Defaults to two for "notification" type and five for "count" type.
+		 * @type {number}
+		 */
+		maxDigits: {
+			type: Number,
+			attribute: 'max-digits'
+		},
+		/**
+		 * REQUIRED: The number to be displayed on the badge; must be a positive integer
+		 * @type {number}
+		 */
+		number: {
+			type: Number,
+			attribute: 'number'
+		},
+		/**
+		 * The size of the badge
+		 * @type {'small'|'large'}
+		 */
+		size: {
+			type: String,
+			reflect: true,
+			attribute: 'size'
+		},
+		/**
+		 * ACCESSIBILITY: Adds a tab stop to the badge, which allows screen reader and keyboard users to easily tab to the badge
+		 * @type {boolean}
+		 */
+		tabStop: {
+			type: Boolean,
+			attribute: 'tab-stop'
+		},
+		/**
+		 * ACCESSIBILITY: REQUIRED: Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled
+		 * @type {string}
+		 */
+		text: {
+			type: String
+		},
+		/**
+		 * The type of the badge
+		 * @type {'count'|'notification'}
+		 */
+		type: {
+			type: String,
+			reflect: true,
+			attribute: 'type'
+		}
+	};
 
-	static get styles() {
-		return [super.styles, offscreenStyles, css`
-			:host([hidden]) {
-				display: none;
-			}
+	static styles = [super.styles, offscreenStyles, css`
+		:host([hidden]) {
+			display: none;
+		}
 
-			:host {
-				display: inline-block;
-				min-width: 0.9rem;
-			}
+		:host {
+			display: inline-block;
+			min-width: 0.9rem;
+		}
 
-			.d2l-count-badge-number {
-				font-weight: bold;
-			}
+		.d2l-count-badge-number {
+			font-weight: bold;
+		}
 
-			:host([type="notification"]) .d2l-count-badge-number {
-				background-color: var(--d2l-theme-notification-background-color);
-				color: var(--d2l-theme-notification-text-color);
-			}
+		:host([type="notification"]) .d2l-count-badge-number {
+			background-color: var(--d2l-theme-notification-background-color);
+			color: var(--d2l-theme-notification-text-color);
+		}
 
-			:host([type="count"]) .d2l-count-badge-number {
-				background-color: var(--d2l-count-badge-background-color, var(--d2l-theme-badge-background-color));
-				color: var(--d2l-count-badge-foreground-color, var(--d2l-theme-badge-text-color));
-			}
+		:host([type="count"]) .d2l-count-badge-number {
+			background-color: var(--d2l-count-badge-background-color, var(--d2l-theme-badge-background-color));
+			color: var(--d2l-count-badge-foreground-color, var(--d2l-theme-badge-text-color));
+		}
 
-			:host([size="small"]) .d2l-count-badge-number {
-				border-radius: 0.55rem;
-				font-size: 0.6rem;
-				line-height: 0.9rem;
-				padding-left: 0.3rem;
-				padding-right: 0.3rem;
-			}
+		:host([size="small"]) .d2l-count-badge-number {
+			border-radius: 0.55rem;
+			font-size: 0.6rem;
+			line-height: 0.9rem;
+			padding-left: 0.3rem;
+			padding-right: 0.3rem;
+		}
 
-			:host([size="large"]) .d2l-count-badge-number {
-				border-radius: 0.7rem;
-				font-size: 0.8rem;
-				line-height: 1.2rem;
-				padding-left: 0.4rem;
-				padding-right: 0.4rem;
-			}
-		`];
-	}
+		:host([size="large"]) .d2l-count-badge-number {
+			border-radius: 0.7rem;
+			font-size: 0.8rem;
+			line-height: 1.2rem;
+			padding-left: 0.4rem;
+			padding-right: 0.4rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/count-badge/count-badge.js
+++ b/components/count-badge/count-badge.js
@@ -8,23 +8,21 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 class CountBadge extends FocusMixin(CountBadgeMixin(LitElement)) {
 
-	static get styles() {
-		return [super.styles, css`
-		${getFocusRingStyles(pseudoClass => `:host([focus-ring]) .d2l-count-badge-wrapper, .d2l-count-badge-wrapper:${pseudoClass}`)}
-		.d2l-count-badge-wrapper {
-			--d2l-focus-ring-offset: 0;
-			border: 2px solid transparent;
-		}
-
-		:host([size="small"]) .d2l-count-badge-wrapper {
-			border-radius: 0.65rem;
-		}
-
-		:host([size="large"]) .d2l-count-badge-wrapper {
-			border-radius: 0.8rem;
-		}
-		`];
+	static styles = [super.styles, css`
+	${getFocusRingStyles(pseudoClass => `:host([focus-ring]) .d2l-count-badge-wrapper, .d2l-count-badge-wrapper:${pseudoClass}`)}
+	.d2l-count-badge-wrapper {
+		--d2l-focus-ring-offset: 0;
+		border: 2px solid transparent;
 	}
+
+	:host([size="small"]) .d2l-count-badge-wrapper {
+		border-radius: 0.65rem;
+	}
+
+	:host([size="large"]) .d2l-count-badge-wrapper {
+		border-radius: 0.8rem;
+	}
+	`];
 
 	constructor() {
 		super();

--- a/components/demo/code-view.js
+++ b/components/demo/code-view.js
@@ -6,17 +6,13 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 class CodeView extends LitElement {
 
-	static get properties() {
-		return {
-			hideLanguage: { type: Boolean, reflect: true, attribute: 'hide-language' },
-			language: { type: String, reflect: true },
-			_code: { type: String }
-		};
-	}
+	static properties = {
+		hideLanguage: { type: Boolean, reflect: true, attribute: 'hide-language' },
+		language: { type: String, reflect: true },
+		_code: { type: String }
+	};
 
-	static get styles() {
-		return [ themeStyles, styles ];
-	}
+	static styles = [ themeStyles, styles ];
 
 	constructor() {
 		super();

--- a/components/demo/demo-page-settings.js
+++ b/components/demo/demo-page-settings.js
@@ -17,15 +17,12 @@ const localeSettings = getDocumentLocaleSettings();
 
 class DemoPageSettings extends LitElement {
 
-	static get properties() {
-		return {
-			panelTitle: { type: String, attribute: 'panel-title' },
-			_language: { state: true }
-		};
-	}
+	static properties = {
+		panelTitle: { type: String, attribute: 'panel-title' },
+		_language: { state: true }
+	};
 
-	static get styles() {
-		return [ inputLabelStyles, selectStyles, css`
+	static styles = [ inputLabelStyles, selectStyles, css`
 			:host {
 				display: block;
 			}
@@ -45,7 +42,6 @@ class DemoPageSettings extends LitElement {
 				margin-block-end: 0;
 			}
 		`];
-	}
 
 	constructor() {
 		super();

--- a/components/demo/demo-page.js
+++ b/components/demo/demo-page.js
@@ -21,44 +21,40 @@ window.isD2LDemoPage = true;
 
 class DemoPage extends LitElement {
 
-	static get properties() {
-		return {
-			pageTitle: { type: String, attribute: 'page-title' },
-			_noScroll: { state: true }
-		};
-	}
+	static properties = {
+		pageTitle: { type: String, attribute: 'page-title' },
+		_noScroll: { state: true }
+	};
 
-	static get styles() {
-		return [ css`
-			:host {
-				background-color: var(--d2l-theme-background-color-sunken);
-				display: block;
-				padding: 30px;
-			}
-			main.no-scroll {
-				height: 0;
-				overflow: hidden;
-				padding: 0;
-			}
-			header {
-				margin-bottom: 1.5rem;
-				max-width: 900px;
-			}
-			.d2l-demo-page-content > ::slotted(h2),
-			.d2l-demo-page-content > ::slotted(h3) {
-				color: var(--d2l-theme-text-color-static-standard);
-				font-size: 0.8rem;
-				font-weight: 700;
-				line-height: 1.2rem;
-				margin: 1.5rem 0 1.5rem 0;
-			}
+	static styles = [ css`
+		:host {
+			background-color: var(--d2l-theme-background-color-sunken);
+			display: block;
+			padding: 30px;
+		}
+		main.no-scroll {
+			height: 0;
+			overflow: hidden;
+			padding: 0;
+		}
+		header {
+			margin-bottom: 1.5rem;
+			max-width: 900px;
+		}
+		.d2l-demo-page-content > ::slotted(h2),
+		.d2l-demo-page-content > ::slotted(h3) {
+			color: var(--d2l-theme-text-color-static-standard);
+			font-size: 0.8rem;
+			font-weight: 700;
+			line-height: 1.2rem;
+			margin: 1.5rem 0 1.5rem 0;
+		}
 
-			.d2l-demo-page-content > ::slotted(d2l-code-view),
-			.d2l-demo-page-content > ::slotted(d2l-demo-snippet) {
-				margin-bottom: 36px;
-			}
-		`];
-	}
+		.d2l-demo-page-content > ::slotted(d2l-code-view),
+		.d2l-demo-page-content > ::slotted(d2l-demo-snippet) {
+			margin-bottom: 36px;
+		}
+	`];
 
 	connectedCallback() {
 		super.connectedCallback();

--- a/components/demo/demo-passthrough-mixin.js
+++ b/components/demo/demo-passthrough-mixin.js
@@ -8,9 +8,7 @@ import { LitElement } from 'lit';
  * @param { String } target The element name or other selector string of the element to pass properties to.
  */
 export const DemoPassthroughMixin = (superclass, target) => class extends LitElement {
-	static get properties() {
-		return Object.fromEntries(superclass.elementProperties);
-	}
+	static properties = Object.fromEntries(superclass.elementProperties);
 
 	firstUpdated() {
 		this.target = this.shadowRoot.querySelector(target);

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -15,108 +15,104 @@ function setIndent(text, indent = 0, skipFirstLine = false) {
 
 class DemoSnippet extends LitElement {
 
-	static get properties() {
-		return {
-			codeViewHidden: { type: Boolean, reflect: true, attribute: 'code-view-hidden' },
-			fullWidth: { type: Boolean, reflect: true, attribute: 'full-width' },
-			noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
-			overflowHidden: { type: Boolean, reflect: true, attribute: 'overflow-hidden' },
-			_code: { type: String },
-			_fullscreen: { state: true },
-			_hasSkeleton: { type: Boolean, attribute: false },
-			_settingsPeek: { state: true },
-			_skeletonOn: { type: Boolean, reflect: false }
-		};
-	}
+	static properties = {
+		codeViewHidden: { type: Boolean, reflect: true, attribute: 'code-view-hidden' },
+		fullWidth: { type: Boolean, reflect: true, attribute: 'full-width' },
+		noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
+		overflowHidden: { type: Boolean, reflect: true, attribute: 'overflow-hidden' },
+		_code: { type: String },
+		_fullscreen: { state: true },
+		_hasSkeleton: { type: Boolean, attribute: false },
+		_settingsPeek: { state: true },
+		_skeletonOn: { type: Boolean, reflect: false }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				background-color: var(--d2l-theme-background-color-base);
-				border: 1px solid var(--d2l-theme-border-color-standard);
-				border-radius: 6px;
-				box-shadow: var(--d2l-theme-shadow-floating);
-				display: block;
-				max-width: 900px;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([full-width]) {
-				max-width: unset;
-			}
-			.d2l-demo-snippet-demo-wrapper {
-				display: flex;
-			}
-			.d2l-demo-snippet-demo-wrapper.fullscreen {
-				background-color: var(--d2l-theme-background-color-base);
-				height: 100vh;
-				inset: 0;
-				overflow: auto;
-				position: absolute;
-				z-index: 2;
-			}
-			.d2l-demo-snippet-demo {
-				flex: 1 1 auto;
-				min-width: 0;
-				position: relative;
-			}
-			:host([full-width]) .d2l-demo-snippet-demo-wrapper.fullscreen .d2l-demo-snippet-demo {
-				width: 100vw;
-			}
-			:host([overflow-hidden]) .d2l-demo-snippet-demo {
-				overflow: hidden;
-			}
-			.d2l-demo-snippet-demo-padding {
-				padding: 18px;
-			}
-			:host([no-padding]) .d2l-demo-snippet-demo-padding,
-			.d2l-demo-snippet-demo-wrapper.fullscreen .d2l-demo-snippet-demo-padding {
-				padding: 0;
-			}
-			.d2l-demo-snippet-settings {
-				border-inline-start: 1px solid var(--d2l-theme-border-color-standard);
-				flex: 0 0 auto;
-				padding: 6px;
-			}
-			.d2l-demo-snippet-demo-wrapper.fullscreen .d2l-demo-snippet-settings {
-				position: sticky;
-				top: 0;
-			}
+	static styles = css`
+		:host {
+			background-color: var(--d2l-theme-background-color-base);
+			border: 1px solid var(--d2l-theme-border-color-standard);
+			border-radius: 6px;
+			box-shadow: var(--d2l-theme-shadow-floating);
+			display: block;
+			max-width: 900px;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([full-width]) {
+			max-width: unset;
+		}
+		.d2l-demo-snippet-demo-wrapper {
+			display: flex;
+		}
+		.d2l-demo-snippet-demo-wrapper.fullscreen {
+			background-color: var(--d2l-theme-background-color-base);
+			height: 100vh;
+			inset: 0;
+			overflow: auto;
+			position: absolute;
+			z-index: 2;
+		}
+		.d2l-demo-snippet-demo {
+			flex: 1 1 auto;
+			min-width: 0;
+			position: relative;
+		}
+		:host([full-width]) .d2l-demo-snippet-demo-wrapper.fullscreen .d2l-demo-snippet-demo {
+			width: 100vw;
+		}
+		:host([overflow-hidden]) .d2l-demo-snippet-demo {
+			overflow: hidden;
+		}
+		.d2l-demo-snippet-demo-padding {
+			padding: 18px;
+		}
+		:host([no-padding]) .d2l-demo-snippet-demo-padding,
+		.d2l-demo-snippet-demo-wrapper.fullscreen .d2l-demo-snippet-demo-padding {
+			padding: 0;
+		}
+		.d2l-demo-snippet-settings {
+			border-inline-start: 1px solid var(--d2l-theme-border-color-standard);
+			flex: 0 0 auto;
+			padding: 6px;
+		}
+		.d2l-demo-snippet-demo-wrapper.fullscreen .d2l-demo-snippet-settings {
+			position: sticky;
+			top: 0;
+		}
+		d2l-dropdown.settings-dropdown {
+			background-color: var(--d2l-theme-background-color-base);
+			border-radius: 6px;
+			outline: 1px solid var(--d2l-color-celestine-minus-1);
+			position: fixed;
+			right: 1rem;
+			top: -0.25rem;
+			translate: 0 -1.5rem;
+			z-index: 9999; /* stack on top of sticky headers */
+		}
+		@media (prefers-reduced-motion: no-preference) {
 			d2l-dropdown.settings-dropdown {
-				background-color: var(--d2l-theme-background-color-base);
-				border-radius: 6px;
-				outline: 1px solid var(--d2l-color-celestine-minus-1);
-				position: fixed;
-				right: 1rem;
-				top: -0.25rem;
-				translate: 0 -1.5rem;
-				z-index: 9999; /* stack on top of sticky headers */
+				transition: translate 0.15s, box-shadow 0.15s;
 			}
-			@media (prefers-reduced-motion: no-preference) {
-				d2l-dropdown.settings-dropdown {
-					transition: translate 0.15s, box-shadow 0.15s;
-				}
-			}
-			d2l-dropdown.settings-dropdown.peek,
-			d2l-dropdown.settings-dropdown:hover,
-			d2l-dropdown.settings-dropdown:focus-within {
-				box-shadow: 0 -1px 0 1px white;
-				translate: 0;
-			}
-			d2l-code-view {
-				border: none;
-				border-top-left-radius: 0;
-				border-top-right-radius: 0;
-				box-shadow: none;
-				margin: 0;
-				max-width: 100%;
-			}
-			:host([code-view-hidden]) d2l-code-view {
-				display: none;
-			}
-		`;
-	}
+		}
+		d2l-dropdown.settings-dropdown.peek,
+		d2l-dropdown.settings-dropdown:hover,
+		d2l-dropdown.settings-dropdown:focus-within {
+			box-shadow: 0 -1px 0 1px white;
+			translate: 0;
+		}
+		d2l-code-view {
+			border: none;
+			border-top-left-radius: 0;
+			border-top-right-radius: 0;
+			box-shadow: none;
+			margin: 0;
+			max-width: 100%;
+		}
+		:host([code-view-hidden]) d2l-code-view {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/description-list/README.md
+++ b/components/description-list/README.md
@@ -38,9 +38,7 @@ For very long values, or very small container sizes, the description list can us
 
   class TestDescriptionList extends LitElement {
 
-    static get styles() {
-      return descriptionListStyles;
-    }
+    static styles = descriptionListStyles;
 
     render() {
       return html`
@@ -77,15 +75,11 @@ The `d2l-dl-wrapper` component can be combined with `descriptionListStyles` to a
 
   class TestDescriptionList extends LitElement {
 
-    static get styles() {
-      return descriptionListStyles;
-    }
+    static styles = descriptionListStyles;
 
-    static get properties() {
-      return {
-        breakpoint: { type: Number },
-      }
-    }
+    static properties = {
+      breakpoint: { type: Number },
+    };
 
     render() {
       return html`
@@ -133,28 +127,26 @@ The `dt` and `dd` elements can contain non-text content such as links or profile
 
   class TestDescriptionList extends LitElement {
 
-    static get styles() {
-      return [
-        descriptionListStyles, css`
-          .user {
-            align-items: center;
-            display: flex;
-            gap: 0.5rem;
-          }
-          .avatar {
-            align-items: center;
-            background-color: var(--d2l-color-cinnabar-minus-1);
-            border-radius: 0.25rem;
-            color: white;
-            display: flex;
-            font-size: 0.7rem;
-            font-weight: 700;
-            height: 1.5rem;
-            justify-content: center;
-            width: 1.5rem;
-          }
-      `];
-    }
+    static styles = [
+      descriptionListStyles, css`
+        .user {
+          align-items: center;
+          display: flex;
+          gap: 0.5rem;
+        }
+        .avatar {
+          align-items: center;
+          background-color: var(--d2l-color-cinnabar-minus-1);
+          border-radius: 0.25rem;
+          color: white;
+          display: flex;
+          font-size: 0.7rem;
+          font-weight: 700;
+          height: 1.5rem;
+          justify-content: center;
+          width: 1.5rem;
+        }
+    `];
 
     render() {
       return html`

--- a/components/description-list/demo/description-list-test.js
+++ b/components/description-list/demo/description-list-test.js
@@ -4,46 +4,42 @@ import { descriptionListStyles } from '../description-list-wrapper.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 class TestDescriptionList extends LitElement {
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Width for component to use a stacked layout
 			 * @type {number}
 			 */
-			breakpoint: { type: Number, reflect: true },
-			/**
+		breakpoint: { type: Number, reflect: true },
+		/**
 			 * Force the component to always use a stacked layout; will override breakpoint attribute
 			 * @type {boolean}
 			 */
-			forceStacked: { type: Boolean, reflect: true, attribute: 'force-stacked' },
-			/**
+		forceStacked: { type: Boolean, reflect: true, attribute: 'force-stacked' },
+		/**
 			 * @ignore
 			 */
-			type: { type: String, reflect: true },
-		};
-	}
+		type: { type: String, reflect: true },
+	};
 
-	static get styles() {
-		return [descriptionListStyles, css`
-			.user {
-				align-items: center;
-				display: flex;
-				gap: 0.5rem;
-			}
-			.avatar {
-				align-items: center;
-				background-color: var(--d2l-color-cinnabar-minus-1);
-				border-radius: 0.25rem;
-				color: white;
-				display: flex;
-				font-size: 0.7rem;
-				font-weight: 700;
-				height: 1.5rem;
-				justify-content: center;
-				width: 1.5rem;
-			}
-		`];
-	}
+	static styles = [descriptionListStyles, css`
+		.user {
+			align-items: center;
+			display: flex;
+			gap: 0.5rem;
+		}
+		.avatar {
+			align-items: center;
+			background-color: var(--d2l-color-cinnabar-minus-1);
+			border-radius: 0.25rem;
+			color: white;
+			display: flex;
+			font-size: 0.7rem;
+			font-weight: 700;
+			height: 1.5rem;
+			justify-content: center;
+			width: 1.5rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/description-list/description-list-wrapper.js
+++ b/components/description-list/description-list-wrapper.js
@@ -36,38 +36,34 @@ export const descriptionListStyles = [
  * @slot - Content to wrap
  */
 class DescriptionListWrapper extends LitElement {
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Width for component to use a stacked layout
 			 * @type {number}
 			 */
-			breakpoint: { type: Number, reflect: true },
-			/**
+		breakpoint: { type: Number, reflect: true },
+		/**
 			 * Force the component to always use a stacked layout; will override breakpoint attribute
 			 * @type {boolean}
 			 */
-			forceStacked: { type: Boolean, reflect: true, attribute: 'force-stacked' },
-			_stacked: { state: true },
-		};
-	}
+		forceStacked: { type: Boolean, reflect: true, attribute: 'force-stacked' },
+		_stacked: { state: true },
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.stacked {
-				--d2l-dl-wrapper-dl-display: block;
-				--d2l-dl-wrapper-dt-max-width: none;
-				--d2l-dl-wrapper-dt-margin: 0 0 0.3rem 0;
-				--d2l-dl-wrapper-dd-margin: 0 0 0.9rem 0;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.stacked {
+			--d2l-dl-wrapper-dl-display: block;
+			--d2l-dl-wrapper-dt-max-width: none;
+			--d2l-dl-wrapper-dt-margin: 0 0 0.3rem 0;
+			--d2l-dl-wrapper-dd-margin: 0 0 0.9rem 0;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/dialog/README.md
+++ b/components/dialog/README.md
@@ -278,11 +278,9 @@ Notes on this example:
 
   class DialogAsyncContentUntil extends LoadingCompleteMixin(LitElement) {
 
-    static get properties() {
-      return {
-        key: { type: String }
-      };
-    }
+    static properties = {
+      key: { type: String }
+    };
     
     constructor() {
       super();

--- a/components/dialog/demo/dialog-async-content-until.js
+++ b/components/dialog/demo/dialog-async-content-until.js
@@ -10,14 +10,11 @@ import { until } from 'lit/directives/until.js';
 
 class DialogAsyncContentUntil extends LoadingCompleteMixin(LitElement) {
 
-	static get properties() {
-		return {
-			href: { type: String }
-		};
-	}
+	static properties = {
+		href: { type: String }
+	};
 
-	static get styles() {
-		return css`
+	static styles = css`
 			.content-button {
 				padding-block: 1rem;
 			}
@@ -25,7 +22,6 @@ class DialogAsyncContentUntil extends LoadingCompleteMixin(LitElement) {
 				text-align: center;
 			}
 		`;
-	}
 
 	constructor() {
 		super();

--- a/components/dialog/demo/dialog-async-content.js
+++ b/components/dialog/demo/dialog-async-content.js
@@ -7,11 +7,9 @@ import { LoadingCompleteMixin } from '../../../mixins/loading-complete/loading-c
 
 class DialogAsyncContent extends LoadingCompleteMixin(LitElement) {
 
-	static get properties() {
-		return {
-			href: { type: String }
-		};
-	}
+	static properties = {
+		href: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/dialog/demo/dialog-container.js
+++ b/components/dialog/demo/dialog-container.js
@@ -4,11 +4,9 @@ import { html, LitElement } from 'lit';
 
 class DialogContainer extends LitElement {
 
-	static get properties() {
-		return {
-			opened: { type: Boolean }
-		};
-	}
+	static properties = {
+		opened: { type: Boolean }
+	};
 
 	constructor() {
 		super();

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -15,79 +15,75 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 class DialogConfirm extends LocalizeCoreElement(DialogMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether the dialog should indicate that its message is important to the user
 			 */
-			critical: { type: Boolean },
+		critical: { type: Boolean },
 
-			/**
+		/**
 			 * REQUIRED: The text content for the confirmation dialog. Newline characters (`&#10;` in HTML or `\n` in JavaScript) will render as multiple paragraphs.
 			 * @type {string}
 			 */
-			text: { type: String }
-		};
-	}
+		text: { type: String }
+	};
 
-	static get styles() {
-		return [ _generateResetStyles(':host'), dialogStyles, heading3Styles, css`
+	static styles = [ _generateResetStyles(':host'), dialogStyles, heading3Styles, css`
 
+		.d2l-dialog-outer {
+			max-width: 420px;
+		}
+
+		.d2l-dialog-header > h2 {
+			margin: 0;
+			width: fit-content;
+		}
+
+		${getFocusRingStyles(pseudoClass => `.d2l-dialog-content:${pseudoClass} > div`, { extraStyles: css`
+
+			--d2l-focus-ring-offset: -1px; border-radius: 6px;`
+		})}
+		.d2l-dialog-content:focus,
+		.d2l-dialog-content:focus-visible {
+			outline: none;
+		}
+
+		.d2l-dialog-content {
+			padding-top: 30px;
+		}
+
+		.d2l-dialog-header + .d2l-dialog-content {
+			padding-top: 0;
+		}
+
+		.d2l-dialog-content p {
+			margin: 1rem 0;
+		}
+
+		.d2l-dialog-content p:first-child {
+			margin-top: 0;
+		}
+
+		.d2l-dialog-content p:last-child {
+			margin-bottom: 0;
+		}
+
+		@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+
+			dialog.d2l-dialog-outer,
 			.d2l-dialog-outer {
-				max-width: 420px;
-			}
-
-			.d2l-dialog-header > h2 {
-				margin: 0;
-				width: fit-content;
-			}
-
-			${getFocusRingStyles(pseudoClass => `.d2l-dialog-content:${pseudoClass} > div`, { extraStyles: css`
-
-				--d2l-focus-ring-offset: -1px; border-radius: 6px;`
-			})}
-			.d2l-dialog-content:focus,
-			.d2l-dialog-content:focus-visible {
-				outline: none;
+				bottom: 0;
+				margin: auto;
+				top: 0;
 			}
 
 			.d2l-dialog-content {
-				padding-top: 30px;
+				padding-top: 20px;
 			}
 
-			.d2l-dialog-header + .d2l-dialog-content {
-				padding-top: 0;
-			}
+		}
 
-			.d2l-dialog-content p {
-				margin: 1rem 0;
-			}
-
-			.d2l-dialog-content p:first-child {
-				margin-top: 0;
-			}
-
-			.d2l-dialog-content p:last-child {
-				margin-bottom: 0;
-			}
-
-			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
-
-				dialog.d2l-dialog-outer,
-				.d2l-dialog-outer {
-					bottom: 0;
-					margin: auto;
-					top: 0;
-				}
-
-				.d2l-dialog-content {
-					padding-top: 20px;
-				}
-
-			}
-
-		`];
-	}
+	`];
 
 	constructor() {
 		super();

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -22,172 +22,168 @@ const mediaQueryList = window.matchMedia('(max-width: 615px), (max-height: 420px
  */
 class DialogFullscreen extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether to render a loading-spinner and wait for state changes via AsyncContainerMixin
 			 * @type {boolean}
 			 */
-			async: { type: Boolean },
-			/**
+		async: { type: Boolean },
+		/**
 			 * Render with no content padding
 			 * @type {boolean}
 			 */
-			noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
-			/**
+		noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
+		/**
 			 * REQUIRED: the title for the dialog
 			 */
-			titleText: { type: String, attribute: 'title-text', required: true },
-			/**
+		titleText: { type: String, attribute: 'title-text', required: true },
+		/**
 			 * The preferred width (unit-less) for the dialog. Minimum 1170 (anything smaller will have no effect).
 			 */
-			width: { type: Number },
-			_autoSize: { state: true }, /* DE52039 This is only redefined here to suppress a lit-analyzer linting issue */
-			_hasFooterContent: { state: true },
-			_icon: { state: true },
-			_headerStyle: { state: true },
-		};
-	}
+		width: { type: Number },
+		_autoSize: { state: true }, /* DE52039 This is only redefined here to suppress a lit-analyzer linting issue */
+		_hasFooterContent: { state: true },
+		_icon: { state: true },
+		_headerStyle: { state: true },
+	};
 
-	static get styles() {
-		return [ _generateResetStyles(':host'), dialogStyles, heading2Styles, heading3Styles, css`
+	static styles = [ _generateResetStyles(':host'), dialogStyles, heading2Styles, heading3Styles, css`
 
-			.d2l-dialog-footer.d2l-footer-no-content {
-				display: none;
+		.d2l-dialog-footer.d2l-footer-no-content {
+			display: none;
+		}
+
+		.d2l-dialog-content-loading {
+			text-align: center;
+		}
+
+		.d2l-dialog-outer {
+			max-width: calc(100% - 3rem);
+		}
+
+		:host([no-padding]) .d2l-dialog-content {
+			--d2l-list-controls-padding: 0px; /* stylelint-disable-line length-zero-no-unit */
+			padding: 0;
+		}
+
+		@media (min-width: 616px) {
+
+			.d2l-dialog-header {
+				border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
+				padding-bottom: 0.9rem;
+				padding-top: 1rem;
 			}
 
-			.d2l-dialog-content-loading {
-				text-align: center;
+			.d2l-dialog-content > div {
+				/* required to properly calculate preferred height when there are bottom
+				margins at the end of the slotted content */
+				border-bottom: 1px solid transparent;
+				box-sizing: border-box;
+				height: calc(100% - 1rem);
+				padding-top: 1rem;
 			}
 
-			.d2l-dialog-outer {
-				max-width: calc(100% - 3rem);
+			:host([no-padding]) .d2l-dialog-content > div {
+				height: 100%;
+				padding-top: 0;
 			}
 
-			:host([no-padding]) .d2l-dialog-content {
-				--d2l-list-controls-padding: 0px; /* stylelint-disable-line length-zero-no-unit */
-				padding: 0;
+			.d2l-dialog-header > div > d2l-button-icon {
+				flex: none;
+				margin-block: -2px 0;
+				margin-inline: 0 -12px;
 			}
 
-			@media (min-width: 616px) {
+			dialog.d2l-dialog-outer,
+			div.d2l-dialog-outer {
+				animation: d2l-dialog-fullscreen-close 200ms ease-in;
+				border-radius: 8px;
+				margin: 1.5rem;
+				top: 0;
+				width: auto;
+			}
 
-				.d2l-dialog-header {
-					border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
-					padding-bottom: 0.9rem;
-					padding-top: 1rem;
-				}
+			@keyframes d2l-dialog-fullscreen-close {
+				0% { opacity: 1; transform: translateY(0); }
+				100% { opacity: 0; transform: translateY(-50px) scale(0.97); }
+			}
 
-				.d2l-dialog-content > div {
-					/* required to properly calculate preferred height when there are bottom
-					margins at the end of the slotted content */
-					border-bottom: 1px solid transparent;
-					box-sizing: border-box;
-					height: calc(100% - 1rem);
-					padding-top: 1rem;
-				}
+			@keyframes d2l-dialog-fullscreen-open {
+				0% { opacity: 0; transform: translateY(-50px) scale(0.97); }
+				100% { opacity: 1; transform: translateY(0); }
+			}
 
-				:host([no-padding]) .d2l-dialog-content > div {
-					height: 100%;
-					padding-top: 0;
-				}
+			dialog.d2l-dialog-outer.d2l-dialog-fullscreen-within,
+			div.d2l-dialog-outer.d2l-dialog-fullscreen-within {
+				/* no margins when there is a fullscreen element within */
+				margin: 0;
+			}
 
-				.d2l-dialog-header > div > d2l-button-icon {
-					flex: none;
-					margin-block: -2px 0;
-					margin-inline: 0 -12px;
-				}
+			:host(:not([in-iframe])) dialog.d2l-dialog-outer,
+			:host(:not([in-iframe])) div.d2l-dialog-outer {
+				height: calc(100% - 3rem);
+			}
 
+			/* for screens wider than 1170px + 60px margins */
+			@media (min-width: 1230px) {
 				dialog.d2l-dialog-outer,
 				div.d2l-dialog-outer {
-					animation: d2l-dialog-fullscreen-close 200ms ease-in;
-					border-radius: 8px;
-					margin: 1.5rem;
-					top: 0;
-					width: auto;
+					/* center the dialog */
+					margin-left: auto;
+					margin-right: auto;
 				}
+			}
 
-				@keyframes d2l-dialog-fullscreen-close {
-					0% { opacity: 1; transform: translateY(0); }
-					100% { opacity: 0; transform: translateY(-50px) scale(0.97); }
-				}
+			:host([_state="showing"]) dialog.d2l-dialog-outer,
+			:host([_state="showing"]) div.d2l-dialog-outer {
+				animation: d2l-dialog-fullscreen-open 400ms ease-out;
+			}
 
-				@keyframes d2l-dialog-fullscreen-open {
-					0% { opacity: 0; transform: translateY(-50px) scale(0.97); }
-					100% { opacity: 1; transform: translateY(0); }
-				}
+			:host([_state="showing"]) dialog::backdrop {
+				transition-duration: 400ms;
+			}
 
-				dialog.d2l-dialog-outer.d2l-dialog-fullscreen-within,
-				div.d2l-dialog-outer.d2l-dialog-fullscreen-within {
-					/* no margins when there is a fullscreen element within */
-					margin: 0;
-				}
+			.d2l-dialog-footer {
+				border-top: 1px solid var(--d2l-theme-border-color-subtle);
+				padding-bottom: 0; /* 0.9rem padding included on button */
+				padding-top: 0.9rem;
+			}
 
-				:host(:not([in-iframe])) dialog.d2l-dialog-outer,
-				:host(:not([in-iframe])) div.d2l-dialog-outer {
-					height: calc(100% - 3rem);
-				}
+			@media (prefers-reduced-motion: reduce) {
 
-				/* for screens wider than 1170px + 60px margins */
-				@media (min-width: 1230px) {
-					dialog.d2l-dialog-outer,
-					div.d2l-dialog-outer {
-						/* center the dialog */
-						margin-left: auto;
-						margin-right: auto;
-					}
-				}
-
+				dialog.d2l-dialog-outer,
+				div.d2l-dialog-outer,
 				:host([_state="showing"]) dialog.d2l-dialog-outer,
 				:host([_state="showing"]) div.d2l-dialog-outer {
-					animation: d2l-dialog-fullscreen-open 400ms ease-out;
+					animation: none;
 				}
 
-				:host([_state="showing"]) dialog::backdrop {
-					transition-duration: 400ms;
-				}
-
-				.d2l-dialog-footer {
-					border-top: 1px solid var(--d2l-theme-border-color-subtle);
-					padding-bottom: 0; /* 0.9rem padding included on button */
-					padding-top: 0.9rem;
-				}
-
-				@media (prefers-reduced-motion: reduce) {
-
-					dialog.d2l-dialog-outer,
-					div.d2l-dialog-outer,
-					:host([_state="showing"]) dialog.d2l-dialog-outer,
-					:host([_state="showing"]) div.d2l-dialog-outer {
-						animation: none;
-					}
-
-					dialog::backdrop {
-						transition: none;
-					}
+				dialog::backdrop {
+					transition: none;
 				}
 			}
+		}
 
-			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+		@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
 
-				.d2l-dialog-header {
-					padding-bottom: 15px;
-				}
-
-				.d2l-dialog-footer.d2l-footer-no-content {
-					padding: 0 0 5px 0;
-				}
-
-				.d2l-dialog-content > div {
-					/* required to properly calculate preferred height when there are bottom
-					margins at the end of the slotted content */
-					border-bottom: 1px solid transparent;
-					/* required to render full height in an i-Frame */
-					height: calc(100% - 1px);
-				}
-
+			.d2l-dialog-header {
+				padding-bottom: 15px;
 			}
-		`];
-	}
+
+			.d2l-dialog-footer.d2l-footer-no-content {
+				padding: 0 0 5px 0;
+			}
+
+			.d2l-dialog-content > div {
+				/* required to properly calculate preferred height when there are bottom
+				margins at the end of the slotted content */
+				border-bottom: 1px solid transparent;
+				/* required to render full height in an i-Frame */
+				height: calc(100% - 1px);
+			}
+
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -30,47 +30,45 @@ const closeDialogWhenDisconnectedFlag = getFlag('GAUD-10113-close-dialog-when-di
 
 export const DialogMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			focusableContentElemPresent: { state: true },
-			/**
-			 * Whether or not the dialog is open
-			 */
-			opened: { type: Boolean, reflect: true },
-			/**
-			 * ADVANCED: Opt out of dialog content scrolling
-			 */
-			noContentScroll: { type: Boolean, attribute: 'no-content-scroll', reflect: true },
-			/**
-			 * @ignore
-			 * Do NOT use this
-			 */
-			preferNative: { type: Boolean, attribute: 'prefer-native' },
-			/**
-			 * The optional title for the dialog
-			 */
-			titleText: { type: String, attribute: 'title-text' },
-			_autoSize: { state: true },
-			_fullscreenWithin: { state: true },
-			_height: { state: true },
-			_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
-			_isFullHeight: { state: true },
-			_left: { state: true },
-			_margin: { state: true },
-			_nestedShowing: { state: true },
-			_overflowBottom: { state: true },
-			_overflowTop: { state: true },
-			_parentDialog: { state: true },
-			_scroll: { state: true },
-			_state: { type: String, reflect: true },
-			_top: { state: true },
-			_width: { state: true },
-			_useNative: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		focusableContentElemPresent: { state: true },
+		/**
+		 * Whether or not the dialog is open
+		 */
+		opened: { type: Boolean, reflect: true },
+		/**
+		 * ADVANCED: Opt out of dialog content scrolling
+		 */
+		noContentScroll: { type: Boolean, attribute: 'no-content-scroll', reflect: true },
+		/**
+		 * @ignore
+		 * Do NOT use this
+		 */
+		preferNative: { type: Boolean, attribute: 'prefer-native' },
+		/**
+		 * The optional title for the dialog
+		 */
+		titleText: { type: String, attribute: 'title-text' },
+		_autoSize: { state: true },
+		_fullscreenWithin: { state: true },
+		_height: { state: true },
+		_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
+		_isFullHeight: { state: true },
+		_left: { state: true },
+		_margin: { state: true },
+		_nestedShowing: { state: true },
+		_overflowBottom: { state: true },
+		_overflowTop: { state: true },
+		_parentDialog: { state: true },
+		_scroll: { state: true },
+		_state: { type: String, reflect: true },
+		_top: { state: true },
+		_width: { state: true },
+		_useNative: { state: true }
+	};
 
 	constructor() {
 		super();

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -22,80 +22,76 @@ const mediaQueryList = window.matchMedia('(max-width: 615px), (max-height: 420px
  */
 class Dialog extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether to render a loading-spinner and wait for state changes via AsyncContainerMixin
 			 */
-			async: { type: Boolean },
+		async: { type: Boolean },
 
-			/**
+		/**
 			 * Whether the dialog should indicate that its message is important to the user
 			 */
-			critical: { type: Boolean },
+		critical: { type: Boolean },
 
-			/**
+		/**
 			 * Causes screen readers to announce the content of the dialog on open. Only use if the content is concise and contains only text since screen readers ignore HTML semantics and some have a ~250 character limit.
 			 */
-			describeContent: { type: Boolean, attribute: 'describe-content' },
+		describeContent: { type: Boolean, attribute: 'describe-content' },
 
-			/**
+		/**
 			 * Whether to render the dialog at the maximum height
 			 */
-			fullHeight: { type: Boolean, attribute: 'full-height' },
+		fullHeight: { type: Boolean, attribute: 'full-height' },
 
-			/**
+		/**
 			 * REQUIRED: the title for the dialog
 			 */
-			titleText: { type: String, attribute: 'title-text', required: true },
+		titleText: { type: String, attribute: 'title-text', required: true },
 
-			/**
+		/**
 			 * The preferred width (unit-less) for the dialog
 			 */
-			width: { type: Number },
-			_hasFooterContent: { type: Boolean, attribute: false }
-		};
-	}
+		width: { type: Number },
+		_hasFooterContent: { type: Boolean, attribute: false }
+	};
 
-	static get styles() {
-		return [ _generateResetStyles(':host'), dialogStyles, heading3Styles, css`
+	static styles = [ _generateResetStyles(':host'), dialogStyles, heading3Styles, css`
+
+		.d2l-dialog-header,
+		:host([critical]) .d2l-dialog-header {
+			padding-bottom: 15px;
+		}
+
+		.d2l-dialog-header > div > d2l-button-icon {
+			flex: none;
+			margin-block: -4px 0;
+			margin-inline: 15px -15px;
+		}
+
+		.d2l-dialog-content > div {
+			/* required to properly calculate preferred height when there are bottom
+			margins at the end of the slotted content */
+			border-bottom: 1px solid transparent;
+		}
+
+		.d2l-dialog-content-loading {
+			text-align: center;
+		}
+
+		.d2l-dialog-footer.d2l-footer-no-content {
+			padding: 0 0 5px 0;
+		}
+
+		@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
 
 			.d2l-dialog-header,
 			:host([critical]) .d2l-dialog-header {
-				padding-bottom: 15px;
+				padding-bottom: 9px;
 			}
 
-			.d2l-dialog-header > div > d2l-button-icon {
-				flex: none;
-				margin-block: -4px 0;
-				margin-inline: 15px -15px;
-			}
+		}
 
-			.d2l-dialog-content > div {
-				/* required to properly calculate preferred height when there are bottom
-				margins at the end of the slotted content */
-				border-bottom: 1px solid transparent;
-			}
-
-			.d2l-dialog-content-loading {
-				text-align: center;
-			}
-
-			.d2l-dialog-footer.d2l-footer-no-content {
-				padding: 0 0 5px 0;
-			}
-
-			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
-
-				.d2l-dialog-header,
-				:host([critical]) .d2l-dialog-header {
-					padding-bottom: 9px;
-				}
-
-			}
-
-		`];
-	}
+	`];
 
 	constructor() {
 		super();

--- a/components/dialog/test/dialog-mixin.vdiff.js
+++ b/components/dialog/test/dialog-mixin.vdiff.js
@@ -6,11 +6,9 @@ import { LoadingCompleteMixin } from '../../../mixins/loading-complete/loading-c
 
 const delayedTag = defineCE(
 	class extends LoadingCompleteMixin(LitElement) {
-		static get properties() {
-			return {
-				loaded: { type: Boolean }
-			};
-		}
+		static properties = {
+			loaded: { type: Boolean }
+		};
 		constructor() {
 			super();
 			this.loaded = false;

--- a/components/dropdown/demo/dropdown-menu-demo-view.js
+++ b/components/dropdown/demo/dropdown-menu-demo-view.js
@@ -6,20 +6,18 @@ import { LocalizeCoreElement } from '../../../helpers/localize-core-element.js';
 
 class DemoView extends LocalizeCoreElement(HierarchicalViewMixin(LitElement)) {
 
-	static get styles() {
-		return [ super.styles,
-			css`
-				:host {
-					box-sizing: border-box;
-					color: var(--d2l-color-ferrite);
-					cursor: default;
-				}
-				.d2l-hierarchical-view-content {
-					padding: 12px;
-				}
-			`
-		];
-	}
+	static styles = [ super.styles,
+		css`
+			:host {
+				box-sizing: border-box;
+				color: var(--d2l-color-ferrite);
+				cursor: default;
+			}
+			.d2l-hierarchical-view-content {
+				padding: 12px;
+			}
+		`
+	];
 
 	render() {
 		return html`

--- a/components/dropdown/dropdown-button-subtle.js
+++ b/components/dropdown/dropdown-button-subtle.js
@@ -10,31 +10,27 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  */
 class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * A description to be added to the opener button for accessibility when text on button does not provide enough context
 			 * @type {string}
 			 */
-			description: { type: String },
+		description: { type: String },
 
-			/**
+		/**
 			* Aligns the leading edge of text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
 			* @type {'text'|'text-end'|''}
 			*/
-			hAlign: { type: String, reflect: true, attribute: 'h-align' },
+		hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
-			/**
+		/**
 			 * REQUIRED: Text for the button
 			 * @type {string}
 			 */
-			text: { type: String }
-		};
-	}
+		text: { type: String }
+	};
 
-	static get styles() {
-		return dropdownOpenerStyles;
-	}
+	static styles = dropdownOpenerStyles;
 
 	render() {
 		return html`

--- a/components/dropdown/dropdown-button.js
+++ b/components/dropdown/dropdown-button.js
@@ -10,43 +10,39 @@ import { dropdownOpenerStyles } from './dropdown-opener-styles.js';
  */
 class DropdownButton extends DropdownOpenerMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Optionally render button as primary button
 			 * @type {boolean}
 			 */
-			primary: {
-				type: Boolean,
-				reflect: true
-			},
+		primary: {
+			type: Boolean,
+			reflect: true
+		},
 
-			/**
+		/**
 			 * REQUIRED: Text for the button
 			 * @type {string}
 			 */
-			text: {
-				type: String
-			}
-		};
-	}
+		text: {
+			type: String
+		}
+	};
 
-	static get styles() {
-		return [dropdownOpenerStyles, css`
-			d2l-icon {
-				height: 0.8rem;
-				margin-inline-start: 0.6rem;
-				pointer-events: none;
-				width: 0.8rem;
-			}
-			:host([primary]) d2l-icon {
-				color: var(--d2l-theme-text-color-static-inverted);
-			}
-			d2l-button {
-				width: 100%;
-			}
-		`];
-	}
+	static styles = [dropdownOpenerStyles, css`
+		d2l-icon {
+			height: 0.8rem;
+			margin-inline-start: 0.6rem;
+			pointer-events: none;
+			width: 0.8rem;
+		}
+		:host([primary]) d2l-icon {
+			color: var(--d2l-theme-text-color-static-inverted);
+		}
+		d2l-button {
+			width: 100%;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/dropdown/dropdown-context-menu.js
+++ b/components/dropdown/dropdown-context-menu.js
@@ -10,39 +10,35 @@ import { dropdownOpenerStyles } from './dropdown-opener-styles.js';
  */
 class DropdownContextMenu extends DropdownOpenerMixin(VisibleOnAncestorMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Label for the context-menu button
 			 * @type {string}
 			 */
-			text: {
-				type: String
-			},
+		text: {
+			type: String
+		},
 
-			/**
+		/**
 			 * Attribute for busy/rich backgrounds
 			 * @type {boolean}
 			 */
-			translucent: {
-				type: Boolean
-			},
-		};
-	}
+		translucent: {
+			type: Boolean
+		},
+	};
 
-	static get styles() {
-		return [dropdownOpenerStyles, visibleOnAncestorStyles, css`
-			:host {
-				--d2l-dropdown-context-menu-min-height: calc(2rem + 2px);
-				--d2l-dropdown-context-menu-min-width: calc(2rem + 2px);
-				display: inline-block;
-			}
-			d2l-button-icon {
-				--d2l-button-icon-min-height: var(--d2l-dropdown-context-menu-min-height);
-				--d2l-button-icon-min-width: var(--d2l-dropdown-context-menu-min-height);
-			}
-		`];
-	}
+	static styles = [dropdownOpenerStyles, visibleOnAncestorStyles, css`
+		:host {
+			--d2l-dropdown-context-menu-min-height: calc(2rem + 2px);
+			--d2l-dropdown-context-menu-min-width: calc(2rem + 2px);
+			display: inline-block;
+		}
+		d2l-button-icon {
+			--d2l-button-icon-min-height: var(--d2l-dropdown-context-menu-min-height);
+			--d2l-button-icon-min-width: var(--d2l-dropdown-context-menu-min-height);
+		}
+	`];
 	constructor() {
 		super();
 		this.translucent = false;

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -14,43 +14,39 @@ const dropdownDelay = 300;
  */
 class DropdownMenu extends ThemeMixin(DropdownPopoverMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			_closeRadio: { type: Boolean, reflect: true, attribute: '_close-radio' },
-		};
-	}
+	static properties = {
+		_closeRadio: { type: Boolean, reflect: true, attribute: '_close-radio' },
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				--d2l-dropdown-close-animation-name: d2l-dropdown-close-animation;
-			}
+	static styles = [super.styles, css`
+		:host {
+			--d2l-dropdown-close-animation-name: d2l-dropdown-close-animation;
+		}
 
-			:host([theme="dark"]) {
-				--d2l-dropdown-close-animation-name: d2l-dropdown-close-animation-dark;
-			}
+		:host([theme="dark"]) {
+			--d2l-dropdown-close-animation-name: d2l-dropdown-close-animation-dark;
+		}
 
+		:host([_close-radio]) {
+			animation: var(--d2l-dropdown-close-animation-name) ${dropdownDelay}ms ease-out;
+			animation-delay: 50ms;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
 			:host([_close-radio]) {
-				animation: var(--d2l-dropdown-close-animation-name) ${dropdownDelay}ms ease-out;
-				animation-delay: 50ms;
+				animation: none !important;
 			}
+		}
+		@keyframes d2l-dropdown-close-animation {
+			0% { opacity: 1; transform: translate(0, 0); }
+			100% { opacity: 0; transform: translate(0, -10px); }
+		}
 
-			@media (prefers-reduced-motion: reduce) {
-				:host([_close-radio]) {
-					animation: none !important;
-				}
-			}
-			@keyframes d2l-dropdown-close-animation {
-				0% { opacity: 1; transform: translate(0, 0); }
-				100% { opacity: 0; transform: translate(0, -10px); }
-			}
-
-			@keyframes d2l-dropdown-close-animation-dark {
-				0% { opacity: 0.9; transform: translate(0, 0); }
-				100% { opacity: 0; transform: translate(0, -10px); }
-			}
-		`];
-	}
+		@keyframes d2l-dropdown-close-animation-dark {
+			0% { opacity: 0.9; transform: translate(0, 0); }
+			100% { opacity: 0; transform: translate(0, -10px); }
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/dropdown/dropdown-more.js
+++ b/components/dropdown/dropdown-more.js
@@ -10,33 +10,29 @@ import { dropdownOpenerStyles } from './dropdown-opener-styles.js';
  */
 class DropdownMore extends DropdownOpenerMixin(VisibleOnAncestorMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Label for the more button
 			 * @type {string}
 			 */
-			text: {
-				type: String
-			},
+		text: {
+			type: String
+		},
 
-			/**
+		/**
 			 * Attribute for busy/rich backgrounds
 			 * @type {boolean}
 			 */
-			translucent: {
-				type: Boolean
-			},
-		};
-	}
+		translucent: {
+			type: Boolean
+		},
+	};
 
-	static get styles() {
-		return [dropdownOpenerStyles, visibleOnAncestorStyles, css`
+	static styles = [dropdownOpenerStyles, visibleOnAncestorStyles, css`
 			:host {
 				display: inline-block;
 			}
 		`];
-	}
 	constructor() {
 		super();
 		this.translucent = false;

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -3,52 +3,50 @@ import { isComposedAncestor } from '../../helpers/dom.js';
 
 export const DropdownOpenerMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables the dropdown opener
 			 * @type {boolean}
 			 */
-			disabled: {
-				type: Boolean,
-				reflect: true
-			},
+		disabled: {
+			type: Boolean,
+			reflect: true
+		},
 
-			/**
+		/**
 			 * @ignore
 			 */
-			dropdownOpened: { state: true },
+		dropdownOpened: { state: true },
 
-			/**
+		/**
 			 * @ignore
 			 */
-			dropdownOpener: {
-				type: Boolean
-			},
+		dropdownOpener: {
+			type: Boolean
+		},
 
-			/**
+		/**
 			 * Prevents the dropdown from opening automatically on or on key press
 			 * @type {boolean}
 			 */
-			noAutoOpen: {
-				type: Boolean,
-				reflect: true,
-				attribute: 'no-auto-open'
-			},
+		noAutoOpen: {
+			type: Boolean,
+			reflect: true,
+			attribute: 'no-auto-open'
+		},
 
-			/**
+		/**
 			 * Optionally open dropdown on click or hover action
 			 * @type {boolean}
 			 */
-			openOnHover: {
-				type: Boolean,
-				attribute: 'open-on-hover'
-			},
-			_isHovering: { type: Boolean },
-			_isOpenedViaClick: { type: Boolean },
-			_isFading: { type: Boolean }
-		};
-	}
+		openOnHover: {
+			type: Boolean,
+			attribute: 'open-on-hover'
+		},
+		_isHovering: { type: Boolean },
+		_isOpenedViaClick: { type: Boolean },
+		_isFading: { type: Boolean }
+	};
 
 	constructor() {
 		super();

--- a/components/dropdown/dropdown-popover-mixin.js
+++ b/components/dropdown/dropdown-popover-mixin.js
@@ -10,166 +10,162 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 export const DropdownPopoverMixin = superclass => class extends LocalizeCoreElement(PopoverMixin(superclass)) {
 
-	static get properties() {
-		return {
-			/**
-			 * Optionally align dropdown to either start or end. If not set, the dropdown will attempt to be centred.
-			 * @type {'start'|'end'}
-			 */
-			align: { type: String },
-			/**
-			 * Override max-height. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
-			 * @type {number}
-			 */
-			maxHeight: { type: Number, attribute: 'max-height' },
-			/**
-			 * Override default max-width (undefined). Specify a number that would be the px value.
-			 * @type {number}
-			 */
-			maxWidth: { type: Number, attribute: 'max-width' },
-			/**
-			 * Override default height used for required space when `no-auto-fit` is true. Specify a number that would be the px value. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
-			 * @type {number}
-			 */
-			minHeight: { type: Number, attribute: 'min-height' },
-			/**
-			 * Override default min-width (undefined). Specify a number that would be the px value.
-			 * @type {number}
-			 */
-			minWidth: { type: Number, attribute: 'min-width' },
-			/**
-			 * Override the breakpoint at which mobile styling is used. Defaults to 616px.
-			 * @type {number}
-			 */
-			mobileBreakpointOverride: { type: Number, attribute: 'mobile-breakpoint' },
-			/**
-			 * Mobile dropdown style.
-			 * @type {'left'|'right'|'bottom'}
-			 */
-			mobileTray: { type: String, attribute: 'mobile-tray' },
-			/**
-			 * Opt out of automatically closing on focus or click outside of the dropdown content
-			 * @type {boolean}
-			 */
-			noAutoClose: { type: Boolean, attribute: 'no-auto-close' },
-			/**
-			 * Opt out of auto-sizing
-			 * @type {boolean}
-			 */
-			noAutoFit: { type: Boolean, attribute: 'no-auto-fit' },
-			/**
-			 * Opt out of focus being automatically moved to the first focusable element in the dropdown when opened
-			 * @type {boolean}
-			 */
-			noAutoFocus: { type: Boolean, attribute: 'no-auto-focus' },
-			/**
-			 * Opt-out of showing a close button in the footer of tray-style mobile dropdowns.
-			 * @type {boolean}
-			 */
-			noMobileCloseButton: { type: Boolean, attribute: 'no-mobile-close-button' },
-			/**
-			 * Render with no padding
-			 * @type {boolean}
-			 */
-			noPadding: { type: Boolean, attribute: 'no-padding' },
-			/**
-			 * Render the footer with no padding (if it has content)
-			 * @type {boolean}
-			 */
-			noPaddingFooter: { type: Boolean, attribute: 'no-padding-footer' },
-			/**
-			 * Render the header with no padding (if it has content)
-			 * @type {boolean}
-			 */
-			noPaddingHeader: { type: Boolean, attribute: 'no-padding-header' },
-			/**
-			 * Render without a pointer
-			 * @type {boolean}
-			 */
-			noPointer: { type: Boolean, attribute: 'no-pointer' },
-			/**
-			 * Whether the dropdown is open or not
-			 * @type {boolean}
-			 */
-			opened: { type: Boolean, reflect: true },
-			/**
+	static properties = {
+		/**
+		 * Optionally align dropdown to either start or end. If not set, the dropdown will attempt to be centred.
+		 * @type {'start'|'end'}
+		 */
+		align: { type: String },
+		/**
+		 * Override max-height. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
+		 * @type {number}
+		 */
+		maxHeight: { type: Number, attribute: 'max-height' },
+		/**
+		 * Override default max-width (undefined). Specify a number that would be the px value.
+		 * @type {number}
+		 */
+		maxWidth: { type: Number, attribute: 'max-width' },
+		/**
+		 * Override default height used for required space when `no-auto-fit` is true. Specify a number that would be the px value. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
+		 * @type {number}
+		 */
+		minHeight: { type: Number, attribute: 'min-height' },
+		/**
+		 * Override default min-width (undefined). Specify a number that would be the px value.
+		 * @type {number}
+		 */
+		minWidth: { type: Number, attribute: 'min-width' },
+		/**
+		 * Override the breakpoint at which mobile styling is used. Defaults to 616px.
+		 * @type {number}
+		 */
+		mobileBreakpointOverride: { type: Number, attribute: 'mobile-breakpoint' },
+		/**
+		 * Mobile dropdown style.
+		 * @type {'left'|'right'|'bottom'}
+		 */
+		mobileTray: { type: String, attribute: 'mobile-tray' },
+		/**
+		 * Opt out of automatically closing on focus or click outside of the dropdown content
+		 * @type {boolean}
+		 */
+		noAutoClose: { type: Boolean, attribute: 'no-auto-close' },
+		/**
+		 * Opt out of auto-sizing
+		 * @type {boolean}
+		 */
+		noAutoFit: { type: Boolean, attribute: 'no-auto-fit' },
+		/**
+		 * Opt out of focus being automatically moved to the first focusable element in the dropdown when opened
+		 * @type {boolean}
+		 */
+		noAutoFocus: { type: Boolean, attribute: 'no-auto-focus' },
+		/**
+		 * Opt-out of showing a close button in the footer of tray-style mobile dropdowns.
+		 * @type {boolean}
+		 */
+		noMobileCloseButton: { type: Boolean, attribute: 'no-mobile-close-button' },
+		/**
+		 * Render with no padding
+		 * @type {boolean}
+		 */
+		noPadding: { type: Boolean, attribute: 'no-padding' },
+		/**
+		 * Render the footer with no padding (if it has content)
+		 * @type {boolean}
+		 */
+		noPaddingFooter: { type: Boolean, attribute: 'no-padding-footer' },
+		/**
+		 * Render the header with no padding (if it has content)
+		 * @type {boolean}
+		 */
+		noPaddingHeader: { type: Boolean, attribute: 'no-padding-header' },
+		/**
+		 * Render without a pointer
+		 * @type {boolean}
+		 */
+		noPointer: { type: Boolean, attribute: 'no-pointer' },
+		/**
+		 * Whether the dropdown is open or not
+		 * @type {boolean}
+		 */
+		opened: { type: Boolean, reflect: true },
+		/**
  			 * Optionally render a d2l-focus-trap around the dropdown content
-			 * @type {boolean}
+		 * @type {boolean}
  			 */
-			trapFocus: { type: Boolean, attribute: 'trap-focus' },
-			/**
-			 * Provide custom offset, positive or negative
-			 * @type {string}
-			 */
-			verticalOffset: { type: String, attribute: 'vertical-offset' },
-			_blockEndScroll: { state: true },
-			_blockStartScroll: { state: true },
-			_dropdownContent: { type: Boolean, attribute: 'dropdown-content', reflect: true },
-			_hasFooterSlotContent: { state: true },
-			_hasHeaderSlotContent: { state: true }
-		};
-	}
+		trapFocus: { type: Boolean, attribute: 'trap-focus' },
+		/**
+		 * Provide custom offset, positive or negative
+		 * @type {string}
+		 */
+		verticalOffset: { type: String, attribute: 'vertical-offset' },
+		_blockEndScroll: { state: true },
+		_blockStartScroll: { state: true },
+		_dropdownContent: { type: Boolean, attribute: 'dropdown-content', reflect: true },
+		_hasFooterSlotContent: { state: true },
+		_hasHeaderSlotContent: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			.dropdown-content-layout {
-				align-items: stretch;
-				display: flex;
-				flex-direction: column;
-			}
-			.dropdown-content {
-				box-sizing: border-box;
-				flex: auto;
-				max-width: 100%;
-				overflow-y: auto;
-				padding: 1rem;
-			}
-			.dropdown-header,
-			.dropdown-footer {
-				box-sizing: border-box;
-				flex: none;
-				max-width: 100%;
-				min-height: 5px;
-				padding: 1rem;
-				position: relative;
-				width: 100%;
-				z-index: 2;
-			}
-			.dropdown-header {
-				border-block-end: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
-				border-start-end-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
-				border-start-start-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
-			}
-			.dropdown-footer {
-				border-block-start: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
-				border-end-end-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
-				border-end-start-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
-			}
-			.dropdown-no-header {
-				border-block-end: none;
-				padding: 0;
-			}
-			.dropdown-no-footer {
-				border-block-start: none;
-				padding: 0;
-			}
-			.dropdown-no-padding {
-				padding: 0;
-			}
-			.dropdown-header-scroll {
-				box-shadow: 0 3px 3px 0 var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
-			}
-			.dropdown-footer-scroll {
-				box-shadow: 0 -3px 3px 0 var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
-			}
+	static styles = [super.styles, css`
+		.dropdown-content-layout {
+			align-items: stretch;
+			display: flex;
+			flex-direction: column;
+		}
+		.dropdown-content {
+			box-sizing: border-box;
+			flex: auto;
+			max-width: 100%;
+			overflow-y: auto;
+			padding: 1rem;
+		}
+		.dropdown-header,
+		.dropdown-footer {
+			box-sizing: border-box;
+			flex: none;
+			max-width: 100%;
+			min-height: 5px;
+			padding: 1rem;
+			position: relative;
+			width: 100%;
+			z-index: 2;
+		}
+		.dropdown-header {
+			border-block-end: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
+			border-start-end-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
+			border-start-start-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
+		}
+		.dropdown-footer {
+			border-block-start: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
+			border-end-end-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
+			border-end-start-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
+		}
+		.dropdown-no-header {
+			border-block-end: none;
+			padding: 0;
+		}
+		.dropdown-no-footer {
+			border-block-start: none;
+			padding: 0;
+		}
+		.dropdown-no-padding {
+			padding: 0;
+		}
+		.dropdown-header-scroll {
+			box-shadow: 0 3px 3px 0 var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
+		}
+		.dropdown-footer-scroll {
+			box-shadow: 0 -3px 3px 0 var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
+		}
 
-			:host([_mobile][_mobile-tray-location="inline-start"][opened]) .dropdown-content-layout,
-			:host([_mobile][_mobile-tray-location="inline-end"][opened]) .dropdown-content-layout {
-				height: calc(var(--d2l-vh, 1vh) * 100);
-				height: 100dvh;
-			}
-		`];
-	}
+		:host([_mobile][_mobile-tray-location="inline-start"][opened]) .dropdown-content-layout,
+		:host([_mobile][_mobile-tray-location="inline-end"][opened]) .dropdown-content-layout {
+			height: calc(var(--d2l-vh, 1vh) * 100);
+			height: 100dvh;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/dropdown/dropdown-tabs.js
+++ b/components/dropdown/dropdown-tabs.js
@@ -10,13 +10,11 @@ import { DropdownPopoverMixin } from './dropdown-popover-mixin.js';
  */
 class DropdownTabs extends DropdownPopoverMixin(LitElement) {
 
-	static get styles() {
-		return [super.styles, css`
-			::slotted(d2l-tabs) {
-				margin-bottom: 0;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		::slotted(d2l-tabs) {
+			margin-bottom: 0;
+		}
+	`];
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);

--- a/components/dropdown/dropdown.js
+++ b/components/dropdown/dropdown.js
@@ -8,9 +8,7 @@ import { dropdownOpenerStyles } from './dropdown-opener-styles.js';
  */
 class Dropdown extends DropdownOpenerMixin(LitElement) {
 
-	static get styles() {
-		return dropdownOpenerStyles;
-	}
+	static styles = dropdownOpenerStyles;
 
 	render() {
 		return html`<slot></slot>`;

--- a/components/dropdown/test/dropdown-content.test.js
+++ b/components/dropdown/test/dropdown-content.test.js
@@ -108,11 +108,9 @@ const menuFixture = html`
 
 const wrappedDropdown = defineCE(
 	class extends LitElement {
-		static get styles() {
-			return css`
-				:host { display: inline-block; }
-			`;
-		}
+		static styles = css`
+			:host { display: inline-block; }
+		`;
 		render() {
 			return html`
 				<div>

--- a/components/dropdown/test/dropdown-openers.vdiff.js
+++ b/components/dropdown/test/dropdown-openers.vdiff.js
@@ -10,11 +10,9 @@ import { css, LitElement } from 'lit';
 
 const wrappedDropdown = defineCE(
 	class extends LitElement {
-		static get styles() {
-			return css`
-				:host { display: inline-block; }
-			`;
-		}
+		static styles = css`
+			:host { display: inline-block; }
+		`;
 		render() {
 			return html`
 				<d2l-dropdown>

--- a/components/empty-state/empty-state-action-button.js
+++ b/components/empty-state/empty-state-action-button.js
@@ -12,29 +12,25 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class EmptyStateActionButton extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: The action text to be used in the button
 			 * @type {string}
 			 */
-			text: { type: String, required: true },
-			/**
+		text: { type: String, required: true },
+		/**
 			 * This will change the action button to use a primary button instead of the default subtle button. The primary attribute is only valid when `d2l-empty-state-action-button` is placed within `d2l-empty-state-illustrated` components
 			 * @type {boolean}
 			 */
-			primary: { type: Boolean },
-			_illustrated: { state: true }
-		};
-	}
+		primary: { type: Boolean },
+		_illustrated: { state: true }
+	};
 
-	static get styles() {
-		return css`
+	static styles = css`
 					.d2l-empty-state-action {
 						vertical-align: top;
 					}
 				`;
-	}
 
 	constructor() {
 		super();

--- a/components/empty-state/empty-state-action-link.js
+++ b/components/empty-state/empty-state-action-link.js
@@ -9,24 +9,20 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class EmptyStateActionLink extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: The action text to be used in the subtle button
 			 * @type {string}
 			 */
-			text: { type: String, required: true },
-			/**
+		text: { type: String, required: true },
+		/**
 			 * REQUIRED: The action URL or URL fragment of the link
 			 * @type {string}
 			 */
-			href: { type: String, required: true },
-		};
-	}
+		href: { type: String, required: true },
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, linkStyles];
-	}
+	static styles = [bodyCompactStyles, linkStyles];
 
 	static get focusElementSelector() {
 		return '.d2l-link';

--- a/components/empty-state/empty-state-illustrated.js
+++ b/components/empty-state/empty-state-illustrated.js
@@ -18,31 +18,27 @@ const illustrationAspectRatio = 500 / 330;
  */
 class EmptyStateIllustrated extends LoadingCompleteMixin(EmptyStateMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: A description giving details about the empty state
 			 * @type {string}
 			 */
-			description: { type: String, required: true },
-			/**
+		description: { type: String, required: true },
+		/**
 			 * The name of the preset image you would like to display in the component
 			 * @type {string}
 			 */
-			illustrationName: { type: String, attribute: 'illustration-name' },
-			/**
+		illustrationName: { type: String, attribute: 'illustration-name' },
+		/**
 			 * REQUIRED: A title for the empty state
 			 * @type {string}
 			 */
-			titleText: { type: String, attribute: 'title-text', required: true },
-			_contentHeight: { state: true },
-			_titleSmall: { state: true }
-		};
-	}
+		titleText: { type: String, attribute: 'title-text', required: true },
+		_contentHeight: { state: true },
+		_titleSmall: { state: true }
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, emptyStateStyles, emptyStateIllustratedStyles];
-	}
+	static styles = [bodyCompactStyles, emptyStateStyles, emptyStateIllustratedStyles];
 
 	constructor() {
 		super();

--- a/components/empty-state/empty-state-simple.js
+++ b/components/empty-state/empty-state-simple.js
@@ -10,19 +10,15 @@ import { EmptyStateMixin } from './empty-state-mixin.js';
  */
 class EmptyStateSimple extends EmptyStateMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: A description giving details about the empty state
 			 * @type {string}
 			 */
-			description: { type: String, required: true },
-		};
-	}
+		description: { type: String, required: true },
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, emptyStateStyles, emptyStateSimpleStyles];
-	}
+	static styles = [bodyCompactStyles, emptyStateStyles, emptyStateSimpleStyles];
 
 	render() {
 		return html`

--- a/components/expand-collapse/expand-collapse-content.js
+++ b/components/expand-collapse/expand-collapse-content.js
@@ -20,67 +20,63 @@ export const states = {
  */
 class ExpandCollapseContent extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Specifies the expanded/collapsed state of the content
 			 * @type {boolean}
 			 */
-			expanded: { type: Boolean, reflect: true },
-			_height: { type: String },
-			_state: { type: String }
-		};
-	}
+		expanded: { type: Boolean, reflect: true },
+		_height: { type: String },
+		_state: { type: String }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				--d2l-expand-collapse-content-transition-duration: 0.2s;
-				--d2l-expand-collapse-content-transition-function: cubic-bezier(0.4, 0.4, 0.25, 1);
-				display: block;
-			}
+	static styles = css`
+		:host {
+			--d2l-expand-collapse-content-transition-duration: 0.2s;
+			--d2l-expand-collapse-content-transition-function: cubic-bezier(0.4, 0.4, 0.25, 1);
+			display: block;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
+		.d2l-expand-collapse-content-container {
+			display: block;
+			opacity: 0;
+			overflow: hidden;
+			transition:
+				height var(--d2l-expand-collapse-content-transition-duration) var(--d2l-expand-collapse-content-transition-function),
+				opacity var(--d2l-expand-collapse-content-transition-duration) var(--d2l-expand-collapse-content-transition-function);
+		}
+
+		.d2l-expand-collapse-content-container[data-state="collapsed"] {
+			display: none;
+		}
+
+		.d2l-expand-collapse-content-container[data-state="expanded"] {
+			overflow: visible;
+		}
+
+
+		.d2l-expand-collapse-content-container[data-state="expanded"],
+		.d2l-expand-collapse-content-container[data-state="expanding"] {
+			opacity: 1;
+		}
+
+		/* prevent margin colapse on slotted children */
+		.d2l-expand-collapse-content-inner::before,
+		.d2l-expand-collapse-content-inner::after {
+			content: " ";
+			display: table;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
 			.d2l-expand-collapse-content-container {
-				display: block;
-				opacity: 0;
-				overflow: hidden;
-				transition:
-					height var(--d2l-expand-collapse-content-transition-duration) var(--d2l-expand-collapse-content-transition-function),
-					opacity var(--d2l-expand-collapse-content-transition-duration) var(--d2l-expand-collapse-content-transition-function);
+				transition: none;
 			}
-
-			.d2l-expand-collapse-content-container[data-state="collapsed"] {
-				display: none;
-			}
-
-			.d2l-expand-collapse-content-container[data-state="expanded"] {
-				overflow: visible;
-			}
-
-
-			.d2l-expand-collapse-content-container[data-state="expanded"],
-			.d2l-expand-collapse-content-container[data-state="expanding"] {
-				opacity: 1;
-			}
-
-			/* prevent margin colapse on slotted children */
-			.d2l-expand-collapse-content-inner::before,
-			.d2l-expand-collapse-content-inner::after {
-				content: " ";
-				display: table;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				.d2l-expand-collapse-content-container {
-					transition: none;
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/expand-collapse/test/expand-collapse-content.test.js
+++ b/components/expand-collapse/test/expand-collapse-content.test.js
@@ -4,13 +4,11 @@ import { states } from '../expand-collapse-content.js';
 
 const tagName = defineCE(
 	class extends LitElement {
-		static get properties() {
-			return {
-				transitions: { type: Boolean }, //test transition logic
-				empty: { type: Boolean },
-				expanded: { type: Boolean }
-			};
-		}
+		static properties = {
+			transitions: { type: Boolean }, //test transition logic
+			empty: { type: Boolean },
+			expanded: { type: Boolean }
+		};
 
 		constructor() {
 			super();

--- a/components/filter/demo/filter-load-more-demo.js
+++ b/components/filter/demo/filter-load-more-demo.js
@@ -69,11 +69,9 @@ const FullData = [
 
 class FilterLoadMoreDemo extends LitElement {
 
-	static get properties() {
-		return {
-			useOverflowGroup: { type: Boolean, attribute: 'use-overflow-group' }
-		};
-	}
+	static properties = {
+		useOverflowGroup: { type: Boolean, attribute: 'use-overflow-group' }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set-date-text-value.js
+++ b/components/filter/filter-dimension-set-date-text-value.js
@@ -9,42 +9,40 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 class FilterDimensionSetDateTextValue extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether this value in the filter is disabled or not
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * @ignore
 			 */
-			endValue: { type: String },
-			/**
+		endValue: { type: String },
+		/**
 			 * REQUIRED: Unique key to represent this value in the dimension
 			 * @type {string}
 			 */
-			key: { type: String },
-			/**
+		key: { type: String },
+		/**
 			 * REQUIRED: The preset date/time range that the list item represents
 			 * @type {'today'|'lastHour'|'24hours'|'48hours'|'7days'|'14days'|'30days'|'6months'}
 			 */
-			range: { type: String },
-			/**
+		range: { type: String },
+		/**
 			 * Whether this value in the filter is selected or not
 			 * @type {boolean}
 			 */
-			selected: { type: Boolean, reflect: true },
-			/**
+		selected: { type: Boolean, reflect: true },
+		/**
 			 * @ignore
 			 */
-			startValue: { type: String },
-			/**
+		startValue: { type: String },
+		/**
 			 * @ignore
 			 */
-			text: { type: String, reflect: true }
-		};
-	}
+		text: { type: String, reflect: true }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set-date-time-range-value.js
+++ b/components/filter/filter-dimension-set-date-time-range-value.js
@@ -13,53 +13,51 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 class FilterDimensionSetDateTimeRangeValue extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether this value in the filter is disabled or not
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * Value of the end date or date-time input. Expected to be in UTC.
 			 * @type {string}
 			 */
-			endValue: { type: String, attribute: 'end-value' },
-			/**
+		endValue: { type: String, attribute: 'end-value' },
+		/**
 			 * @ignore
 			 */
-			inactive: { type: Boolean },
-			/**
+		inactive: { type: Boolean },
+		/**
 			 * REQUIRED: Unique key to represent this value in the dimension
 			 * @type {string}
 			 */
-			key: { type: String },
-			/**
+		key: { type: String },
+		/**
 			 * Whether this value in the filter is selected or not
 			 * @type {boolean}
 			 */
-			selected: { type: Boolean, reflect: true },
-			/**
+		selected: { type: Boolean, reflect: true },
+		/**
 			 * Value of the start date or date-time input. Expected to be in UTC.
 			 * @type {string}
 			 */
-			startValue: { type: String, attribute: 'start-value' },
-			/**
+		startValue: { type: String, attribute: 'start-value' },
+		/**
 			 * Defaults to "Custom Date Range" (localized). Can be overridden if desired.
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true },
-			/**
+		text: { type: String, reflect: true },
+		/**
 			 * Date/time range input type
 			 * @type {'date'|'date-time'}
 			 */
-			type: { type: String },
-			/**
+		type: { type: String },
+		/**
 			 * @ignore
 			 */
-			valueText: { type: String }
-		};
-	}
+		valueText: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set-empty-state.js
+++ b/components/filter/filter-dimension-set-empty-state.js
@@ -6,25 +6,23 @@ import { LitElement } from 'lit';
  */
 class FilterDimensionSetEmptyState extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * The href that will be used for the empty state action. When set with action-text, d2l-filter will render a link action.
 			 * @type {string}
 			 */
-			actionHref: { type: String, attribute: 'action-href' },
-			/**
+		actionHref: { type: String, attribute: 'action-href' },
+		/**
 			 * The text that will be displayed in the empty state action. When set, d2l-filter renders a button action, or a link if action-href is also defined.
 			 * @type {string}
 			 */
-			actionText: { type: String, attribute: 'action-text' },
-			/**
+		actionText: { type: String, attribute: 'action-text' },
+		/**
 			 * REQUIRED: The text that is displayed in the empty state description
 			 * @type {string}
 			 */
-			description: { type: String }
-		};
-	}
+		description: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set-value.js
+++ b/components/filter/filter-dimension-set-value.js
@@ -6,35 +6,33 @@ import { LitElement } from 'lit';
  */
 class FilterDimensionSetValue extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Count for the value in the list. If no count is provided, no count will be displayed
 			 * @type {number}
 			 */
-			count: { type: Number },
-			/**
+		count: { type: Number },
+		/**
 			 * Whether this value in the filter is disabled or not
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * REQUIRED: Unique key to represent this value in the dimension
 			 * @type {string}
 			 */
-			key: { type: String },
-			/**
+		key: { type: String },
+		/**
 			 * Whether this value in the filter is selected or not
 			 * @type {boolean}
 			 */
-			selected: { type: Boolean, reflect: true },
-			/**
+		selected: { type: Boolean, reflect: true },
+		/**
 			 * REQUIRED: The text that is displayed for the value
 			 * @type {string}
 			 */
-			text: { type: String }
-		};
-	}
+		text: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -9,73 +9,71 @@ import { html, LitElement } from 'lit';
  */
 class FilterDimensionSet extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether the dimension has more values to load. Manual search and selected first should be set if has more is being used
 			 * @type {boolean}
 			 */
-			hasMore: { type: Boolean, attribute: 'has-more' },
-			/**
+		hasMore: { type: Boolean, attribute: 'has-more' },
+		/**
 			 * A heading displayed above the list items. This is usually unnecessary, but can be used to emphasize or promote something specific about the list of items to help orient users.
 			 * @type {string}
 			 */
-			headerText: { type: String, attribute: 'header-text' },
-			/**
+		headerText: { type: String, attribute: 'header-text' },
+		/**
 			 * The introductory text to display at the top of the filter dropdown
 			 * @type {string}
 			 */
-			introductoryText: { type: String, attribute: 'introductory-text' },
-			/**
+		introductoryText: { type: String, attribute: 'introductory-text' },
+		/**
 			 * REQUIRED: Unique key to represent this dimension in the filter
 			 * @type {string}
 			 */
-			key: { type: String },
-			/**
+		key: { type: String },
+		/**
 			 * Whether the values for this dimension are still loading and a loading spinner should be displayed
 			 * @type {boolean}
 			 */
-			loading: { type: Boolean },
-			/**
+		loading: { type: Boolean },
+		/**
 			 * @ignore
 			 */
-			minWidth: { type: Number },
-			/**
+		minWidth: { type: Number },
+		/**
 			 * ADVANCED: Whether to ignore the enforce single selection setting for this dimension.
 			 */
-			ignoreEnforceSelectionSingle: { type: Boolean, attribute: 'ignore-enforce-selection-single' },
-			/**
+		ignoreEnforceSelectionSingle: { type: Boolean, attribute: 'ignore-enforce-selection-single' },
+		/**
 			 * Whether to hide the search input, perform a simple text search, or fire an event on search
 			 * @type {'none'|'automatic'|'manual'}
 			 */
-			searchType: { type: String, attribute: 'search-type' },
-			/**
+		searchType: { type: String, attribute: 'search-type' },
+		/**
 			 * Adds a select all checkbox and summary for this dimension
 			 * @type {boolean}
 			 */
-			selectAll: { type: Boolean, attribute: 'select-all' },
-			/**
+		selectAll: { type: Boolean, attribute: 'select-all' },
+		/**
 			 * Whether to render the selected items at the top of the filter. Forced on if load more paging is being used
 			 * @type {boolean}
 			 */
-			selectedFirst: { type: Boolean, attribute: 'selected-first' },
-			/**
+		selectedFirst: { type: Boolean, attribute: 'selected-first' },
+		/**
 			 * Whether only one value can be selected at a time for this dimension
 			 * @type {boolean}
 			 */
-			selectionSingle: { type: Boolean, attribute: 'selection-single' },
-			/**
+		selectionSingle: { type: Boolean, attribute: 'selection-single' },
+		/**
 			 * REQUIRED: The text that is displayed for the dimension title
 			 * @type {string}
 			 */
-			text: { type: String },
-			/**
+		text: { type: String },
+		/**
 			 * Whether to hide the dimension in the text sent to active filter subscribers
 			 * @type {boolean}
 			 */
-			valueOnlyActiveFilterText: { type: Boolean, attribute: 'value-only-active-filter-text' }
-		};
-	}
+		valueOnlyActiveFilterText: { type: Boolean, attribute: 'value-only-active-filter-text' }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-overflow-group.js
+++ b/components/filter/filter-overflow-group.js
@@ -12,25 +12,21 @@ const updateEvents = ['d2l-filter-dimension-load-more', 'd2l-filter-dimension-se
 */
 class FilterOverflowGroup extends OverflowGroupMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Show `d2l-filter-tags` beneath the filters. Tags will be shown for all filters in the group.
 			 * @type {boolean}
 			 */
-			tags: { type: Boolean },
-			_openedDimensions: { state: true },
-			_filterIds: { state: true }
-		};
-	}
+		tags: { type: Boolean },
+		_openedDimensions: { state: true },
+		_filterIds: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			::slotted(d2l-filter) {
-				margin-inline-end: 0.3rem;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		::slotted(d2l-filter) {
+			margin-inline-end: 0.3rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/filter/filter-tags.js
+++ b/components/filter/filter-tags.js
@@ -11,26 +11,22 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 const CLEAR_TIMEOUT = 310; /** Corresponds to timeout in _dispatchChangeEvent in filter + 10 ms */
 
 class FilterTags extends LocalizeCoreElement(LitElement) {
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Id(s) (space-delimited) of the filter component(s) to subscribe to
 			 * @type {string}
 			 */
-			filterIds: { type: String, attribute: 'filter-ids' }
-		};
-	}
+		filterIds: { type: String, attribute: 'filter-ids' }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -72,143 +72,139 @@ function addSpaceListener() {
  */
 class Filter extends FocusMixin(LocalizeCoreElement(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables the dropdown opener for the filter
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * Indicates if the filter is open
 			 * @type {boolean}
 			 */
-			opened: { type: Boolean, reflect: true },
-			/**
+		opened: { type: Boolean, reflect: true },
+		/**
 			 * Optional override for the button text used for a multi-dimensional filter
 			 * @type {string}
 			 */
-			text: { type: String },
-			_activeDimensionKey: { type: String, attribute: false },
-			_dimensions: { type: Array, attribute: false },
-			_displayKeyboardTooltip: { state: true },
-			_ignoreSlotChanges: { type: Boolean },
-			_minWidth: { type: Number, attribute: false },
-			_totalAppliedCount: { type: Number, attribute: false }
-		};
-	}
+		text: { type: String },
+		_activeDimensionKey: { type: String, attribute: false },
+		_dimensions: { type: Array, attribute: false },
+		_displayKeyboardTooltip: { state: true },
+		_ignoreSlotChanges: { type: Boolean },
+		_minWidth: { type: Number, attribute: false },
+		_totalAppliedCount: { type: Number, attribute: false }
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, bodySmallStyles, bodyStandardStyles, heading4Styles, offscreenStyles, css`
-			[slot="header"] {
-				padding: 0.9rem 0.3rem;
-			}
+	static styles = [bodyCompactStyles, bodySmallStyles, bodyStandardStyles, heading4Styles, offscreenStyles, css`
+		[slot="header"] {
+			padding: 0.9rem 0.3rem;
+		}
 
-			.d2l-filter-dimension-header {
-				padding-bottom: 0.9rem;
-			}
+		.d2l-filter-dimension-header {
+			padding-bottom: 0.9rem;
+		}
 
-			.d2l-filter-dimension-header.with-intro {
-				padding-bottom: 0.6rem;
-			}
+		.d2l-filter-dimension-header.with-intro {
+			padding-bottom: 0.6rem;
+		}
 
-			.d2l-filter-dimension-header,
-			.d2l-filter-dimension-header-actions {
-				align-items: center;
-				display: flex;
-			}
+		.d2l-filter-dimension-header,
+		.d2l-filter-dimension-header-actions {
+			align-items: center;
+			display: flex;
+		}
 
-			.d2l-filter-dimension-header-actions {
-				flex-flow: row wrap;
-			}
+		.d2l-filter-dimension-header-actions {
+			flex-flow: row wrap;
+		}
 
-			d2l-input-search {
-				flex: 1 0;
-				margin-inline: 0.3rem 0.6rem;
-			}
+		d2l-input-search {
+			flex: 1 0;
+			margin-inline: 0.3rem 0.6rem;
+		}
 
-			.d2l-filter-dimension-select-all {
-				flex-basis: 100%;
-				margin-top: 0.9rem;
-			}
+		.d2l-filter-dimension-select-all {
+			flex-basis: 100%;
+			margin-top: 0.9rem;
+		}
 
-			d2l-selection-select-all {
-				padding: 0 0.6rem;
-			}
+		d2l-selection-select-all {
+			padding: 0 0.6rem;
+		}
 
-			.d2l-filter-dimension-header-text {
-				flex-grow: 1;
-				padding-inline-end: calc(2rem + 2px);
-				text-align: center;
-				${overflowEllipsisDeclarations}
-			}
+		.d2l-filter-dimension-header-text {
+			flex-grow: 1;
+			padding-inline-end: calc(2rem + 2px);
+			text-align: center;
+			${overflowEllipsisDeclarations}
+		}
 
-			.d2l-filter-dimension-set-value {
-				align-items: center;
-				color: var(--d2l-color-ferrite);
-				display: flex;
-				gap: 0.45rem;
-				line-height: unset;
-			}
-			.d2l-filter-dimension-set-value d2l-icon {
-				flex-shrink: 0;
-			}
-			d2l-expand-collapse-content[expanded] {
-				margin-inline-start: -2.1rem;
-				padding-block: 0.8rem 0.4rem;
-			}
-			d2l-list-item.expanding-content {
-				overflow-y: hidden;
-			}
+		.d2l-filter-dimension-set-value {
+			align-items: center;
+			color: var(--d2l-color-ferrite);
+			display: flex;
+			gap: 0.45rem;
+			line-height: unset;
+		}
+		.d2l-filter-dimension-set-value d2l-icon {
+			flex-shrink: 0;
+		}
+		d2l-expand-collapse-content[expanded] {
+			margin-inline-start: -2.1rem;
+			padding-block: 0.8rem 0.4rem;
+		}
+		d2l-list-item.expanding-content {
+			overflow-y: hidden;
+		}
 
-			.d2l-filter-dimension-set-value-text {
-				hyphens: auto;
-				${getOverflowDeclarations({ lines: 2 })}
-			}
+		.d2l-filter-dimension-set-value-text {
+			hyphens: auto;
+			${getOverflowDeclarations({ lines: 2 })}
+		}
 
-			d2l-list-item[selection-disabled] .d2l-filter-dimension-set-value,
-			d2l-list-item[selection-disabled] .d2l-body-small {
-				color: var(--d2l-color-chromite);
-			}
+		d2l-list-item[selection-disabled] .d2l-filter-dimension-set-value,
+		d2l-list-item[selection-disabled] .d2l-body-small {
+			color: var(--d2l-color-chromite);
+		}
 
-			.d2l-filter-dimension-intro-text {
-				margin: 0;
-				padding: 0.6rem 1.5rem 1.5rem;
-				text-align: center;
-			}
+		.d2l-filter-dimension-intro-text {
+			margin: 0;
+			padding: 0.6rem 1.5rem 1.5rem;
+			text-align: center;
+		}
 
-			.d2l-filter-dimension-intro-text.multi-dimension {
-				padding: 0 1.5rem 1.5rem;
-			}
+		.d2l-filter-dimension-intro-text.multi-dimension {
+			padding: 0 1.5rem 1.5rem;
+		}
 
-			.d2l-empty-state-container {
-				padding: 0.9rem 0.9rem calc(0.9rem - 5px);
-			}
+		.d2l-empty-state-container {
+			padding: 0.9rem 0.9rem calc(0.9rem - 5px);
+		}
 
-			.list-header-text {
-				color: var(--d2l-color-ferrite);
-				margin: 0;
-				padding-bottom: 0.05rem;
-				padding-top: 0.65rem;
-			}
+		.list-header-text {
+			color: var(--d2l-color-ferrite);
+			margin: 0;
+			padding-bottom: 0.05rem;
+			padding-top: 0.65rem;
+		}
 
-			.d2l-filter-dimension-info-message {
-				color: var(--d2l-color-ferrite);
-				display: flex;
-				justify-content: center;
-			}
+		.d2l-filter-dimension-info-message {
+			color: var(--d2l-color-ferrite);
+			display: flex;
+			justify-content: center;
+		}
 
-			/* Needed to "undo" the menu-item style for multiple dimensions */
-			d2l-hierarchical-view {
-				cursor: auto;
-			}
+		/* Needed to "undo" the menu-item style for multiple dimensions */
+		d2l-hierarchical-view {
+			cursor: auto;
+		}
 
-			d2l-loading-spinner {
-				padding-top: 0.6rem;
-				width: 100%;
-			}
-		`];
-	}
+		d2l-loading-spinner {
+			padding-top: 0.6rem;
+			width: 100%;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -12,27 +12,23 @@ const traps = [];
  */
 class FocusTrap extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether the component should trap user focus.
 			 * @type {boolean}
 			 */
-			trap: { type: Boolean },
-			_legacyPromptIds: { state: true }
-		};
-	}
+		trap: { type: Boolean },
+		_legacyPromptIds: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/form/demo/form-demo.js
+++ b/components/form/demo/form-demo.js
@@ -15,8 +15,7 @@ import { selectStyles } from '../../inputs/input-select-styles.js';
 
 class FormNestedDemo extends LitElement {
 
-	static get styles() {
-		return [inputStyles, selectStyles, css`
+	static styles = [inputStyles, selectStyles, css`
 
 			.d2l-form-demo-split-container {
 				display: flex;
@@ -28,7 +27,6 @@ class FormNestedDemo extends LitElement {
 				padding: 0 20px 20px 0;
 			}
 		`];
-	}
 
 	render() {
 		return html`

--- a/components/form/demo/form-dialog-demo.js
+++ b/components/form/demo/form-dialog-demo.js
@@ -12,14 +12,12 @@ import { selectStyles } from '../../inputs/input-select-styles.js';
 
 class FormDialogDemo extends LitElement {
 
-	static get styles() {
-		return [inputStyles, selectStyles, css`
+	static styles = [inputStyles, selectStyles, css`
 
 			.d2l-form-dialog-demo-container {
 				margin-bottom: 10px;
 			}
 		`];
-	}
 
 	render() {
 		return html`

--- a/components/form/demo/form-panel-demo.js
+++ b/components/form/demo/form-panel-demo.js
@@ -11,26 +11,22 @@ import { inputStyles } from '../../inputs/input-styles.js';
 
 class FormPanelDemo extends LitElement {
 
-	static get properties() {
-		return {
-			_expanded: { type: Boolean, attribute: false }
-		};
-	}
+	static properties = {
+		_expanded: { type: Boolean, attribute: false }
+	};
 
-	static get styles() {
-		return [heading3Styles, inputStyles, css`
-			:host {
-				background-color: var(--d2l-color-gypsum);
-				display: block;
-				flex-basis: 35%;
-				padding: 10px;
-				width: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`];
-	}
+	static styles = [heading3Styles, inputStyles, css`
+		:host {
+			background-color: var(--d2l-color-gypsum);
+			display: block;
+			flex-basis: 35%;
+			padding: 10px;
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/form/docs/form-element-mixin.md
+++ b/components/form/docs/form-element-mixin.md
@@ -67,20 +67,16 @@ import { FormElementMixin } from '@brightspace-ui/core/form/form-element-mixin.j
 // Use the FormElementMixin
 class MyFormElement extends FormElementMixin(LitElement) {
 
-	static get properties() {
-		return {
-			_val1: { type: String },
-			_val2: { type: String }
-		};
-	}
-	static get styles() {
-		return css`
-			/* Add our invalid styles */
-			:host([invalid]) {
-				border: 2px solid var(--d2l-color-cinnabar);
-			}
-		`;
-	}
+	static properties = {
+		_val1: { type: String },
+		_val2: { type: String }
+	};
+	static styles = css`
+		/* Add our invalid styles */
+		:host([invalid]) {
+			border: 2px solid var(--d2l-color-cinnabar);
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/form/docs/form-element-nesting.md
+++ b/components/form/docs/form-element-nesting.md
@@ -35,12 +35,10 @@ import { FormElementMixin } from '@brightspace-ui/core/form/form-element-mixin.j
 // Use the FormElementMixin
 class MyNestingFormElement extends FormElementMixin(LitElement) {
 
-	static get properties() {
-		return {
-			_firstName: { type: String },
-			_lastName: { type: String }
-		};
-	}
+	static properties = {
+		_firstName: { type: String },
+		_lastName: { type: String }
+	};
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);

--- a/components/form/docs/form-element-wrapping.md
+++ b/components/form/docs/form-element-wrapping.md
@@ -23,9 +23,7 @@ import { FormElementMixin } from '@brightspace-ui/core/form/form-element-mixin.j
 // Use the FormElementMixin
 class MyWrappingFormElement extends FormElementMixin(LitElement) {
 
-	static get properties() {
-		return { value: { type: String } };
-	}
+	static properties = { value: { type: String } };
 
 	render() {
 		// Conditionally render our validation error message if there is one

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -77,41 +77,39 @@ export class FormElementValidityState {
 
 export const FormElementMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			forceInvalid: { type: Boolean, attribute: false },
-			/**
+		forceInvalid: { type: Boolean, attribute: false },
+		/**
 			 * @ignore
 			 */
-			invalid: { type: Boolean, reflect: true },
-			/**
+		invalid: { type: Boolean, reflect: true },
+		/**
 			 * Name of the form control. Submitted with the form as part of a name/value pair.
 			 * @type {string}
 			 */
-			name: { type: String },
-			/**
+		name: { type: String },
+		/**
 			 * @ignore
 			 */
-			noValidate: { type: Boolean, attribute: 'novalidate' },
-			/**
+		noValidate: { type: Boolean, attribute: 'novalidate' },
+		/**
 			 * @ignore
 			 * Perform validation immediately instead of waiting for the user to make changes.
 			 */
-			validateOnInit: { type: Boolean, attribute: 'validate-on-init' },
-			/**
+		validateOnInit: { type: Boolean, attribute: 'validate-on-init' },
+		/**
 			 * @ignore
 			 */
-			validationError: { type: String, attribute: false },
-			/**
+		validationError: { type: String, attribute: false },
+		/**
 			 * @ignore
 			 */
-			childErrors: { type: Object, attribute: false },
-			_errors: { type: Array, attribute: false }
-		};
-	}
+		childErrors: { type: Object, attribute: false },
+		_errors: { type: Array, attribute: false }
+	};
 
 	constructor() {
 		super();

--- a/components/form/form-error-summary.js
+++ b/components/form/form-error-summary.js
@@ -7,53 +7,49 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 
 class FormErrorSummary extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			errors: { type: Object, attribute: false },
-			_expanded: { type: Boolean, attribute: false },
-			_hasTopMargin: { type: Boolean, attribute: '_has-top-margin', reflect: true },
-			_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
-		};
-	}
+	static properties = {
+		errors: { type: Object, attribute: false },
+		_expanded: { type: Boolean, attribute: false },
+		_hasTopMargin: { type: Boolean, attribute: '_has-top-margin', reflect: true },
+		_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
+	};
 
-	static get styles() {
-		return [linkStyles, css`
+	static styles = [linkStyles, css`
 
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([_has-top-margin][_has-errors]) {
-				margin-block-start: 1rem;
-			}
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([_has-top-margin][_has-errors]) {
+			margin-block-start: 1rem;
+		}
 
-			.d2l-form-error-summary-header {
-				cursor: pointer;
-				display: flex;
-				justify-content: space-between;
-				padding-block: 0.3rem;
-				padding-inline: 1.2rem 0.3rem;
-			}
+		.d2l-form-error-summary-header {
+			cursor: pointer;
+			display: flex;
+			justify-content: space-between;
+			padding-block: 0.3rem;
+			padding-inline: 1.2rem 0.3rem;
+		}
 
-			.d2l-form-error-summary-text {
-				align-items: center;
-				display: flex;
-			}
+		.d2l-form-error-summary-text {
+			align-items: center;
+			display: flex;
+		}
 
-			.d2l-form-error-summary-error-list {
-				margin-block: 0;
-				margin-inline: 1.2rem 0;
-				padding-bottom: 0.6rem;
-				padding-top: 0.3rem;
-			}
+		.d2l-form-error-summary-error-list {
+			margin-block: 0;
+			margin-inline: 1.2rem 0;
+			padding-bottom: 0.6rem;
+			padding-top: 0.3rem;
+		}
 
-			d2l-alert {
-				max-width: none;
-			}
-		`];
-	}
+		d2l-alert {
+			max-width: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -17,43 +17,39 @@ import { localizeFormElement } from './form-element-localize-helper.js';
  */
 class Form extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Indicates that the form should opt-out of nesting.
 			 * This means that it will not be submitted or validated if an ancestor form is submitted or validated.
 			 * However, directly submitting or validating a form with `no-nesting` will still trigger submission and validation for its descendant forms unless they also opt-out using `no-nesting`.
 			 * @type {boolean}
 			 */
-			noNesting: { type: Boolean, attribute: 'no-nesting', reflect: true },
-			/**
+		noNesting: { type: Boolean, attribute: 'no-nesting', reflect: true },
+		/**
 			 * Indicates that the form should interrupt and warn on navigation if the user has unsaved changes on native elements.
 			 * @type {boolean}
 			 */
-			trackChanges: { type: Boolean, attribute: 'track-changes', reflect: true },
-			/**
+		trackChanges: { type: Boolean, attribute: 'track-changes', reflect: true },
+		/**
 			 * Id for an alternative error summary element
 			 * @type {string}
 			 */
-			summaryId: { type: String, attribute: 'summary-id' },
-			_errors: { type: Object },
-			_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
-		};
-	}
+		summaryId: { type: String, attribute: 'summary-id' },
+		_errors: { type: Object },
+		_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([_has-errors]) ::slotted(d2l-input-group) {
-				margin-block-start: 1rem;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([_has-errors]) ::slotted(d2l-input-group) {
+			margin-block-start: 1rem;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/form/test/form-element.js
+++ b/components/form/test/form-element.js
@@ -4,13 +4,11 @@ import { FormElementMixin } from '../form-element-mixin.js';
 
 class FormElement extends FormElementMixin(LitElement) {
 
-	static get properties() {
-		return {
-			isValidationCustomValid: { type: Boolean },
-			tooltipMessage: { type: String },
-			value: { type: String }
-		};
-	}
+	static properties = {
+		isValidationCustomValid: { type: Boolean },
+		tooltipMessage: { type: String },
+		value: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/form/test/form-element.test.js
+++ b/components/form/test/form-element.test.js
@@ -6,12 +6,10 @@ import { html, LitElement } from 'lit';
 const formTag = defineCE(
 	class extends LitElement {
 
-		static get properties() {
-			return {
-				isValidationCustomValid: { type: Boolean },
-				value: { type: String, reflect: true },
-			};
-		}
+		static properties = {
+			isValidationCustomValid: { type: Boolean },
+			value: { type: String, reflect: true },
+		};
 
 		constructor() {
 			super();

--- a/components/form/test/nested-form.js
+++ b/components/form/test/nested-form.js
@@ -5,11 +5,9 @@ import { html, LitElement } from 'lit';
 
 class NestedForm extends LitElement {
 
-	static get properties() {
-		return {
-			noNesting: { type: Boolean, attribute: 'no-nesting', reflect: true },
-		};
-	}
+	static properties = {
+		noNesting: { type: Boolean, attribute: 'no-nesting', reflect: true },
+	};
 
 	constructor() {
 		super();

--- a/components/hierarchical-view/README.md
+++ b/components/hierarchical-view/README.md
@@ -21,61 +21,60 @@ The `d2l-hierarchical-view` component uses the `d2l-hierarchical-view-mixin` for
         this.showParentView = this.showParentView.bind(this);
     }
     // <!-- docs: start hidden content -->
-    static get styles() {
-      return [css`
-      #view1 {
+    static styles = [css`
+        #view1 {
         width: 100%;
-      }
-      .view {
+        }
+        .view {
         height:100%;
         min-height: 200px;
-      }
-      .layout > * {
+        }
+        .layout > * {
         margin: 0;
-      }
-      .buttons {
+        }
+        .buttons {
         height: 60px;
 
-      }
-      .buttons > .left {
+        }
+        .buttons > .left {
         float: left;
-      }
-      .buttons > .right {
+        }
+        .buttons > .right {
         float: right;
-      }
-      d2l-button {
+        }
+        d2l-button {
         margin: 5px;
-      }
-      h1 {
+        }
+        h1 {
         margin: 0;
-      }
-      .position-display {
+        }
+        .position-display {
         height: 150px;
         margin-top: 15px;
         display: flex;
         vertical-align: middle;
-      }
-      .col {
+        }
+        .col {
         height: 100px;
         justify-content: center;
         display: flex;
         flex-direction: column;
-      }
-      .block {
+        }
+        .block {
         height: 20px;
         width: 100px;
         padding: 10px;
         text-align: center;
         line-height: 20px;
-      }
-      .selected {
+        }
+        .selected {
         border: 1px solid grey;
-      }
-      .position-display {
+        }
+        .position-display {
         display: flex;
         justify-content: space-evenly;
-      }`];
-    }
+        }`
+    ];
 
     // <!-- docs: end hidden content -->
     showSubView(id) {
@@ -208,13 +207,11 @@ This mixin allows for nested views within components. To use, apply the mixin an
 ```js
 import { HierarchicalViewMixin } from '@brightspace-ui/core/components/hierarchical-view/hierarchical-view-mixin.js';
 class MyComponent extends HierarchicalViewMixin(LitElement) {
-  static get styles() {
-        return [ super.styles, css`
-            :host {
-                display: inline-block;
-            }
-        `];
-    }
+    static styles = [ super.styles, css`
+      :host {
+          display: inline-block;
+      }
+    `];
 
     render() {
         return html`

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -8,92 +8,88 @@ const escapeKeyCode = 27;
 
 export const HierarchicalViewMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			hierarchicalView: { type: Boolean },
-			/**
-			 * @ignore
-			 */
-			rootView: { type: Boolean, attribute: 'root-view' },
-			/**
-			 * @ignore
-			 */
-			shown: { type: Boolean, reflect: true },
-			_childView: { type: Boolean, reflect: true, attribute: 'child-view' },
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		hierarchicalView: { type: Boolean },
+		/**
+		 * @ignore
+		 */
+		rootView: { type: Boolean, attribute: 'root-view' },
+		/**
+		 * @ignore
+		 */
+		shown: { type: Boolean, reflect: true },
+		_childView: { type: Boolean, reflect: true, attribute: 'child-view' },
+	};
 
-	static get styles() {
-		return css`
+	static styles = css`
+		:host {
+			--d2l-hierarchical-view-height-transition: height 300ms linear;
+			box-sizing: border-box;
+			display: none;
+			left: 0;
+			overflow: hidden;
+			position: relative;
+			-webkit-transition: var(--d2l-hierarchical-view-height-transition);
+			transition: var(--d2l-hierarchical-view-height-transition);
+			width: 100%;
+		}
+		:host([child-view]) {
+			display: none;
+			left: 100%;
+			position: absolute;
+			top: 0;
+		}
+		:host([shown]) {
+			display: inline-block;
+			vertical-align: top; /* DE37329: required to prevent extra spacing caused by inline-block */
+		}
+		.d2l-hierarchical-view-content {
+			position: relative;
+		}
+		.d2l-hierarchical-view-content.d2l-child-view-show {
+			-webkit-animation: show-child-view-animation forwards 300ms linear;
+			animation: show-child-view-animation 300ms forwards linear;
+		}
+		.d2l-hierarchical-view-content.d2l-child-view-hide {
+			-webkit-animation: hide-child-view-animation forwards 300ms linear;
+			animation: hide-child-view-animation 300ms forwards linear;
+		}
+		@media (prefers-reduced-motion: reduce) {
 			:host {
-				--d2l-hierarchical-view-height-transition: height 300ms linear;
-				box-sizing: border-box;
-				display: none;
-				left: 0;
-				overflow: hidden;
-				position: relative;
-				-webkit-transition: var(--d2l-hierarchical-view-height-transition);
-				transition: var(--d2l-hierarchical-view-height-transition);
-				width: 100%;
-			}
-			:host([child-view]) {
-				display: none;
-				left: 100%;
-				position: absolute;
-				top: 0;
-			}
-			:host([shown]) {
-				display: inline-block;
-				vertical-align: top; /* DE37329: required to prevent extra spacing caused by inline-block */
-			}
-			.d2l-hierarchical-view-content {
-				position: relative;
+				-webkit-transition: none;
+				transition: none;
 			}
 			.d2l-hierarchical-view-content.d2l-child-view-show {
-				-webkit-animation: show-child-view-animation forwards 300ms linear;
-				animation: show-child-view-animation 300ms forwards linear;
+				-webkit-animation: none;
+				animation: none;
+				left: -100%;
 			}
 			.d2l-hierarchical-view-content.d2l-child-view-hide {
-				-webkit-animation: hide-child-view-animation forwards 300ms linear;
-				animation: hide-child-view-animation 300ms forwards linear;
+				-webkit-animation: none;
+				animation: none;
+				left: 0;
 			}
-			@media (prefers-reduced-motion: reduce) {
-				:host {
-					-webkit-transition: none;
-					transition: none;
-				}
-				.d2l-hierarchical-view-content.d2l-child-view-show {
-					-webkit-animation: none;
-					animation: none;
-					left: -100%;
-				}
-				.d2l-hierarchical-view-content.d2l-child-view-hide {
-					-webkit-animation: none;
-					animation: none;
-					left: 0;
-				}
-			}
-			@keyframes show-child-view-animation {
-				0% { left: 0; }
-				100% { left: -100%; }
-			}
-			@-webkit-keyframes show-child-view-animation {
-				0% { left: 0; }
-				100% { left: -100%; }
-			}
-			@keyframes hide-child-view-animation {
-				0% { left: -100%; }
-				100% { left: 0; }
-			}
-			@-webkit-keyframes hide-child-view-animation {
-				0% { left: -100%; }
-				100% { left: 0; }
-			}
-		`;
-	}
+		}
+		@keyframes show-child-view-animation {
+			0% { left: 0; }
+			100% { left: -100%; }
+		}
+		@-webkit-keyframes show-child-view-animation {
+			0% { left: 0; }
+			100% { left: -100%; }
+		}
+		@keyframes hide-child-view-animation {
+			0% { left: -100%; }
+			100% { left: 0; }
+		}
+		@-webkit-keyframes hide-child-view-animation {
+			0% { left: -100%; }
+			100% { left: 0; }
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/hierarchical-view/hierarchical-view.js
+++ b/components/hierarchical-view/hierarchical-view.js
@@ -10,13 +10,11 @@ import { HierarchicalViewMixin } from '../hierarchical-view/hierarchical-view-mi
  */
 class HierarchicalView extends HierarchicalViewMixin(LitElement) {
 
-	static get styles() {
-		return [ super.styles, css`
+	static styles = [ super.styles, css`
 			:host {
 				display: inline-block;
 			}
 		`];
-	}
 
 	render() {
 		return html`

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -565,12 +565,10 @@ helloGrumpy('Wizard');&lt;/code&gt;&lt;/pre&gt;">
 
 			class SomeComponent extends LitElement {
 
-				static get properties() {
-					return {
-						_htmlSnippets: { type: Array },
-						_updateCount: { type: Number }
-					};
-				}
+				static properties = {
+					_htmlSnippets: { type: Array },
+					_updateCount: { type: Number }
+				};
 
 				constructor() {
 					super();

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -198,53 +198,49 @@ const getRenderers = async() => {
  */
 class HtmlBlock extends LoadingCompleteMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether compact styles should be applied
 			 * @type {Boolean}
 			 */
-			compact: { type: Boolean },
-			/**
+		compact: { type: Boolean },
+		/**
 			 * The HTML to be rendered. Ignored if slotted content is provided.
 			 * @type {String}
 			 */
-			html: { type: String },
-			/**
+		html: { type: String },
+		/**
 			 * Whether to display the HTML in inline mode
 			 * @type {Boolean}
 			 */
-			inline: { type: Boolean },
-			/**
+		inline: { type: Boolean },
+		/**
 			 * Whether to disable deferred rendering of the user-authored HTML. Do *not* set this
 			 * unless your HTML relies on script executions that may break upon stamping.
 			 * @type {Boolean}
 			 */
-			noDeferredRendering: { type: Boolean, attribute: 'no-deferred-rendering' },
-			_context: { type: Object, state: true }
-		};
-	}
+		noDeferredRendering: { type: Boolean, attribute: 'no-deferred-rendering' },
+		_context: { type: Object, state: true }
+	};
 
-	static get styles() {
-		return [ htmlBlockContentStyles, css`
-			:host {
-				display: block;
-			}
-			${_generateHtmlBlockRootStyles(':host')}
-			:host([inline]),
-			:host([inline]) .d2l-html-block-rendered {
-				display: inline;
-			}
-			:host([hidden]),
-			:host([no-deferred-rendering]) .d2l-html-block-rendered,
-			slot {
-				display: none;
-			}
-			:host([no-deferred-rendering]) slot {
-				display: contents;
-			}
-		`];
-	}
+	static styles = [ htmlBlockContentStyles, css`
+		:host {
+			display: block;
+		}
+		${_generateHtmlBlockRootStyles(':host')}
+		:host([inline]),
+		:host([inline]) .d2l-html-block-rendered {
+			display: inline;
+		}
+		:host([hidden]),
+		:host([no-deferred-rendering]) .d2l-html-block-rendered,
+		slot {
+			display: none;
+		}
+		:host([no-deferred-rendering]) slot {
+			display: contents;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/icons/demo/icon-color-override.js
+++ b/components/icons/demo/icon-color-override.js
@@ -3,16 +3,14 @@ import { css, html, LitElement } from 'lit';
 
 class IconColorOverride extends LitElement {
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			::slotted(d2l-icon), ::slotted(d2l-icon-custom) {
-				color: var(--d2l-color-celestine-minus-1);
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		::slotted(d2l-icon), ::slotted(d2l-icon-custom) {
+			color: var(--d2l-color-celestine-minus-1);
+		}
+	`;
 
 	render() {
 		return html`<slot></slot>`;

--- a/components/icons/demo/icon-size-override.js
+++ b/components/icons/demo/icon-size-override.js
@@ -2,18 +2,16 @@ import { css, html, LitElement } from 'lit';
 
 class IconSizeOverride extends LitElement {
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			.d2l-icon-size-override-container > ::slotted(d2l-icon),
-			.d2l-icon-size-override-container > ::slotted(d2l-icon-custom) {
-				height: 100px;
-				width: 100px;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		.d2l-icon-size-override-container > ::slotted(d2l-icon),
+		.d2l-icon-size-override-container > ::slotted(d2l-icon-custom) {
+			height: 100px;
+			width: 100px;
+		}
+	`;
 
 	render() {
 		return html`<div class="d2l-icon-size-override-container"><slot></slot></div>`;

--- a/components/icons/icon-custom.js
+++ b/components/icons/icon-custom.js
@@ -4,31 +4,27 @@ import { iconStyles } from './icon-styles.js';
 
 class IconCustom extends LitElement {
 
-	static get properties() {
-		return {
-			size: {
-				type: String,
-				reflect: true
-			}
-		};
-	}
+	static properties = {
+		size: {
+			type: String,
+			reflect: true
+		}
+	};
 
-	static get styles() {
-		return [ iconStyles, css`
-			:host([size="tier1"]) {
-				height: var(--d2l-icon-height, 18px);
-				width: var(--d2l-icon-width, 18px);
-			}
-			:host([size="tier2"]) {
-				height: var(--d2l-icon-height, 24px);
-				width: var(--d2l-icon-width, 24px);
-			}
-			:host([size="tier3"]) {
-				height: var(--d2l-icon-height, 30px);
-				width: var(--d2l-icon-width, 30px);
-			}
-		`];
-	}
+	static styles = [ iconStyles, css`
+		:host([size="tier1"]) {
+			height: var(--d2l-icon-height, 18px);
+			width: var(--d2l-icon-width, 18px);
+		}
+		:host([size="tier2"]) {
+			height: var(--d2l-icon-height, 24px);
+			width: var(--d2l-icon-width, 24px);
+		}
+		:host([size="tier3"]) {
+			height: var(--d2l-icon-height, 30px);
+			width: var(--d2l-icon-width, 30px);
+		}
+	`];
 
 	render() {
 		return html`<slot @slotchange="${this._handleSlotChange}"></slot>`;

--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -9,31 +9,27 @@ import { until } from 'lit/directives/until.js';
 
 class Icon extends LitElement {
 
-	static get properties() {
-		return {
-			icon: {
-				type: String,
-				reflect: true
-			}
-		};
-	}
+	static properties = {
+		icon: {
+			type: String,
+			reflect: true
+		}
+	};
 
-	static get styles() {
-		return [ iconStyles, css`
-			:host([icon*="tier1:"]) {
-				height: var(--d2l-icon-height, 18px);
-				width: var(--d2l-icon-width, 18px);
-			}
-			:host([icon*="tier2:"]) {
-				height: var(--d2l-icon-height, 24px);
-				width: var(--d2l-icon-width, 24px);
-			}
-			:host([icon*="tier3:"]) {
-				height: var(--d2l-icon-height, 30px);
-				width: var(--d2l-icon-width, 30px);
-			}
-		`];
-	}
+	static styles = [ iconStyles, css`
+		:host([icon*="tier1:"]) {
+			height: var(--d2l-icon-height, 18px);
+			width: var(--d2l-icon-width, 18px);
+		}
+		:host([icon*="tier2:"]) {
+			height: var(--d2l-icon-height, 24px);
+			width: var(--d2l-icon-width, 24px);
+		}
+		:host([icon*="tier3:"]) {
+			height: var(--d2l-icon-height, 30px);
+			width: var(--d2l-icon-width, 30px);
+		}
+	`];
 
 	render() {
 		return guard([this.icon], () => until(this._getIcon(), noChange));

--- a/components/icons/slotted-icon-mixin.js
+++ b/components/icons/slotted-icon-mixin.js
@@ -3,23 +3,21 @@ import { css, html, nothing } from 'lit';
 
 export const SlottedIconMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
+	static properties = {
 
-			/**
-			 * Preset icon key (e.g. "tier1:gear")
-			 * @type {string}
-			 */
-			icon: {
-				type: String,
-				reflect: true,
-				required: {
-					validator: (_value, elem, hasValue) => hasValue || elem._hasCustomIcon || !elem._iconRequired
-				}
-			},
-			_hasCustomIcon: { state: true }
-		};
-	}
+		/**
+		 * Preset icon key (e.g. "tier1:gear")
+		 * @type {string}
+		 */
+		icon: {
+			type: String,
+			reflect: true,
+			required: {
+				validator: (_value, elem, hasValue) => hasValue || elem._hasCustomIcon || !elem._iconRequired
+			}
+		},
+		_hasCustomIcon: { state: true }
+	};
 
 	static get styles() {
 		const styles = [ css`

--- a/components/inputs/demo/input-color-palette.js
+++ b/components/inputs/demo/input-color-palette.js
@@ -5,34 +5,30 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 class InputColorPalette extends LitElement {
 
-	static get properties() {
-		return {
-			value: { type: String }
-		};
-	}
+	static properties = {
+		value: { type: String }
+	};
 
-	static get styles() {
-		return [ css`
-			:host {
-				display: block;
-				padding: 12px;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			p {
-				margin-top: 0;
-			}
-			span {
-				margin: 0 0.2rem 0 0.55rem;
-			}
-			div {
-				align-items: flex-end;
-				display: flex;
-				gap: 6px;
-			}
-		`];
-	}
+	static styles = [ css`
+		:host {
+			display: block;
+			padding: 12px;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		p {
+			margin-top: 0;
+		}
+		span {
+			margin: 0 0.2rem 0 0.55rem;
+		}
+		div {
+			align-items: flex-end;
+			display: flex;
+			gap: 6px;
+		}
+	`];
 
 	render() {
 		return html`

--- a/components/inputs/demo/input-radio-label-test.js
+++ b/components/inputs/demo/input-radio-label-test.js
@@ -3,17 +3,15 @@ import { radioStyles } from '../input-radio-styles.js';
 
 class TestInputRadioLabel extends LitElement {
 
-	static get styles() {
-		return [ radioStyles,
-			css`
+	static styles = [ radioStyles,
+		css`
 				:host {
 					display: block;
 					overflow: hidden;
 					width: 200px;
 				}
 			`
-		];
-	}
+	];
 
 	render() {
 		return html`

--- a/components/inputs/demo/input-radio-solo-test.js
+++ b/components/inputs/demo/input-radio-solo-test.js
@@ -3,26 +3,22 @@ import { radioStyles } from '../input-radio-styles.js';
 
 class TestInputRadioSolo extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Selection state
 			 */
-			checked: { type: Boolean },
-			/**
+		checked: { type: Boolean },
+		/**
 			 * Disables the input
 			 */
-			disabled: { type: Boolean },
-			/**
+		disabled: { type: Boolean },
+		/**
 			 * Marks the input as invalid, which is shown in style and also is reflected in `aria-invalid`
 			 */
-			invalid: { type: Boolean }
-		};
-	}
+		invalid: { type: Boolean }
+	};
 
-	static get styles() {
-		return radioStyles;
-	}
+	static styles = radioStyles;
 
 	render() {
 		const invalid = this.invalid ? 'true' : 'false';

--- a/components/inputs/demo/input-select-test.js
+++ b/components/inputs/demo/input-select-test.js
@@ -4,35 +4,31 @@ import { SkeletonMixin } from '../../../components/skeleton/skeleton-mixin.js';
 
 class TestInputSelect extends SkeletonMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables the input
 			 */
-			disabled: { type: Boolean },
-			/**
+		disabled: { type: Boolean },
+		/**
 			 * Marks the input as invalid, which is shown in style and also is reflected in `aria-invalid`
 			 */
-			invalid: { type: Boolean },
-			/**
+		invalid: { type: Boolean },
+		/**
 			 * Sets a max-width on the select element in order to show overflow styles
 			 */
-			overflow: { type: Boolean }
-		};
-	}
+		overflow: { type: Boolean }
+	};
 
-	static get styles() {
-		return [super.styles, selectStyles,
-			css`
-				:host {
-					display: inline-block;
-				}
-				:host([overflow]) select {
-					max-width: 130px;
-				}
-			`
-		];
-	}
+	static styles = [super.styles, selectStyles,
+		css`
+			:host {
+				display: inline-block;
+			}
+			:host([overflow]) select {
+				max-width: 130px;
+			}
+		`
+	];
 
 	render() {
 		const invalid = this.invalid ? 'true' : 'false';

--- a/components/inputs/docs/input-select-styles.md
+++ b/components/inputs/docs/input-select-styles.md
@@ -10,9 +10,7 @@ A Select List allows the user to select a single option out of a relatively larg
 
   class MySelectElem extends LitElement {
 
-    static get styles() {
-      return selectStyles;
-    }
+    static styles = selectStyles;
     render() {
       return html`
         <select class="d2l-input-select" aria-label="Options">
@@ -61,9 +59,7 @@ When applying styles to the native element, we also recommend using the [`Skelet
   import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
   class TestInputSelect extends SkeletonMixin(LitElement) {
-  static get styles() {
-    return [super.styles, selectStyles];
-  }
+  static styles = [super.styles, selectStyles];
 
   render() {
     return html`
@@ -100,9 +96,7 @@ For a visible label, import the label styles and include them in your component'
 
   class TestInputSelect extends LitElement {
 
-    static get styles() {
-      return [inputLabelStyles, selectStyles];
-    }
+    static styles = [inputLabelStyles, selectStyles];
 
     render() {
       return html`

--- a/components/inputs/docs/styling-native-inputs.md
+++ b/components/inputs/docs/styling-native-inputs.md
@@ -16,9 +16,7 @@ Import `input-checkbox-styles.js` and apply the `d2l-input-checkbox` CSS class t
 
   class MyCheckboxElem extends LitElement {
 
-    static get styles() {
-      return checkboxStyles;
-    }
+    static styles = checkboxStyles;
 
     render() {
       return html`<input type="checkbox" class="d2l-input-checkbox">`;
@@ -46,9 +44,7 @@ For disabled items, add the `d2l-input-radio-label-disabled` class on the label 
 
   class MyRadioElem extends LitElement {
 
-    static get styles() {
-      return radioStyles;
-    }
+    static styles = radioStyles;
 
     render() {
       return html`
@@ -85,17 +81,13 @@ If you'd like to manually link the radio input with a label, or use an ARIA labe
 
   class MyRadioElem extends LitElement {
 
-    static get properties() {
-      return {
-        checked: { type: Boolean },
-        disabled: { type: Boolean },
-        invalid: { type: Boolean }
-      };
-    }
+    static properties = {
+      checked: { type: Boolean },
+      disabled: { type: Boolean },
+      invalid: { type: Boolean }
+    };
 
-    static get styles() {
-      return radioStyles;
-    }
+    static styles = radioStyles;
 
     render() {
       const invalid = this.invalid ? 'true' : 'false';
@@ -130,9 +122,7 @@ To align related content below radio buttons, the `d2l-input-radio-spacer` eleme
 
   class MyRadioElem extends LitElement {
 
-    static get styles() {
-      return [ radioStyles, inlineHelpStyles ];
-    }
+    static styles = [ radioStyles, inlineHelpStyles ];
 
     render() {
       return html`
@@ -164,9 +154,7 @@ Import `input-styles.js` and apply the `d2l-input` CSS class to the native `<inp
 
   class MyTextInputElem extends LitElement {
 
-    static get styles() {
-      return inputStyles;
-    }
+    static styles = inputStyles;
 
     render() {
       return html`<input type="text" class="d2l-input">`;
@@ -189,9 +177,7 @@ Import `input-styles.js` and apply the `d2l-input` CSS class to the  native `<te
   import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 
   class MyTextareaInputElem extends LitElement {
-    static get styles() {
-      return inputStyles;
-    }
+    static styles = inputStyles;
     render() {
       return html`
         <textarea class="d2l-input">

--- a/components/inputs/input-checkbox-group.js
+++ b/components/inputs/input-checkbox-group.js
@@ -8,45 +8,41 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class InputCheckboxGroup extends PropertyRequiredMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Label for the group of checkboxes
 			 * @type {string}
 			 */
-			label: { required: true, type: String },
-			/**
+		label: { required: true, type: String },
+		/**
 			 * Hides the label visually
 			 * @type {boolean}
 			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean }
-		};
-	}
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean }
+	};
 
-	static get styles() {
-		return [inputLabelStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.wrapper {
-				display: flex;
-				flex-direction: column;
-				gap: 0.6rem;
-			}
-			::slotted(d2l-input-checkbox) {
-				margin-bottom: 0;
-			}
-			.d2l-input-label {
-				margin-block-end: 0.6rem;
-			}
-			.d2l-input-label[hidden] {
-				display: none;
-			}
-		`];
-	}
+	static styles = [inputLabelStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.wrapper {
+			display: flex;
+			flex-direction: column;
+			gap: 0.6rem;
+		}
+		::slotted(d2l-input-checkbox) {
+			margin-bottom: 0;
+		}
+		.d2l-input-label {
+			margin-block-end: 0.6rem;
+		}
+		.d2l-input-label[hidden] {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -21,116 +21,112 @@ export const checkboxStyles = _generateInputCheckboxStyles('input[type="checkbox
  */
 class InputCheckbox extends FormElementMixin(InputInlineHelpMixin(FocusMixin(SkeletonMixin(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			ariaLabel: { type: String, attribute: 'aria-label' },
-			/**
+		ariaLabel: { type: String, attribute: 'aria-label' },
+		/**
 			 * Checked state
 			 * @type {boolean}
 			 */
-			checked: { type: Boolean },
-			/**
+		checked: { type: Boolean },
+		/**
 			 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
 			 * @type {string}
 			 */
-			description: { type: String },
-			/**
+		description: { type: String },
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean },
-			/**
+		disabled: { type: Boolean },
+		/**
 			 * Tooltip text when disabled
 			 * @type {string}
 			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			/**
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		/**
 			 * Sets checkbox to an indeterminate state
 			 * @type {boolean}
 			 */
-			indeterminate: { type: Boolean },
-			/**
+		indeterminate: { type: Boolean },
+		/**
 			 * REQUIRED: Label for the input
 			 * @type {string}
 			 */
-			label: { type: String },
-			/**
+		label: { type: String },
+		/**
 			 * Hides the label visually
 			 * @type {boolean}
 			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
-			/**
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
+		/**
 			 * Hides the supporting slot when unchecked
 			 * @type {boolean}
 			 */
-			supportingHiddenWhenUnchecked: { type: Boolean, attribute: 'supporting-hidden-when-unchecked', reflect: true },
-			/**
+		supportingHiddenWhenUnchecked: { type: Boolean, attribute: 'supporting-hidden-when-unchecked', reflect: true },
+		/**
 			 * Value of the input
 			 * @type {string}
 			 */
-			value: { type: String },
-			_hasSupporting: { state: true },
-			_isHovered: { state: true },
-		};
-	}
+		value: { type: String },
+		_hasSupporting: { state: true },
+		_isHovered: { state: true },
+	};
 
-	static get styles() {
-		return [ super.styles, checkboxStyles, offscreenStyles,
-			css`
-				:host {
-					display: block;
-					margin-block-end: 0.6rem;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([label-hidden]) {
-					display: inline-block;
-					margin-block-end: 0;
-				}
-				label {
-					display: flex;
-					line-height: ${cssSizes.inputBoxSize}rem;
-					overflow-wrap: anywhere;
-				}
-				.d2l-input-checkbox-wrapper {
-					display: inline-block;
-				}
-				.d2l-input-checkbox-text {
-					color: var(--d2l-theme-text-color-static-standard);
-					display: inline-block;
-					font-size: 0.8rem;
-					font-weight: 400;
-					margin-inline-start: ${cssSizes.checkboxMargin}rem;
-					vertical-align: top;
-					white-space: normal;
-				}
-				:host([label-hidden]) .d2l-input-checkbox-text {
-					margin-inline-start: 0;
-				}
-				:host([skeleton]) .d2l-input-checkbox-text.d2l-skeletize::before {
-					bottom: 0.3rem;
-					top: 0.3rem;
-				}
-				.d2l-input-inline-help,
-				.d2l-input-checkbox-supporting {
-					margin-inline-start: ${cssSizes.inputBoxSize + cssSizes.checkboxMargin}rem;
-				}
-				:host(:not([skeleton])) .d2l-input-checkbox-text-disabled {
-					opacity: 0.5;
-				}
-				input[type="checkbox"].d2l-input-checkbox {
-					vertical-align: top;
-				}
-				.d2l-input-checkbox-supporting {
-					margin-block-start: 0.6rem;
-				}
-			`
-		];
-	}
+	static styles = [ super.styles, checkboxStyles, offscreenStyles,
+		css`
+			:host {
+				display: block;
+				margin-block-end: 0.6rem;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([label-hidden]) {
+				display: inline-block;
+				margin-block-end: 0;
+			}
+			label {
+				display: flex;
+				line-height: ${cssSizes.inputBoxSize}rem;
+				overflow-wrap: anywhere;
+			}
+			.d2l-input-checkbox-wrapper {
+				display: inline-block;
+			}
+			.d2l-input-checkbox-text {
+				color: var(--d2l-theme-text-color-static-standard);
+				display: inline-block;
+				font-size: 0.8rem;
+				font-weight: 400;
+				margin-inline-start: ${cssSizes.checkboxMargin}rem;
+				vertical-align: top;
+				white-space: normal;
+			}
+			:host([label-hidden]) .d2l-input-checkbox-text {
+				margin-inline-start: 0;
+			}
+			:host([skeleton]) .d2l-input-checkbox-text.d2l-skeletize::before {
+				bottom: 0.3rem;
+				top: 0.3rem;
+			}
+			.d2l-input-inline-help,
+			.d2l-input-checkbox-supporting {
+				margin-inline-start: ${cssSizes.inputBoxSize + cssSizes.checkboxMargin}rem;
+			}
+			:host(:not([skeleton])) .d2l-input-checkbox-text-disabled {
+				opacity: 0.5;
+			}
+			input[type="checkbox"].d2l-input-checkbox {
+				vertical-align: top;
+			}
+			.d2l-input-checkbox-supporting {
+				margin-block-start: 0.6rem;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/inputs/input-color.js
+++ b/components/inputs/input-color.js
@@ -88,155 +88,151 @@ const SWATCH_TRANSPARENT = `<svg xmlns="http://www.w3.org/2000/svg" width="24" h
  */
 class InputColor extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: Value of an associated color as a HEX which will be used for color contrast analysis
-			 * @type {string}
-			 */
-			associatedValue: { attribute: 'associated-value', type: String },
-			/**
-			 * Puts the input into a disabled state
-			 * @type {boolean}
-			 */
-			disabled: { reflect: true, type: Boolean },
-			/**
-			 * Disallows the user from selecting "None" as a color value
-			 * @type {boolean}
-			 */
-			disallowNone: { attribute: 'disallow-none', type: Boolean },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Label for the input, comes with a default value for background & foreground types.
-			 * @type {string}
-			 */
-			label: {
-				type: String,
-				required: {
-					dependentProps: ['type'],
-					validator: (_value, elem, hasValue) => elem.type !== 'custom' || hasValue
-				}
-			},
-			/**
-			 * Hides the label visually
-			 * @type {boolean}
-			 */
-			labelHidden: { attribute: 'label-hidden', type: Boolean },
-			/**
-			 * Puts the input into a read-only state
-			 * @type {boolean}
-			 */
-			readonly: { type: Boolean },
-			/**
-			 * Type of color being chosen
-			 * @type {'background'|'foreground'|'custom'}
-			 * @default end
-			 */
-			type: { reflect: true, type: String },
-			/**
-			 * Value of the input as a HEX color
-			 * @type {string}
-			 */
-			value: { type: String },
-			/**
-			 * @ignore
-			 */
-			launchType: { attribute: 'launch-type', type: String },
-			_opened: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * ACCESSIBILITY: Value of an associated color as a HEX which will be used for color contrast analysis
+		 * @type {string}
+		 */
+		associatedValue: { attribute: 'associated-value', type: String },
+		/**
+		 * Puts the input into a disabled state
+		 * @type {boolean}
+		 */
+		disabled: { reflect: true, type: Boolean },
+		/**
+		 * Disallows the user from selecting "None" as a color value
+		 * @type {boolean}
+		 */
+		disallowNone: { attribute: 'disallow-none', type: Boolean },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Label for the input, comes with a default value for background & foreground types.
+		 * @type {string}
+		 */
+		label: {
+			type: String,
+			required: {
+				dependentProps: ['type'],
+				validator: (_value, elem, hasValue) => elem.type !== 'custom' || hasValue
+			}
+		},
+		/**
+		 * Hides the label visually
+		 * @type {boolean}
+		 */
+		labelHidden: { attribute: 'label-hidden', type: Boolean },
+		/**
+		 * Puts the input into a read-only state
+		 * @type {boolean}
+		 */
+		readonly: { type: Boolean },
+		/**
+		 * Type of color being chosen
+		 * @type {'background'|'foreground'|'custom'}
+		 * @default end
+		 */
+		type: { reflect: true, type: String },
+		/**
+		 * Value of the input as a HEX color
+		 * @type {string}
+		 */
+		value: { type: String },
+		/**
+		 * @ignore
+		 */
+		launchType: { attribute: 'launch-type', type: String },
+		_opened: { state: true }
+	};
 
-	static get styles() {
-		return [ super.styles, buttonStyles, inputLabelStyles,
-			css`
-				:host {
-					display: inline-block;
-				}
-				:host([hidden]) {
-					display: none;
-				}
+	static styles = [ super.styles, buttonStyles, inputLabelStyles,
+		css`
+			:host {
+				display: inline-block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
 
-				button {
-					align-items: center;
-					background-color: var(--d2l-color-gypsum);
-					display: flex;
-					gap: 0.15rem;
-					min-height: auto;
-					padding: 0.55rem;
-					position: relative;
-				}
-				button:not([aria-disabled]):hover,
-				button:not([aria-disabled]):focus,
-				button.opened {
-					background-color: var(--d2l-color-mica);
-				}
-				:host([disabled]) button {
-					cursor: default;
-					opacity: 0.5;
-				}
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
+			button {
+				align-items: center;
+				background-color: var(--d2l-color-gypsum);
+				display: flex;
+				gap: 0.15rem;
+				min-height: auto;
+				padding: 0.55rem;
+				position: relative;
+			}
+			button:not([aria-disabled]):hover,
+			button:not([aria-disabled]):focus,
+			button.opened {
+				background-color: var(--d2l-color-mica);
+			}
+			:host([disabled]) button {
+				cursor: default;
+				opacity: 0.5;
+			}
+			/* Firefox includes a hidden border which messes up button dimensions */
+			button::-moz-focus-inner {
+				border: 0;
+			}
 
-				.d2l-input-label {
-					margin-bottom: 0;
-					padding-bottom: 7px; /* prevent margin-collapse with readonly swatch margins */
-				}
+			.d2l-input-label {
+				margin-bottom: 0;
+				padding-bottom: 7px; /* prevent margin-collapse with readonly swatch margins */
+			}
 
+			.swatch {
+				border: 1px inset rgba(0, 0, 0, 0.42);
+				border-radius: 0.1rem;
+				box-sizing: border-box;
+				display: inline-block;
+				height: 0.3rem;
+				width: 1.2rem;
+			}
+			:host([type="custom"]) .swatch {
+				border-radius: 0.15rem;
+				height: 1rem;
+			}
+			.swatch-transparent {
+				background-image: ${svgToCSS(SWATCH_TRANSPARENT)};
+				background-position-y: -1.5px;
+				background-size: cover;
+			}
+			:host([type="custom"]) .swatch-transparent {
+				background-position-y: 0;
+			}
+
+			.icon-wrapper {
+				align-items: center;
+				display: flex;
+				flex-direction: column;
+				gap: 0.1rem;
+			}
+			.icon-wrapper > svg {
+				height: 0.6rem;
+			}
+
+			button,
+			.readonly-wrapper {
+				color: var(--d2l-color-ferrite);
+			}
+
+			.readonly-wrapper {
+				border-radius: 0.1rem;
+				display: block;
+				line-height: 0;
+				margin: 0.55rem 0;
+				outline: none;
+				width: 1.2rem;
+			}
+			${getFocusRingStyles('.readonly-wrapper')}
+			@media (prefers-contrast: more) {
 				.swatch {
-					border: 1px inset rgba(0, 0, 0, 0.42);
-					border-radius: 0.1rem;
-					box-sizing: border-box;
-					display: inline-block;
-					height: 0.3rem;
-					width: 1.2rem;
+					border: 1px solid FieldText;
+					forced-color-adjust: none;
 				}
-				:host([type="custom"]) .swatch {
-					border-radius: 0.15rem;
-					height: 1rem;
-				}
-				.swatch-transparent {
-					background-image: ${svgToCSS(SWATCH_TRANSPARENT)};
-					background-position-y: -1.5px;
-					background-size: cover;
-				}
-				:host([type="custom"]) .swatch-transparent {
-					background-position-y: 0;
-				}
-
-				.icon-wrapper {
-					align-items: center;
-					display: flex;
-					flex-direction: column;
-					gap: 0.1rem;
-				}
-				.icon-wrapper > svg {
-					height: 0.6rem;
-				}
-
-				button,
-				.readonly-wrapper {
-					color: var(--d2l-color-ferrite);
-				}
-
-				.readonly-wrapper {
-					border-radius: 0.1rem;
-					display: block;
-					line-height: 0;
-					margin: 0.55rem 0;
-					outline: none;
-					width: 1.2rem;
-				}
-				${getFocusRingStyles('.readonly-wrapper')}
-				@media (prefers-contrast: more) {
-					.swatch {
-						border: 1px solid FieldText;
-						forced-color-adjust: none;
-					}
-				}
-			`
-		];
-	}
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -34,101 +34,97 @@ export function getShiftedEndDate(startValue, endValue, prevStartValue, inclusiv
  */
 class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ADVANCED: Automatically shifts end date when start date changes to keep same range
 			 * @type {boolean}
 			 */
-			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
-			/**
+		autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
+		/**
 			 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
 			 * @type {boolean}
 			 */
-			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
-			/**
+		childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
+		/**
 			 * Disables the inputs
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: Label for the end date input. Defaults to localized "End Date".
 			 * @type {string}
 			 * @default "End Date"
 			 */
-			endLabel: { attribute: 'end-label', reflect: true, type: String },
-			/**
+		endLabel: { attribute: 'end-label', reflect: true, type: String },
+		/**
 			 * ADVANCED: Indicates if the end calendar dropdown is open
 			 * @type {boolean}
 			 */
-			endOpened: { attribute: 'end-opened', type: Boolean },
-			/**
+		endOpened: { attribute: 'end-opened', type: Boolean },
+		/**
 			 * Value of the end date input
 			 * @type {string}
 			 */
-			endValue: { attribute: 'end-value', reflect: true, type: String },
-			/**
+		endValue: { attribute: 'end-value', reflect: true, type: String },
+		/**
 			 * Validates on inclusive range (i.e., it is valid for start and end dates to be equal)
 			 * @type {boolean}
 			 */
-			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
-			/**
+		inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
+		/**
 			 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date inputs
 			 * @type {string}
 			 */
-			label: { type: String, reflect: true },
-			/**
+		label: { type: String, reflect: true },
+		/**
 			 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
-			/**
+		labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
+		/**
 			 * Maximum valid date that could be selected by a user
 			 * @type {string}
 			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
 			 * Minimum valid date that could be selected by a user
 			 * @type {string}
 			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
 			 * Indicates that values are required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true },
-			/**
+		required: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: Label for the start date input. Defaults to localized "Start Date".
 			 * @type {string}
 			 * @default "Start Date"
 			 */
-			startLabel: { attribute: 'start-label', reflect: true, type: String },
-			/**
+		startLabel: { attribute: 'start-label', reflect: true, type: String },
+		/**
 			 * ADVANCED: Indicates if the start calendar dropdown is open
 			 * @type {boolean}
 			 */
-			startOpened: { attribute: 'start-opened', type: Boolean },
-			/**
+		startOpened: { attribute: 'start-opened', type: Boolean },
+		/**
 			 * Value of the start date input
 			 * @type {string}
 			 */
-			startValue: { attribute: 'start-value', reflect: true, type: String }
-		};
-	}
+		startValue: { attribute: 'start-value', reflect: true, type: String }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-input-date {
-				display: block;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-input-date {
+			display: block;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date-time-range-to.js
+++ b/components/inputs/input-date-time-range-to.js
@@ -16,83 +16,79 @@ function debounce(func, delay) {
 
 class InputDateTimeRangeTo extends SkeletonMixin(LocalizeCoreElement(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Force block (stacked) range display if true
 			 * @type {boolean}
 			 */
-			blockDisplay: { attribute: 'block-display', type: Boolean },
-			/**
+		blockDisplay: { attribute: 'block-display', type: Boolean },
+		/**
 			 * Display localized "to" between the left and right slot contents
 			 * @type {boolean}
 			 */
-			displayTo: { attribute: 'display-to', type: Boolean },
-			/**
+		displayTo: { attribute: 'display-to', type: Boolean },
+		/**
 			 * Add margin-top for case where there would be a label above the range
 			 * @type {boolean}
 			 */
-			topMargin: { attribute: 'top-margin', type: Boolean },
-			_blockDisplay: { attribute: false, type: Boolean }
-		};
-	}
+		topMargin: { attribute: 'top-margin', type: Boolean },
+		_blockDisplay: { attribute: false, type: Boolean }
+	};
 
-	static get styles() {
-		return [ super.styles, bodySmallStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([top-margin]) {
-				margin-top: calc(0.9rem - 7px);
-			}
-			:host(:not([display-to])) .d2l-input-date-time-range-to-to {
-				display: none;
-			}
+	static styles = [ super.styles, bodySmallStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([top-margin]) {
+			margin-top: calc(0.9rem - 7px);
+		}
+		:host(:not([display-to])) .d2l-input-date-time-range-to-to {
+			display: none;
+		}
 
-			/* flex case (not wrapped) */
-			.d2l-input-date-time-range-to-container {
-				column-gap: 1.5rem;
-				display: flex;
-				flex-wrap: wrap;
-			}
-			:host([display-to]) div:not(.d2l-input-date-time-range-to-container-block).d2l-input-date-time-range-to-container,
-			:host([display-to]) div:not(.d2l-input-date-time-range-to-container-block).d2l-input-date-time-range-to-container .d2l-input-date-time-range-end-container {
-				column-gap: 0.9rem;
-			}
-			.d2l-input-date-time-range-end-container {
-				display: flex;
-			}
-			.d2l-input-date-time-range-end-container ::slotted(*) {
-				align-self: flex-end;
-			}
+		/* flex case (not wrapped) */
+		.d2l-input-date-time-range-to-container {
+			column-gap: 1.5rem;
+			display: flex;
+			flex-wrap: wrap;
+		}
+		:host([display-to]) div:not(.d2l-input-date-time-range-to-container-block).d2l-input-date-time-range-to-container,
+		:host([display-to]) div:not(.d2l-input-date-time-range-to-container-block).d2l-input-date-time-range-to-container .d2l-input-date-time-range-end-container {
+			column-gap: 0.9rem;
+		}
+		.d2l-input-date-time-range-end-container {
+			display: flex;
+		}
+		.d2l-input-date-time-range-end-container ::slotted(*) {
+			align-self: flex-end;
+		}
 
-			/* block case (wrapped) */
-			.d2l-input-date-time-range-to-container-block.d2l-input-date-time-range-to-container {
-				display: block;
-				margin-bottom: -1.2rem;
-			}
-			.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-start-container {
-				margin-inline: 0;
-				margin-bottom: 1.2rem;
-			}
-			:host([display-to]) .d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-start-container {
-				margin-bottom: 0.6rem;
-			}
-			.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-end-container {
-				display: block;
-				margin-bottom: 1.2rem;
-			}
-			.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-to-to {
-				display: inline-block;
-				margin-bottom: 0.6rem;
-				margin-top: auto;
-				vertical-align: top;
-			}
-		`];
-	}
+		/* block case (wrapped) */
+		.d2l-input-date-time-range-to-container-block.d2l-input-date-time-range-to-container {
+			display: block;
+			margin-bottom: -1.2rem;
+		}
+		.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-start-container {
+			margin-inline: 0;
+			margin-bottom: 1.2rem;
+		}
+		:host([display-to]) .d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-start-container {
+			margin-bottom: 0.6rem;
+		}
+		.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-end-container {
+			display: block;
+			margin-bottom: 1.2rem;
+		}
+		.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-to-to {
+			display: inline-block;
+			margin-bottom: 0.6rem;
+			margin-top: auto;
+			vertical-align: top;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -67,121 +67,117 @@ export function getShiftedEndDateTime(startValue, endValue, prevStartValue, incl
  */
 class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ADVANCED: Automatically shifts end date when start date changes to keep same range. If start and end date are equal, automatically shifts end time when start time changes.
 			 * @type {boolean}
 			 */
-			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
-			/**
+		autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
+		/**
 			 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
 			 * @type {boolean}
 			 */
-			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
-			/**
+		childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
+		/**
 			 * Disables the inputs
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: Label for the end date-time input. Defaults to localized "End Date".
 			 * @type {string}
 			 * @default "End Date"
 			 */
-			endLabel: { attribute: 'end-label', reflect: true, type: String },
-			/**
+		endLabel: { attribute: 'end-label', reflect: true, type: String },
+		/**
 			 * ADVANCED: Indicates if the end date or time dropdown is open
 			 * @type {boolean}
 			 */
-			endOpened: { attribute: 'end-opened', type: Boolean },
-			/**
+		endOpened: { attribute: 'end-opened', type: Boolean },
+		/**
 			 * Value of the end date-time input
 			 * @type {string}
 			 */
-			endValue: { attribute: 'end-value', reflect: true, type: String },
-			/**
+		endValue: { attribute: 'end-value', reflect: true, type: String },
+		/**
 			 * Validates on inclusive range (i.e., it is valid for start and end date-times to be equal)
 			 * @type {boolean}
 			 */
-			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
-			/**
+		inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
+		/**
 			 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date-time inputs
 			 * @type {string}
 			 */
-			label: { type: String, reflect: true },
-			/**
+		label: { type: String, reflect: true },
+		/**
 			 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
-			/**
+		labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
+		/**
 			 * Indicates that localization will be handled by the consumer. `*value` will not be converted from/to UTC.
 			 * @type {boolean}
 			 */
-			localized: { reflect: true, type: Boolean },
-			/**
+		localized: { reflect: true, type: Boolean },
+		/**
 			 * Maximum valid date/time that could be selected by a user
 			 * @type {string}
 			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
 			 * Minimum valid date/time that could be selected by a user
 			 * @type {string}
 			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
 			 * Indicates that values are required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true },
-			/**
+		required: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: Label for the start date-time input. Defaults to localized "Start Date".
 			 * @type {string}
 			 * @default "Start Date"
 			 */
-			startLabel: { attribute: 'start-label', reflect: true, type: String },
-			/**
+		startLabel: { attribute: 'start-label', reflect: true, type: String },
+		/**
 			 * ADVANCED: Indicates if the start date or time dropdown is open
 			 * @type {boolean}
 			 */
-			startOpened: { attribute: 'start-opened', type: Boolean },
-			/**
+		startOpened: { attribute: 'start-opened', type: Boolean },
+		/**
 			 * Value of the start date-time input
 			 * @type {string}
 			 */
-			startValue: { attribute: 'start-value', reflect: true, type: String },
-			/**
+		startValue: { attribute: 'start-value', reflect: true, type: String },
+		/**
 			 * Time zone identifier for the time inputs to use.
 			 * @type {string}
 			 */
-			timeZoneId: { attribute: 'time-zone-id', type: String },
-			/**
+		timeZoneId: { attribute: 'time-zone-id', type: String },
+		/**
 			 * Hides the time zone inside the time selection dropdowns. Should only be used when the time input values are not related to any one time zone
 			 * @type {Boolean}
 			 */
-			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
-			_slotOccupied: { type: Boolean }
-		};
-	}
+		timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
+		_slotOccupied: { type: Boolean }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-input-date-time {
-				display: block;
-			}
-			::slotted(*) {
-				margin-top: 0.6rem;
-			}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-input-date-time {
+			display: block;
+		}
+		::slotted(*) {
+			margin-top: 0.6rem;
+		}
 
-		`];
-	}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -43,85 +43,81 @@ function _getFormattedDefaultTime(defaultValue) {
  */
 class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean },
-			/**
+		disabled: { type: Boolean },
+		/**
 			 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
-			/**
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
+		/**
 			 * Indicates that localization will be handled by the consumer. `*value` will not be converted from/to UTC.
 			 * @type {boolean}
 			 */
-			localized: { reflect: true, type: Boolean },
-			/**
+		localized: { reflect: true, type: Boolean },
+		/**
 			 * Maximum valid date/time that could be selected by a user
 			 * @type {string}
 			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
 			 * Minimum valid date/time that could be selected by a user
 			 * @type {string}
 			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
 			 * Indicates if the date or time dropdown is open
 			 * @type {boolean}
 			 */
-			opened: { type: Boolean },
-			/**
+		opened: { type: Boolean },
+		/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true },
-			/**
+		required: { type: Boolean, reflect: true },
+		/**
 			 * Default value of time input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
 			 * @type {string}
 			 */
-			timeDefaultValue: { attribute: 'time-default-value', reflect: true, type: String },
-			/**
+		timeDefaultValue: { attribute: 'time-default-value', reflect: true, type: String },
+		/**
 			 * Time zone identifier for the time input to use.
 			 * @type {string}
 			 */
-			timeZoneId: { type: String, attribute: 'time-zone-id' },
-			/**
+		timeZoneId: { type: String, attribute: 'time-zone-id' },
+		/**
 			 * Hides the time zone inside the time selection dropdown. Should only be used when the time input value is not related to any one time zone
 			 * @type {Boolean}
 			 */
-			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
-			/**
+		timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
+		/**
 			 * Value of the input
 			 * @type {string}
 			 */
-			value: { type: String },
-			_maxValueLocalized: { type: String },
-			_minValueLocalized: { type: String }
-		};
-	}
+		value: { type: String },
+		_maxValueLocalized: { type: String },
+		_minValueLocalized: { type: String }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-input-date-time-container {
-				margin-top: -0.3rem;
-			}
-			d2l-input-date,
-			d2l-input-time {
-				margin-top: 0.3rem;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-input-date-time-container {
+			margin-top: -0.3rem;
+		}
+		d2l-input-date,
+		d2l-input-time {
+			margin-top: 0.3rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -30,111 +30,107 @@ export function formatISODateInUserCalDescriptor(val) {
  */
 class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean },
-			/**
+		disabled: { type: Boolean },
+		/**
 			 * @ignore
 			 * Optionally add a 'Now' button to be used in date-time pickers only.
 			 */
-			hasNow: { attribute: 'has-now', type: Boolean },
-			/**
+		hasNow: { attribute: 'has-now', type: Boolean },
+		/**
 			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
 			 * Maximum valid date that could be selected by a user
 			 * @type {string}
 			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
 			 * Minimum valid date that could be selected by a user
 			 * @type {string}
 			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
 			 * @ignore
 			 * Disables validation of max and min value. The min and max value will still be enforced but the component will not be put into an error state or show an error tooltip.
 			 */
-			noValidateMinMax: { attribute: 'novalidateminmax', type: Boolean },
-			/**
+		noValidateMinMax: { attribute: 'novalidateminmax', type: Boolean },
+		/**
 			 * Indicates if the calendar dropdown is open
 			 * @type {boolean}
 			 */
-			opened: { type: Boolean, reflect: true },
-			/**
+		opened: { type: Boolean, reflect: true },
+		/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true },
-			/**
+		required: { type: Boolean, reflect: true },
+		/**
 			 * Value of the input
 			 * @type {string}
 			 */
-			value: { type: String },
-			_hiddenContentWidth: { type: String },
-			_dateTimeDescriptor: { type: Object },
-			_dropdownFirstOpened: { type: Boolean },
-			_formattedValue: { type: String },
-			_inputTextFocusShowTooltip: { type: Boolean },
-			_showInfoTooltip: { type: Boolean },
-			_shownValue: { type: String },
-			_showRevertInstructions: { state: true },
-			_showRevertTooltip: { state: true }
-		};
-	}
+		value: { type: String },
+		_hiddenContentWidth: { type: String },
+		_dateTimeDescriptor: { type: Object },
+		_dropdownFirstOpened: { type: Boolean },
+		_formattedValue: { type: String },
+		_inputTextFocusShowTooltip: { type: Boolean },
+		_showInfoTooltip: { type: Boolean },
+		_shownValue: { type: String },
+		_showRevertInstructions: { state: true },
+		_showRevertTooltip: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-				width: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-dropdown {
-				width: 100%;
-			}
-			d2l-icon {
-				--d2l-icon-height: 0.8rem;
-				--d2l-icon-width: 0.8rem;
-				margin-left: 0.6rem;
-				margin-right: 0.6rem;
-			}
-			:host([disabled]) d2l-icon {
-				opacity: 0.5;
-			}
-			.d2l-input-date-hidden-text {
-				font-family: inherit;
-				font-size: 0.8rem;
-				font-weight: 400;
-				letter-spacing: 0.02rem;
-				line-height: 1.4rem;
-				position: absolute;
-				visibility: hidden;
-				width: auto;
-			}
-			.d2l-input-date-hidden-text > div {
-				padding-left: 2rem; /* simulates space taken up by the icon */
-			}
-			d2l-calendar {
-				padding: 0.25rem 0.6rem;
-			}
-			.d2l-calendar-slot-buttons {
-				border-top: 1px solid var(--d2l-color-gypsum);
-				display: flex;
-				justify-content: center;
-				margin-top: 0.3rem;
-				padding-top: 0.3rem;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-dropdown {
+			width: 100%;
+		}
+		d2l-icon {
+			--d2l-icon-height: 0.8rem;
+			--d2l-icon-width: 0.8rem;
+			margin-left: 0.6rem;
+			margin-right: 0.6rem;
+		}
+		:host([disabled]) d2l-icon {
+			opacity: 0.5;
+		}
+		.d2l-input-date-hidden-text {
+			font-family: inherit;
+			font-size: 0.8rem;
+			font-weight: 400;
+			letter-spacing: 0.02rem;
+			line-height: 1.4rem;
+			position: absolute;
+			visibility: hidden;
+			width: auto;
+		}
+		.d2l-input-date-hidden-text > div {
+			padding-left: 2rem; /* simulates space taken up by the icon */
+		}
+		d2l-calendar {
+			padding: 0.25rem 0.6rem;
+		}
+		.d2l-calendar-slot-buttons {
+			border-top: 1px solid var(--d2l-color-gypsum);
+			display: flex;
+			justify-content: center;
+			margin-top: 0.3rem;
+			padding-top: 0.3rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-fieldset.js
+++ b/components/inputs/input-fieldset.js
@@ -16,50 +16,46 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  */
 class InputFieldset extends PropertyRequiredMixin(InputInlineHelpMixin(SkeletonMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Label for the fieldset
 			 * @type {string}
 			 */
-			label: { type: String, required: true },
-			/**
+		label: { type: String, required: true },
+		/**
 			 * Hides the label visually
 			 * @type {boolean}
 			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
-			/**
+		labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
+		/**
 			 * Style of the fieldset label
 			 * @type {'default'|'heading'}
 			 */
-			labelStyle: { type: String, attribute: 'label-style', reflect: true },
-			/**
+		labelStyle: { type: String, attribute: 'label-style', reflect: true },
+		/**
 			 * Indicates that a value is required for inputs in the fieldset
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true }
-		};
-	}
+		required: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return [ super.styles, heading4Styles, inputLabelStyles, offscreenStyles,
-			css`
-				:host {
-					display: block;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([label-style="heading"]:not([label-hidden])) {
-					margin-block-start: 0.3rem;
-				}
-				legend.d2l-heading-4 {
-					margin-block: 0 0.6rem;
-					padding: 0;
-				}
-			`
-		];
-	}
+	static styles = [ super.styles, heading4Styles, inputLabelStyles, offscreenStyles,
+		css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([label-style="heading"]:not([label-hidden])) {
+				margin-block-start: 0.3rem;
+			}
+			legend.d2l-heading-4 {
+				margin-block: 0 0.6rem;
+				padding: 0;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/inputs/input-group.js
+++ b/components/inputs/input-group.js
@@ -6,18 +6,16 @@ import { css, html, LitElement } from 'lit';
  */
 class InputGroup extends LitElement {
 
-	static get styles() {
-		return css`
-			:host {
-				display: flex;
-				flex-direction: column;
-				gap: 0.9rem;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: flex;
+			flex-direction: column;
+			gap: 0.9rem;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	render() {
 		return html`<slot></slot>`;

--- a/components/inputs/input-inline-help.js
+++ b/components/inputs/input-inline-help.js
@@ -14,11 +14,9 @@ export const inlineHelpStyles = [
 
 export const InputInlineHelpMixin = superclass => class extends SkeletonMixin(superclass) {
 
-	static get properties() {
-		return {
-			_hasInlineHelp: { type: Boolean, reflect: true, attribute: '_has-inline-help' }
-		};
-	}
+	static properties = {
+		_hasInlineHelp: { type: Boolean, reflect: true, attribute: '_has-inline-help' }
+	};
 
 	static get styles() {
 		const styles = [ inlineHelpStyles, css`

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -80,124 +80,120 @@ function roundPrecisely(val, maxFractionDigits) {
  */
 class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Specifies which types of values [can be autofilled](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) by the browser.
 			 * @type {string}
 			 */
-			autocomplete: { type: String },
-			/**
+		autocomplete: { type: String },
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean },
-			/**
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean },
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean },
-			/**
+		disabled: { type: Boolean },
+		/**
 			 * ADVANCED: Hide the alert icon when input is invalid
 			 * @type {boolean}
 			 */
-			hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
-			/**
+		hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
+		/**
 			 * Restricts the maximum width of the input box without restricting the width of the label
 			 * @type {string}
 			 */
-			inputWidth: { attribute: 'input-width', type: String },
-			/**
+		inputWidth: { attribute: 'input-width', type: String },
+		/**
 			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
 			 * Maximum value allowed
 			 * @type {number}
 			 */
-			max: { type: Number },
-			/**
+		max: { type: Number },
+		/**
 			 * Indicates whether the max value is exclusive
 			 * @type {boolean}
 			 */
-			maxExclusive: { type: Boolean, attribute: 'max-exclusive' },
-			/**
+		maxExclusive: { type: Boolean, attribute: 'max-exclusive' },
+		/**
 			 * Maximum number of digits allowed after the decimal place. Must be between 0 and 20 and greater than or equal to `minFractionDigits`. Default is Greater of `minFractionDigits` or `3`.
 			 * @type {number}
 			 */
-			maxFractionDigits: { type: Number, attribute: 'max-fraction-digits' },
-			/**
+		maxFractionDigits: { type: Number, attribute: 'max-fraction-digits' },
+		/**
 			 * Minimum value allowed
 			 * @type {number}
 			 */
-			min: { type: Number },
-			/**
+		min: { type: Number },
+		/**
 			 * Indicates whether the min value is exclusive
 			 * @type {boolean}
 			 */
-			minExclusive: { type: Boolean, attribute: 'min-exclusive' },
-			/**
+		minExclusive: { type: Boolean, attribute: 'min-exclusive' },
+		/**
 			 * Minimum number of digits allowed after the decimal place. Must be between 0 and 20 and less than or equal to `maxFractionDigits`. Default is `0`.
 			 * @type {number}
 			 */
-			minFractionDigits: { type: Number, attribute: 'min-fraction-digits' },
-			/**
+		minFractionDigits: { type: Number, attribute: 'min-fraction-digits' },
+		/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean },
-			/**
+		required: { type: Boolean },
+		/**
 			 * @ignore
 			 */
-			trailingZeroes: { type: Boolean, attribute: 'trailing-zeroes' },
-			/**
+		trailingZeroes: { type: Boolean, attribute: 'trailing-zeroes' },
+		/**
 			 * Unit associated with the input value, displayed next to input and announced as part of the label
 			 * @type {string}
 			 */
-			unit: { type: String },
-			/**
+		unit: { type: String },
+		/**
 			 * ACCESSIBILITY: Label for the unit, which is only picked up by screenreaders. Required if `unit` is used.
 			 * @type {string}
 			 */
-			unitLabel: { attribute: 'unit-label', type: String },
-			/**
+		unitLabel: { attribute: 'unit-label', type: String },
+		/**
 			 * Value of the input
 			 * @type {number}
 			 */
-			value: { type: Number, converter: numberConverter },
-			/**
+		value: { type: Number, converter: numberConverter },
+		/**
 			 * Alignment of the value text within the input
 			 * @type {'start'|'end'}
 			 */
-			valueAlign: { attribute: 'value-align', type: String },
-			/**
+		valueAlign: { attribute: 'value-align', type: String },
+		/**
 			 * @ignore
 			 */
-			valueTrailingZeroes: { type: String, attribute: 'value-trailing-zeroes' },
-			_afterSlotWidth: { state: true },
-			_hintType: { state: true },
-			_formattedValue: { state: true }
-		};
-	}
+		valueTrailingZeroes: { type: String, attribute: 'value-trailing-zeroes' },
+		_afterSlotWidth: { state: true },
+		_hintType: { state: true },
+		_formattedValue: { state: true }
+	};
 
-	static get styles() {
-		return [ super.styles,
-			css`
-				:host {
-					display: inline-block;
-					position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				d2l-input-text:not([skeleton]) {
-					width: auto;
-				}
-			`
-		];
-	}
+	static styles = [ super.styles,
+		css`
+			:host {
+				display: inline-block;
+				position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
+				width: 100%;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			d2l-input-text:not([skeleton]) {
+				width: auto;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -15,65 +15,61 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  */
 class InputPercent extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean },
-			/**
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean },
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean },
-			/**
+		disabled: { type: Boolean },
+		/**
 			 * Restricts the maximum width of the input box without restricting the width of the label.
 			 * @type {string}
 			 */
-			inputWidth: { attribute: 'input-width', type: String },
-			/**
+		inputWidth: { attribute: 'input-width', type: String },
+		/**
 			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
 			 * Maximum number of decimal values to show (rounds value up or down).
 			 * @type {number}
 			 */
-			maxFractionDigits: { type: Number, attribute: 'max-fraction-digits' },
-			/**
+		maxFractionDigits: { type: Number, attribute: 'max-fraction-digits' },
+		/**
 			 * Minimum number of decimal values to show.
 			 * @type {number}
 			 */
-			minFractionDigits: { type: Number, attribute: 'min-fraction-digits' },
-			/**
+		minFractionDigits: { type: Number, attribute: 'min-fraction-digits' },
+		/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean },
-			/**
+		required: { type: Boolean },
+		/**
 			 * Value of the input
 			 * @type {number}
 			 */
-			value: { type: Number }
-		};
-	}
+		value: { type: Number }
+	};
 
-	static get styles() {
-		return [ super.styles,
-			css`
-				:host {
-					display: inline-block;
-					position: relative;
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-			`
-		];
-	}
+	static styles = [ super.styles,
+		css`
+			:host {
+				display: inline-block;
+				position: relative;
+				width: 100%;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/inputs/input-radio-group.js
+++ b/components/inputs/input-radio-group.js
@@ -13,57 +13,53 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  */
 class InputRadioGroup extends PropertyRequiredMixin(SkeletonMixin(FormElementMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Display the radio buttons horizontally
 			 * @type {boolean}
 			 */
-			horizontal: { type: Boolean, reflect: true },
-			/**
+		horizontal: { type: Boolean, reflect: true },
+		/**
 			 * REQUIRED: Label for the group of radio inputs
 			 * @type {string}
 			 */
-			label: { required: true, type: String },
-			/**
+		label: { required: true, type: String },
+		/**
 			 * Hides the label visually
 			 * @type {boolean}
 			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
-			/**
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
+		/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true }
-		};
-	}
+		required: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return [super.styles, inputLabelStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			div[role="radiogroup"] {
-				display: flex;
-				flex-direction: column;
-				gap: 0.6rem;
-			}
-			:host([horizontal]) div[role="radiogroup"] {
-				flex-direction: row;
-				flex-wrap: wrap;
-			}
+	static styles = [super.styles, inputLabelStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		div[role="radiogroup"] {
+			display: flex;
+			flex-direction: column;
+			gap: 0.6rem;
+		}
+		:host([horizontal]) div[role="radiogroup"] {
+			flex-direction: row;
+			flex-wrap: wrap;
+		}
 
-			.d2l-input-label[hidden] {
-				display: none;
-			}
-			::slotted(:not(d2l-input-radio)) {
-				display: none;
-			}
-		`];
-	}
+		.d2l-input-label[hidden] {
+			display: none;
+		}
+		::slotted(:not(d2l-input-radio)) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-radio-spacer.js
+++ b/components/inputs/input-radio-spacer.js
@@ -6,19 +6,17 @@ import { css, html, LitElement } from 'lit';
  */
 class InputRadioSpacer extends LitElement {
 
-	static get styles() {
-		return css`
-				:host {
-					box-sizing: border-box;
-					display: block;
-					margin-bottom: 0.9rem;
-					padding-inline-start: 1.7rem;
-				}
-				:host(.d2l-input-inline-help) {
-					margin-bottom: 0.9rem !important;
-				}
-			`;
-	}
+	static styles = css`
+			:host {
+				box-sizing: border-box;
+				display: block;
+				margin-bottom: 0.9rem;
+				padding-inline-start: 1.7rem;
+			}
+			:host(.d2l-input-inline-help) {
+				margin-bottom: 0.9rem !important;
+			}
+		`;
 
 	render() {
 		return html`<slot></slot>`;

--- a/components/inputs/input-radio.js
+++ b/components/inputs/input-radio.js
@@ -18,73 +18,69 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class InputRadio extends InputInlineHelpMixin(SkeletonMixin(FocusMixin(PropertyRequiredMixin(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Checked state
 			 * @type {boolean}
 			 */
-			checked: { type: Boolean, reflect: true },
-			/**
+		checked: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
 			 * @type {string}
 			 */
-			description: { type: String },
-			/**
+		description: { type: String },
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * Tooltip text displayed when the input is disabled
 			 * @type {string}
 			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			/**
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		/**
 			 * REQUIRED: Label for the input
 			 * @type {string}
 			 */
-			label: { required: true, type: String },
-			/**
+		label: { required: true, type: String },
+		/**
 			 * Hides the supporting slot when unchecked
 			 * @type {boolean}
 			 */
-			supportingHiddenWhenUnchecked: { type: Boolean, attribute: 'supporting-hidden-when-unchecked', reflect: true },
-			/**
+		supportingHiddenWhenUnchecked: { type: Boolean, attribute: 'supporting-hidden-when-unchecked', reflect: true },
+		/**
 			 * Value of the input
 			 * @type {string}
 			 */
-			value: { type: String },
-			_checked: { state: true },
-			_focusable: { state: true },
-			_hasSupporting: { state: true },
-			_horizontal: { state: true },
-			_isHovered: { state: true },
-			_invalid: { state: true }
-		};
-	}
+		value: { type: String },
+		_checked: { state: true },
+		_focusable: { state: true },
+		_hasSupporting: { state: true },
+		_horizontal: { state: true },
+		_isHovered: { state: true },
+		_invalid: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, radioStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-input-radio-label {
-				cursor: default;
-				margin-block-end: 0;
-			}
-			.d2l-input-inline-help,
-			.d2l-input-radio-supporting {
-				margin-inline-start: 1.7rem;
-			}
-			.d2l-input-radio-supporting {
-				margin-block-start: 0.6rem;
-			}
-		`];
-	}
+	static styles = [super.styles, radioStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-input-radio-label {
+			cursor: default;
+			margin-block-end: 0;
+		}
+		.d2l-input-inline-help,
+		.d2l-input-radio-supporting {
+			margin-inline-start: 1.7rem;
+		}
+		.d2l-input-radio-supporting {
+			margin-block-start: 0.6rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -17,74 +17,70 @@ export const SUPPRESS_ENTER_TIMEOUT_MS = 1000;
  */
 class InputSearch extends FocusMixin(LocalizeCoreElement(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
 			 * @type {string}
 			 */
-			description: { type: String, reflect: true },
-			/**
+		description: { type: String, reflect: true },
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean },
-			/**
+		disabled: { type: Boolean },
+		/**
 			 * ACCESSIBILITY: REQUIRED: Acts as the primary label for the input. Not visible.
 			 * @type {string}
 			 */
-			label: { type: String },
-			/**
+		label: { type: String },
+		/**
 			 * @ignore
 			 */
-			lastSearchValue: { type: String, attribute: false },
-			/**
+		lastSearchValue: { type: String, attribute: false },
+		/**
 			 * Imposes an upper character limit
 			 * @type {number}
 			 */
-			maxlength: { type: Number },
-			/**
+		maxlength: { type: Number },
+		/**
 			 * Prevents the "clear" button from appearing
 			 * @type {boolean}
 			 */
-			noClear: { type: Boolean, attribute: 'no-clear' },
-			/**
+		noClear: { type: Boolean, attribute: 'no-clear' },
+		/**
 			 * Placeholder text (default: "Search...")
 			 * @type {string}
 			 */
-			placeholder: { type: String },
-			/**
+		placeholder: { type: String },
+		/**
 			 * Dispatch search events after each input event
 			 * @type {boolean}
 			 */
-			searchOnInput: { type: Boolean, attribute: 'search-on-input' },
-			/**
+		searchOnInput: { type: Boolean, attribute: 'search-on-input' },
+		/**
 			 * Value of the input
 			 * @type {string}
 			 */
-			value: { type: String }
-		};
-	}
+		value: { type: String }
+	};
 
-	static get styles() {
-		return [inputStyles, css`
-				:host {
-					display: inline-block;
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				d2l-button-icon {
-					--d2l-button-icon-min-height: 1.5rem;
-					--d2l-button-icon-min-width: 1.5rem;
-					--d2l-button-icon-border-radius: 4px;
-					--d2l-focus-ring-offset: 1px;
-					margin-inline: 0.3rem;
-				}
-			`
-		];
-	}
+	static styles = [inputStyles, css`
+			:host {
+				display: inline-block;
+				width: 100%;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			d2l-button-icon {
+				--d2l-button-icon-min-height: 1.5rem;
+				--d2l-button-icon-min-width: 1.5rem;
+				--d2l-button-icon-border-radius: 4px;
+				--d2l-focus-ring-offset: 1px;
+				margin-inline: 0.3rem;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -29,258 +29,254 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class InputText extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(LitElement))))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ADVANCED: Indicates that the input has a popup menu
-			 * @type {string}
-			 */
-			ariaHaspopup: { type: String, attribute: 'aria-haspopup' },
-			/**
-			 * ADVANCED: Indicates that the input value is invalid
-			 * @type {string}
-			 */
-			ariaInvalid: { type: String, attribute: 'aria-invalid' },
-			/**
-			 * ADVANCED: Specifies which types of values can be autofilled by the browser
-			 * @type {string}
-			 */
-			autocomplete: { type: String },
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean },
-			/**
-			 * Additional information communicated in the aria-describedby on the input
-			 * @type {string}
-			 */
-			description: { type: String, reflect: true },
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * ADVANCED: Hide the alert icon when input is invalid
-			 * @type {boolean}
-			 */
-			hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
-			/**
-			 * ADVANCED: Hide the tooltip when input is invalid
-			 * @type {boolean}
-			 */
-			hideInvalidTooltip: { attribute: 'hide-invalid-tooltip', type: Boolean, reflect: true },
-			/**
-			 * Restricts the maximum width of the input box without restricting the width of the label.
-			 * @type {string}
-			 */
-			inputWidth: { attribute: 'input-width', type: String },
-			/**
-			 * ADVANCED: Additional information relating to how to use the component
-			 * @type {string}
-			 */
-			instructions: { type: String, attribute: 'instructions' },
-			/**
-			 * Hides the label visually (moves it to the input's "aria-label" attribute)
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
-			 * For number inputs, maximum value
-			 * @type {string}
-			 */
-			max: { type: String },
-			/**
-			 * Imposes an upper character limit
-			 * @type {number}
-			 */
-			maxlength: { type: Number },
-			/**
-			 * For number inputs, minimum value
-			 * @type {string}
-			 */
-			min: { type: String },
-			/**
-			 * Imposes a lower character limit
-			 * @type {number}
-			 */
-			minlength: { type: Number },
-			/**
-			 * ADVANCED: Regular expression pattern to validate the value
-			 * @type {string}
-			 */
-			pattern: { type: String },
-			/**
-			 * ADVANCED: Text to display when input fails validation against the pattern.  If a list of characters is included in the message, use `LocalizeMixin`'s `localizeCharacter`.
-			 */
-			patternFailureText: { type: String, attribute: 'pattern-failure-text' },
-			/**
-			 * @ignore
-			 */
-			placeholder: { type: String },
-			/**
-			 * Prevents pressing ENTER from submitting forms
-			 * @type {boolean}
-			 */
-			preventSubmit: { type: Boolean, attribute: 'prevent-submit' },
-			/**
-			 * ADVANCED: Makes the input read-only
-			 * @type {boolean}
-			 */
-			readonly: { type: Boolean },
-			/**
-			 * Indicates that a value is required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true },
-			/**
-			 * Size of the input
-			 * @type {number}
-			 */
-			size: { type: Number },
-			/**
-			 * ADVANCED: For number inputs, sets the step size
-			 * @type {number}
-			 */
-			step: { type: Number },
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			title: { type: String },
-			/**
-			 * The type of the text input
-			 * @type {'text'|'email'|'number'|'password'|'search'|'tel'|'url'}
-			 */
-			type: { type: String },
-			/**
-			 * Unit associated with the input value, displayed next to input and announced as part of the label
-			 * @type {string}
-			 */
-			unit: { type: String },
-			/**
-			 * Accessible label for the unit which will not be visually rendered
-			 * @type {string}
-			 */
-			unitLabel: {
-				attribute: 'unit-label',
-				required: {
-					dependentProps: ['unit'],
-					message: (_value, elem) => `<d2l-input-text>: missing required attribute "unit-label" for unit "${elem.unit}"`,
-					validator: (_value, elem, hasValue) => {
-						const hasUnit = (typeof elem.unit === 'string') && elem.unit.length > 0;
-						return !(hasUnit && elem.unit !== '%' && !hasValue);
-					}
-				},
-				type: String
+	static properties = {
+		/**
+		 * ADVANCED: Indicates that the input has a popup menu
+		 * @type {string}
+		 */
+		ariaHaspopup: { type: String, attribute: 'aria-haspopup' },
+		/**
+		 * ADVANCED: Indicates that the input value is invalid
+		 * @type {string}
+		 */
+		ariaInvalid: { type: String, attribute: 'aria-invalid' },
+		/**
+		 * ADVANCED: Specifies which types of values can be autofilled by the browser
+		 * @type {string}
+		 */
+		autocomplete: { type: String },
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean },
+		/**
+		 * Additional information communicated in the aria-describedby on the input
+		 * @type {string}
+		 */
+		description: { type: String, reflect: true },
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * ADVANCED: Hide the alert icon when input is invalid
+		 * @type {boolean}
+		 */
+		hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
+		/**
+		 * ADVANCED: Hide the tooltip when input is invalid
+		 * @type {boolean}
+		 */
+		hideInvalidTooltip: { attribute: 'hide-invalid-tooltip', type: Boolean, reflect: true },
+		/**
+		 * Restricts the maximum width of the input box without restricting the width of the label.
+		 * @type {string}
+		 */
+		inputWidth: { attribute: 'input-width', type: String },
+		/**
+		 * ADVANCED: Additional information relating to how to use the component
+		 * @type {string}
+		 */
+		instructions: { type: String, attribute: 'instructions' },
+		/**
+		 * Hides the label visually (moves it to the input's "aria-label" attribute)
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
+		 * For number inputs, maximum value
+		 * @type {string}
+		 */
+		max: { type: String },
+		/**
+		 * Imposes an upper character limit
+		 * @type {number}
+		 */
+		maxlength: { type: Number },
+		/**
+		 * For number inputs, minimum value
+		 * @type {string}
+		 */
+		min: { type: String },
+		/**
+		 * Imposes a lower character limit
+		 * @type {number}
+		 */
+		minlength: { type: Number },
+		/**
+		 * ADVANCED: Regular expression pattern to validate the value
+		 * @type {string}
+		 */
+		pattern: { type: String },
+		/**
+		 * ADVANCED: Text to display when input fails validation against the pattern.  If a list of characters is included in the message, use `LocalizeMixin`'s `localizeCharacter`.
+		 */
+		patternFailureText: { type: String, attribute: 'pattern-failure-text' },
+		/**
+		 * @ignore
+		 */
+		placeholder: { type: String },
+		/**
+		 * Prevents pressing ENTER from submitting forms
+		 * @type {boolean}
+		 */
+		preventSubmit: { type: Boolean, attribute: 'prevent-submit' },
+		/**
+		 * ADVANCED: Makes the input read-only
+		 * @type {boolean}
+		 */
+		readonly: { type: Boolean },
+		/**
+		 * Indicates that a value is required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true },
+		/**
+		 * Size of the input
+		 * @type {number}
+		 */
+		size: { type: Number },
+		/**
+		 * ADVANCED: For number inputs, sets the step size
+		 * @type {number}
+		 */
+		step: { type: Number },
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		title: { type: String },
+		/**
+		 * The type of the text input
+		 * @type {'text'|'email'|'number'|'password'|'search'|'tel'|'url'}
+		 */
+		type: { type: String },
+		/**
+		 * Unit associated with the input value, displayed next to input and announced as part of the label
+		 * @type {string}
+		 */
+		unit: { type: String },
+		/**
+		 * Accessible label for the unit which will not be visually rendered
+		 * @type {string}
+		 */
+		unitLabel: {
+			attribute: 'unit-label',
+			required: {
+				dependentProps: ['unit'],
+				message: (_value, elem) => `<d2l-input-text>: missing required attribute "unit-label" for unit "${elem.unit}"`,
+				validator: (_value, elem, hasValue) => {
+					const hasUnit = (typeof elem.unit === 'string') && elem.unit.length > 0;
+					return !(hasUnit && elem.unit !== '%' && !hasValue);
+				}
 			},
-			/**
-			 * Value of the input
-			 * @type {string}
-			 */
-			value: { type: String },
-			/**
-			 * ADVANCED: Alignment of the value text within the input
-			 * @type {'start'|'end'}
-			 */
-			valueAlign: { attribute: 'value-align', type: String },
-			_firstSlotWidth: { type: Number },
-			_hasAfterContent: { type: Boolean, attribute: false },
-			_focused: { type: Boolean },
-			_hovered: { type: Boolean },
-			_lastSlotWidth: { type: Number }
-		};
-	}
+			type: String
+		},
+		/**
+		 * Value of the input
+		 * @type {string}
+		 */
+		value: { type: String },
+		/**
+		 * ADVANCED: Alignment of the value text within the input
+		 * @type {'start'|'end'}
+		 */
+		valueAlign: { attribute: 'value-align', type: String },
+		_firstSlotWidth: { type: Number },
+		_hasAfterContent: { type: Boolean, attribute: false },
+		_focused: { type: Boolean },
+		_hovered: { type: Boolean },
+		_lastSlotWidth: { type: Number }
+	};
 
-	static get styles() {
-		return [ super.styles, inputStyles, inputLabelStyles, offscreenStyles,
-			css`
-				:host {
-					display: inline-block;
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([value-align="end"]) {
-					--d2l-input-text-align: end;
-				}
-				.d2l-input-label {
-					display: inline-block;
-					vertical-align: bottom;
-				}
-				:host(:not([skeleton])) .d2l-input-label {
-					margin: 0;
-					padding-block: 0 0.4rem;
-					padding-inline: 0;
-				}
-				:host(:not([skeleton]):not([input-width])) .d2l-input-label {
-					width: 100%;
-				}
-				.d2l-input-container {
-					display: flex;
-				}
-				.d2l-input-text-container {
-					flex: 1 1 auto;
-					position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
-				}
-				.d2l-input {
-					-webkit-appearance: textfield;
-					appearance: textfield;
-					overflow: hidden;
-					text-overflow: ellipsis;
-					white-space: nowrap;
-				}
-				#after-slot {
-					display: inline-block;
-					flex: 0 0 auto;
-				}
-				.d2l-input-inside-before, .d2l-input-inside-after {
-					align-items: center;
-					display: flex;
-					position: absolute;
-					top: 50%;
-					transform: translateY(-50%);
-				}
-				.d2l-input-inside-before {
-					left: 0;
-				}
-				.d2l-input-inside-after {
-					right: 0;
-				}
-				.d2l-input-unit {
-					color: var(--d2l-theme-text-color-static-faint);
-					font-size: 0.7rem;
-					margin-top: 0.05rem;
-				}
-				.d2l-input-inside-before .d2l-input-unit {
-					margin-left: 12px;
-					margin-right: 6px;
-				}
-				.d2l-input-inside-after .d2l-input-unit {
-					display: inline-block;
-					margin-left: 6px;
-					margin-right: 12px;
-				}
-				:host([disabled]) .d2l-input-unit {
-					opacity: var(--d2l-theme-opacity-disabled-control);
-				}
-				.d2l-input-text-invalid-icon {
-					background-image: var(--d2l-input-invalid-image);
-					background-position: center center;
-					background-repeat: no-repeat;
-					background-size: 0.8rem 0.8rem;
-					display: flex;
-					height: 22px;
-					position: absolute;
-					top: 50%;
-					transform: translateY(-50%);
-					width: 22px;
-				}
-			`
-		];
-	}
+	static styles = [ super.styles, inputStyles, inputLabelStyles, offscreenStyles,
+		css`
+			:host {
+				display: inline-block;
+				width: 100%;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([value-align="end"]) {
+				--d2l-input-text-align: end;
+			}
+			.d2l-input-label {
+				display: inline-block;
+				vertical-align: bottom;
+			}
+			:host(:not([skeleton])) .d2l-input-label {
+				margin: 0;
+				padding-block: 0 0.4rem;
+				padding-inline: 0;
+			}
+			:host(:not([skeleton]):not([input-width])) .d2l-input-label {
+				width: 100%;
+			}
+			.d2l-input-container {
+				display: flex;
+			}
+			.d2l-input-text-container {
+				flex: 1 1 auto;
+				position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
+			}
+			.d2l-input {
+				-webkit-appearance: textfield;
+				appearance: textfield;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+			#after-slot {
+				display: inline-block;
+				flex: 0 0 auto;
+			}
+			.d2l-input-inside-before, .d2l-input-inside-after {
+				align-items: center;
+				display: flex;
+				position: absolute;
+				top: 50%;
+				transform: translateY(-50%);
+			}
+			.d2l-input-inside-before {
+				left: 0;
+			}
+			.d2l-input-inside-after {
+				right: 0;
+			}
+			.d2l-input-unit {
+				color: var(--d2l-theme-text-color-static-faint);
+				font-size: 0.7rem;
+				margin-top: 0.05rem;
+			}
+			.d2l-input-inside-before .d2l-input-unit {
+				margin-left: 12px;
+				margin-right: 6px;
+			}
+			.d2l-input-inside-after .d2l-input-unit {
+				display: inline-block;
+				margin-left: 6px;
+				margin-right: 12px;
+			}
+			:host([disabled]) .d2l-input-unit {
+				opacity: var(--d2l-theme-opacity-disabled-control);
+			}
+			.d2l-input-text-invalid-icon {
+				background-image: var(--d2l-input-invalid-image);
+				background-position: center center;
+				background-repeat: no-repeat;
+				background-size: 0.8rem 0.8rem;
+				display: flex;
+				height: 22px;
+				position: absolute;
+				top: 50%;
+				transform: translateY(-50%);
+				width: 22px;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -22,139 +22,135 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class InputTextArea extends InputInlineHelpMixin(FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ADVANCED: Indicates that the input value is invalid
 			 * @type {string}
 			 */
-			ariaInvalid: { type: String, attribute: 'aria-invalid' },
-			/**
+		ariaInvalid: { type: String, attribute: 'aria-invalid' },
+		/**
 			 * Additional information communicated in the aria-describedby on the input
 			 * @type {string}
 			 */
-			description: { type: String, reflect: true },
-			/**
+		description: { type: String, reflect: true },
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * Restricts the maximum width of the input box without restricting the width of the label.
 			 * @type {string}
 			 */
-			inputWidth: { attribute: 'input-width', type: String },
-			/**
+		inputWidth: { attribute: 'input-width', type: String },
+		/**
 			 * Hides the label visually (moves it to the input's "aria-label" attribute)
 			 * @type {boolean}
 			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
 			 * Imposes an upper character limit
 			 * @type {number}
 			 */
-			maxlength: { type: Number },
-			/**
+		maxlength: { type: Number },
+		/**
 			 * Maximum number of rows before scrolling
 			 * @type {number}
 			 */
-			maxRows: { type: Number, attribute: 'max-rows' },
-			/**
+		maxRows: { type: Number, attribute: 'max-rows' },
+		/**
 			 * Imposes a lower character limit
 			 * @type {number}
 			 */
-			minlength: { type: Number },
-			/**
+		minlength: { type: Number },
+		/**
 			 * Hides the border
 			 * @type {boolean}
 			 */
-			noBorder: { type: Boolean, attribute: 'no-border' },
-			/**
+		noBorder: { type: Boolean, attribute: 'no-border' },
+		/**
 			 * Removes default left/right padding
 			 * @type {boolean}
 			 */
-			noPadding: { type: Boolean, attribute: 'no-padding' },
-			/**
+		noPadding: { type: Boolean, attribute: 'no-padding' },
+		/**
 			 * @ignore
 			 */
-			placeholder: { type: String },
-			/**
+		placeholder: { type: String },
+		/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true },
-			/**
+		required: { type: Boolean, reflect: true },
+		/**
 			 * Minimum number of rows
 			 * @type {number}
 			 */
-			rows: { type: Number },
-			/**
+		rows: { type: Number },
+		/**
 			 * Value of the input
 			 * @type {string}
 			 */
-			value: { type: String }
-		};
-	}
+		value: { type: String }
+	};
 
-	static get styles() {
-		return [ super.styles, inputStyles, inputLabelStyles, offscreenStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-input-label {
-				display: inline-block;
-				vertical-align: bottom;
-			}
-			:host(:not([skeleton])) .d2l-input-label {
-				margin: 0;
-				padding-block: 0 0.4rem;
-				padding-inline: 0;
-			}
-			:host(:not([skeleton]):not([input-width])) .d2l-input-label {
-				width: 100%;
-			}
-			.d2l-input-textarea-container {
-				height: 100%;
-				max-width: 100%;
-				position: relative;
-			}
-			textarea.d2l-input {
-				height: 100%;
-				left: 0;
-				line-height: 1rem;
-				position: absolute;
-				resize: none;
-				top: 0;
-			}
-			:host([no-border]) textarea.d2l-input {
-				border-color: transparent;
-				box-shadow: none;
-			}
-			/* mirror dimensions must match textarea - match border + padding */
-			.d2l-input-textarea-mirror {
-				line-height: 1rem;
-				overflow: hidden;
-				overflow-wrap: anywhere; /* prevent width from growing */
-				padding-bottom: 0.5rem;
-				padding-top: 0.5rem;
-				visibility: hidden;
-			}
-			:host([no-padding]) .d2l-input {
-				padding-inline: 0;
-			}
-			:host([no-border][no-padding]) textarea.d2l-input:hover,
-			:host([no-border][no-padding]) textarea.d2l-input:focus {
-				border-left-width: 1px;
-				border-right-width: 1px;
-			}
-			.d2l-input-textarea-mirror[aria-invalid="true"] {
-				padding-inline-end: calc(18px + 0.8rem);
-			}
-		`];
-	}
+	static styles = [ super.styles, inputStyles, inputLabelStyles, offscreenStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-input-label {
+			display: inline-block;
+			vertical-align: bottom;
+		}
+		:host(:not([skeleton])) .d2l-input-label {
+			margin: 0;
+			padding-block: 0 0.4rem;
+			padding-inline: 0;
+		}
+		:host(:not([skeleton]):not([input-width])) .d2l-input-label {
+			width: 100%;
+		}
+		.d2l-input-textarea-container {
+			height: 100%;
+			max-width: 100%;
+			position: relative;
+		}
+		textarea.d2l-input {
+			height: 100%;
+			left: 0;
+			line-height: 1rem;
+			position: absolute;
+			resize: none;
+			top: 0;
+		}
+		:host([no-border]) textarea.d2l-input {
+			border-color: transparent;
+			box-shadow: none;
+		}
+		/* mirror dimensions must match textarea - match border + padding */
+		.d2l-input-textarea-mirror {
+			line-height: 1rem;
+			overflow: hidden;
+			overflow-wrap: anywhere; /* prevent width from growing */
+			padding-bottom: 0.5rem;
+			padding-top: 0.5rem;
+			visibility: hidden;
+		}
+		:host([no-padding]) .d2l-input {
+			padding-inline: 0;
+		}
+		:host([no-border][no-padding]) textarea.d2l-input:hover,
+		:host([no-border][no-padding]) textarea.d2l-input:focus {
+			border-left-width: 1px;
+			border-right-width: 1px;
+		}
+		.d2l-input-textarea-mirror[aria-invalid="true"] {
+			padding-inline-end: calc(18px + 0.8rem);
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -41,111 +41,107 @@ function getValidISOTimeAtInterval(val, timeInterval) {
 
 class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ADVANCED: Automatically shifts end time when start time changes to keep same range
 			 * @type {boolean}
 			 */
-			autoShiftTimes: { attribute: 'auto-shift-times', reflect: true, type: Boolean },
-			/**
+		autoShiftTimes: { attribute: 'auto-shift-times', reflect: true, type: Boolean },
+		/**
 			 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
 			 * @type {boolean}
 			 */
-			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
-			/**
+		childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
+		/**
 			 * Disables the inputs
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: Label for the end time input. Defaults to localized "End Time".
 			 * @type {string}
 			 * @default "End Time"
 			 */
-			endLabel: { attribute: 'end-label', reflect: true, type: String },
-			/**
+		endLabel: { attribute: 'end-label', reflect: true, type: String },
+		/**
 			 * ADVANCED: Indicates if the end dropdown is open
 			 * @type {boolean}
 			 */
-			endOpened: { attribute: 'end-opened', type: Boolean },
-			/**
+		endOpened: { attribute: 'end-opened', type: Boolean },
+		/**
 			 * Value of the end time input
 			 * @type {string}
 			 */
-			endValue: { attribute: 'end-value', reflect: true, type: String },
-			/**
+		endValue: { attribute: 'end-value', reflect: true, type: String },
+		/**
 			 * Rounds typed input up to nearest valid interval time (specified with "time-interval")
 			 * @type {boolean}
 			 */
-			enforceTimeIntervals: { attribute: 'enforce-time-intervals', reflect: true, type: Boolean },
-			/**
+		enforceTimeIntervals: { attribute: 'enforce-time-intervals', reflect: true, type: Boolean },
+		/**
 			 * Validates on inclusive range (i.e., it is valid for start and end times to be equal)
 			 * @type {boolean}
 			 */
-			inclusiveTimeRange: { attribute: 'inclusive-time-range', reflect: true, type: Boolean },
-			/**
+		inclusiveTimeRange: { attribute: 'inclusive-time-range', reflect: true, type: Boolean },
+		/**
 			 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the time inputs
 			 * @type {string}
 			 */
-			label: { type: String, reflect: true },
-			/**
+		label: { type: String, reflect: true },
+		/**
 			 * Hides the fieldset label visually.  Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
-			/**
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
+		/**
 			 * Indicates that values are required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true },
-			/**
+		required: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: Label for the start time input. Defaults to localized "Start Time".
 			 * @type {string}
 			 * @default "Start Time"
 			 */
-			startLabel: { attribute: 'start-label', reflect: true, type: String },
-			/**
+		startLabel: { attribute: 'start-label', reflect: true, type: String },
+		/**
 			 * ADVANCED: Indicates if the start dropdown is open
 			 * @type {boolean}
 			 */
-			startOpened: { attribute: 'start-opened', type: Boolean },
-			/**
+		startOpened: { attribute: 'start-opened', type: Boolean },
+		/**
 			 * Value of the start time input
 			 * @type {string}
 			 */
-			startValue: { attribute: 'start-value', reflect: true, type: String },
-			/**
+		startValue: { attribute: 'start-value', reflect: true, type: String },
+		/**
 			 * Number of minutes between times shown in dropdown menu
 			 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
 			 */
-			timeInterval: { attribute: 'time-interval', reflect: true, type: String },
-			/**
+		timeInterval: { attribute: 'time-interval', reflect: true, type: String },
+		/**
 			 * Time zone identifier for the inputs to use.
 			 * @type {string}
 			 */
-			timeZoneId: { type: String },
-			/**
+		timeZoneId: { type: String },
+		/**
 			 * Hides the time zone inside the selection dropdowns. Should only be used when the input values are not related to any one time zone
 			 * @type {Boolean}
 			 */
-			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
-		};
-	}
+		timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-input-time {
-				display: block;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-input-time {
+			display: block;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -126,120 +126,116 @@ function initIntervals(size, enforceTimeIntervals) {
  */
 class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Default value of input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
 			 * @type {string}
 			 */
-			defaultValue: { type: String, attribute: 'default-value' },
-			/**
+		defaultValue: { type: String, attribute: 'default-value' },
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean },
-			/**
+		disabled: { type: Boolean },
+		/**
 			 * Rounds typed input up to nearest valid interval time (specified with "time-interval")
 			 * @type {boolean}
 			 */
-			enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
-			/**
+		enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
+		/**
 			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 			 * @type {boolean}
 			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
 			 * Overrides max-height of the time dropdown menu
 			 * @type {number}
 			 */
-			maxHeight: { type: Number, attribute: 'max-height' },
-			/**
+		maxHeight: { type: Number, attribute: 'max-height' },
+		/**
 			 * Indicates if the dropdown is open
 			 * @type {boolean}
 			 */
-			opened: { type: Boolean },
-			/**
+		opened: { type: Boolean },
+		/**
 			 * Indicates that a value is required
 			 * @type {boolean}
 			 */
-			required: { type: Boolean, reflect: true },
-			/**
+		required: { type: Boolean, reflect: true },
+		/**
 			 * Number of minutes between times shown in dropdown menu
 			 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
 			 */
-			timeInterval: { type: String, attribute: 'time-interval' },
-			/**
+		timeInterval: { type: String, attribute: 'time-interval' },
+		/**
 			 * Time zone identifier for the input to use. e.g. America/Toronto. Defaults to the user's account or device time zone setting.
 			 * @type {string}
 			 */
-			timeZoneId: { type: String, attribute: 'time-zone-id' },
-			/**
+		timeZoneId: { type: String, attribute: 'time-zone-id' },
+		/**
 			 * Hides the time zone inside the selection dropdown. Should only be used when the input value is not related to any one time zone
 			 * @type {Boolean}
 			 */
-			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
-			/**
+		timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
+		/**
 			 * Value of the input
 			 * @type {string}
 			 */
-			value: { type: String },
-			_dropdownFirstOpened: { type: Boolean },
-			_formattedValue: { type: String },
-			_hiddenContentWidth: { type: String },
-			_timeZone: { state: true },
-		};
-	}
+		value: { type: String },
+		_dropdownFirstOpened: { type: Boolean },
+		_formattedValue: { type: String },
+		_hiddenContentWidth: { type: String },
+		_timeZone: { state: true },
+	};
 
-	static get styles() {
-		return [
-			super.styles,
-			bodySmallStyles,
-			inputLabelStyles,
-			inputStyles,
-			offscreenStyles,
-			css`
-				:host {
-					display: inline-block;
-					max-width: 6rem;
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				d2l-dropdown-menu[data-mobile][mobile-tray] .d2l-input-time-menu {
-					text-align: center;
-				}
-				.d2l-input-label {
-					display: inline-block;
-					vertical-align: top;
-				}
-				.d2l-input-time-time-zone {
-					line-height: 1.8rem;
-					text-align: center;
-					vertical-align: middle;
-					width: auto;
-				}
-				.d2l-input-time-time-zone.d2l-input-time-time-zone-custom {
-					align-items: center;
-					column-gap: 0.3rem;
-					display: flex;
-					font-weight: 700;
-					justify-content: center;
-				}
+	static styles = [
+		super.styles,
+		bodySmallStyles,
+		inputLabelStyles,
+		inputStyles,
+		offscreenStyles,
+		css`
+			:host {
+				display: inline-block;
+				max-width: 6rem;
+				width: 100%;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			d2l-dropdown-menu[data-mobile][mobile-tray] .d2l-input-time-menu {
+				text-align: center;
+			}
+			.d2l-input-label {
+				display: inline-block;
+				vertical-align: top;
+			}
+			.d2l-input-time-time-zone {
+				line-height: 1.8rem;
+				text-align: center;
+				vertical-align: middle;
+				width: auto;
+			}
+			.d2l-input-time-time-zone.d2l-input-time-time-zone-custom {
+				align-items: center;
+				column-gap: 0.3rem;
+				display: flex;
+				font-weight: 700;
+				justify-content: center;
+			}
 
-				.d2l-input-time-hidden-content {
-					font-family: inherit;
-					font-size: 0.8rem;
-					font-weight: 400;
-					letter-spacing: 0.02rem;
-					line-height: 1.4rem;
-					position: absolute;
-					visibility: hidden;
-					width: auto;
-				}
-			`
-		];
-	}
+			.d2l-input-time-hidden-content {
+				font-family: inherit;
+				font-size: 0.8rem;
+				font-weight: 400;
+				letter-spacing: 0.02rem;
+				line-height: 1.4rem;
+				position: absolute;
+				visibility: hidden;
+				width: auto;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/inputs/test/input-fieldset.vdiff.js
+++ b/components/inputs/test/input-fieldset.vdiff.js
@@ -7,11 +7,9 @@ const inputs = html`<div style="border: 1px solid black; padding: 10px;">Inputs 
 
 const fieldsetManualTag = defineCE(class extends LitElement {
 
-	static get properties() {
-		return { required: { type: Boolean } };
-	}
+	static properties = { required: { type: Boolean } };
 
-	static get styles() { return [inputLabelStyles]; }
+	static styles = [inputLabelStyles];
 
 	render() {
 		return html`

--- a/components/inputs/test/input-label.vdiff.js
+++ b/components/inputs/test/input-label.vdiff.js
@@ -9,13 +9,9 @@ const viewport = { width: 376 };
 
 const refTag = defineCE(class extends LitElement {
 
-	static get properties() {
-		return { required: { type: Boolean } };
-	}
+	static properties = { required: { type: Boolean } };
 
-	static get styles() {
-		return [inputStyles, inputLabelStyles, css`:host { display: block; }`];
-	}
+	static styles = [inputStyles, inputLabelStyles, css`:host { display: block; }`];
 
 	render() {
 		const ariaRequired = this.required ? 'true' : undefined;
@@ -29,13 +25,9 @@ const refTag = defineCE(class extends LitElement {
 
 const wrapTag = defineCE(class extends LitElement {
 
-	static get properties() {
-		return { isRequired: { type: Boolean, attribute: 'is-required' } };
-	}
+	static properties = { isRequired: { type: Boolean, attribute: 'is-required' } };
 
-	static get styles() {
-		return [inputStyles, inputLabelStyles, css`:host { display: block; }`];
-	}
+	static styles = [inputStyles, inputLabelStyles, css`:host { display: block; }`];
 
 	render() {
 		const classes = {

--- a/components/inputs/test/input-number.test.js
+++ b/components/inputs/test/input-number.test.js
@@ -34,11 +34,9 @@ function dispatchKeypressEvent(elem, key) {
 
 const inputWrapperTag = defineCE(
 	class extends LitElement {
-		static get properties() {
-			return {
-				number: { type: Number }
-			};
-		}
+		static properties = {
+			number: { type: Number }
+		};
 		constructor() {
 			super();
 			this.number = 1;

--- a/components/link/README.md
+++ b/components/link/README.md
@@ -70,7 +70,7 @@ Alternately, you can apply link styles to a native `<a>` element by importing th
 
   class MyLinkElem extends LitElement {
 
-    static get styles() { return [ linkStyles ] }
+    static styles = [ linkStyles ];
 
     render() {
       return html`

--- a/components/link/link-mixin.js
+++ b/components/link/link-mixin.js
@@ -7,50 +7,46 @@ import { offscreenStyles } from '../offscreen/offscreen.js';
 
 export const LinkMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Prompts the user to save the linked URL instead of navigating to it.
-			 * Must be to a resource on the same origin.
-			 * Can be used with or without a value, when set the value becomes the filename.
-			 * @type {string}
-			 */
-			download: { type: String },
-			/**
-			 * REQUIRED: URL or URL fragment of the link
-			 * @type {string}
-			 */
-			href: { type: String },
-			/**
-			 * Where to display the linked URL
-			 * @type {string}
-			 */
-			target: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Prompts the user to save the linked URL instead of navigating to it.
+		 * Must be to a resource on the same origin.
+		 * Can be used with or without a value, when set the value becomes the filename.
+		 * @type {string}
+		 */
+		download: { type: String },
+		/**
+		 * REQUIRED: URL or URL fragment of the link
+		 * @type {string}
+		 */
+		href: { type: String },
+		/**
+		 * Where to display the linked URL
+		 * @type {string}
+		 */
+		target: { type: String }
+	};
 
-	static get styles() {
-		return [offscreenStyles, css`
-			#new-window {
-				line-height: 0;
-				white-space: nowrap;
-			}
+	static styles = [offscreenStyles, css`
+		#new-window {
+			line-height: 0;
+			white-space: nowrap;
+		}
+		d2l-icon {
+			color: inherit;
+			height: calc(1em - 1px);
+			margin-inline-start: 0.315em;
+			transform: translateY(0.1em);
+			vertical-align: inherit;
+			width: calc(1em - 1px);
+		}
+
+		@media print {
 			d2l-icon {
-				color: inherit;
-				height: calc(1em - 1px);
-				margin-inline-start: 0.315em;
-				transform: translateY(0.1em);
-				vertical-align: inherit;
-				width: calc(1em - 1px);
+				display: none;
 			}
-
-			@media print {
-				d2l-icon {
-					display: none;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	getNewWindowDescription(label) {
 		return label && this.target === '_blank' ? this.localize('components.link.open-in-new-window') : undefined;

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -20,129 +20,125 @@ export const linkStyles = _generateLinkStyles('.d2l-link', true);
  */
 class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: Label to provide more context for screen reader users when the link text is not enough
 			 * @type {string}
 			 */
-			ariaLabel: { type: String, attribute: 'aria-label' },
-			/**
+		ariaLabel: { type: String, attribute: 'aria-label' },
+		/**
 			 * Disables the link
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * Tooltip text when disabled
 			 * @type {string}
 			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip', reflect: true },
-			/**
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip', reflect: true },
+		/**
 			 * Download a URL instead of navigating to it
 			 * @type {boolean}
 			 */
-			download: { type: Boolean },
-			/**
+		download: { type: Boolean },
+		/**
 			 * REQUIRED: URL or URL fragment of the link
 			 * @type {string}
 			 */
-			href: { type: String },
-			/**
+		href: { type: String },
+		/**
 			 * Whether to apply the "main" link style
 			 * @type {boolean}
 			 */
-			main: { type: Boolean, reflect: true },
-			/**
+		main: { type: Boolean, reflect: true },
+		/**
 			 * The number of lines to display before truncating text with an ellipsis. The text will not be truncated unless a value is specified.
 			 * @type {number}
 			 */
-			lines: { type: Number },
-			/**
+		lines: { type: Number },
+		/**
 			 * Whether to apply the "small" link style
 			 * @type {boolean}
 			 */
-			small: { type: Boolean, reflect: true },
-			/**
+		small: { type: Boolean, reflect: true },
+		/**
 			 * Where to display the linked URL
 			 * @type {string}
 			 */
-			target: { type: String }
-		};
-	}
+		target: { type: String }
+	};
 
-	static get styles() {
-		return [ linkStyles, offscreenStyles,
-			css`
-				:host {
-					display: inline;
-				}
-				:host([hidden]) {
+	static styles = [ linkStyles, offscreenStyles,
+		css`
+			:host {
+				display: inline;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([small]) {
+				/* needed to keep host element same height as link */
+				font-size: 0.7rem;
+				line-height: 1.05rem;
+			}
+			:host([lines]) {
+				min-width: 0;
+			}
+			a {
+				display: inherit;
+			}
+			:host([lines]) a {
+				align-items: baseline;
+				display: flex;
+			}
+			a span.truncate {
+				${getOverflowDeclarations({ lines: 1 })}
+			}
+			a span.truncate-one {
+				${overflowEllipsisDeclarations}
+			}
+			#new-window {
+				line-height: 0;
+				white-space: nowrap;
+			}
+			d2l-icon {
+				color: var(--d2l-theme-text-color-interactive-default);
+				height: calc(1em - 1px);
+				margin-inline-start: 0.315em;
+				transform: translateY(0.1em);
+				vertical-align: inherit;
+				width: calc(1em - 1px);
+			}
+
+			a:hover d2l-icon {
+				--d2l-icon-fill-color: var(--d2l-theme-text-color-interactive-hover);
+			}
+
+			:host([disabled]:not([disabled-tooltip])) a:hover {
+				color: var(--d2l-theme-text-color-interactive-default);
+				text-decoration: none;
+			}
+			:host([disabled]:not([disabled-tooltip])) a:hover d2l-icon {
+				--d2l-icon-fill-color: var(--d2l-theme-text-color-interactive-default);
+			}
+			a[aria-disabled="true"],
+			a[aria-disabled="true"]:active {
+				cursor: default;
+			}
+			a[aria-disabled="true"] .d2l-link-content {
+				opacity: var(--d2l-theme-opacity-disabled-link);
+			}
+			a[aria-disabled="true"] d2l-icon {
+				opacity: var(--d2l-theme-opacity-disabled-linkicon);
+			}
+
+			@media print {
+				d2l-icon {
 					display: none;
 				}
-				:host([small]) {
-					/* needed to keep host element same height as link */
-					font-size: 0.7rem;
-					line-height: 1.05rem;
-				}
-				:host([lines]) {
-					min-width: 0;
-				}
-				a {
-					display: inherit;
-				}
-				:host([lines]) a {
-					align-items: baseline;
-					display: flex;
-				}
-				a span.truncate {
-					${getOverflowDeclarations({ lines: 1 })}
-				}
-				a span.truncate-one {
-					${overflowEllipsisDeclarations}
-				}
-				#new-window {
-					line-height: 0;
-					white-space: nowrap;
-				}
-				d2l-icon {
-					color: var(--d2l-theme-text-color-interactive-default);
-					height: calc(1em - 1px);
-					margin-inline-start: 0.315em;
-					transform: translateY(0.1em);
-					vertical-align: inherit;
-					width: calc(1em - 1px);
-				}
-
-				a:hover d2l-icon {
-					--d2l-icon-fill-color: var(--d2l-theme-text-color-interactive-hover);
-				}
-
-				:host([disabled]:not([disabled-tooltip])) a:hover {
-					color: var(--d2l-theme-text-color-interactive-default);
-					text-decoration: none;
-				}
-				:host([disabled]:not([disabled-tooltip])) a:hover d2l-icon {
-					--d2l-icon-fill-color: var(--d2l-theme-text-color-interactive-default);
-				}
-				a[aria-disabled="true"],
-				a[aria-disabled="true"]:active {
-					cursor: default;
-				}
-				a[aria-disabled="true"] .d2l-link-content {
-					opacity: var(--d2l-theme-opacity-disabled-link);
-				}
-				a[aria-disabled="true"] d2l-icon {
-					opacity: var(--d2l-theme-opacity-disabled-linkicon);
-				}
-
-				@media print {
-					d2l-icon {
-						display: none;
-					}
-				}
-			`
-		];
-	}
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/link/test/link-mixin.test.js
+++ b/components/link/test/link-mixin.test.js
@@ -5,11 +5,9 @@ import { LitElement } from 'lit';
 
 const tagName = defineCE(
 	class extends LinkMixin(LitElement) {
-		static get properties() {
-			return {
-				label: { type: String }
-			};
-		}
+		static properties = {
+			label: { type: String }
+		};
 
 		render() {
 			return this._render(html`Link Test${this._renderNewWindowIcon()}`, { ariaLabel: this.label });

--- a/components/list/README.md
+++ b/components/list/README.md
@@ -403,11 +403,9 @@ If an item is draggable, the `drag-handle-text` attribute should be used to prov
   import { css, html, LitElement } from 'lit';
 
   class ListDemoDragAndDropUsage extends LitElement {
-    static get properties() {
-      return {
-        list: { type: Array }
-      };
-    }
+    static properties = {
+      list: { type: Array }
+    };
 
     constructor() {
       super();
@@ -467,15 +465,11 @@ These scenarios can be seen in the demo below.
   import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 
   class ListDemoDragAndDropInteractiveUsage extends LitElement {
-    static get properties() {
-      return {
-        list: { type: Array }
-      };
-    }
+    static properties = {
+      list: { type: Array }
+    };
 
-    static get styles() {
-      return labelStyles;
-    }
+    static styles = labelStyles;
 
     constructor() {
       super();
@@ -1058,9 +1052,7 @@ class ListItem extends ListItemMixin(LitElement) {
 
 How add the styles:
 ```javascript
-static get styles() {
-  return [ super.styles ];
-}
+static styles = [ super.styles ];
 ```
 
 How to render the list item:

--- a/components/list/demo/demo-list-nav.js
+++ b/components/list/demo/demo-list-nav.js
@@ -11,17 +11,14 @@ import { repeat } from 'lit/directives/repeat.js';
 
 class ListDemoNav extends LitElement {
 
-	static get properties() {
-		return {
-			addButton: { type: Boolean, attribute: 'add-button' },
-			indentation: { type: Boolean },
-			_currentItem: { state: true }
-		};
-	}
+	static properties = {
+		addButton: { type: Boolean, attribute: 'add-button' },
+		indentation: { type: Boolean },
+		_currentItem: { state: true }
+	};
 
-	static get styles() {
-		return [
-			css`
+	static styles = [
+		css`
 				:host {
 					display: block;
 					max-width: 400px;
@@ -33,8 +30,7 @@ class ListDemoNav extends LitElement {
 					padding: 5px;
 				}
 			`
-		];
-	}
+	];
 
 	constructor() {
 		super();

--- a/components/list/demo/demo-list-nested-iterations-helper.js
+++ b/components/list/demo/demo-list-nested-iterations-helper.js
@@ -6,53 +6,49 @@ import { css, html, LitElement, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 class ListNestedIterationsHelper extends LitElement {
-	static get properties() {
-		return {
-			isDraggable: { attribute: 'is-draggable', type: Boolean },
-			separators: { type: String }
-		};
-	}
+	static properties = {
+		isDraggable: { attribute: 'is-draggable', type: Boolean },
+		separators: { type: String }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
-			table {
-				border-collapse: collapse;
-				font-size: 0.8rem;
-				table-layout: fixed;
-				width: 100%;
-			}
-			table > * > tr > * {
-				border: 1px solid var(--d2l-color-mica);
-				font-weight: 400;
-				height: 41px;
-				padding: 0.5rem 1rem;
-				text-align: start;
-				vertical-align: middle;
-			}
-			table > * > tr > td {
-				vertical-align: top;
-			}
-			table > thead > tr > th,
-			table > * > tr.header > th {
-				background-color: var(--d2l-color-regolith);
-				font-size: 0.7rem;
-				height: 27px;
-				line-height: 0.9rem;
-			}
+	static styles = css`
+		:host {
+			display: block;
+		}
+		table {
+			border-collapse: collapse;
+			font-size: 0.8rem;
+			table-layout: fixed;
+			width: 100%;
+		}
+		table > * > tr > * {
+			border: 1px solid var(--d2l-color-mica);
+			font-weight: 400;
+			height: 41px;
+			padding: 0.5rem 1rem;
+			text-align: start;
+			vertical-align: middle;
+		}
+		table > * > tr > td {
+			vertical-align: top;
+		}
+		table > thead > tr > th,
+		table > * > tr.header > th {
+			background-color: var(--d2l-color-regolith);
+			font-size: 0.7rem;
+			height: 27px;
+			line-height: 0.9rem;
+		}
 
-			d2l-list:not([slot="nested"]) {
-				border: solid 1px black;
-				margin: 1rem;
-				padding: 1rem;
-			}
-			.minimize-width {
-				width: 4.5rem;
-			}
-		`;
-	}
+		d2l-list:not([slot="nested"]) {
+			border: solid 1px black;
+			margin: 1rem;
+			padding: 1rem;
+		}
+		.minimize-width {
+			width: 4.5rem;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/list/demo/demo-list-nested-lazy-load.js
+++ b/components/list/demo/demo-list-nested-lazy-load.js
@@ -10,11 +10,9 @@ import { repeat } from 'lit/directives/repeat.js';
 
 class ListDemoNestedLazyLoad extends LitElement {
 
-	static get properties() {
-		return {
-			_items: { state: true },
-		};
-	}
+	static properties = {
+		_items: { state: true },
+	};
 
 	constructor() {
 		super();

--- a/components/list/demo/demo-list-nested.js
+++ b/components/list/demo/demo-list-nested.js
@@ -17,40 +17,36 @@ import { repeat } from 'lit/directives/repeat.js';
 
 class ListDemoNested extends LitElement {
 
-	static get properties() {
-		return {
-			addButton: { type: Boolean, attribute: 'add-button' },
-			demoItemKey: { type: String, attribute: 'demo-item-key' },
-			isDraggable: { attribute: 'is-draggable', type: Boolean },
-			selectable: { type: Boolean },
-			keyboardDragDisabled: { type: Boolean, attribute: 'keyboard-drag-disabled' },
-			disableExpandFeature: { type: Boolean, attribute: 'disable-expand-feature' },
-			dropNestedOnly: { type: Boolean, attribute: 'drop-nested-only' },
-			expanded: { type: Boolean },
-			includeSecondaryActions: { type: Boolean, attribute: 'include-secondary-actions' },
-			includeListControls: { type: Boolean, attribute: 'include-list-controls' },
-			includeActionHref: { type: Boolean, attribute: 'include-action-href' },
-			useButtonListItem: { type: Boolean, attribute: 'use-button-item' },
-			showLoadMore: { type: Boolean, attribute: 'show-load-more' },
-			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
-			disableListGrid: { type: Boolean, attribute: 'disable-list-grid' },
-			dragHandleShowAlways: { type: Boolean, attribute: 'drag-handle-show-always' },
-			_items: { state: true },
-			_loadedItems: { state: true },
-			_remainingItemCount: { state: true },
-			_lastItemLoadedIndex: { state: true }
-		};
-	}
+	static properties = {
+		addButton: { type: Boolean, attribute: 'add-button' },
+		demoItemKey: { type: String, attribute: 'demo-item-key' },
+		isDraggable: { attribute: 'is-draggable', type: Boolean },
+		selectable: { type: Boolean },
+		keyboardDragDisabled: { type: Boolean, attribute: 'keyboard-drag-disabled' },
+		disableExpandFeature: { type: Boolean, attribute: 'disable-expand-feature' },
+		dropNestedOnly: { type: Boolean, attribute: 'drop-nested-only' },
+		expanded: { type: Boolean },
+		includeSecondaryActions: { type: Boolean, attribute: 'include-secondary-actions' },
+		includeListControls: { type: Boolean, attribute: 'include-list-controls' },
+		includeActionHref: { type: Boolean, attribute: 'include-action-href' },
+		useButtonListItem: { type: Boolean, attribute: 'use-button-item' },
+		showLoadMore: { type: Boolean, attribute: 'show-load-more' },
+		noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
+		disableListGrid: { type: Boolean, attribute: 'disable-list-grid' },
+		dragHandleShowAlways: { type: Boolean, attribute: 'drag-handle-show-always' },
+		_items: { state: true },
+		_loadedItems: { state: true },
+		_remainingItemCount: { state: true },
+		_lastItemLoadedIndex: { state: true }
+	};
 
-	static get styles() {
-		return [
-			css`
+	static styles = [
+		css`
 				.secondary-actions {
 					padding-right: 6px;
 				}
 			`
-		];
-	}
+	];
 
 	constructor() {
 		super();

--- a/components/list/demo/demo-list.js
+++ b/components/list/demo/demo-list.js
@@ -114,29 +114,25 @@ const items = [{
 
 class DemoList extends LitElement {
 
-	static get properties() {
-		return {
-			addButton: { type: Boolean, attribute: 'add-button' },
-			grid: { type: Boolean },
-			extendSeparators: { type: Boolean, attribute: 'extend-separators' },
-			_lastItemLoadedIndex: { state: true }
-		};
-	}
+	static properties = {
+		addButton: { type: Boolean, attribute: 'add-button' },
+		grid: { type: Boolean },
+		extendSeparators: { type: Boolean, attribute: 'extend-separators' },
+		_lastItemLoadedIndex: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			img {
-				height: 500px;
-				object-fit: cover;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		img {
+			height: 500px;
+			object-fit: cover;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/list/demo/list-drag-and-drop-position.js
+++ b/components/list/demo/list-drag-and-drop-position.js
@@ -7,19 +7,17 @@ import { repeat } from 'lit/directives/repeat.js';
 
 class ListDemoDragAndDropPosition extends LitElement {
 
-	static get properties() {
-		return {
-			addButton: { type: Boolean, attribute: 'add-button' },
-			list: { type: Array },
-			// below are for demonstration only
-			grid: { type: Boolean },
-			hrefs: { type: Boolean },
-			selectable: { type: Boolean },
-			tiles: { type: Boolean },
-			tileHeader: { type: Boolean, attribute: 'tile-header' },
-			actions: { type: Boolean, attribute: 'actions' }
-		};
-	}
+	static properties = {
+		addButton: { type: Boolean, attribute: 'add-button' },
+		list: { type: Array },
+		// below are for demonstration only
+		grid: { type: Boolean },
+		hrefs: { type: Boolean },
+		selectable: { type: Boolean },
+		tiles: { type: Boolean },
+		tileHeader: { type: Boolean, attribute: 'tile-header' },
+		actions: { type: Boolean, attribute: 'actions' }
+	};
 
 	static styles = css`
 		.actions-containter {

--- a/components/list/list-controls.js
+++ b/components/list/list-controls.js
@@ -7,36 +7,32 @@ import { SelectionControls } from '../selection/selection-controls.js';
  * Controls for list components containing select-all, etc.
  */
 export class ListControls extends SelectionControls {
-	static get properties() {
-		return {
-			_extendSeparator: { state: true },
-			_siblingHasColor: { state: true }
-		};
-	}
+	static properties = {
+		_extendSeparator: { state: true },
+		_siblingHasColor: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				--d2l-selection-controls-background-color: var(--d2l-list-controls-background-color);
-				--d2l-selection-controls-offset: -12px;
-				--d2l-selection-controls-padding: var(--d2l-list-controls-padding, 18px);
-				z-index: 6; /* must be greater than d2l-list-item-active-border */
-			}
-			:host([no-sticky]) {
-				z-index: auto;
-			}
-			.d2l-list-controls-color {
-				padding-inline-start: 1.8rem;
-			}
-			.d2l-list-controls-extend-separator {
-				--d2l-selection-controls-offset: 0;
-				padding: 0 0.9rem;
-			}
-			.d2l-list-controls-color.d2l-list-controls-extend-separator {
-				padding-inline-start: calc(0.6rem + 9px);
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			--d2l-selection-controls-background-color: var(--d2l-list-controls-background-color);
+			--d2l-selection-controls-offset: -12px;
+			--d2l-selection-controls-padding: var(--d2l-list-controls-padding, 18px);
+			z-index: 6; /* must be greater than d2l-list-item-active-border */
+		}
+		:host([no-sticky]) {
+			z-index: auto;
+		}
+		.d2l-list-controls-color {
+			padding-inline-start: 1.8rem;
+		}
+		.d2l-list-controls-extend-separator {
+			--d2l-selection-controls-offset: 0;
+			padding: 0 0.9rem;
+		}
+		.d2l-list-controls-color.d2l-list-controls-extend-separator {
+			padding-inline-start: calc(0.6rem + 9px);
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/list/list-item-button-mixin.js
+++ b/components/list/list-item-button-mixin.js
@@ -5,16 +5,14 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 export const ListItemButtonMixin = superclass => class extends ListItemMixin(superclass) {
-	static get properties() {
-		return {
-			/**
-			 * Disables the primary action button
-			 * @type {boolean}
-			 */
-			buttonDisabled : { type: Boolean, attribute: 'button-disabled', reflect: true },
-			_ariaCurrent: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the primary action button
+		 * @type {boolean}
+		 */
+		buttonDisabled : { type: Boolean, attribute: 'button-disabled', reflect: true },
+		_ariaCurrent: { type: String }
+	};
 
 	static get styles() {
 

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -8,41 +8,39 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * **Selection:** Disables selection
-			 * @type {boolean}
-			 */
-			selectionDisabled: { type: Boolean, attribute: 'selection-disabled', reflect: true },
-			/**
-			 * **Selection:** Tooltip text when selection is disabled
-			 * @type {string}
-			 */
-			selectionDisabledTooltip: { type: String, attribute: 'selection-disabled-tooltip' },
-			/**
-			 * **Selection:** Value to identify item if selectable
-			 * @type {string}
-			 */
-			key: { type: String, reflect: true },
-			/**
-			 * **Selection:** Indicates an input should be rendered for selecting the item
-			 * @type {boolean}
-			 */
-			selectable: { type: Boolean },
-			/**
-			 * **Selection:** Whether the item is selected
-			 * @type {boolean}
-			 */
-			selected: { type: Boolean, reflect: true },
-			/**
-			 * Private. The selection info (set by the selection component).
-			 * @ignore
-			 */
-			selectionInfo: { type: Object, attribute: false },
-			_hoveringSelection: { type: Boolean, attribute: '_hovering-selection', reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * **Selection:** Disables selection
+		 * @type {boolean}
+		 */
+		selectionDisabled: { type: Boolean, attribute: 'selection-disabled', reflect: true },
+		/**
+		 * **Selection:** Tooltip text when selection is disabled
+		 * @type {string}
+		 */
+		selectionDisabledTooltip: { type: String, attribute: 'selection-disabled-tooltip' },
+		/**
+		 * **Selection:** Value to identify item if selectable
+		 * @type {string}
+		 */
+		key: { type: String, reflect: true },
+		/**
+		 * **Selection:** Indicates an input should be rendered for selecting the item
+		 * @type {boolean}
+		 */
+		selectable: { type: Boolean },
+		/**
+		 * **Selection:** Whether the item is selected
+		 * @type {boolean}
+		 */
+		selected: { type: Boolean, reflect: true },
+		/**
+		 * Private. The selection info (set by the selection component).
+		 * @ignore
+		 */
+		selectionInfo: { type: Object, attribute: false },
+		_hoveringSelection: { type: Boolean, attribute: '_hovering-selection', reflect: true }
+	};
 
 	static get styles() {
 		const styles = [ css`

--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -10,41 +10,39 @@ import { css, html, LitElement } from 'lit';
  */
 class ListItemContent extends LitElement {
 
-	static get styles() {
-		return [ bodySmallStyles, bodyCompactStyles, css`
-			:host {
-				min-width: 0;
-			}
+	static styles = [ bodySmallStyles, bodyCompactStyles, css`
+		:host {
+			min-width: 0;
+		}
 
-			.d2l-list-item-content-text {
-				margin: 0;
-			}
+		.d2l-list-item-content-text {
+			margin: 0;
+		}
 
-			.d2l-list-item-content-text > div {
-				border-radius: var(--d2l-list-item-content-text-border-radius);
-				color: var(--d2l-list-item-content-text-color);
-				display: block; /* multi-line clamping won't work inside of inline-block in Safari - the compromise is the outline is full width */
-				max-width: 100%;
-				outline: var(--d2l-list-item-content-text-outline, none);
-				outline-offset: var(--d2l-list-item-content-text-outline-offset);
-				overflow-wrap: anywhere;
-				text-decoration: var(--d2l-list-item-content-text-decoration, none);
-			}
+		.d2l-list-item-content-text > div {
+			border-radius: var(--d2l-list-item-content-text-border-radius);
+			color: var(--d2l-list-item-content-text-color);
+			display: block; /* multi-line clamping won't work inside of inline-block in Safari - the compromise is the outline is full width */
+			max-width: 100%;
+			outline: var(--d2l-list-item-content-text-outline, none);
+			outline-offset: var(--d2l-list-item-content-text-outline-offset);
+			overflow-wrap: anywhere;
+			text-decoration: var(--d2l-list-item-content-text-decoration, none);
+		}
 
-			.d2l-list-item-content-text-secondary {
-				color: var(--d2l-list-item-content-text-secondary-color, var(--d2l-color-tungsten));
-			}
+		.d2l-list-item-content-text-secondary {
+			color: var(--d2l-list-item-content-text-secondary-color, var(--d2l-color-tungsten));
+		}
 
-			.d2l-list-item-content-text-supporting-info {
-				color: var(--d2l-color-ferrite);
-			}
+		.d2l-list-item-content-text-supporting-info {
+			color: var(--d2l-color-ferrite);
+		}
 
-			.d2l-list-item-content-text-secondary ::slotted(*),
-			.d2l-list-item-content-text-supporting-info ::slotted(*) {
-				margin-top: 0.15rem;
-			}
-		`];
-	}
+		.d2l-list-item-content-text-secondary ::slotted(*),
+		.d2l-list-item-content-text-supporting-info ::slotted(*) {
+			margin-top: 0.15rem;
+		}
+	`];
 
 	render() {
 		return html`

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -248,52 +248,50 @@ export class NewPositionEventDetails {
 
 export const ListItemDragDropMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * **Drag & drop:** Disables keyboard dragging interaction. If draggable, a keyboard alternative should be provided for the dragging functionality.
-			 * @type {boolean}
-			 */
-			keyboardDragDisabled: { type: Boolean, attribute: 'keyboard-drag-disabled' },
-			/**
-			 * **Drag & drop:** Whether the item is draggable
-			 * @type {boolean}
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			draggable: { type: Boolean, reflect: true },
-			/**
-			 * @ignore
-			 */
-			dragging: { type: Boolean, reflect: true },
-			/**
-			 * **Drag & drop:** The drag-handle label for assistive technology. If implementing drag & drop, you should change this to dynamically announce what the drag-handle is moving for assistive technology in keyboard mode.
-			 * @type {string}
-			*/
-			dragHandleText: { type: String, attribute: 'drag-handle-text' },
-			/**
-			 * **Drag & drop:** Whether nested items can be dropped on this item
-			 * @type {boolean}
-			*/
-			dropNested: { type: Boolean, attribute: 'drop-nested' },
-			/**
-			 * **Drag & drop:** Text to drag and drop
-			 * @type {string}
-			*/
-			dropText: { type: String, attribute: 'drop-text' },
-			/**
-			 * Value to identify item if selectable
-			 * @type {string}
-			*/
-			key: { type: String, reflect: true },
-			_dragHandleShowAlways: { type: Boolean, attribute: '_drag-handle-show-always', reflect: true },
-			_draggingOver: { type: Boolean },
-			_dropLocation: { type: Number, reflect: true, attribute: '_drop-location' },
-			_focusingDragHandle: { type: Boolean },
-			_hovering: { type: Boolean },
-			_keyboardActive: { type: Boolean },
-			_keyboardTextInfo: { type: Object }
-		};
-	}
+	static properties = {
+		/**
+		 * **Drag & drop:** Disables keyboard dragging interaction. If draggable, a keyboard alternative should be provided for the dragging functionality.
+		 * @type {boolean}
+		 */
+		keyboardDragDisabled: { type: Boolean, attribute: 'keyboard-drag-disabled' },
+		/**
+		 * **Drag & drop:** Whether the item is draggable
+		 * @type {boolean}
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		draggable: { type: Boolean, reflect: true },
+		/**
+		 * @ignore
+		 */
+		dragging: { type: Boolean, reflect: true },
+		/**
+		 * **Drag & drop:** The drag-handle label for assistive technology. If implementing drag & drop, you should change this to dynamically announce what the drag-handle is moving for assistive technology in keyboard mode.
+		 * @type {string}
+		*/
+		dragHandleText: { type: String, attribute: 'drag-handle-text' },
+		/**
+		 * **Drag & drop:** Whether nested items can be dropped on this item
+		 * @type {boolean}
+		*/
+		dropNested: { type: Boolean, attribute: 'drop-nested' },
+		/**
+		 * **Drag & drop:** Text to drag and drop
+		 * @type {string}
+		*/
+		dropText: { type: String, attribute: 'drop-text' },
+		/**
+		 * Value to identify item if selectable
+		 * @type {string}
+		*/
+		key: { type: String, reflect: true },
+		_dragHandleShowAlways: { type: Boolean, attribute: '_drag-handle-show-always', reflect: true },
+		_draggingOver: { type: Boolean },
+		_dropLocation: { type: Number, reflect: true, attribute: '_drop-location' },
+		_focusingDragHandle: { type: Boolean },
+		_hovering: { type: Boolean },
+		_keyboardActive: { type: Boolean },
+		_keyboardTextInfo: { type: Object }
+	};
 
 	static get styles() {
 		const styles = [ css`

--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -47,91 +47,87 @@ export const resetDisplayedTooltip = () => {
  */
 class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables the handle
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * Additional context information for accessibility
 			 * @type {object}
 			 */
-			keyboardTextInfo: { type: Object, attribute: 'keyboard-text-info' },
-			/**
+		keyboardTextInfo: { type: Object, attribute: 'keyboard-text-info' },
+		/**
 			 * The drag-handle label for assistive technology
 			 * @type {string}
 			 */
-			text: { type: String },
-			/**
+		text: { type: String },
+		/**
 			 * When layout = tile, the drag handle become horizontal
 			 */
-			layout: { type: String },
-			_displayKeyboardTooltip: { type: Boolean },
-			_keyboardActive: { type: Boolean }
-		};
-	}
+		layout: { type: String },
+		_displayKeyboardTooltip: { type: Boolean },
+		_keyboardActive: { type: Boolean }
+	};
 
-	static get styles() {
-		return [ buttonStyles, css`
-			:host {
-				display: flex;
-				margin: 0.25rem;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-list-item-drag-handle-dragger-button {
-				background-color: unset;
-				display: block;
-				margin: 0;
-				min-height: 1.8rem;
-				padding: 0;
-				width: 0.9rem;
-			}
-			/* Firefox includes a hidden border which messes up button dimensions */
-			button::-moz-focus-inner {
-				border: 0;
-			}
-			.d2l-button-dragger-icon {
-				height: 0.9rem;
-				width: 0.9rem;
-			}
-			button,
-			button[disabled]:hover,
-			button[disabled]:focus {
-				background-color: var(--d2l-color-gypsum);
-				color: var(--d2l-color-ferrite);
-			}
-			.d2l-list-item-drag-handle-dragger-button:hover,
-			.d2l-list-item-drag-handle-dragger-button:focus {
-				background-color: var(--d2l-color-mica);
-			}
-			button[disabled] {
-				cursor: default;
-				opacity: 0.5;
-			}
-			d2l-tooltip > div {
-				font-weight: 700;
-			}
-			d2l-tooltip > ul {
-				padding-inline-start: 1rem;
-			}
-			.d2l-list-item-drag-handle-tooltip-key {
-				font-weight: 700;
-			}
-			d2l-button-move {
-				pointer-events: auto; /* required since ancestors may set point-events: none; (see generic layout) */
-			}
+	static styles = [ buttonStyles, css`
+		:host {
+			display: flex;
+			margin: 0.25rem;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-list-item-drag-handle-dragger-button {
+			background-color: unset;
+			display: block;
+			margin: 0;
+			min-height: 1.8rem;
+			padding: 0;
+			width: 0.9rem;
+		}
+		/* Firefox includes a hidden border which messes up button dimensions */
+		button::-moz-focus-inner {
+			border: 0;
+		}
+		.d2l-button-dragger-icon {
+			height: 0.9rem;
+			width: 0.9rem;
+		}
+		button,
+		button[disabled]:hover,
+		button[disabled]:focus {
+			background-color: var(--d2l-color-gypsum);
+			color: var(--d2l-color-ferrite);
+		}
+		.d2l-list-item-drag-handle-dragger-button:hover,
+		.d2l-list-item-drag-handle-dragger-button:focus {
+			background-color: var(--d2l-color-mica);
+		}
+		button[disabled] {
+			cursor: default;
+			opacity: 0.5;
+		}
+		d2l-tooltip > div {
+			font-weight: 700;
+		}
+		d2l-tooltip > ul {
+			padding-inline-start: 1rem;
+		}
+		.d2l-list-item-drag-handle-tooltip-key {
+			font-weight: 700;
+		}
+		d2l-button-move {
+			pointer-events: auto; /* required since ancestors may set point-events: none; (see generic layout) */
+		}
 
-			:host([layout="tile"]) {
-				align-items: center;
-				display: flex;
-				height: 39px;
-			}
-		`];
-	}
+		:host([layout="tile"]) {
+			align-items: center;
+			display: flex;
+			height: 39px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/list/list-item-drag-image.js
+++ b/components/list/list-item-drag-image.js
@@ -8,88 +8,84 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 class ListItemDragImage extends LocalizeCoreElement(SkeletonMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			count: { type: Number },
-			includePlusSign: { type: Boolean, attribute: 'include-plus-sign' }
-		};
-	}
+		count: { type: Number },
+		includePlusSign: { type: Boolean, attribute: 'include-plus-sign' }
+	};
 
-	static get styles() {
-		return [ super.styles, bodySmallStyles, css`
-			:host {
-				display: block;
-				height: 70px;
-				inset-inline-start: -10000px;
-				position: absolute;
-				width: 340px;
-				z-index: 0;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.first, .second, .third {
-				background-color: white;
-				border: 1px solid var(--d2l-color-mica);
-				border-radius: 4px;
-				box-sizing: border-box;
-				height: 100%;
-				position: absolute;
-				width: 100%;
-			}
-			.first {
-				align-items: start;
-				display: flex;
-				padding: 16px 8px;
-			}
-			.second {
-				margin-inline-start: 6px;
-				margin-top: 6px;
-				z-index: -1;
-			}
-			.third {
-				margin-inline-start: 12px;
-				margin-top: 12px;
-				z-index: -2;
-			}
-			.text {
-				width: 100%;
-			}
-			.line-1 {
-				height: 24px;
-				margin-bottom: 4px;
-				width: 100%;
-			}
-			.line-2 {
-				height: 16px;
-				width: 25%;
-			}
-			d2l-input-checkbox {
-				line-height: 0;
-				margin: 0;
-				margin-inline-start: 16px;
-			}
-			.count {
-				background-color: var(--d2l-color-celestine);
-				border-radius: 0.7rem;
-				box-sizing: border-box;
-				color: white;
-				left: 26px;
-				min-width: 1.4rem;
-				padding: 0.25rem 0.4rem;
-				position: absolute;
-				text-align: center;
-				top: 30px;
-				z-index: 998; /* must be higher than the skeleton z-index */
-			}
-			.count:dir(rtl) {
-				left: 14px;
-			}
-		`];
-	}
+	static styles = [ super.styles, bodySmallStyles, css`
+		:host {
+			display: block;
+			height: 70px;
+			inset-inline-start: -10000px;
+			position: absolute;
+			width: 340px;
+			z-index: 0;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.first, .second, .third {
+			background-color: white;
+			border: 1px solid var(--d2l-color-mica);
+			border-radius: 4px;
+			box-sizing: border-box;
+			height: 100%;
+			position: absolute;
+			width: 100%;
+		}
+		.first {
+			align-items: start;
+			display: flex;
+			padding: 16px 8px;
+		}
+		.second {
+			margin-inline-start: 6px;
+			margin-top: 6px;
+			z-index: -1;
+		}
+		.third {
+			margin-inline-start: 12px;
+			margin-top: 12px;
+			z-index: -2;
+		}
+		.text {
+			width: 100%;
+		}
+		.line-1 {
+			height: 24px;
+			margin-bottom: 4px;
+			width: 100%;
+		}
+		.line-2 {
+			height: 16px;
+			width: 25%;
+		}
+		d2l-input-checkbox {
+			line-height: 0;
+			margin: 0;
+			margin-inline-start: 16px;
+		}
+		.count {
+			background-color: var(--d2l-color-celestine);
+			border-radius: 0.7rem;
+			box-sizing: border-box;
+			color: white;
+			left: 26px;
+			min-width: 1.4rem;
+			padding: 0.25rem 0.4rem;
+			position: absolute;
+			text-align: center;
+			top: 30px;
+			z-index: 998; /* must be higher than the skeleton z-index */
+		}
+		.count:dir(rtl) {
+			left: 14px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/list/list-item-expand-collapse-mixin.js
+++ b/components/list/list-item-expand-collapse-mixin.js
@@ -10,23 +10,21 @@ const dragHoverDropTime = 1000;
 
 export const ListItemExpandCollapseMixin = superclass => class extends SkeletonMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether to show the expand collapse toggle
-			 * @type {boolean}
-			 */
-			expandable: { type: Boolean },
-			/**
-			 * Default state for expand collapse toggle - if not set, collapsed will be the default state
-			 * @type {boolean}
-			 */
-			expanded: { type: Boolean, reflect: true },
-			_siblingHasNestedItems: { state: true },
-			_renderExpandCollapseSlot: { type: Boolean, reflect: true, attribute: '_render-expand-collapse-slot' },
-			_showNestedLoadingSpinner: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Whether to show the expand collapse toggle
+		 * @type {boolean}
+		 */
+		expandable: { type: Boolean },
+		/**
+		 * Default state for expand collapse toggle - if not set, collapsed will be the default state
+		 * @type {boolean}
+		 */
+		expanded: { type: Boolean, reflect: true },
+		_siblingHasNestedItems: { state: true },
+		_renderExpandCollapseSlot: { type: Boolean, reflect: true, attribute: '_render-expand-collapse-slot' },
+		_showNestedLoadingSpinner: { state: true }
+	};
 
 	static get styles() {
 		const styles = [ css`

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -35,264 +35,260 @@ function isRtl() {
  */
 class ListItemGenericLayout extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * How to align content in the nested slot
 			 * @type {'content'|'control'}
 			 */
-			alignNested: { type: String, reflect: true, attribute: 'align-nested' },
-			/**
+		alignNested: { type: String, reflect: true, attribute: 'align-nested' },
+		/**
 			 * Whether to constrain actions so they do not fill the item. Required if slotted content is interactive.
 			 * @type {boolean}
 			 */
-			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action', reflect: true },
-			/**
+		noPrimaryAction: { type: Boolean, attribute: 'no-primary-action', reflect: true },
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
-			/**
+		// eslint-disable-next-line lit/no-native-attributes
+		role: { type: String, reflect: true },
+		/**
 			 * Specifies whether the grid is active or not
 			 * @type {boolean}
 			 */
-			gridActive: { type: Boolean, attribute: 'grid-active' },
-			/**
+		gridActive: { type: Boolean, attribute: 'grid-active' },
+		/**
 			 * Inline start padding (in px) to apply to list item(s) in the nested slot. When used, nested list items will not use the grid start calcuations and will only use this number to determine indentation.
 			 * @type {number}
 			 */
-			indentation: { type: Number, reflect: true },
-			/**
+		indentation: { type: Number, reflect: true },
+		/**
 			 * @ignore
 			 */
-			layout: { type: String, reflect: true },
-		};
-	}
+		layout: { type: String, reflect: true },
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: grid;
-				grid-template-columns:
-					[start outside-control-start] minmax(0, min-content)
-					[color-start outside-control-end] minmax(0, min-content)
-					[expand-collapse-start color-end] minmax(0, min-content)
-					[control-start expand-collapse-end] minmax(0, min-content)
-					[control-end content-start] minmax(0, auto)
-					[content-end actions-start] minmax(0, min-content)
-					[end actions-end];
-				grid-template-rows:
-					[start add-top-start] minmax(0, min-content)
-					[add-top-end main-start] minmax(0, min-content)
-					[main-end nested-start] minmax(0, min-content)
-					[nested-end add-start] minmax(0, min-content)
-					[add-end end];
-			}
+	static styles = css`
+		:host {
+			display: grid;
+			grid-template-columns:
+				[start outside-control-start] minmax(0, min-content)
+				[color-start outside-control-end] minmax(0, min-content)
+				[expand-collapse-start color-end] minmax(0, min-content)
+				[control-start expand-collapse-end] minmax(0, min-content)
+				[control-end content-start] minmax(0, auto)
+				[content-end actions-start] minmax(0, min-content)
+				[end actions-end];
+			grid-template-rows:
+				[start add-top-start] minmax(0, min-content)
+				[add-top-end main-start] minmax(0, min-content)
+				[main-end nested-start] minmax(0, min-content)
+				[nested-end add-start] minmax(0, min-content)
+				[add-end end];
+		}
 
-			:host([align-nested="control"]) ::slotted([slot="nested"]) {
-				grid-column: control-start / end;
-			}
+		:host([align-nested="control"]) ::slotted([slot="nested"]) {
+			grid-column: control-start / end;
+		}
 
-			::slotted([slot="drop-target"]) {
-				grid-column: start / end;
-			}
+		::slotted([slot="drop-target"]) {
+			grid-column: start / end;
+		}
 
-			::slotted([slot="outside-control"]),
-			::slotted([slot="color-indicator"]),
-			::slotted([slot="expand-collapse"]),
-			::slotted([slot="control"]),
-			::slotted([slot="content"]),
-			::slotted([slot="actions"]),
-			::slotted([slot="outside-control-action"]),
-			::slotted([slot="before-content"]),
-			::slotted([slot="control-action"]),
-			::slotted([slot="content-action"]),
-			::slotted([slot="outside-control-container"]),
-			::slotted([slot="control-container"]),
-			::slotted([slot="drop-target"]) {
-				grid-row: 2 / 3;
-			}
+		::slotted([slot="outside-control"]),
+		::slotted([slot="color-indicator"]),
+		::slotted([slot="expand-collapse"]),
+		::slotted([slot="control"]),
+		::slotted([slot="content"]),
+		::slotted([slot="actions"]),
+		::slotted([slot="outside-control-action"]),
+		::slotted([slot="before-content"]),
+		::slotted([slot="control-action"]),
+		::slotted([slot="content-action"]),
+		::slotted([slot="outside-control-container"]),
+		::slotted([slot="control-container"]),
+		::slotted([slot="drop-target"]) {
+			grid-row: 2 / 3;
+		}
 
-			::slotted([slot="outside-control"]) {
-				grid-column: outside-control-start / outside-control-end;
-			}
+		::slotted([slot="outside-control"]) {
+			grid-column: outside-control-start / outside-control-end;
+		}
 
-			::slotted([slot="outside-control"]:not(.handle-only)) {
-				pointer-events: none;
-			}
+		::slotted([slot="outside-control"]:not(.handle-only)) {
+			pointer-events: none;
+		}
 
-			::slotted([slot="expand-collapse"]) {
-				cursor: pointer;
-				grid-column: expand-collapse-start / expand-collapse-end;
-			}
+		::slotted([slot="expand-collapse"]) {
+			cursor: pointer;
+			grid-column: expand-collapse-start / expand-collapse-end;
+		}
 
-			::slotted([slot="control"]) {
-				grid-column: control-start / control-end;
-				pointer-events: none;
-				width: 2.1rem;
-			}
+		::slotted([slot="control"]) {
+			grid-column: control-start / control-end;
+			pointer-events: none;
+			width: 2.1rem;
+		}
 
-			::slotted([slot="content"]) {
-				grid-column: content-start / content-end;
-			}
+		::slotted([slot="content"]) {
+			grid-column: content-start / content-end;
+		}
 
-			::slotted([slot="color-indicator"]) {
-				grid-column: color-start / color-end;
-			}
+		::slotted([slot="color-indicator"]) {
+			grid-column: color-start / color-end;
+		}
 
-			::slotted([slot="before-content"]) {
-				grid-column: color-start / content-start;
-			}
+		::slotted([slot="before-content"]) {
+			grid-column: color-start / content-start;
+		}
 
-			::slotted([slot="control-action"]) ~ ::slotted([slot="content"]),
-			::slotted([slot="outside-control-action"]) ~ ::slotted([slot="content"]) {
-				pointer-events: unset;
-			}
+		::slotted([slot="control-action"]) ~ ::slotted([slot="content"]),
+		::slotted([slot="outside-control-action"]) ~ ::slotted([slot="content"]) {
+			pointer-events: unset;
+		}
 
-			slot[name="actions"] {
-				white-space: nowrap;
-			}
+		slot[name="actions"] {
+			white-space: nowrap;
+		}
 
-			::slotted([slot="actions"]) {
-				grid-column: actions-start / actions-end;
-				justify-self: end;
-			}
+		::slotted([slot="actions"]) {
+			grid-column: actions-start / actions-end;
+			justify-self: end;
+		}
 
-			::slotted([slot="outside-control-action"]) {
-				grid-column: start / end;
-			}
-			:host([no-primary-action]) ::slotted([slot="outside-control-action"]) {
-				grid-column: start / outside-control-end;
-			}
+		::slotted([slot="outside-control-action"]) {
+			grid-column: start / end;
+		}
+		:host([no-primary-action]) ::slotted([slot="outside-control-action"]) {
+			grid-column: start / outside-control-end;
+		}
 
-			::slotted([slot="content-action"]) {
-				grid-column: content-start / content-end;
-			}
+		::slotted([slot="content-action"]) {
+			grid-column: content-start / content-end;
+		}
 
-			:host([no-primary-action]) ::slotted([slot="content-action"]) {
-				display: none;
-			}
+		:host([no-primary-action]) ::slotted([slot="content-action"]) {
+			display: none;
+		}
 
-			::slotted([slot="control-action"]) {
-				grid-column-start: control-start;
-			}
+		::slotted([slot="control-action"]) {
+			grid-column-start: control-start;
+		}
 
-			:host(:not([no-primary-action])) ::slotted([slot="outside-control-action"]) {
-				grid-column-end: end;
-			}
+		:host(:not([no-primary-action])) ::slotted([slot="outside-control-action"]) {
+			grid-column-end: end;
+		}
 
-			:host(:not([no-primary-action])) ::slotted([slot="control-action"]) {
-				grid-column-end: actions-start;
-			}
+		:host(:not([no-primary-action])) ::slotted([slot="control-action"]) {
+			grid-column-end: actions-start;
+		}
 
-			::slotted([slot="outside-control-container"]) {
-				grid-column: start / end;
-			}
-			::slotted([slot="control-container"]) {
-				grid-column: color-start / end;
-			}
+		::slotted([slot="outside-control-container"]) {
+			grid-column: start / end;
+		}
+		::slotted([slot="control-container"]) {
+			grid-column: color-start / end;
+		}
 
-			::slotted([slot="nested"]) {
-				grid-column: content-start / end;
-				grid-row: nested;
-			}
+		::slotted([slot="nested"]) {
+			grid-column: content-start / end;
+			grid-row: nested;
+		}
 
-			:host([indentation]) ::slotted([slot="nested"]) {
-				grid-column-start: start;
-				padding-inline-start: var(--d2l-list-item-generic-layout-nested-indentation);
-			}
+		:host([indentation]) ::slotted([slot="nested"]) {
+			grid-column-start: start;
+			padding-inline-start: var(--d2l-list-item-generic-layout-nested-indentation);
+		}
 
-			::slotted([slot="add"]) {
-				grid-row: add;
-			}
-			::slotted([slot="add-top"]) {
-				grid-row: add-top;
-			}
-			::slotted([slot="add-top"]),
-			::slotted([slot="add"]) {
-				grid-column: color-start / end;
-			}
+		::slotted([slot="add"]) {
+			grid-row: add;
+		}
+		::slotted([slot="add-top"]) {
+			grid-row: add-top;
+		}
+		::slotted([slot="add-top"]),
+		::slotted([slot="add"]) {
+			grid-column: color-start / end;
+		}
 
-			:host([layout="tile"]) {
-				grid-template-columns:
-					[start outside-control-start] minmax(0, 26px)
-					[outside-control-end control-start] minmax(0, min-content)
-					[control-end actions-start] minmax(0, auto)
-					[actions-end end];
-				grid-template-rows:
-					[start header-start] minmax(0, min-content)
-					[header-end content-start] auto
-					[content-end end];
-				height: 100%;
-			}
+		:host([layout="tile"]) {
+			grid-template-columns:
+				[start outside-control-start] minmax(0, 26px)
+				[outside-control-end control-start] minmax(0, min-content)
+				[control-end actions-start] minmax(0, auto)
+				[actions-end end];
+			grid-template-rows:
+				[start header-start] minmax(0, min-content)
+				[header-end content-start] auto
+				[content-end end];
+			height: 100%;
+		}
 
-			:host([layout="tile"]:not([is-draggable])) {
-				grid-template-columns:
-					[start outside-control-start] 0
-					[outside-control-end control-start] minmax(0, min-content)
-					[control-end actions-start] minmax(0, auto)
-					[actions-end end];
-				grid-template-rows:
-					[start header-start] minmax(0, min-content)
-					[header-end content-start] auto
-					[content-end end];
-				height: 100%;
-			}
+		:host([layout="tile"]:not([is-draggable])) {
+			grid-template-columns:
+				[start outside-control-start] 0
+				[outside-control-end control-start] minmax(0, min-content)
+				[control-end actions-start] minmax(0, auto)
+				[actions-end end];
+			grid-template-rows:
+				[start header-start] minmax(0, min-content)
+				[header-end content-start] auto
+				[content-end end];
+			height: 100%;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="header"]) {
-				grid-column: start / end;
-				grid-row: header-start / header-end;
-			}
+		:host([layout="tile"]) ::slotted([slot="header"]) {
+			grid-column: start / end;
+			grid-row: header-start / header-end;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="content"]),
-			:host([layout="tile"]) ::slotted([slot="content-action"]),
-			:host([layout="tile"]) ::slotted([slot="control-action"]) {
-				grid-column: start / end;
-				grid-row: content-start / end;
-			}
-			:host([layout="tile"]) ::slotted([slot="outside-control-container"]) {
-				grid-column: start / end;
-				grid-row: start / end;
-			}
-			:host([layout="tile"]) ::slotted([slot="control"]) {
-				grid-column: control-start / control-end;
-				grid-row: start / start;
-				pointer-events: all;
-				width: unset;
-			}
+		:host([layout="tile"]) ::slotted([slot="content"]),
+		:host([layout="tile"]) ::slotted([slot="content-action"]),
+		:host([layout="tile"]) ::slotted([slot="control-action"]) {
+			grid-column: start / end;
+			grid-row: content-start / end;
+		}
+		:host([layout="tile"]) ::slotted([slot="outside-control-container"]) {
+			grid-column: start / end;
+			grid-row: start / end;
+		}
+		:host([layout="tile"]) ::slotted([slot="control"]) {
+			grid-column: control-start / control-end;
+			grid-row: start / start;
+			pointer-events: all;
+			width: unset;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="actions"]) {
-				grid-column: actions-start / actions-end;
-				grid-row: start / start;
-			}
+		:host([layout="tile"]) ::slotted([slot="actions"]) {
+			grid-column: actions-start / actions-end;
+			grid-row: start / start;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="color-indicator"]) {
-				grid-column: start;
-				grid-row: content-start / content-end;
-			}
+		:host([layout="tile"]) ::slotted([slot="color-indicator"]) {
+			grid-column: start;
+			grid-row: content-start / content-end;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="outside-control"]) {
-				grid-column: outside-control-start / outside-control-end;
-				grid-row: start / start;
-				width: min-content;
-			}
+		:host([layout="tile"]) ::slotted([slot="outside-control"]) {
+			grid-column: outside-control-start / outside-control-end;
+			grid-row: start / start;
+			width: min-content;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="outside-control-action"]) {
-				grid-column: start / end;
-				grid-row: start / start;
-			}
+		:host([layout="tile"]) ::slotted([slot="outside-control-action"]) {
+			grid-column: start / end;
+			grid-row: start / start;
+		}
 
-			:host(:not([layout="tile"])) slot[name="header"],
-			:host([layout="tile"]) slot[name="add-top"],
-			:host([layout="tile"]) slot[name="control-container"],
-			:host([layout="tile"]) slot[name="before-content"],
-			:host([layout="tile"]) slot[name="expand-collapse"],
-			:host([layout="tile"]) slot[name="nested"],
-			:host([layout="tile"]) slot[name="add"] {
-				display: none;
-			}
-		`;
-	}
+		:host(:not([layout="tile"])) slot[name="header"],
+		:host([layout="tile"]) slot[name="add-top"],
+		:host([layout="tile"]) slot[name="control-container"],
+		:host([layout="tile"]) slot[name="before-content"],
+		:host([layout="tile"]) slot[name="expand-collapse"],
+		:host([layout="tile"]) slot[name="nested"],
+		:host([layout="tile"]) slot[name="add"] {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/list/list-item-link-mixin.js
+++ b/components/list/list-item-link-mixin.js
@@ -6,16 +6,14 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 export const ListItemLinkMixin = superclass => class extends ListItemMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Address of item link if navigable
-			 * @type {string}
-			 */
-			actionHref: { type: String, attribute: 'action-href', reflect: true },
-			_ariaCurrent: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Address of item link if navigable
+		 * @type {string}
+		 */
+		actionHref: { type: String, attribute: 'action-href', reflect: true },
+		_ariaCurrent: { type: String }
+	};
 
 	static get styles() {
 

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -63,75 +63,73 @@ export const ListItemMixin = superclass => class extends composeMixins(
 	ListItemRoleMixin,
 	SkeletonMixin) {
 
-	static get properties() {
-		return {
-			/**
-			 * A color indicator to appear at the beginning of a list item. Expected value is a valid 3, 4, 6, or 8 character CSS color hex code (e.g., #006fbf).
-			 * @type {string}
-			 */
-			color: { type: String },
-			/**
-			 * @ignore
-			 */
-			first: { type: Boolean, reflect: true },
-			/**
-			 * Whether to allow the drag target to be the handle only rather than the entire cell
-			 * @type {boolean}
-			 */
-			dragTargetHandleOnly: { type: Boolean, attribute: 'drag-target-handle-only' },
-			/**
-			 * Inline start padding (in px) to apply to list item(s) in the nested slot. When used, nested list items will not use the grid start calcuations and will only use this number to determine indentation.
-			 * @type {number}
-			 */
-			indentation: { type: Number, reflect: true },
-			/**
-			 * @ignore
-			 */
-			last: { type: Boolean, reflect: true },
-			/**
-			 * @ignore
-			 */
-			layout: { type: String, reflect: true },
-			/**
-			 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
-			 * @type {boolean}
-			 */
-			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
-			/**
-			 * How much padding to render in standard/normal list items
-			 * @type {'normal'|'none'}
-			 */
-			paddingType: { type: String, attribute: 'padding-type' },
-			/**
-			 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
-			 * @type {boolean}
-			 */
-			tileHeader: { type: Boolean, reflect: true, attribute: 'tile-header' },
-			/**
-			 * How much padding to render in tile list items
-			 * @type {'normal'|'none'}
-			 * @default "normal"
-			 */
-			tilePaddingType: { type: String, attribute: 'tile-padding-type' },
-			_addButtonText: { state: true },
-			_displayKeyboardTooltip: { type: Boolean },
-			_hasColorSlot: { type: Boolean, reflect: true, attribute: '_has-color-slot' },
-			_hasListItemContent: { state: true },
-			_hasNestedList: { type: Boolean, reflect: true, attribute: '_has-nested-list' },
-			_hasNestedListAddButton: { type: Boolean, reflect: true, attribute: '_has-nested-list-add-button' },
-			_hovering: { type: Boolean, reflect: true },
-			_hoveringControl: { type: Boolean, attribute: '_hovering-control', reflect: true },
-			_hoveringPrimaryAction: { type: Boolean, attribute: '_hovering-primary-action', reflect: true },
-			_focusing: { type: Boolean, reflect: true },
-			_focusingPrimaryAction: { type: Boolean, attribute: '_focusing-primary-action', reflect: true },
-			_forceShowSelection: { type: Boolean, attribute: '_force-show-selection', reflect: true },
-			_highlight: { type: Boolean, reflect: true },
-			_highlighting: { type: Boolean, reflect: true },
-			_showAddButton: { type: Boolean, attribute: '_show-add-button', reflect: true },
-			_selectionWhenInteracted: { type: Boolean, attribute: '_selection-when-interacted', reflect: true },
-			_siblingHasColor: { state: true },
-		};
-	}
+	static properties = {
+		/**
+		 * A color indicator to appear at the beginning of a list item. Expected value is a valid 3, 4, 6, or 8 character CSS color hex code (e.g., #006fbf).
+		 * @type {string}
+		 */
+		color: { type: String },
+		/**
+		 * @ignore
+		 */
+		first: { type: Boolean, reflect: true },
+		/**
+		 * Whether to allow the drag target to be the handle only rather than the entire cell
+		 * @type {boolean}
+		 */
+		dragTargetHandleOnly: { type: Boolean, attribute: 'drag-target-handle-only' },
+		/**
+		 * Inline start padding (in px) to apply to list item(s) in the nested slot. When used, nested list items will not use the grid start calcuations and will only use this number to determine indentation.
+		 * @type {number}
+		 */
+		indentation: { type: Number, reflect: true },
+		/**
+		 * @ignore
+		 */
+		last: { type: Boolean, reflect: true },
+		/**
+		 * @ignore
+		 */
+		layout: { type: String, reflect: true },
+		/**
+		 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
+		 * @type {boolean}
+		 */
+		noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
+		/**
+		 * How much padding to render in standard/normal list items
+		 * @type {'normal'|'none'}
+		 */
+		paddingType: { type: String, attribute: 'padding-type' },
+		/**
+		 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
+		 * @type {boolean}
+		 */
+		tileHeader: { type: Boolean, reflect: true, attribute: 'tile-header' },
+		/**
+		 * How much padding to render in tile list items
+		 * @type {'normal'|'none'}
+		 * @default "normal"
+		 */
+		tilePaddingType: { type: String, attribute: 'tile-padding-type' },
+		_addButtonText: { state: true },
+		_displayKeyboardTooltip: { type: Boolean },
+		_hasColorSlot: { type: Boolean, reflect: true, attribute: '_has-color-slot' },
+		_hasListItemContent: { state: true },
+		_hasNestedList: { type: Boolean, reflect: true, attribute: '_has-nested-list' },
+		_hasNestedListAddButton: { type: Boolean, reflect: true, attribute: '_has-nested-list-add-button' },
+		_hovering: { type: Boolean, reflect: true },
+		_hoveringControl: { type: Boolean, attribute: '_hovering-control', reflect: true },
+		_hoveringPrimaryAction: { type: Boolean, attribute: '_hovering-primary-action', reflect: true },
+		_focusing: { type: Boolean, reflect: true },
+		_focusingPrimaryAction: { type: Boolean, attribute: '_focusing-primary-action', reflect: true },
+		_forceShowSelection: { type: Boolean, attribute: '_force-show-selection', reflect: true },
+		_highlight: { type: Boolean, reflect: true },
+		_highlighting: { type: Boolean, reflect: true },
+		_showAddButton: { type: Boolean, attribute: '_show-add-button', reflect: true },
+		_selectionWhenInteracted: { type: Boolean, attribute: '_selection-when-interacted', reflect: true },
+		_siblingHasColor: { state: true },
+	};
 
 	static get styles() {
 

--- a/components/list/list-item-nav-mixin.js
+++ b/components/list/list-item-nav-mixin.js
@@ -4,23 +4,21 @@ import { ListItemLinkMixin } from './list-item-link-mixin.js';
 
 export const ListItemNavMixin = superclass => class extends ListItemLinkMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether the list item is the current page in a navigation context. At most one list item should have the `current` attribute at any time; this will be managed by the `list` after initial render.
-			 * @type {boolean}
-			 */
-			current: { type: Boolean, reflect: true },
-			/**
-			 * Whether to prevent the default navigation behavior of the link
-			 * @type {boolean}
-			 */
-			preventNavigation: { type: Boolean, attribute: 'prevent-navigation' },
-			_childCurrent: { type: Boolean, reflect: true, attribute: '_child-current' },
-			_hasCurrentParent: { type: Boolean, reflect: true, attribute: '_has-current-parent' },
-			_nextSiblingCurrent: { type: Boolean, reflect: true, attribute: '_next-sibling-current' },
-		};
-	}
+	static properties = {
+		/**
+		 * Whether the list item is the current page in a navigation context. At most one list item should have the `current` attribute at any time; this will be managed by the `list` after initial render.
+		 * @type {boolean}
+		 */
+		current: { type: Boolean, reflect: true },
+		/**
+		 * Whether to prevent the default navigation behavior of the link
+		 * @type {boolean}
+		 */
+		preventNavigation: { type: Boolean, attribute: 'prevent-navigation' },
+		_childCurrent: { type: Boolean, reflect: true, attribute: '_child-current' },
+		_hasCurrentParent: { type: Boolean, reflect: true, attribute: '_has-current-parent' },
+		_nextSiblingCurrent: { type: Boolean, reflect: true, attribute: '_next-sibling-current' },
+	};
 
 	static get styles() {
 

--- a/components/list/list-item-placement-marker.js
+++ b/components/list/list-item-placement-marker.js
@@ -7,73 +7,71 @@ class ListItemPlacementMarker extends LitElement {
 		vertical: { type: Boolean, reflect: true }
 	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
+	static styles = css`
+		:host {
+			display: block;
+		}
 
-			:host([vertical]) {
-				height: 100%;
-			}
+		:host([vertical]) {
+			height: 100%;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
-			:host([vertical]) .d2l-list-drag-marker-line {
-				height: 100%;
-				margin: -1px 0;
-				width: 12px;
-			}
+		:host([vertical]) .d2l-list-drag-marker-line {
+			height: 100%;
+			margin: -1px 0;
+			width: 12px;
+		}
 
-			.d2l-list-drag-marker-line {
-				height: 12px;
-				margin-inline: -1px;
-				stroke: var(--d2l-color-celestine);
-				stroke-width: 3px;
-				width: 100%;
-			}
+		.d2l-list-drag-marker-line {
+			height: 12px;
+			margin-inline: -1px;
+			stroke: var(--d2l-color-celestine);
+			stroke-width: 3px;
+			width: 100%;
+		}
 
-			:host([vertical]) .d2l-list-drag-marker-linecap {
-				height: 4px;
-				margin-inline: 0 -2px;
-				width: 12px;
-			}
+		:host([vertical]) .d2l-list-drag-marker-linecap {
+			height: 4px;
+			margin-inline: 0 -2px;
+			width: 12px;
+		}
 
-			.d2l-list-drag-marker-linecap {
-				fill: var(--d2l-color-celestine);
-				height: 12px;
-				margin-inline: -1px 0;
-				stroke: none;
-				width: 4px;
-			}
+		.d2l-list-drag-marker-linecap {
+			fill: var(--d2l-color-celestine);
+			height: 12px;
+			margin-inline: -1px 0;
+			stroke: none;
+			width: 4px;
+		}
 
-			:host([vertical]) .d2l-list-drag-marker-circle {
-				margin-inline: 0 0;
-			}
+		:host([vertical]) .d2l-list-drag-marker-circle {
+			margin-inline: 0 0;
+		}
 
 
-			.d2l-list-drag-marker-circle {
-				fill: none;
-				height: 12px;
-				margin-inline: 0 -1px;
-				stroke: var(--d2l-color-celestine);
-				stroke-width: 3px;
-				width: 12px;
-			}
+		.d2l-list-drag-marker-circle {
+			fill: none;
+			height: 12px;
+			margin-inline: 0 -1px;
+			stroke: var(--d2l-color-celestine);
+			stroke-width: 3px;
+			width: 12px;
+		}
 
-			.d2l-list-drag-marker {
-				display: flex;
-				flex-wrap: nowrap;
-			}
+		.d2l-list-drag-marker {
+			display: flex;
+			flex-wrap: nowrap;
+		}
 
-			:host([vertical]) .d2l-list-drag-marker {
-				flex-direction: column;
-				height: 100%;
-			}
-		`;
-	}
+		:host([vertical]) .d2l-list-drag-marker {
+			flex-direction: column;
+			height: 100%;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/list/list-item-role-mixin.js
+++ b/components/list/list-item-role-mixin.js
@@ -2,17 +2,15 @@ import { findComposedAncestor } from '../../helpers/dom.js';
 
 export const ListItemRoleMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
-			_nested: { type: Boolean, reflect: true },
-			_separators: { type: String, reflect: true }
-		};
-	}
+		// eslint-disable-next-line lit/no-native-attributes
+		role: { type: String, reflect: true },
+		_nested: { type: Boolean, reflect: true },
+		_separators: { type: String, reflect: true }
+	};
 
 	constructor() {
 		super();

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -10,15 +10,13 @@ import { LitElement } from 'lit';
  */
 class ListItem extends ListItemLinkMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Address of item link if navigable
 			 * @type {string}
 			 */
-			href: { type: String }
-		};
-	}
+		href: { type: String }
+	};
 
 	get href() {
 		return this.actionHref;

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -35,134 +35,130 @@ const ro = new ResizeObserver(entries => {
  */
 class List extends PageableMixin(SelectionMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * When true, show the inline add button after each list item.
 			 * @type {boolean}
 			 */
-			addButton: { type: Boolean, reflect: true, attribute: 'add-button' },
-			/**
+		addButton: { type: Boolean, reflect: true, attribute: 'add-button' },
+		/**
 			 * Text to show in label tooltip on inline add button. Defaults to "Add Item".
 			 * @type {string}
 			 */
-			addButtonText: { type: String, reflect: true, attribute: 'add-button-text' },
-			/**
+		addButtonText: { type: String, reflect: true, attribute: 'add-button-text' },
+		/**
 			 * Breakpoints for responsiveness in pixels. There are four different breakpoints and only the four largest breakpoints will be used.
 			 * @type {array}
 			 */
-			breakpoints: { type: Array },
-			/**
+		breakpoints: { type: Array },
+		/**
 			 * Always show drag handle
 			 * @type {boolean}
 			 */
-			dragHandleShowAlways: { type: Boolean, attribute: 'drag-handle-show-always' },
-			/**
+		dragHandleShowAlways: { type: Boolean, attribute: 'drag-handle-show-always' },
+		/**
 			 * Whether the user can drag multiple items
 			 * @type {boolean}
  			 */
-			dragMultiple: { type: Boolean, reflect: true, attribute: 'drag-multiple' },
-			/**
+		dragMultiple: { type: Boolean, reflect: true, attribute: 'drag-multiple' },
+		/**
 			 * Disable ability to drop items above or below this item
 			 * @type {boolean}
 			 */
-			dropNestedOnly: { type: Boolean, attribute: 'drop-nested-only' },
-			/**
+		dropNestedOnly: { type: Boolean, attribute: 'drop-nested-only' },
+		/**
 			 * Whether to extend the separators beyond the content's edge
 			 * @type {boolean}
 			 */
-			extendSeparators: { type: Boolean, reflect: true, attribute: 'extend-separators' },
-			/**
+		extendSeparators: { type: Boolean, reflect: true, attribute: 'extend-separators' },
+		/**
 			 * Use grid to manage focus with arrow keys. See [Accessibility](#accessibility).
 			 * @type {boolean}
 			 */
-			grid: { type: Boolean },
-			/**
+		grid: { type: Boolean },
+		/**
 			 * Sets an accessible label. For use when the list context is unclear. This property is only valid on top-level lists and will have no effect on nested lists.
 			 * @type {string}
  			 */
-			label: { type: String },
-			/**
+		label: { type: String },
+		/**
 			 * The type of layout for the list items. Valid values are "list" (default) and "tiles". The tile layout is only valid for single level (non-nested) lists.
 			 * @type {'list'|'tiles'}
 			 * @default "list"
 			 */
-			layout: { type: String, reflect: true },
-			/**
+		layout: { type: String, reflect: true },
+		/**
 			 * Display separators. Valid values are "all" (default), "between", "none"
 			 * @type {'all'|'between'|'none'}
 			 * @default "all"
 			 */
-			separators: { type: String, reflect: true },
-			/**
+		separators: { type: String, reflect: true },
+		/**
 			 * Show selection only on hover, focus or if at least one item is selected. Exclusive for the tile layout
 			 * @type {boolean}
 			 */
-			selectionWhenInteracted: { type: Boolean, attribute: 'selection-when-interacted', reflect: true },
-			_breakpoint: { type: Number, reflect: true },
-			_slimColor: { type: Boolean, reflect: true, attribute: '_slim-color' }
-		};
-	}
+		selectionWhenInteracted: { type: Boolean, attribute: 'selection-when-interacted', reflect: true },
+		_breakpoint: { type: Number, reflect: true },
+		_slimColor: { type: Boolean, reflect: true, attribute: '_slim-color' }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				--d2l-list-item-color-border-radius: 6px;
-				--d2l-list-item-color-width: 6px;
-				--d2l-list-item-illustration-margin-inline-end: 0.9rem;
-				--d2l-list-item-illustration-max-height: 2.6rem;
-				--d2l-list-item-illustration-max-width: 4.5rem;
-				display: block;
-			}
-			:host([layout="tiles"]) > .d2l-list-content {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 0.9rem;
-				justify-content: normal;
-			}
-			:host(:not([slot="nested"])) > .d2l-list-content {
-				padding-bottom: 1px;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			slot[name="pager"]::slotted(*) {
-				margin-top: 10px;
-			}
-			:host([extend-separators]) slot[name="pager"]::slotted(*) {
-				margin-left: 0.9rem;
-				margin-right: 0.9rem;
-			}
-			:host([_breakpoint="1"]) {
-				--d2l-list-item-illustration-max-height: 3.55rem;
-				--d2l-list-item-illustration-max-width: 6rem;
-			}
-			:host([_breakpoint="2"]) {
-				--d2l-list-item-illustration-max-height: 5.1rem;
-				--d2l-list-item-illustration-max-width: 9rem;
-			}
-			:host([_breakpoint="3"]) {
-				--d2l-list-item-illustration-max-height: 6rem;
-				--d2l-list-item-illustration-max-width: 10.8rem;
-			}
-			:host([_slim-color]) {
-				--d2l-list-item-color-border-radius: 3px;
-				--d2l-list-item-color-width: 3px;
-			}
-			:host([add-button]) ::slotted([slot="controls"]) {
-				margin-bottom: calc(6px + 0.4rem); /* controls section margin-bottom + spacing for add-button */
-			}
+	static styles = css`
+		:host {
+			--d2l-list-item-color-border-radius: 6px;
+			--d2l-list-item-color-width: 6px;
+			--d2l-list-item-illustration-margin-inline-end: 0.9rem;
+			--d2l-list-item-illustration-max-height: 2.6rem;
+			--d2l-list-item-illustration-max-width: 4.5rem;
+			display: block;
+		}
+		:host([layout="tiles"]) > .d2l-list-content {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.9rem;
+			justify-content: normal;
+		}
+		:host(:not([slot="nested"])) > .d2l-list-content {
+			padding-bottom: 1px;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		slot[name="pager"]::slotted(*) {
+			margin-top: 10px;
+		}
+		:host([extend-separators]) slot[name="pager"]::slotted(*) {
+			margin-left: 0.9rem;
+			margin-right: 0.9rem;
+		}
+		:host([_breakpoint="1"]) {
+			--d2l-list-item-illustration-max-height: 3.55rem;
+			--d2l-list-item-illustration-max-width: 6rem;
+		}
+		:host([_breakpoint="2"]) {
+			--d2l-list-item-illustration-max-height: 5.1rem;
+			--d2l-list-item-illustration-max-width: 9rem;
+		}
+		:host([_breakpoint="3"]) {
+			--d2l-list-item-illustration-max-height: 6rem;
+			--d2l-list-item-illustration-max-width: 10.8rem;
+		}
+		:host([_slim-color]) {
+			--d2l-list-item-color-border-radius: 3px;
+			--d2l-list-item-color-width: 3px;
+		}
+		:host([add-button]) ::slotted([slot="controls"]) {
+			margin-bottom: calc(6px + 0.4rem); /* controls section margin-bottom + spacing for add-button */
+		}
 
-			::slotted(.d2l-list-tile-break) {
-				display: none;
-			}
-			:host([layout="tiles"]) ::slotted(.d2l-list-tile-break) {
-				display: block;
-				flex-basis: 100%;
-				height: 0;
-			}
-		`;
-	}
+		::slotted(.d2l-list-tile-break) {
+			display: none;
+		}
+		:host([layout="tiles"]) ::slotted(.d2l-list-tile-break) {
+			display: block;
+			flex-basis: 100%;
+			height: 0;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/loading-spinner/demo/loading-spinner-override.js
+++ b/components/loading-spinner/demo/loading-spinner-override.js
@@ -4,26 +4,22 @@ import { css, html, LitElement } from 'lit';
 
 class LoadingSpinnerOverride extends LitElement {
 
-	static get properties() {
-		return {
-			overrideColor: { type: Boolean, attribute: 'override-color' },
-			overrideSize: { type: Boolean, attribute: 'override-size' }
-		};
-	}
+	static properties = {
+		overrideColor: { type: Boolean, attribute: 'override-color' },
+		overrideSize: { type: Boolean, attribute: 'override-size' }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([override-color]) {
-				--d2l-loading-spinner-color: var(--d2l-color-cinnabar);
-			}
-			:host([override-size]) {
-				--d2l-loading-spinner-size: 100px;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([override-color]) {
+			--d2l-loading-spinner-color: var(--d2l-color-cinnabar);
+		}
+		:host([override-size]) {
+			--d2l-loading-spinner-size: 100px;
+		}
+	`;
 
 	render() {
 		return html`<d2l-loading-spinner></d2l-loading-spinner>`;

--- a/components/loading-spinner/loading-spinner.js
+++ b/components/loading-spinner/loading-spinner.js
@@ -7,109 +7,105 @@ import { classMap } from 'lit/directives/class-map.js';
  */
 class LoadingSpinner extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 * Color of the animated bar
 			 * @type {string}
 			 * @default var(--d2l-color-celestine)
 			 */
-			color: { type: String },
-			/**
+		color: { type: String },
+		/**
 			 * Height and width (px) of the spinner
 			 * @type {number}
 			 * @default 50
 			 */
-			size: { type: Number }
-		};
-	}
-	static get styles() {
-		return css`
+		size: { type: Number }
+	};
+	static styles = css`
 
-			:host {
-				color: var(--d2l-loading-spinner-color, var(--d2l-color-celestine));
-				display: inline-block;
-				text-align: initial;
-			}
+		:host {
+			color: var(--d2l-loading-spinner-color, var(--d2l-color-celestine));
+			display: inline-block;
+			text-align: initial;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
-			.d2l-loading-spinner-wrapper {
-				height: var(--d2l-loading-spinner-size, 48px);
-				margin: auto;
-				overflow: hidden;
-				position: relative;
-				width: var(--d2l-loading-spinner-size, 48px);
-			}
-			svg {
-				background: radial-gradient(rgba(0, 0, 0, 0.42), transparent 70%); /* 70% ≈ 100%/sqrt(2) = radius of circle since corners lie on 100% of radial gradient */
-				height: 100%;
-				position: absolute;
-				top: 0;
-				width: 100%;
-			}
-			.outer-circle {
-				fill: white;
-				stroke: none;
-			}
-			.inner-circle {
-				fill: none;
-				stroke: var(--d2l-loading-spinner-color, var(--d2l-color-celestine));
-				stroke-width: 3;
-			}
+		.d2l-loading-spinner-wrapper {
+			height: var(--d2l-loading-spinner-size, 48px);
+			margin: auto;
+			overflow: hidden;
+			position: relative;
+			width: var(--d2l-loading-spinner-size, 48px);
+		}
+		svg {
+			background: radial-gradient(rgba(0, 0, 0, 0.42), transparent 70%); /* 70% ≈ 100%/sqrt(2) = radius of circle since corners lie on 100% of radial gradient */
+			height: 100%;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
+		.outer-circle {
+			fill: white;
+			stroke: none;
+		}
+		.inner-circle {
+			fill: none;
+			stroke: var(--d2l-loading-spinner-color, var(--d2l-color-celestine));
+			stroke-width: 3;
+		}
 
-			.slice {
-				animation-duration: 1.5s;
-				animation-iteration-count: infinite;
-				animation-timing-function: cubic-bezier(0.5, 0, 0.5, 1);
-				transform-origin: center;
-			}
-			.slice-1 {
-				animation-name: slicespin1;
-				transform: rotate(54deg);
-			}
-			.slice-2 {
-				animation-name: slicespin2;
-				transform: rotate(124deg);
-			}
-			.slice-3 {
-				animation-name: slicespin3;
-				transform: rotate(198deg);
-			}
-			.slice-4 {
-				animation-name: slicespin4;
-				transform: rotate(270deg);
-			}
-			.slice-5 {
-				animation-name: slicespin5;
-				transform: rotate(344deg);
-			}
+		.slice {
+			animation-duration: 1.5s;
+			animation-iteration-count: infinite;
+			animation-timing-function: cubic-bezier(0.5, 0, 0.5, 1);
+			transform-origin: center;
+		}
+		.slice-1 {
+			animation-name: slicespin1;
+			transform: rotate(54deg);
+		}
+		.slice-2 {
+			animation-name: slicespin2;
+			transform: rotate(124deg);
+		}
+		.slice-3 {
+			animation-name: slicespin3;
+			transform: rotate(198deg);
+		}
+		.slice-4 {
+			animation-name: slicespin4;
+			transform: rotate(270deg);
+		}
+		.slice-5 {
+			animation-name: slicespin5;
+			transform: rotate(344deg);
+		}
 
-			@keyframes slicespin1 {
-				0% { transform: rotate(54deg); }
-				80%, 100% { transform: rotate(430deg); }
-			}
-			@keyframes slicespin2 {
-				0%, 10% { transform: rotate(124deg); }
-				80%, 100% { transform: rotate(500deg); }
-			}
-			@keyframes slicespin3 {
-				0%, 20% { transform: rotate(198deg); }
-				80%, 100% { transform: rotate(574deg); }
-			}
-			@keyframes slicespin4 {
-				0%, 35% { transform: rotate(270deg); }
-				80%, 100% { transform: rotate(644deg); }
-			}
-			@keyframes slicespin5 {
-				80%, 100% { transform: rotate(720deg); }
-			}
+		@keyframes slicespin1 {
+			0% { transform: rotate(54deg); }
+			80%, 100% { transform: rotate(430deg); }
+		}
+		@keyframes slicespin2 {
+			0%, 10% { transform: rotate(124deg); }
+			80%, 100% { transform: rotate(500deg); }
+		}
+		@keyframes slicespin3 {
+			0%, 20% { transform: rotate(198deg); }
+			80%, 100% { transform: rotate(574deg); }
+		}
+		@keyframes slicespin4 {
+			0%, 35% { transform: rotate(270deg); }
+			80%, 100% { transform: rotate(644deg); }
+		}
+		@keyframes slicespin5 {
+			80%, 100% { transform: rotate(720deg); }
+		}
 
-		`;
-	}
+	`;
 
 	render() {
 		return html`

--- a/components/menu/demo/custom-menu-item.js
+++ b/components/menu/demo/custom-menu-item.js
@@ -4,27 +4,23 @@ import { menuItemStyles } from '../menu-item-styles.js';
 
 class CustomMenuItem extends MenuItemMixin(LitElement) {
 
-	static get properties() {
-		return {
-			text: { type: String }
-		};
-	}
+	static properties = {
+		text: { type: String }
+	};
 
-	static get styles() {
-		return [ menuItemStyles,
-			css`
-				:host {
-					padding: 0.75rem 1.5rem;
-				}
-				:host(:hover) .d2l-menu-item-text,
-				:host(:focus) .d2l-menu-item-text {
-					-webkit-transform: rotateY(360deg);
-					transform: rotateY(360deg);
-					transition: transform 2s;
-				}
-			`
-		];
-	}
+	static styles = [ menuItemStyles,
+		css`
+			:host {
+				padding: 0.75rem 1.5rem;
+			}
+			:host(:hover) .d2l-menu-item-text,
+			:host(:focus) .d2l-menu-item-text {
+				-webkit-transform: rotateY(360deg);
+				transform: rotateY(360deg);
+				transition: transform 2s;
+			}
+		`
+	];
 
 	render() {
 		return html`

--- a/components/menu/demo/custom-view.js
+++ b/components/menu/demo/custom-view.js
@@ -3,9 +3,8 @@ import { HierarchicalViewMixin } from '../../hierarchical-view/hierarchical-view
 
 class CustomView extends HierarchicalViewMixin(LitElement) {
 
-	static get styles() {
-		return [ super.styles,
-			css`
+	static styles = [ super.styles,
+		css`
 				:host {
 					background-color: black;
 					border: 1px solid black;
@@ -26,8 +25,7 @@ class CustomView extends HierarchicalViewMixin(LitElement) {
 					font-size: 0.7rem;
 				}
 			`
-		];
-	}
+	];
 
 	firstUpdated() {
 		super.firstUpdated();

--- a/components/menu/menu-item-checkbox.js
+++ b/components/menu/menu-item-checkbox.js
@@ -9,9 +9,7 @@ import { menuItemSelectableStyles } from './menu-item-selectable-styles.js';
  */
 class MenuItemCheckbox extends MenuItemSelectableMixin(LitElement) {
 
-	static get styles() {
-		return menuItemSelectableStyles;
-	}
+	static styles = menuItemSelectableStyles;
 
 	constructor() {
 		super();

--- a/components/menu/menu-item-link.js
+++ b/components/menu/menu-item-link.js
@@ -10,43 +10,39 @@ import { menuItemStyles } from './menu-item-styles.js';
  */
 class MenuItemLink extends LinkMixin(MenuItemMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			_ariaDescription: { type: String, attribute: 'aria-description', reflect: true },
-		};
-	}
+	static properties = {
+		_ariaDescription: { type: String, attribute: 'aria-description', reflect: true },
+	};
 
-	static get styles() {
-		return [ super.styles, menuItemStyles,
-			css`
-				:host {
-					display: block;
-					padding: 0;
-				}
+	static styles = [ super.styles, menuItemStyles,
+		css`
+			:host {
+				display: block;
+				padding: 0;
+			}
 
-				:host > a {
-					align-items: center;
-					color: inherit;
-					display: flex;
-					line-height: 1rem;
-					outline: none;
-					overflow-x: hidden;
-					padding: 0.75rem 1rem;
-					text-decoration: none;
-				}
+			:host > a {
+				align-items: center;
+				color: inherit;
+				display: flex;
+				line-height: 1rem;
+				outline: none;
+				overflow-x: hidden;
+				padding: 0.75rem 1rem;
+				text-decoration: none;
+			}
 
-				:host([target="_blank"]) .d2l-menu-item-text {
-					align-self: baseline;
-					flex: 0 1 auto;
-				}
+			:host([target="_blank"]) .d2l-menu-item-text {
+				align-self: baseline;
+				flex: 0 1 auto;
+			}
 
-				#new-window {
-					align-self: baseline;
-					flex: auto;
-				}
-			`
-		];
-	}
+			#new-window {
+				align-self: baseline;
+				flex: auto;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/menu/menu-item-mixin.js
+++ b/components/menu/menu-item-mixin.js
@@ -4,60 +4,58 @@ const defaultLines = 2;
 
 export const MenuItemMixin = superclass => class extends PropertyRequiredMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables the menu item
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * @ignore
 			 */
-			first: { type: Boolean, reflect: true }, // set by d2l-menu
-			/**
+		first: { type: Boolean, reflect: true }, // set by d2l-menu
+		/**
 			 * @ignore
 			 */
-			hasChildView: { type: Boolean },
-			/**
+		hasChildView: { type: Boolean },
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			hidden: { type: Boolean, reflect: true },
-			/**
+		// eslint-disable-next-line lit/no-native-attributes
+		hidden: { type: Boolean, reflect: true },
+		/**
 			 * @ignore
 			 */
-			last: { type: String, reflect: true }, // set by d2l-menu
-			/**
+		last: { type: String, reflect: true }, // set by d2l-menu
+		/**
 			 * The number of lines to display before truncating text with an ellipsis. Defaults to 2.
 			 * @type {number}
 			 */
-			lines: { type: Number },
-			/**
+		lines: { type: Number },
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
-			/**
+		// eslint-disable-next-line lit/no-native-attributes
+		role: { type: String, reflect: true },
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			tabindex: { type: String, reflect: true },
-			/**
+		// eslint-disable-next-line lit/no-native-attributes
+		tabindex: { type: String, reflect: true },
+		/**
 			 * REQUIRED: Text displayed by the menu item
 			 * @type {string}
 			 */
-			text: { type: String, required: true },
-			/**
+		text: { type: String, required: true },
+		/**
 			 * ACCESSIBILITY: A description of the menu item that will be used by screen readers for additional context
 			 * @type {string}
 			 */
-			description: { type: String },
-			_ariaDisabled: { type: String, attribute: 'aria-disabled', reflect: true },
-			_ariaLabel: { type: String, attribute: 'aria-label', reflect: true },
-			_letClickPropagate: { state: true }
-		};
-	}
+		description: { type: String },
+		_ariaDisabled: { type: String, attribute: 'aria-disabled', reflect: true },
+		_ariaLabel: { type: String, attribute: 'aria-label', reflect: true },
+		_letClickPropagate: { state: true }
+	};
 
 	constructor() {
 		super();

--- a/components/menu/menu-item-radio.js
+++ b/components/menu/menu-item-radio.js
@@ -9,9 +9,7 @@ import { menuItemSelectableStyles } from './menu-item-selectable-styles.js';
  */
 export class MenuItemRadio extends MenuItemRadioMixin(LitElement) {
 
-	static get styles() {
-		return menuItemSelectableStyles;
-	}
+	static styles = menuItemSelectableStyles;
 
 	render() {
 		return html`

--- a/components/menu/menu-item-return.js
+++ b/components/menu/menu-item-return.js
@@ -7,9 +7,8 @@ import { overflowEllipsisDeclarations } from '../../helpers/overflow.js';
 
 class MenuItemReturn extends LocalizeCoreElement(MenuItemMixin(LitElement)) {
 
-	static get styles() {
-		return [ menuItemStyles,
-			css`
+	static styles = [ menuItemStyles,
+		css`
 				:host {
 					display: flex;
 					padding: 0.75rem 1rem;
@@ -27,8 +26,7 @@ class MenuItemReturn extends LocalizeCoreElement(MenuItemMixin(LitElement)) {
 					margin-top: 0.1rem;
 				}
 			`
-		];
-	}
+	];
 
 	constructor() {
 		super();

--- a/components/menu/menu-item-selectable-mixin.js
+++ b/components/menu/menu-item-selectable-mixin.js
@@ -2,20 +2,18 @@ import { MenuItemMixin } from './menu-item-mixin.js';
 
 export const MenuItemSelectableMixin = superclass => class extends MenuItemMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * This will set the item to be selected by default
 			 * @type {boolean}
 			 */
-			selected: { type: Boolean, reflect: true },
-			/**
+		selected: { type: Boolean, reflect: true },
+		/**
 			 * REQUIRED: The selectable item's value
 			 * @type {string}
 			 */
-			value: { type: String }
-		};
-	}
+		value: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/menu/menu-item-separator.js
+++ b/components/menu/menu-item-separator.js
@@ -5,17 +5,15 @@ import { css, LitElement } from 'lit';
  */
 class MenuItemSeparator extends LitElement {
 
-	static get styles() {
-		return css`
-			:host {
-				border-top: 1px solid var(--d2l-menu-separator-color);
-				display: block;
-				margin-top: -1px;
-				position: relative;
-				z-index: 1;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			border-top: 1px solid var(--d2l-menu-separator-color);
+			display: block;
+			margin-top: -1px;
+			position: relative;
+			z-index: 1;
+		}
+	`;
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);

--- a/components/menu/menu-item.js
+++ b/components/menu/menu-item.js
@@ -10,9 +10,8 @@ import { menuItemStyles } from './menu-item-styles.js';
  */
 class MenuItem extends MenuItemMixin(LitElement) {
 
-	static get styles() {
-		return [ menuItemStyles,
-			css`
+	static styles = [ menuItemStyles,
+		css`
 				:host {
 					align-items: center;
 					display: flex;
@@ -23,8 +22,7 @@ class MenuItem extends MenuItemMixin(LitElement) {
 					margin-inline-start: 6px;
 				}
 			`
-		];
-	}
+	];
 
 	render() {
 		const icon = this.hasChildView ?

--- a/components/menu/menu.js
+++ b/components/menu/menu.js
@@ -23,62 +23,58 @@ const keyCodes = {
  */
 class Menu extends PropertyRequiredMixin(ThemeMixin(HierarchicalViewMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			active: { type: Boolean, reflect: true },
-			/**
+		active: { type: Boolean, reflect: true },
+		/**
 			 * ACCESSIBILITY: Acts as the primary label for the menu (REQUIRED for root menu)
 			 * @type {string}
 			 */
-			label: { type: String, required: true },
-			/**
+		label: { type: String, required: true },
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, attribute: 'role' }
-		};
-	}
+		// eslint-disable-next-line lit/no-native-attributes
+		role: { type: String, attribute: 'role' }
+	};
 
-	static get styles() {
-		return [ super.styles, css`
-			:host {
-				--d2l-menu-background-color: var(--d2l-theme-background-color-base);
-				--d2l-menu-background-color-hover: var(--d2l-theme-brand-color-highlight);
-				--d2l-menu-border-color: var(--d2l-theme-border-color-subtle);
-				--d2l-menu-border-color-hover: var(--d2l-theme-border-color-focus);
-				--d2l-menu-foreground-color: var(--d2l-theme-text-color-static-standard);
-				--d2l-menu-foreground-color-hover: var(--d2l-theme-brand-color-primary-hover);
-				--d2l-menu-separator-color: var(--d2l-theme-border-color-emphasized);
-				box-sizing: border-box;
-				display: block;
-				min-width: 180px;
-				padding-top: 1px;
-				width: 100%;
-			}
+	static styles = [ super.styles, css`
+		:host {
+			--d2l-menu-background-color: var(--d2l-theme-background-color-base);
+			--d2l-menu-background-color-hover: var(--d2l-theme-brand-color-highlight);
+			--d2l-menu-border-color: var(--d2l-theme-border-color-subtle);
+			--d2l-menu-border-color-hover: var(--d2l-theme-border-color-focus);
+			--d2l-menu-foreground-color: var(--d2l-theme-text-color-static-standard);
+			--d2l-menu-foreground-color-hover: var(--d2l-theme-brand-color-primary-hover);
+			--d2l-menu-separator-color: var(--d2l-theme-border-color-emphasized);
+			box-sizing: border-box;
+			display: block;
+			min-width: 180px;
+			padding-top: 1px;
+			width: 100%;
+		}
 
-			:host([active]) .d2l-menu-items d2l-menu-item-return[role="menuitem"],
-			:host([active]) .d2l-menu-items ::slotted([role="menuitem"]),
-			:host([active]) .d2l-menu-items ::slotted([role="menuitemcheckbox"]),
-			:host([active]) .d2l-menu-items ::slotted([role="menuitemradio"]) {
-				position: relative;
-			}
+		:host([active]) .d2l-menu-items d2l-menu-item-return[role="menuitem"],
+		:host([active]) .d2l-menu-items ::slotted([role="menuitem"]),
+		:host([active]) .d2l-menu-items ::slotted([role="menuitemcheckbox"]),
+		:host([active]) .d2l-menu-items ::slotted([role="menuitemradio"]) {
+			position: relative;
+		}
 
-			:host([theme="dark"]) {
-				--d2l-menu-background-color: #333536; /* tungsten @ 70% */
-				--d2l-menu-background-color-hover: #123559; /* celestine-1 @ 50% */
-				--d2l-menu-border-color: var(--d2l-color-tungsten);
-				--d2l-menu-border-color-hover: #ffffff;
-				--d2l-menu-foreground-color: var(--d2l-color-sylvite);
-				--d2l-menu-foreground-color-hover: #ffffff;
-				--d2l-menu-separator-color: var(--d2l-color-galena);
-				--d2l-icon-fill-color: var(--d2l-color-mica);
-				background-color: var(--d2l-menu-background-color); /* so that opacity on disabled items works */
-			}
-		`];
-	}
+		:host([theme="dark"]) {
+			--d2l-menu-background-color: #333536; /* tungsten @ 70% */
+			--d2l-menu-background-color-hover: #123559; /* celestine-1 @ 50% */
+			--d2l-menu-border-color: var(--d2l-color-tungsten);
+			--d2l-menu-border-color-hover: #ffffff;
+			--d2l-menu-foreground-color: var(--d2l-color-sylvite);
+			--d2l-menu-foreground-color-hover: #ffffff;
+			--d2l-menu-separator-color: var(--d2l-color-galena);
+			--d2l-icon-fill-color: var(--d2l-color-mica);
+			background-color: var(--d2l-menu-background-color); /* so that opacity on disabled items works */
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/menu/test/custom-view.js
+++ b/components/menu/test/custom-view.js
@@ -4,32 +4,30 @@ import { HierarchicalViewMixin } from '../../hierarchical-view/hierarchical-view
 
 class CustomView extends HierarchicalViewMixin(LitElement) {
 
-	static get styles() {
-		return [ super.styles,
-			css`
-				:host {
-					background-color: orange;
-					border: 1px solid black;
-					border-radius: 0.3rem;
-					box-sizing: border-box;
-					color: white;
-					font-size: 1.5rem;
-				}
-				:host .d2l-hierarchical-view-content {
-					min-height: 100px;
-					padding: 1rem;
-				}
-				:host .d2l-custom-view-back-container {
-					margin-top: 1rem;
-				}
-				:host a {
-					color: var(--d2l-color-ferrite);
-					font-size: 0.7rem;
-					outline: none;
-				}
-			`
-		];
-	}
+	static styles = [ super.styles,
+		css`
+			:host {
+				background-color: orange;
+				border: 1px solid black;
+				border-radius: 0.3rem;
+				box-sizing: border-box;
+				color: white;
+				font-size: 1.5rem;
+			}
+			:host .d2l-hierarchical-view-content {
+				min-height: 100px;
+				padding: 1rem;
+			}
+			:host .d2l-custom-view-back-container {
+				margin-top: 1rem;
+			}
+			:host a {
+				color: var(--d2l-color-ferrite);
+				font-size: 0.7rem;
+				outline: none;
+			}
+		`
+	];
 
 	firstUpdated() {
 		super.firstUpdated();

--- a/components/menu/test/menu.test.js
+++ b/components/menu/test/menu.test.js
@@ -277,11 +277,9 @@ describe('d2l-menu', () => {
 		let makeReady;
 		const delayedUpdateMenuItem = defineCE(
 			class extends MenuItemMixin(LitElement) {
-				static get properties() {
-					return {
-						_ready: { type: Boolean, state: true }
-					};
-				}
+				static properties = {
+					_ready: { type: Boolean, state: true }
+				};
 				constructor() {
 					super();
 					this._ready = false;

--- a/components/meter/meter-circle.js
+++ b/components/meter/meter-circle.js
@@ -9,24 +9,22 @@ import { meterStyles } from './meter-styles.js';
  * A circular progress indicator.
  */
 class MeterCircle extends MeterMixin(LitElement) {
-	static get styles() {
-		return [ bodySmallStyles, bodyStandardStyles, meterStyles, css`
-		:host {
-			display: inline-block;
-			width: 2.4rem;
-		}
-		.d2l-meter-full-bar,
-		.d2l-meter-progress-bar {
-			stroke-width: 6;
-		}
-		.d2l-meter-full-bar {
-			fill: var(--d2l-meter-circle-fill, none);
-		}
-		.d2l-meter-circle-text {
-			font-size: 0.55rem;
-		}
-	` ];
+	static styles = [ bodySmallStyles, bodyStandardStyles, meterStyles, css`
+	:host {
+		display: inline-block;
+		width: 2.4rem;
 	}
+	.d2l-meter-full-bar,
+	.d2l-meter-progress-bar {
+		stroke-width: 6;
+	}
+	.d2l-meter-full-bar {
+		fill: var(--d2l-meter-circle-fill, none);
+	}
+	.d2l-meter-circle-text {
+		font-size: 0.55rem;
+	}
+	` ];
 
 	render() {
 		const lengthOfLine = 21 * Math.PI * 2; // approximation perimeter of circle

--- a/components/meter/meter-linear.js
+++ b/components/meter/meter-linear.js
@@ -7,94 +7,90 @@ import { MeterMixin } from './meter-mixin.js';
  * A horizontal progress bar.
  */
 class MeterLinear extends MeterMixin(LitElement) {
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Keeps the meter to a single line
 			 * @type {boolean}
 			 */
-			textInline: { type: Boolean, attribute: 'text-inline', reflect: true },
-			/**
+		textInline: { type: Boolean, attribute: 'text-inline', reflect: true },
+		/**
 			 * Force text to be aligned to the end of the meter
 			 * @type {boolean}
 			 */
-			textAlignEnd: { type: Boolean, attribute: 'text-align-end', reflect: true }
-		};
-	}
-	static get styles() {
-		return [bodySmallStyles, css`
-			:host {
-				display: block;
-				position: relative;
-			}
+		textAlignEnd: { type: Boolean, attribute: 'text-align-end', reflect: true }
+	};
+	static styles = [bodySmallStyles, css`
+		:host {
+			display: block;
+			position: relative;
+		}
 
-			:host > div {
-				display: flex;
-				flex-direction: column;
-				gap: 0.45rem;
-			}
+		:host > div {
+			display: flex;
+			flex-direction: column;
+			gap: 0.45rem;
+		}
 
-			:host([text-inline]) > div {
-				align-items: center;
-				flex-direction: row;
-			}
+		:host([text-inline]) > div {
+			align-items: center;
+			flex-direction: row;
+		}
 
-			.d2l-meter-linear-full-bar,
-			.d2l-meter-linear-inner-bar {
-				border-radius: 0.225rem;
-				flex-grow: 1;
-				flex-shrink: 1;
-				height: 0.45rem;
-			}
+		.d2l-meter-linear-full-bar,
+		.d2l-meter-linear-inner-bar {
+			border-radius: 0.225rem;
+			flex-grow: 1;
+			flex-shrink: 1;
+			height: 0.45rem;
+		}
 
-			.d2l-meter-linear-full-bar {
-				background-color: var(--d2l-color-gypsum);
-				position: relative;
-			}
+		.d2l-meter-linear-full-bar {
+			background-color: var(--d2l-color-gypsum);
+			position: relative;
+		}
 
-			:host([foreground-light]) .d2l-meter-linear-full-bar {
-				background-color: rgba(255, 255, 255, 0.5);
-			}
+		:host([foreground-light]) .d2l-meter-linear-full-bar {
+			background-color: rgba(255, 255, 255, 0.5);
+		}
 
-			.d2l-meter-linear-inner-bar {
-				background-color: var(--d2l-color-celestine);
-				inset-inline-start: 0;
-				max-width: 100%;
-				position: absolute;
-				top: 0;
-			}
-			:host([foreground-light]) .d2l-meter-linear-inner-bar {
-				background-color: white;
-			}
+		.d2l-meter-linear-inner-bar {
+			background-color: var(--d2l-color-celestine);
+			inset-inline-start: 0;
+			max-width: 100%;
+			position: absolute;
+			top: 0;
+		}
+		:host([foreground-light]) .d2l-meter-linear-inner-bar {
+			background-color: white;
+		}
 
-			.d2l-meter-linear-text {
-				color: var(--d2l-color-ferrite);
-				display: flex;
-				flex-direction: row;
-				gap: 0.45rem;
-				line-height: 1em;
-				width: 100%;
-			}
-			:host([foreground-light]) .d2l-meter-linear-text {
-				color: white;
-			}
-			:host([text-inline]) .d2l-meter-linear-text {
-				width: auto;
-			}
+		.d2l-meter-linear-text {
+			color: var(--d2l-color-ferrite);
+			display: flex;
+			flex-direction: row;
+			gap: 0.45rem;
+			line-height: 1em;
+			width: 100%;
+		}
+		:host([foreground-light]) .d2l-meter-linear-text {
+			color: white;
+		}
+		:host([text-inline]) .d2l-meter-linear-text {
+			width: auto;
+		}
 
-			.d2l-meter-linear-text-space-between {
-				justify-content: space-between;
-			}
+		.d2l-meter-linear-text-space-between {
+			justify-content: space-between;
+		}
 
-			.d2l-meter-linear-secondary {
-				align-self: flex-end;
-			}
+		.d2l-meter-linear-secondary {
+			align-self: flex-end;
+		}
 
-			.d2l-meter-linear-primary-ltr {
-				direction: ltr;
-			}
-		`];
-	}
+		.d2l-meter-linear-primary-ltr {
+			direction: ltr;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/meter/meter-mixin.js
+++ b/components/meter/meter-mixin.js
@@ -3,42 +3,40 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 
 export const MeterMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Max number of units that are being measured by this meter.
 			 * Valid values: A number > 0
 			 * @type {number}
 			 */
-			max: { type: Number },
-			/**
+		max: { type: Number },
+		/**
 			 * Shows a percentage instead of "value/max"
 			 * @type {boolean}
 			 */
-			percent: { type: Boolean },
-			/**
+		percent: { type: Boolean },
+		/**
 			 * Rounding mode for percentage text values
 			 * @type {"round" | "ceil" | "floor"}
 			 */
-			percentRoundingMode: { type: String, attribute: 'percent-rounding-mode' },
-			/**
+		percentRoundingMode: { type: String, attribute: 'percent-rounding-mode' },
+		/**
 			 * Context information for the meter. If the text contains {%} or {x/y}, they will be replaced with a percentage or fraction respectively.
 			 * @type {string}
 			 */
-			text: { type: String },
-			/**
+		text: { type: String },
+		/**
 			 * Hides the text visually
 			 * @type {boolean}
 			 */
-			textHidden: { type: Boolean, attribute: 'text-hidden' },
-			/**
+		textHidden: { type: Boolean, attribute: 'text-hidden' },
+		/**
 			 * REQUIRED: Current number of completed units.
 			 * Valid values: A number between 0 and max
 			 * @type {number}
 			 */
-			value: { type: Number }
-		};
-	}
+		value: { type: Number }
+	};
 
 	constructor() {
 		super();

--- a/components/meter/meter-radial.js
+++ b/components/meter/meter-radial.js
@@ -9,8 +9,7 @@ import { meterStyles } from './meter-styles.js';
  * A half-circle progress indicator.
  */
 class MeterRadial extends MeterMixin(LitElement) {
-	static get styles() {
-		return [ heading4Styles, bodySmallStyles, meterStyles, css`
+	static styles = [ heading4Styles, bodySmallStyles, meterStyles, css`
 		:host {
 			display: inline-block;
 			width: 4.2rem;
@@ -20,7 +19,6 @@ class MeterRadial extends MeterMixin(LitElement) {
 			stroke-width: 9;
 		}
 	` ];
-	}
 
 	render() {
 		const lengthOfLine = 115; // found by approximating half the perimeter of the ellipse with radii 38 and 35

--- a/components/more-less/demo/more-less-test.js
+++ b/components/more-less/demo/more-less-test.js
@@ -7,23 +7,19 @@ const text = {
 };
 
 class MoreLessTest extends LitElement {
-	static get properties() {
-		return {
-			text: { type: String },
-			margin: { type: Boolean, reflect: true },
-			extraItems: { type: Number }
-		};
-	}
-	static get styles() {
-		return css`
-			button:last-of-type {
-				margin-bottom: 2em;
-			}
-			:host([margin]) .hidden-div {
-				margin-bottom: 500px;
-			}
-		`;
-	}
+	static properties = {
+		text: { type: String },
+		margin: { type: Boolean, reflect: true },
+		extraItems: { type: Number }
+	};
+	static styles = css`
+		button:last-of-type {
+			margin-bottom: 2em;
+		}
+		:host([margin]) .hidden-div {
+			margin-bottom: 500px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/more-less/more-less.js
+++ b/components/more-less/more-less.js
@@ -17,71 +17,67 @@ const transitionDur = matchMedia('(prefers-reduced-motion: reduce)').matches ? 0
  */
 class MoreLess extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Indicates whether element is in "more" state
 			 * @type {boolean}
 			 */
-			expanded: { type: Boolean, reflect: true },
+		expanded: { type: Boolean, reflect: true },
 
-			/**
+		/**
 			 * Aligns the leading edge of more/less button text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
 			 * @type {'text'|'text-end'|''}
 			 */
-			hAlign: { type: String, attribute: 'h-align' },
+		hAlign: { type: String, attribute: 'h-align' },
 
-			/**
+		/**
 			 * The maximum height of the content when in "less" state
 			 * @type {string}
 			 */
-			height: { type: String },
+		height: { type: String },
 
-			/**
+		/**
 			 * Whether the component is active or inactive
 			 * @type {boolean}
 			 */
-			inactive: { type: Boolean, reflect: true },
-			__maxHeight: { state: true },
-			__transitionAdded: { state: true }
-		};
-	}
+		inactive: { type: Boolean, reflect: true },
+		__maxHeight: { state: true },
+		__transitionAdded: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: flow-root;
-			}
+	static styles = css`
+		:host {
+			display: flow-root;
+		}
 
-			.d2l-more-less-content {
-				display: flow-root;
-				margin: -1em -1em 0;
-				padding: 1em 1em 0;
-				${overflowHiddenDeclarations}
-			}
+		.d2l-more-less-content {
+			display: flow-root;
+			margin: -1em -1em 0;
+			padding: 1em 1em 0;
+			${overflowHiddenDeclarations}
+		}
+		.d2l-more-less-transition {
+			transition: max-height ${transitionDur}ms cubic-bezier(0, 0.7, 0.5, 1);
+		}
+		:host(:not([expanded]):not([inactive])) .d2l-more-less-content {
+			-webkit-mask-image: linear-gradient(to top, transparent, #000000 1em);
+			mask-image: linear-gradient(to top, transparent, #000000 1em);
+		}
+		:host([inactive]) .d2l-more-less-toggle {
+			display: none;
+		}
+
+		.force-margin-scroll {
+			height: 1px;
+			margin-top: -1px;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
 			.d2l-more-less-transition {
-				transition: max-height ${transitionDur}ms cubic-bezier(0, 0.7, 0.5, 1);
+				transition: none;
 			}
-			:host(:not([expanded]):not([inactive])) .d2l-more-less-content {
-				-webkit-mask-image: linear-gradient(to top, transparent, #000000 1em);
-				mask-image: linear-gradient(to top, transparent, #000000 1em);
-			}
-			:host([inactive]) .d2l-more-less-toggle {
-				display: none;
-			}
-
-			.force-margin-scroll {
-				height: 1px;
-				margin-top: -1px;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				.d2l-more-less-transition {
-					transition: none;
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/object-property-list/object-property-list-item-link.js
+++ b/components/object-property-list/object-property-list-item-link.js
@@ -9,25 +9,23 @@ import { ObjectPropertyListItem } from './object-property-list-item.js';
  * rendered as a link and with an optional icon.
  */
 class ObjectPropertyListItemLink extends FocusMixin(ObjectPropertyListItem) {
-	static get properties() {
-		return {
-			/**
-			 * Download a URL instead of navigating to it
-			 * @type {boolean}
-			 */
-			download: { type: Boolean },
-			/**
-			 * REQUIRED: URL or URL fragment of the link
-			 * @type {string}
-			 */
-			href: { type: String },
-			/**
-			 * Where to display the linked URL
-			 * @type {string}
-			 */
-			target: { type: String },
-		};
-	}
+	static properties = {
+		/**
+		 * Download a URL instead of navigating to it
+		 * @type {boolean}
+		 */
+		download: { type: Boolean },
+		/**
+		 * REQUIRED: URL or URL fragment of the link
+		 * @type {string}
+		 */
+		href: { type: String },
+		/**
+		 * Where to display the linked URL
+		 * @type {string}
+		 */
+		target: { type: String },
+	};
 
 	static get focusElementSelector() {
 		return 'd2l-link';

--- a/components/object-property-list/object-property-list-item-tooltip-help.js
+++ b/components/object-property-list/object-property-list-item-tooltip-help.js
@@ -11,15 +11,13 @@ import { ObjectPropertyListItem } from './object-property-list-item.js';
  * @slot icon - Optional slot for a custom icon
  */
 class ObjectPropertyListItemTooltipHelp extends FocusMixin(ObjectPropertyListItem) {
-	static get properties() {
-		return {
-			/**
-			 * Preset icon key (e.g. "tier1:gear")
-			 * @type {string}
-			 */
-			icon: { type: String, reflect: true, },
-		};
-	}
+	static properties = {
+		/**
+		 * Preset icon key (e.g. "tier1:gear")
+		 * @type {string}
+		 */
+		icon: { type: String, reflect: true, },
+	};
 
 	static get focusElementSelector() {
 		return 'd2l-tooltip-help';

--- a/components/object-property-list/object-property-list-item.js
+++ b/components/object-property-list/object-property-list-item.js
@@ -9,62 +9,58 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  * with an optional icon.
  */
 export class ObjectPropertyListItem extends SkeletonMixin(LitElement) {
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			hidden: { type: Boolean },
-			/**
+		// eslint-disable-next-line lit/no-native-attributes
+		hidden: { type: Boolean },
+		/**
 			 * Name of an optional icon to display
 			 * @type {string}
 			 */
-			icon: { type: String },
-			/**
+		icon: { type: String },
+		/**
 			 * REQUIRED: Text to display on the item
 			 * @type {string}
 			 */
-			text: { type: String },
-			_showSeparator: { state: true },
-		};
-	}
+		text: { type: String },
+		_showSeparator: { state: true },
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				unicode-bidi: isolate;
-				vertical-align: middle;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-icon {
-				height: 1.2857em; /* 18px desired height at main font size (14px), but using em to scale properly at smaller breakpoint. */
-				width: 1.2857em;
-			}
-			.separator {
-				margin: 0 -0.05rem; /* 10px desired margin, subtract 5px arbitrary whitespace and 6px whitespace inside bullet icon. */
-			}
-			.separator d2l-icon {
-				color: var(--d2l-theme-text-color-static-faint);
-			}
-			.item-icon {
-				margin-inline-end: 0.05rem; /* 6px desired margin, subtract 5px arbitrary whitespace. */
-				margin-top: -0.1rem;
-			}
-			:host([skeleton]) d2l-icon {
-				color: var(--d2l-theme-background-color-interactive-faint-hover);
-			}
-			:host([skeleton]) .d2l-skeletize {
-				display: inline-block;
-				max-width: 80%;
-				overflow: hidden;
-				vertical-align: middle;
-				white-space: nowrap;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			unicode-bidi: isolate;
+			vertical-align: middle;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-icon {
+			height: 1.2857em; /* 18px desired height at main font size (14px), but using em to scale properly at smaller breakpoint. */
+			width: 1.2857em;
+		}
+		.separator {
+			margin: 0 -0.05rem; /* 10px desired margin, subtract 5px arbitrary whitespace and 6px whitespace inside bullet icon. */
+		}
+		.separator d2l-icon {
+			color: var(--d2l-theme-text-color-static-faint);
+		}
+		.item-icon {
+			margin-inline-end: 0.05rem; /* 6px desired margin, subtract 5px arbitrary whitespace. */
+			margin-top: -0.1rem;
+		}
+		:host([skeleton]) d2l-icon {
+			color: var(--d2l-theme-background-color-interactive-faint-hover);
+		}
+		:host([skeleton]) .d2l-skeletize {
+			display: inline-block;
+			max-width: 80%;
+			overflow: hidden;
+			vertical-align: middle;
+			white-space: nowrap;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/object-property-list/object-property-list.js
+++ b/components/object-property-list/object-property-list.js
@@ -11,34 +11,30 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  * @slot status - Slot for a single `d2l-status-indicator` to be rendered before the list
  */
 class ObjectPropertyList extends LocalizeCoreElement(SkeletonMixin(LitElement)) {
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Number of skeleton items to insert
 			 * @type {number}
 			 */
-			skeletonCount: { type: Number, attribute: 'skeleton-count' },
-		};
-	}
+		skeletonCount: { type: Number, attribute: 'skeleton-count' },
+	};
 
-	static get styles() {
-		return [super.styles, bodySmallStyles, css`
-			:host {
-				display: block;
-				overflow-wrap: anywhere;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			::slotted([slot="status"]) {
-				display: none;
-			}
-			::slotted(d2l-status-indicator[slot="status"]:first-of-type) {
-				display: inline-block;
-				margin-inline-end: 0.25rem; /* 10px desired margin, subtract 5px arbitrary whitespace. */
-			}
-		`];
-	}
+	static styles = [super.styles, bodySmallStyles, css`
+		:host {
+			display: block;
+			overflow-wrap: anywhere;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		::slotted([slot="status"]) {
+			display: none;
+		}
+		::slotted(d2l-status-indicator[slot="status"]:first-of-type) {
+			display: inline-block;
+			margin-inline-end: 0.25rem; /* 10px desired margin, subtract 5px arbitrary whitespace. */
+		}
+	`];
 
 	firstUpdated() {
 		this.addEventListener('d2l-object-property-list-item-visibility-change', () => this._onItemsChanged());

--- a/components/offscreen/README.md
+++ b/components/offscreen/README.md
@@ -34,7 +34,7 @@ import { offscreenStyles } from './offscreen.js';
 
 class MyElement extends LitElement {
 
-  static get styles() { return [ offscreenStyles ] }
+  static styles = [ offscreenStyles ];
 
   render() {
     return html`

--- a/components/offscreen/demo/offscreen-demo.js
+++ b/components/offscreen/demo/offscreen-demo.js
@@ -3,9 +3,7 @@ import { offscreenStyles } from '../offscreen.js';
 
 class OffscreenDemo extends LitElement {
 
-	static get styles() {
-		return offscreenStyles;
-	}
+	static styles = offscreenStyles;
 
 	render() {
 		return html`<span class="d2l-offscreen">This message will only be visible to assistive technology, such as a screen reader.</span>`;

--- a/components/offscreen/offscreen.js
+++ b/components/offscreen/offscreen.js
@@ -28,13 +28,11 @@ export const offscreenStyles = css`
  * @slot - Default content placed inside of the component
  */
 class Offscreen extends LitElement {
-	static get styles() {
-		return css`
+	static styles = css`
 			:host {
 				${_offscreenStyleDeclarations}
 			}
 		`;
-	}
 	render() {
 		return html`<slot></slot>`;
 	}

--- a/components/offscreen/screen-reader-pause.js
+++ b/components/offscreen/screen-reader-pause.js
@@ -3,9 +3,7 @@ import { getSeparator } from '@brightspace-ui/intl/lib/list.js';
 import { offscreenStyles } from './offscreen.js';
 
 export class ScreenReaderPause extends LitElement {
-	static get styles() {
-		return offscreenStyles;
-	}
+	static styles = offscreenStyles;
 
 	render() {
 		return html`<span class="d2l-offscreen">${getSeparator({ nonBreaking: true })}</span>`;

--- a/components/overflow-group/README.md
+++ b/components/overflow-group/README.md
@@ -102,9 +102,7 @@ class OtherOverflowGroup extends OverflowGroupMixin(LitElement) {
 **Styles:**
 
 ```javascript
-static get styles() {
-  return [ super.styles ];
-}
+static styles = [ super.styles ];
 ```
 
 **Functionality:**

--- a/components/overflow-group/overflow-group-mixin.js
+++ b/components/overflow-group/overflow-group-mixin.js
@@ -24,65 +24,61 @@ async function filterAsync(arr, callback) {
 
 export const OverflowGroupMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			autoShow: {
-				type: Boolean,
-				attribute: 'auto-show',
-			},
-			/**
-			 * minimum amount of slotted items to show
-			 * @type {number}
-			 */
-			minToShow: {
-				type: Number,
-				reflect: true,
-				attribute: 'min-to-show',
-			},
-			/**
-			 * maximum amount of slotted items to show
-			 * @type {number}
-			 */
-			maxToShow: {
-				type: Number,
-				reflect: true,
-				attribute: 'max-to-show',
-			},
-			/**
-			 * @ignore
-			 */
-			openerType: {
-				type: String,
-				attribute: 'opener-type'
-			},
-			_chompIndex: { state: true },
-			_itemGap: { state: true },
-			_mini: { state: true },
-			_wrapping: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		autoShow: {
+			type: Boolean,
+			attribute: 'auto-show',
+		},
+		/**
+		 * minimum amount of slotted items to show
+		 * @type {number}
+		 */
+		minToShow: {
+			type: Number,
+			reflect: true,
+			attribute: 'min-to-show',
+		},
+		/**
+		 * maximum amount of slotted items to show
+		 * @type {number}
+		 */
+		maxToShow: {
+			type: Number,
+			reflect: true,
+			attribute: 'max-to-show',
+		},
+		/**
+		 * @ignore
+		 */
+		openerType: {
+			type: String,
+			attribute: 'opener-type'
+		},
+		_chompIndex: { state: true },
+		_itemGap: { state: true },
+		_mini: { state: true },
+		_wrapping: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-overflow-group-container {
-				align-items: var(--d2l-overflow-group-align-items, normal);
-				display: flex;
-				justify-content: var(--d2l-overflow-group-justify-content, normal);
-			}
-			.d2l-overflow-group-container ::slotted([data-is-chomped]) {
-				display: none !important;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-overflow-group-container {
+			align-items: var(--d2l-overflow-group-align-items, normal);
+			display: flex;
+			justify-content: var(--d2l-overflow-group-justify-content, normal);
+		}
+		.d2l-overflow-group-container ::slotted([data-is-chomped]) {
+			display: none !important;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/overflow-group/overflow-group.js
+++ b/components/overflow-group/overflow-group.js
@@ -69,49 +69,45 @@ function createMenuItemSeparator() {
 */
 class OverflowGroup extends OverflowGroupMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Setting this property will change the style of the overflow menu opener
 			 * @type {'default'|'subtle'}
 			 * @default "default"
 			 */
-			openerStyle: {
-				type: String,
-				reflect: true,
-				attribute: 'opener-style',
-			}
-		};
-	}
+		openerStyle: {
+			type: String,
+			reflect: true,
+			attribute: 'opener-style',
+		}
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host([opener-style="subtle"]) {
-				--d2l-button-icon-fill-color: var(--d2l-theme-text-color-interactive-default);
-				--d2l-button-icon-fill-color-hover: var(--d2l-theme-text-color-interactive-hover);
-			}
+	static styles = [super.styles, css`
+		:host([opener-style="subtle"]) {
+			--d2l-button-icon-fill-color: var(--d2l-theme-text-color-interactive-default);
+			--d2l-button-icon-fill-color-hover: var(--d2l-theme-text-color-interactive-hover);
+		}
 
-			::slotted(d2l-button),
-			::slotted(d2l-link),
-			::slotted(span),
-			::slotted(d2l-dropdown:not(.d2l-overflow-dropdown)),
-			::slotted(d2l-dropdown-button) {
-				margin-inline-end: 0.6rem;
-			}
-			::slotted(d2l-button-subtle),
-			::slotted(d2l-button-icon),
-			::slotted(d2l-dropdown-button-subtle),
-			::slotted(d2l-dropdown-more),
-			::slotted(d2l-dropdown-context-menu),
-			::slotted(d2l-selection-action),
-			::slotted(d2l-selection-action-dropdown) {
-				margin-inline-end: 0.2rem;
-			}
-			::slotted(*:last-child) {
-				margin-inline-end: 0;
-			}
-		`];
-	}
+		::slotted(d2l-button),
+		::slotted(d2l-link),
+		::slotted(span),
+		::slotted(d2l-dropdown:not(.d2l-overflow-dropdown)),
+		::slotted(d2l-dropdown-button) {
+			margin-inline-end: 0.6rem;
+		}
+		::slotted(d2l-button-subtle),
+		::slotted(d2l-button-icon),
+		::slotted(d2l-dropdown-button-subtle),
+		::slotted(d2l-dropdown-more),
+		::slotted(d2l-dropdown-context-menu),
+		::slotted(d2l-selection-action),
+		::slotted(d2l-selection-action-dropdown) {
+			margin-inline-end: 0.2rem;
+		}
+		::slotted(*:last-child) {
+			margin-inline-end: 0;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/page/page-header-button.js
+++ b/components/page/page-header-button.js
@@ -12,52 +12,48 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  */
 class PageHeaderButton extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables the button
 			 * @type {boolean}
 			 */
-			disabled: { reflect: true, type: Boolean },
-			/**
+		disabled: { reflect: true, type: Boolean },
+		/**
 			 * REQUIRED: Preset icon key (e.g. "tier1:gear")
 			 * @type {string}
 			 */
-			icon: { type: String },
-			/**
+		icon: { type: String },
+		/**
 			 * Position of the icon.
 			 * @type {'start'|'end'}
 			 */
-			iconPosition: { attribute: 'icon-position', type: String },
-			/**
+		iconPosition: { attribute: 'icon-position', type: String },
+		/**
 			 * REQUIRED: Text for the button
 			 * @type {string}
 			 */
-			text: { type: String },
-			/**
+		text: { type: String },
+		/**
 			 * Visually hides the text but still accessible
 			 * @type {boolean}
 			 */
-			textHidden: { attribute: 'text-hidden', type: Boolean },
-			/**
+		textHidden: { attribute: 'text-hidden', type: Boolean },
+		/**
 			 * Offset of the tooltip
 			 * @type {Number}
 			 */
-			tooltipOffset: { attribute: 'tooltip-offset', type: Number },
-		};
-	}
+		tooltipOffset: { attribute: 'tooltip-offset', type: Number },
+	};
 
-	static get styles() {
-		return [highlightBorderStyles, highlightButtonStyles, css`
-			:host {
-				display: inline-block;
-				height: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`];
-	}
+	static styles = [highlightBorderStyles, highlightButtonStyles, css`
+		:host {
+			display: inline-block;
+			height: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/page/page-header-custom.js
+++ b/components/page/page-header-custom.js
@@ -16,125 +16,121 @@ const customScroll = isWindows && !isMobile;
  */
 class PageHeaderCustom extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * When set, the bottom slot will be a "d2l-visible-on-ancestor-target"
 			 * @type {boolean}
 			 */
-			bottomIsVisibleOnAncestorTarget: { type: Boolean, attribute: 'bottom-is-visible-on-ancestor-target' },
-			/**
+		bottomIsVisibleOnAncestorTarget: { type: Boolean, attribute: 'bottom-is-visible-on-ancestor-target' },
+		/**
 			 * Whether to render a skip nav link
 			 * @type {boolean}
 			 */
-			hasSkipNav: { type: Boolean, attribute: 'has-skip-nav', reflect: true },
-			_hasBottom: { state: true }
-		};
-	}
+		hasSkipNav: { type: Boolean, attribute: 'has-skip-nav', reflect: true },
+		_hasBottom: { state: true }
+	};
 
-	static get styles() {
-		return [css`
-			:host {
-				background-color: white;
-				display: block;
-				position: relative;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.band {
-				background: linear-gradient(180deg, var(--d2l-branding-primary-color, var(--d2l-color-celestine)) 1.5rem, #ffffff 0%);
-				line-height: 0;
-				min-height: 4px;
-				position: relative; /* Needed for Firefox */
-			}
-			.band .padding {
-				display: inline-block;
-				position: unset;
-				vertical-align: top;
-			}
+	static styles = [css`
+		:host {
+			background-color: white;
+			display: block;
+			position: relative;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.band {
+			background: linear-gradient(180deg, var(--d2l-branding-primary-color, var(--d2l-color-celestine)) 1.5rem, #ffffff 0%);
+			line-height: 0;
+			min-height: 4px;
+			position: relative; /* Needed for Firefox */
+		}
+		.band .padding {
+			display: inline-block;
+			position: unset;
+			vertical-align: top;
+		}
+		.band-scroll {
+			overflow-x: auto;
+			overflow-y: hidden;
+			scroll-behavior: smooth;
+		}
+		@media (prefers-reduced-motion: reduce) {
 			.band-scroll {
-				overflow-x: auto;
-				overflow-y: hidden;
-				scroll-behavior: smooth;
+				scroll-behavior: auto;
 			}
-			@media (prefers-reduced-motion: reduce) {
-				.band-scroll {
-					scroll-behavior: auto;
-				}
-			}
-			.band-scroll[data-custom-scroll] {
-				/* Firefox Styles */
-				scrollbar-color: var(--d2l-color-galena) var(--d2l-color-sylvite);
-				scrollbar-width: thin;
-			}
-			/* Webkit Styles */
-			.band-scroll[data-custom-scroll]::-webkit-scrollbar {
-				background-color: var(--d2l-color-sylvite);
-				border-radius: 8px;
-				height: 9px;
-			}
-			.band-scroll[data-custom-scroll]::-webkit-scrollbar-thumb {
-				background-color: var(--d2l-color-galena);
-				border-bottom: 1px solid var(--d2l-color-sylvite);
-				border-radius: 8px;
-				border-top: 1px solid var(--d2l-color-sylvite);
-			}
-			/* Faded edges styles */
+		}
+		.band-scroll[data-custom-scroll] {
+			/* Firefox Styles */
+			scrollbar-color: var(--d2l-color-galena) var(--d2l-color-sylvite);
+			scrollbar-width: thin;
+		}
+		/* Webkit Styles */
+		.band-scroll[data-custom-scroll]::-webkit-scrollbar {
+			background-color: var(--d2l-color-sylvite);
+			border-radius: 8px;
+			height: 9px;
+		}
+		.band-scroll[data-custom-scroll]::-webkit-scrollbar-thumb {
+			background-color: var(--d2l-color-galena);
+			border-bottom: 1px solid var(--d2l-color-sylvite);
+			border-radius: 8px;
+			border-top: 1px solid var(--d2l-color-sylvite);
+		}
+		/* Faded edges styles */
+		.band-scroll-before,
+		.band-scroll-after {
+			height: 100%;
+			max-height: 1.5rem; /* should match linear-background height */
+			pointer-events: none;
+			position: absolute;
+			top: 0;
+			width: var(--d2l-page-padding, 30px);
+			z-index: 2;
+		}
+		.band-scroll-before {
+			background: linear-gradient(to right, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
+			left: 0;
+		}
+		.band-scroll-after {
+			background: linear-gradient(to left, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
+			right: 0;
+		}
+		@media (max-width: 615px) {
 			.band-scroll-before,
 			.band-scroll-after {
-				height: 100%;
-				max-height: 1.5rem; /* should match linear-background height */
-				pointer-events: none;
-				position: absolute;
-				top: 0;
-				width: var(--d2l-page-padding, 30px);
-				z-index: 2;
+				width: 15px;
 			}
-			.band-scroll-before {
-				background: linear-gradient(to right, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
-				left: 0;
-			}
+		}
+		@media (min-width: 1230px) {
+			.band-scroll-before,
 			.band-scroll-after {
-				background: linear-gradient(to left, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
-				right: 0;
+				width: 30px;
 			}
-			@media (max-width: 615px) {
-				.band-scroll-before,
-				.band-scroll-after {
-					width: 15px;
-				}
-			}
-			@media (min-width: 1230px) {
-				.band-scroll-before,
-				.band-scroll-after {
-					width: 30px;
-				}
-			}
-			.bottom,
-			.top {
-				border-bottom: 1px solid rgba(124, 134, 149, 0.18);
-			}
-			.bottom {
-				background-color: var(--d2l-page-header-bottom-background-color, transparent);
-			}
-			.shadow {
-				background-color: rgba(0, 0, 0, 0.02);
-				bottom: -4px;
-				height: 4px;
-				pointer-events: none;
-				position: absolute;
-				width: 100%;
-			}
-			.max-width {
-				margin-inline: var(--d2l-page-margin-inline, auto);
-				max-width: var(--d2l-page-header-max-width, 1230px);
-			}
-			.padding {
-				padding-inline: var(--d2l-page-padding, 30px);
-			}
-		`];
-	}
+		}
+		.bottom,
+		.top {
+			border-bottom: 1px solid rgba(124, 134, 149, 0.18);
+		}
+		.bottom {
+			background-color: var(--d2l-page-header-bottom-background-color, transparent);
+		}
+		.shadow {
+			background-color: rgba(0, 0, 0, 0.02);
+			bottom: -4px;
+			height: 4px;
+			pointer-events: none;
+			position: absolute;
+			width: 100%;
+		}
+		.max-width {
+			margin-inline: var(--d2l-page-margin-inline, auto);
+			max-width: var(--d2l-page-header-max-width, 1230px);
+		}
+		.padding {
+			padding-inline: var(--d2l-page-padding, 30px);
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/page/page-header-immersive.js
+++ b/components/page/page-header-immersive.js
@@ -11,80 +11,76 @@ import { RequesterMixin } from '../../mixins/provider/provider-mixin.js';
 
 class PageHeaderImmersive extends RequesterMixin(LocalizeCoreElement(LitElement)) {
 
-	static get properties() {
-		return {
-			backHref: { attribute: 'back-href', type: String },
-			backCustomText: { attribute: 'back-custom-text', type: String },
-			titleText: { attribute: 'title-text', type: String },
-			subtitleText: { attribute: 'subtitle-text', type: String },
-			_error: { state: true },
-			_hasActions: { state: true }
-		};
-	}
+	static properties = {
+		backHref: { attribute: 'back-href', type: String },
+		backCustomText: { attribute: 'back-custom-text', type: String },
+		titleText: { attribute: 'title-text', type: String },
+		subtitleText: { attribute: 'subtitle-text', type: String },
+		_error: { state: true },
+		_hasActions: { state: true }
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, heading3Styles, labelStyles, highlightBorderStyles, highlightLinkStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]),
-			.actions[hidden] {
+	static styles = [bodyCompactStyles, heading3Styles, labelStyles, highlightBorderStyles, highlightLinkStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]),
+		.actions[hidden] {
+			display: none;
+		}
+		.container {
+			align-items: stretch;
+			display: flex;
+			gap: 24px;
+			height: 3.1rem;
+		}
+		.title {
+			flex: 0 1 auto;
+			min-width: 0;
+			width: 100%;
+		}
+		.back,
+		.actions {
+			flex: 0 0 auto;
+		}
+		.title,
+		.actions {
+			border-inline-start: 1px solid var(--d2l-color-gypsum);
+			padding-inline-start: 24px;
+		}
+		.title h1 {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			justify-content: center;
+			margin: 0;
+		}
+		.actions {
+			align-items: center;
+			display: flex;
+			gap: 0.6rem;
+		}
+		.title h1 .d2l-heading-3 {
+			margin: 0;
+		}
+		.back-text-short {
+			display: none;
+		}
+		@media (max-width: 615px) {
+			.back-text-long {
 				display: none;
-			}
-			.container {
-				align-items: stretch;
-				display: flex;
-				gap: 24px;
-				height: 3.1rem;
-			}
-			.title {
-				flex: 0 1 auto;
-				min-width: 0;
-				width: 100%;
-			}
-			.back,
-			.actions {
-				flex: 0 0 auto;
-			}
-			.title,
-			.actions {
-				border-inline-start: 1px solid var(--d2l-color-gypsum);
-				padding-inline-start: 24px;
-			}
-			.title h1 {
-				display: flex;
-				flex-direction: column;
-				height: 100%;
-				justify-content: center;
-				margin: 0;
-			}
-			.actions {
-				align-items: center;
-				display: flex;
-				gap: 0.6rem;
-			}
-			.title h1 .d2l-heading-3 {
-				margin: 0;
 			}
 			.back-text-short {
-				display: none;
+				display: inline;
 			}
-			@media (max-width: 615px) {
-				.back-text-long {
-					display: none;
-				}
-				.back-text-short {
-					display: inline;
-				}
-			}
-			d2l-alert {
-				margin: 10px auto;
-			}
-			.title-text {
-				${overflowEllipsisDeclarations}
-			}
-		`];
-	}
+		}
+		d2l-alert {
+			margin: 10px auto;
+		}
+		.title-text {
+			${overflowEllipsisDeclarations}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/page/page-header-separator.js
+++ b/components/page/page-header-separator.js
@@ -7,20 +7,18 @@ import { css, html, LitElement } from 'lit';
  */
 class PageHeaderSeparator extends LitElement {
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-				margin: 0 9px;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-icon {
-				color: var(--d2l-color-mica);
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+			margin: 0 9px;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-icon {
+			color: var(--d2l-color-mica);
+		}
+	`;
 
 	render() {
 		return html`

--- a/components/paging/pageable-mixin.js
+++ b/components/paging/pageable-mixin.js
@@ -4,11 +4,9 @@ import { SubscriberRegistryController } from '../../controllers/subscriber/subsc
 
 export const PageableMixin = superclass => class extends CollectionMixin(superclass) {
 
-	static get properties() {
-		return {
-			_itemShowingCount: { state: true },
-		};
-	}
+	static properties = {
+		_itemShowingCount: { state: true },
+	};
 
 	constructor() {
 		super();

--- a/components/paging/pageable-subscriber-mixin.js
+++ b/components/paging/pageable-subscriber-mixin.js
@@ -2,16 +2,14 @@ import { EventSubscriberController, IdSubscriberController } from '../../control
 
 export const PageableSubscriberMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Id of the `PageableMixin` component this component wants to observe (if not located within that component)
 			 * @type {string}
 			 */
-			pageableFor: { type: String, reflect: true, attribute: 'pageable-for' },
-			_pageableInfo: { state: true }
-		};
-	}
+		pageableFor: { type: String, reflect: true, attribute: 'pageable-for' },
+		_pageableInfo: { state: true }
+	};
 
 	constructor() {
 		super();

--- a/components/paging/pager-load-more.js
+++ b/components/paging/pager-load-more.js
@@ -20,57 +20,53 @@ const nativeFocus = document.createElement('div').focus;
  */
 class LoadMore extends PageableSubscriberMixin(FocusMixin(LocalizeCoreElement(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether there are more items that can be loaded.
 			 * @type {boolean}
 			 */
-			hasMore: { type: Boolean, attribute: 'has-more', reflect: true },
-			/**
+		hasMore: { type: Boolean, attribute: 'has-more', reflect: true },
+		/**
 			 * The number of additional items to load.
 			 * @type {number}
 			 */
-			pageSize: { type: Number, attribute: 'page-size', reflect: true },
-			_loading: { state: true }
-		};
-	}
+		pageSize: { type: Number, attribute: 'page-size', reflect: true },
+		_loading: { state: true }
+	};
 
-	static get styles() {
-		return [ buttonStyles, labelStyles, offscreenStyles, css`
-			:host {
-				display: block;
-			}
-			:host(:not([has-more])),
-			:host([hidden]) {
-				display: none;
-			}
-			button {
-				align-items: center;
-				background-color: var(--d2l-theme-background-color-interactive-faint-default);
-				border: 1px solid var(--d2l-theme-border-color-subtle);
-				display: flex;
-				font-family: inherit;
-				gap: 0.5rem;
-				justify-content: center;
-				width: 100%;
-			}
-			button:hover {
-				background-color: var(--d2l-theme-background-color-interactive-faint-hover);
-			}
-			.action {
-				color: var(--d2l-theme-text-color-interactive-default);
-			}
-			.separator {
-				border-right: 1px solid var(--d2l-theme-border-color-standard);
-				height: 0.8rem;
-			}
-			.info {
-				color: var(--d2l-theme-text-color-static-faint);
-				font-weight: 400;
-			}
-		`];
-	}
+	static styles = [ buttonStyles, labelStyles, offscreenStyles, css`
+		:host {
+			display: block;
+		}
+		:host(:not([has-more])),
+		:host([hidden]) {
+			display: none;
+		}
+		button {
+			align-items: center;
+			background-color: var(--d2l-theme-background-color-interactive-faint-default);
+			border: 1px solid var(--d2l-theme-border-color-subtle);
+			display: flex;
+			font-family: inherit;
+			gap: 0.5rem;
+			justify-content: center;
+			width: 100%;
+		}
+		button:hover {
+			background-color: var(--d2l-theme-background-color-interactive-faint-hover);
+		}
+		.action {
+			color: var(--d2l-theme-text-color-interactive-default);
+		}
+		.separator {
+			border-right: 1px solid var(--d2l-theme-border-color-standard);
+			height: 0.8rem;
+		}
+		.info {
+			color: var(--d2l-theme-text-color-static-faint);
+			font-weight: 400;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/popover/popover-mixin.js
+++ b/components/popover/popover-mixin.js
@@ -51,215 +51,211 @@ const SCROLLBAR_WIDTH = (() => {
 
 export const PopoverMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			_contentHeight: { state: true },
-			_location: { type: String, reflect: true, attribute: '_location' },
-			_margin: { state: true },
-			_maxHeight: { state: true },
-			_maxWidth: { state: true },
-			_minHeight: { state: true },
-			_minWidth: { state: true },
-			_mobile: { type: Boolean, reflect: true, attribute: '_mobile' },
-			_mobileBreakpoint: { state: true },
-			_mobileTrayLocation: { type: String, reflect: true, attribute: '_mobile-tray-location' },
-			_noAutoClose: { state: true },
-			_noAutoFit: { state: true },
-			_noAutoFocus: { state: true },
-			_noPointer: { state: true },
-			_offscreen: { type: Boolean, reflect: true, attribute: '_offscreen' },
-			_offset: { state: true },
-			_opened: { type: Boolean, reflect: true, attribute: '_opened' },
-			_pointerPosition: { state: true },
-			_position: { state: true },
-			_preferredPosition: { state: true },
-			_rtl: { state: true },
-			_showBackdrop: { state: true },
-			_trapFocus: { state: true },
-			_useNativePopover: { type: String, reflect: true, attribute: 'popover' },
-			_width: { state: true }
-		};
-	}
+	static properties = {
+		_contentHeight: { state: true },
+		_location: { type: String, reflect: true, attribute: '_location' },
+		_margin: { state: true },
+		_maxHeight: { state: true },
+		_maxWidth: { state: true },
+		_minHeight: { state: true },
+		_minWidth: { state: true },
+		_mobile: { type: Boolean, reflect: true, attribute: '_mobile' },
+		_mobileBreakpoint: { state: true },
+		_mobileTrayLocation: { type: String, reflect: true, attribute: '_mobile-tray-location' },
+		_noAutoClose: { state: true },
+		_noAutoFit: { state: true },
+		_noAutoFocus: { state: true },
+		_noPointer: { state: true },
+		_offscreen: { type: Boolean, reflect: true, attribute: '_offscreen' },
+		_offset: { state: true },
+		_opened: { type: Boolean, reflect: true, attribute: '_opened' },
+		_pointerPosition: { state: true },
+		_position: { state: true },
+		_preferredPosition: { state: true },
+		_rtl: { state: true },
+		_showBackdrop: { state: true },
+		_trapFocus: { state: true },
+		_useNativePopover: { type: String, reflect: true, attribute: 'popover' },
+		_width: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				--d2l-popover-default-animation-name: d2l-popover-animation;
-				--d2l-popover-default-background-color: var(--d2l-theme-background-color-base);
-				--d2l-popover-default-border-color: var(--d2l-theme-border-color-standard);
-				--d2l-popover-default-border-radius: 0.3rem;
-				--d2l-popover-default-foreground-color: var(--d2l-theme-text-color-static-standard);
-				--d2l-popover-default-shadow-color: var(--d2l-theme-shadow-floating-color);
-				background-color: transparent; /* override popover default */
-				border: none; /* override popover */
-				box-sizing: border-box;
-				color: var(--d2l-popover-foreground-color, var(--d2l-popover-default-foreground-color));
-				display: none;
-				height: fit-content; /* normalize popover */
-				inset: 0; /* normalize popover */
-				margin: 0; /* override popover */
-				overflow: visible; /* override popover */
-				padding: 0; /* override popover */
-				position: fixed; /* normalize popover */
-				text-align: start;
-				width: fit-content; /* normalize popover */
-			}
-			:host([theme="dark"]) {
-				--d2l-popover-default-animation-name: d2l-popover-animation-dark;
-				--d2l-popover-default-background-color: #333536; /* tungsten @ 70% */
-				--d2l-popover-default-border-color: var(--d2l-color-tungsten);
-				--d2l-popover-default-foreground-color: var(--d2l-color-sylvite);
-				--d2l-popover-default-shadow-color: rgba(0, 0, 0, 1);
-				opacity: 0.9;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host(:not([popover])) {
-				z-index: 998; /* position on top of floating buttons */
-			}
+	static styles = css`
+		:host {
+			--d2l-popover-default-animation-name: d2l-popover-animation;
+			--d2l-popover-default-background-color: var(--d2l-theme-background-color-base);
+			--d2l-popover-default-border-color: var(--d2l-theme-border-color-standard);
+			--d2l-popover-default-border-radius: 0.3rem;
+			--d2l-popover-default-foreground-color: var(--d2l-theme-text-color-static-standard);
+			--d2l-popover-default-shadow-color: var(--d2l-theme-shadow-floating-color);
+			background-color: transparent; /* override popover default */
+			border: none; /* override popover */
+			box-sizing: border-box;
+			color: var(--d2l-popover-foreground-color, var(--d2l-popover-default-foreground-color));
+			display: none;
+			height: fit-content; /* normalize popover */
+			inset: 0; /* normalize popover */
+			margin: 0; /* override popover */
+			overflow: visible; /* override popover */
+			padding: 0; /* override popover */
+			position: fixed; /* normalize popover */
+			text-align: start;
+			width: fit-content; /* normalize popover */
+		}
+		:host([theme="dark"]) {
+			--d2l-popover-default-animation-name: d2l-popover-animation-dark;
+			--d2l-popover-default-background-color: #333536; /* tungsten @ 70% */
+			--d2l-popover-default-border-color: var(--d2l-color-tungsten);
+			--d2l-popover-default-foreground-color: var(--d2l-color-sylvite);
+			--d2l-popover-default-shadow-color: rgba(0, 0, 0, 1);
+			opacity: 0.9;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host(:not([popover])) {
+			z-index: 998; /* position on top of floating buttons */
+		}
+		:host([_opened]) {
+			display: inline-block;
+		}
+		:host([_location="block-start"]) {
+			bottom: 0;
+			top: auto;
+		}
+
+		.content-position {
+			display: inline-block;
+			position: absolute;
+		}
+		.content-width {
+			background-color: var(--d2l-popover-background-color, var(--d2l-popover-default-background-color));
+			border: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
+			border-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
+			box-shadow: var(--d2l-theme-shadow-floating-offset-x) var(--d2l-theme-shadow-floating-offset-y) var(--d2l-theme-shadow-floating-blur-radius) var(--d2l-theme-shadow-floating-spread-radius) var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
+			box-sizing: border-box;
+			display: flex;
+			max-width: 370px;
+			min-width: 70px;
+			outline: var(--d2l-popover-outline-width, 0) solid var(--d2l-popover-outline-color, transparent);
+			width: 100vw;
+		}
+		.content-container {
+			box-sizing: border-box;
+			display: inline-block;
+			max-width: 100%;
+			min-width: inherit;
+			outline: none;
+			overflow-y: auto;
+		}
+
+		.pointer {
+			clip: rect(-5px, 21px, 8px, -7px);
+			display: inline-block;
+			position: absolute;
+			z-index: 1;
+		}
+		:host([_location="block-start"]) .pointer {
+			clip: rect(9px, 21px, 22px, -3px);
+		}
+		:host([_location="inline-start"]) .pointer,
+		:host([_location="inline-end"]) .pointer.pointer-mirror {
+			clip: rect(-3px, 21px, 21px, 10px);
+		}
+		:host([_location="inline-end"]) .pointer,
+		:host([_location="inline-start"]) .pointer.pointer-mirror {
+			clip: rect(-3px, 8px, 21px, -3px);
+		}
+
+		.pointer > div {
+			background-color: var(--d2l-popover-background-color, var(--d2l-popover-default-background-color));
+			border: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
+			border-radius: 0.1rem;
+			box-shadow: -4px -4px 12px -5px var(--d2l-theme-shadow-floating-color);
+			height: ${pointerLength}px;
+			outline: var(--d2l-popover-outline-width, 0) solid var(--d2l-popover-outline-color, transparent);
+			transform: rotate(45deg);
+			width: ${pointerLength}px;
+		}
+
+		:host([_location="block-start"]) .pointer > div {
+			box-shadow: 4px 4px 12px -5px var(--d2l-theme-shadow-floating-color);
+		}
+
+		@keyframes d2l-popover-animation {
+			0% { opacity: 0; transform: translate(0, -10px); }
+			100% { opacity: 1; transform: translate(0, 0); }
+		}
+		@keyframes d2l-popover-animation-dark {
+			0% { opacity: 0; transform: translate(0, -10px); }
+			100% { opacity: 0.9; transform: translate(0, 0); }
+		}
+		@media (prefers-reduced-motion: no-preference) {
 			:host([_opened]) {
-				display: inline-block;
+				animation: var(--d2l-popover-animation-name, var(--d2l-popover-default-animation-name)) 300ms ease;
 			}
-			:host([_location="block-start"]) {
-				bottom: 0;
-				top: auto;
-			}
+		}
 
-			.content-position {
-				display: inline-block;
-				position: absolute;
-			}
-			.content-width {
-				background-color: var(--d2l-popover-background-color, var(--d2l-popover-default-background-color));
-				border: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
-				border-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
-				box-shadow: var(--d2l-theme-shadow-floating-offset-x) var(--d2l-theme-shadow-floating-offset-y) var(--d2l-theme-shadow-floating-blur-radius) var(--d2l-theme-shadow-floating-spread-radius) var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
-				box-sizing: border-box;
-				display: flex;
-				max-width: 370px;
-				min-width: 70px;
-				outline: var(--d2l-popover-outline-width, 0) solid var(--d2l-popover-outline-color, transparent);
-				width: 100vw;
-			}
-			.content-container {
-				box-sizing: border-box;
-				display: inline-block;
-				max-width: 100%;
-				min-width: inherit;
-				outline: none;
-				overflow-y: auto;
-			}
+		:host([_mobile][_mobile-tray-location]) .content-width {
+			position: fixed;
+			z-index: 1000;
+		}
 
-			.pointer {
-				clip: rect(-5px, 21px, 8px, -7px);
-				display: inline-block;
-				position: absolute;
-				z-index: 1;
-			}
-			:host([_location="block-start"]) .pointer {
-				clip: rect(9px, 21px, 22px, -3px);
-			}
-			:host([_location="inline-start"]) .pointer,
-			:host([_location="inline-end"]) .pointer.pointer-mirror {
-				clip: rect(-3px, 21px, 21px, 10px);
-			}
-			:host([_location="inline-end"]) .pointer,
-			:host([_location="inline-start"]) .pointer.pointer-mirror {
-				clip: rect(-3px, 8px, 21px, -3px);
-			}
+		:host([_mobile][_mobile-tray-location="inline-start"]) .content-width,
+		:host([_mobile][_mobile-tray-location="inline-end"]) .content-width {
+			inset-block-end: 0;
+			inset-block-start: 0;
+		}
 
-			.pointer > div {
-				background-color: var(--d2l-popover-background-color, var(--d2l-popover-default-background-color));
-				border: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
-				border-radius: 0.1rem;
-				box-shadow: -4px -4px 12px -5px var(--d2l-theme-shadow-floating-color);
-				height: ${pointerLength}px;
-				outline: var(--d2l-popover-outline-width, 0) solid var(--d2l-popover-outline-color, transparent);
-				transform: rotate(45deg);
-				width: ${pointerLength}px;
-			}
+		:host([_mobile][_mobile-tray-location="inline-start"]) .content-width {
+			border-end-start-radius: 0;
+			border-start-start-radius: 0;
+		}
 
-			:host([_location="block-start"]) .pointer > div {
-				box-shadow: 4px 4px 12px -5px var(--d2l-theme-shadow-floating-color);
-			}
+		:host([_mobile][_mobile-tray-location="inline-end"]) .content-width {
+			border-end-end-radius: 0;
+			border-start-end-radius: 0;
+		}
 
-			@keyframes d2l-popover-animation {
-				0% { opacity: 0; transform: translate(0, -10px); }
-				100% { opacity: 1; transform: translate(0, 0); }
-			}
-			@keyframes d2l-popover-animation-dark {
-				0% { opacity: 0; transform: translate(0, -10px); }
-				100% { opacity: 0.9; transform: translate(0, 0); }
-			}
-			@media (prefers-reduced-motion: no-preference) {
-				:host([_opened]) {
-					animation: var(--d2l-popover-animation-name, var(--d2l-popover-default-animation-name)) 300ms ease;
-				}
-			}
+		:host([_mobile][_mobile-tray-location="block-end"]) .content-width {
+			border-end-end-radius: 0;
+			border-end-start-radius: 0;
+			inset-inline-start: 0;
+		}
 
-			:host([_mobile][_mobile-tray-location]) .content-width {
-				position: fixed;
-				z-index: 1000;
-			}
+		:host([_mobile][_mobile-tray-location="inline-end"][opened]) .content-width {
+			inset-inline-end: 0;
+		}
 
-			:host([_mobile][_mobile-tray-location="inline-start"]) .content-width,
-			:host([_mobile][_mobile-tray-location="inline-end"]) .content-width {
-				inset-block-end: 0;
-				inset-block-start: 0;
-			}
+		:host([_mobile][_mobile-tray-location="inline-start"][opened]) .content-width {
+			inset-inline-start: 0;
+		}
 
-			:host([_mobile][_mobile-tray-location="inline-start"]) .content-width {
-				border-end-start-radius: 0;
-				border-start-start-radius: 0;
-			}
+		:host([_mobile][_mobile-tray-location="block-end"][opened]) .content-width {
+			inset-block-end: 0;
+		}
 
-			:host([_mobile][_mobile-tray-location="inline-end"]) .content-width {
-				border-end-end-radius: 0;
-				border-start-end-radius: 0;
-			}
+		:host([_mobile][_mobile-tray-location="inline-start"][opened]) .content-container,
+		:host([_mobile][_mobile-tray-location="inline-end"][opened]) .content-container {
+			height: calc(var(--d2l-vh, 1vh) * 100);
+			height: 100dvh;
+		}
 
-			:host([_mobile][_mobile-tray-location="block-end"]) .content-width {
-				border-end-end-radius: 0;
-				border-end-start-radius: 0;
-				inset-inline-start: 0;
-			}
+		:host([_mobile][_mobile-tray-location]) > .pointer {
+			display: none;
+		}
 
-			:host([_mobile][_mobile-tray-location="inline-end"][opened]) .content-width {
-				inset-inline-end: 0;
-			}
+		:host([_mobile][_mobile-tray-location][opened]) {
+			animation: none;
+		}
 
-			:host([_mobile][_mobile-tray-location="inline-start"][opened]) .content-width {
-				inset-inline-start: 0;
-			}
+		:host([_offscreen]) {
+			${_offscreenStyleDeclarations}
+		}
 
-			:host([_mobile][_mobile-tray-location="block-end"][opened]) .content-width {
-				inset-block-end: 0;
-			}
-
-			:host([_mobile][_mobile-tray-location="inline-start"][opened]) .content-container,
-			:host([_mobile][_mobile-tray-location="inline-end"][opened]) .content-container {
-				height: calc(var(--d2l-vh, 1vh) * 100);
-				height: 100dvh;
-			}
-
-			:host([_mobile][_mobile-tray-location]) > .pointer {
-				display: none;
-			}
-
-			:host([_mobile][_mobile-tray-location][opened]) {
-				animation: none;
-			}
-
-			:host([_offscreen]) {
-				${_offscreenStyleDeclarations}
-			}
-
-			d2l-focus-trap {
-				display: block;
-			}
-		`;
-	}
+		d2l-focus-trap {
+			display: block;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/popover/test/popover.js
+++ b/components/popover/test/popover.js
@@ -5,75 +5,72 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 class Popover extends PopoverMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Margin to include when computing space available.
 			 * @type {number}
 			 */
-			margin: { type: Number, reflect: true, attribute: 'margin' },
-			/**
+		margin: { type: Number, reflect: true, attribute: 'margin' },
+		/**
 			 * Max-height. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
 			 * @type {number}
 			 */
-			maxHeight: { type: Number, reflect: true, attribute: 'max-height' },
-			/**
+		maxHeight: { type: Number, reflect: true, attribute: 'max-height' },
+		/**
 			 * Max-width (undefined). Specify a number that would be the px value.
 			 * @type {number}
 			 */
-			maxWidth: { type: Number, reflect: true, attribute: 'max-width' },
-			/**
+		maxWidth: { type: Number, reflect: true, attribute: 'max-width' },
+		/**
 			 * Min-height used when `no-auto-fit` is true. Specify a number that would be the px value. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
 			 * @type {number}
 			 */
-			minHeight: { type: Number, reflect: true, attribute: 'min-height' },
-			/**
+		minHeight: { type: Number, reflect: true, attribute: 'min-height' },
+		/**
 			 * Min-width (undefined). Specify a number that would be the px value.
 			 * @type {number}
 			 */
-			minWidth: { type: Number, reflect: true, attribute: 'min-width' },
-			/**
+		minWidth: { type: Number, reflect: true, attribute: 'min-width' },
+		/**
 			 * Mobile tray location.
 			 * @type {'inline-start'|'inline-end'|'block-end'}
 			 */
-			mobileTrayLocation: { type: String, reflect: true, attribute: 'mobile-tray-location' },
-			/**
+		mobileTrayLocation: { type: String, reflect: true, attribute: 'mobile-tray-location' },
+		/**
 			 * Whether to disable auto-close/light-dismiss
 			 * @type {boolean}
 			 */
-			noAutoClose: { type: Boolean, reflect: true, attribute: 'no-auto-close' },
-			/**
+		noAutoClose: { type: Boolean, reflect: true, attribute: 'no-auto-close' },
+		/**
 			 * Whether to disable auto-focus on the first focusable element when opened
 			 * @type {boolean}
 			 */
-			noAutoFocus: { type: Boolean, reflect: true, attribute: 'no-auto-focus' },
-			/**
+		noAutoFocus: { type: Boolean, reflect: true, attribute: 'no-auto-focus' },
+		/**
 			 * Render without a pointer
 			 * @type {boolean}
 			 */
-			noPointer: { type: Boolean, reflect: true, attribute: 'no-pointer' },
-			/**
+		noPointer: { type: Boolean, reflect: true, attribute: 'no-pointer' },
+		/**
 			 * Position the popover before or after the opener. Default is "block-end" (after).
 			 * @type {'block-start'|'block-end'}
 			 */
-			positionLocation: { type: String, reflect: true, attribute: 'position-location' },
-			/**
+		positionLocation: { type: String, reflect: true, attribute: 'position-location' },
+		/**
 			 * Position the popover to span from the opener edge to this grid line. Default is "all" (centered).
 			 * @type {'start'|'end'|'all'}
 			 */
-			positionSpan: { type: String, reflect: true, attribute: 'position-span' },
-			/**
+		positionSpan: { type: String, reflect: true, attribute: 'position-span' },
+		/**
 			 * Whether to render a d2l-focus-trap around the content
 			 * @type {boolean}
 			*/
-			trapFocus: { type: Boolean, reflect: true, attribute: 'trap-focus' },
-			_hasFooterSlotContent: { state: true },
-			_hasHeaderSlotContent: { state: true }
-		};
-	}
+		trapFocus: { type: Boolean, reflect: true, attribute: 'trap-focus' },
+		_hasFooterSlotContent: { state: true },
+		_hasHeaderSlotContent: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
+	static styles = [super.styles, css`
 			.test-content-layout {
 				align-items: flex-start;
 				display: flex;
@@ -111,7 +108,6 @@ class Popover extends PopoverMixin(LitElement) {
 				margin-block-start: 0;
 			}
 		`];
-	}
 
 	constructor() {
 		super();

--- a/components/progress/progress.js
+++ b/components/progress/progress.js
@@ -8,173 +8,169 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 
 class Progress extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * The maximum value of the progress bar
 			 * @type {number}
 			 */
-			max: { type: Number, attribute: 'max' },
-			/**
+		max: { type: Number, attribute: 'max' },
+		/**
 			 * The current value of the progress bar
 			 * @type {number}
 			 */
-			value: { type: Number, reflect: true },
-			/**
+		value: { type: Number, reflect: true },
+		/**
 			 * REQUIRED: Label for the progress bar
 			 * @type {string}
 			 */
-			label: { type: String },
-			/**
+		label: { type: String },
+		/**
 			 * Hide the bar's label
 			 * @type {boolean}
 			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
 			 * Announce the label when it changes
 			 * @type {boolean}
 			 */
-			announceLabel: { type: Boolean, attribute: 'announce-label' },
-			/**
+		announceLabel: { type: Boolean, attribute: 'announce-label' },
+		/**
 			 * Hide the bar's value
 			 * @type {boolean}
 			 */
-			valueHidden: { type: Boolean, attribute: 'value-hidden', reflect: true },
-			/**
+		valueHidden: { type: Boolean, attribute: 'value-hidden', reflect: true },
+		/**
 			 * The size of the progress bar
 			 * @type {'small'|'medium'|'large'}
 			 */
-			size: { type: String, reflect: true }
-		};
-	}
+		size: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [bodySmallStyles, bodyCompactStyles, css`
-				:host {
-					align-items: center;
-					display: grid;
-					grid-template: auto auto / 1fr auto;
-					grid-template-areas:
-						"label label"
-						"bar value";
-					min-width: 6rem;
-				}
-				:host([hidden]) {
-					display: none;
-				}
+	static styles = [bodySmallStyles, bodyCompactStyles, css`
+			:host {
+				align-items: center;
+				display: grid;
+				grid-template: auto auto / 1fr auto;
+				grid-template-areas:
+					"label label"
+					"bar value";
+				min-width: 6rem;
+			}
+			:host([hidden]) {
+				display: none;
+			}
 
-				#label {
-					grid-area: label;
-					width: 100%;
-				}
+			#label {
+				grid-area: label;
+				width: 100%;
+			}
 
-				progress {
-					--d2l-progress-color: var(--d2l-color-celestine);
-					-moz-appearance: none;
-					-webkit-appearance: none;
-					appearance: none;
-					background-color: var(--d2l-color-gypsum);
-					box-shadow: inset 0 2px var(--d2l-color-mica);
-					overflow: hidden;
-					width: 100%;
-				}
+			progress {
+				--d2l-progress-color: var(--d2l-color-celestine);
+				-moz-appearance: none;
+				-webkit-appearance: none;
+				appearance: none;
+				background-color: var(--d2l-color-gypsum);
+				box-shadow: inset 0 2px var(--d2l-color-mica);
+				overflow: hidden;
+				width: 100%;
+			}
+			.bar {
+				border: none;
+				border-radius: 0.9rem;
+				display: block;
+				grid-area: bar;
+				height: 0.6rem;
+			}
+			.value {
+				grid-area: value;
+				margin-inline-start: 0.4rem;
+				text-align: end;
+				width: 2.42rem;
+			}
+
+			:host([size="small"]) {
 				.bar {
-					border: none;
-					border-radius: 0.9rem;
-					display: block;
-					grid-area: bar;
-					height: 0.6rem;
+					height: 0.3rem;
+				}
+
+				.value {
+					margin-inline-start: 0.3rem;
+					width: 2.15rem;
+				}
+			}
+
+			:host([size="large"]) {
+				line-height: 1.5rem;
+				.bar {
+					height: 0.9rem;
 				}
 				.value {
-					grid-area: value;
-					margin-inline-start: 0.4rem;
-					text-align: end;
-					width: 2.42rem;
+					margin-inline-start: 0.5rem;
+					width: 2.82rem;
 				}
+			}
 
-				:host([size="small"]) {
-					.bar {
-						height: 0.3rem;
-					}
-
-					.value {
-						margin-inline-start: 0.3rem;
-						width: 2.15rem;
-					}
-				}
-
-				:host([size="large"]) {
-					line-height: 1.5rem;
-					.bar {
-						height: 0.9rem;
-					}
-					.value {
-						margin-inline-start: 0.5rem;
-						width: 2.82rem;
-					}
-				}
-
-				progress.complete {
-					--d2l-progress-color: var(--d2l-color-olivine);
-				}
-				/* this is necessary to avoid white bleed over rounded corners in chrome and safari */
-				progress::-webkit-progress-bar {
-					background-color: transparent;
-				}
+			progress.complete {
+				--d2l-progress-color: var(--d2l-color-olivine);
+			}
+			/* this is necessary to avoid white bleed over rounded corners in chrome and safari */
+			progress::-webkit-progress-bar {
+				background-color: transparent;
+			}
 
 
-				:host(:not([value-hidden]):not([value])) .bar {
-					margin-bottom: 0.3rem;
-				}
+			:host(:not([value-hidden]):not([value])) .bar {
+				margin-bottom: 0.3rem;
+			}
 
-				:host(:not([value]):not([label-hidden])),
-				:host([value-hidden]:not([label-hidden])) {
-					row-gap: 0.3rem;
-				}
+			:host(:not([value]):not([label-hidden])),
+			:host([value-hidden]:not([label-hidden])) {
+				row-gap: 0.3rem;
+			}
 
-				.indeterminate-bar-container {
-					overflow: hidden;
+			.indeterminate-bar-container {
+				overflow: hidden;
+			}
+			.indeterminate-bar {
+				--d2l-progress-indeterminate-width: calc(100% / 3);
+				animation: 1450ms 50ms ease-in-out indeterminateState alternate infinite;
+				background-color: var(--d2l-color-celestine);
+				height: 100%;
+				margin-inline-start: calc(var(--d2l-progress-indeterminate-width) * -0.75);
+				width: var(--d2l-progress-indeterminate-width);
+			}
+			@keyframes indeterminateState {
+				100% {
+					margin-inline-start: calc(100% - var(--d2l-progress-indeterminate-width) * 0.25);
 				}
-				.indeterminate-bar {
-					--d2l-progress-indeterminate-width: calc(100% / 3);
-					animation: 1450ms 50ms ease-in-out indeterminateState alternate infinite;
-					background-color: var(--d2l-color-celestine);
-					height: 100%;
-					margin-inline-start: calc(var(--d2l-progress-indeterminate-width) * -0.75);
-					width: var(--d2l-progress-indeterminate-width);
-				}
-				@keyframes indeterminateState {
-					100% {
-						margin-inline-start: calc(100% - var(--d2l-progress-indeterminate-width) * 0.25);
-					}
-				}
-			`,
-		/* comma separating the selectors for these pseudo-elements causes them to break */
-		/* note: unable to get firefox to animate the width... seems animation is not implemented for progress in FF */
-		...['-webkit-progress-value', '-moz-progress-bar'].map(selector => css`
+			}
+		`,
+	/* comma separating the selectors for these pseudo-elements causes them to break */
+	/* note: unable to get firefox to animate the width... seems animation is not implemented for progress in FF */
+	...['-webkit-progress-value', '-moz-progress-bar'].map(selector => css`
+			progress::${unsafeCSS(selector)} {
+				background-color: var(--d2l-progress-color);
+				border: 1px solid transparent;
+				border-radius: 0.9rem;
+				transition: width 0.4s ease-out;
+			}
+			/* these are necessary to avoid showing border when value is 0 */
+			progress:not([value])::${unsafeCSS(selector)},
+			progress[value="0"]::${unsafeCSS(selector)} {
+				border: none;
+			}
+
+			progress:not([value])::${unsafeCSS(selector)} {
+				transition: none;
+			}
+			@media (prefers-reduced-motion: reduce) {
 				progress::${unsafeCSS(selector)} {
-					background-color: var(--d2l-progress-color);
-					border: 1px solid transparent;
-					border-radius: 0.9rem;
-					transition: width 0.4s ease-out;
-				}
-				/* these are necessary to avoid showing border when value is 0 */
-				progress:not([value])::${unsafeCSS(selector)},
-				progress[value="0"]::${unsafeCSS(selector)} {
-					border: none;
-				}
-
-				progress:not([value])::${unsafeCSS(selector)} {
 					transition: none;
 				}
-				@media (prefers-reduced-motion: reduce) {
-					progress::${unsafeCSS(selector)} {
-						transition: none;
-					}
-				}
-			`)
-		];
-	}
+			}
+		`)
+	];
 
 	constructor() {
 		super();

--- a/components/scroll-wrapper/demo/scroll-wrapper-test.js
+++ b/components/scroll-wrapper/demo/scroll-wrapper-test.js
@@ -5,37 +5,33 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 class TestScrollWrapper extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			hideActions: { attribute: 'hide-actions', type: Boolean },
-			scroll: { attribute: 'scroll', type: Number },
-			splitScrollers: { attribute: 'split-scrollers', type: Boolean },
-			width: { type: Number },
-			_customScrollers: { state: true }
-		};
-	}
+	static properties = {
+		hideActions: { attribute: 'hide-actions', type: Boolean },
+		scroll: { attribute: 'scroll', type: Number },
+		splitScrollers: { attribute: 'split-scrollers', type: Boolean },
+		width: { type: Number },
+		_customScrollers: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
-			.d2l-scroll-wrapper-gradient {
-				background: linear-gradient(to right, #e66465, #9198e5);
-				height: 100px;
-			}
-			.d2l-scroll-wrapper-gradient-secondary {
-				background: linear-gradient(to left, #e66465, #9198e5);
-				height: 40px;
-				position: relative;
-			}
-			.d2l-scroll-wrapper-gradient-secondary button {
-				inset-inline-end: 0;
-				position: absolute;
-				top: 0;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: block;
+		}
+		.d2l-scroll-wrapper-gradient {
+			background: linear-gradient(to right, #e66465, #9198e5);
+			height: 100px;
+		}
+		.d2l-scroll-wrapper-gradient-secondary {
+			background: linear-gradient(to left, #e66465, #9198e5);
+			height: 40px;
+			position: relative;
+		}
+		.d2l-scroll-wrapper-gradient-secondary button {
+			inset-inline-end: 0;
+			position: absolute;
+			top: 0;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/scroll-wrapper/scroll-wrapper.js
+++ b/components/scroll-wrapper/scroll-wrapper.js
@@ -36,126 +36,122 @@ function getStyleSheetInsertionPoint(elem) {
  */
 class ScrollWrapper extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * An object containing custom primary/secondary scroll containers
 			 * @type {Object}
 			 */
-			customScrollers: {
-				attribute: false,
-				type: Object
-			},
-			/**
+		customScrollers: {
+			attribute: false,
+			type: Object
+		},
+		/**
 			 * Whether to hide left/right scroll buttons
 			 * @type {boolean}
 			 */
-			hideActions: {
-				attribute: 'hide-actions',
-				type: Boolean
-			},
-			/**
+		hideActions: {
+			attribute: 'hide-actions',
+			type: Boolean
+		},
+		/**
 			 * The area in pixels to offset scroll width calculations
 			 * @type {number}
 			 */
-			scrollAreaOffset: {
-				attribute: 'scroll-area-offset',
-				type: Number
-			},
-			_hScrollbar: {
-				attribute: 'h-scrollbar',
-				reflect: true,
-				type: Boolean
-			},
-			_scrollbarLeft: {
-				attribute: 'scrollbar-left',
-				reflect: true,
-				type: Boolean
-			},
-			_scrollbarRight: {
-				attribute: 'scrollbar-right',
-				reflect: true,
-				type: Boolean
-			}
-		};
-	}
+		scrollAreaOffset: {
+			attribute: 'scroll-area-offset',
+			type: Number
+		},
+		_hScrollbar: {
+			attribute: 'h-scrollbar',
+			reflect: true,
+			type: Boolean
+		},
+		_scrollbarLeft: {
+			attribute: 'scrollbar-left',
+			reflect: true,
+			type: Boolean
+		},
+		_scrollbarRight: {
+			attribute: 'scrollbar-right',
+			reflect: true,
+			type: Boolean
+		}
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-				position: relative;
-			}
-			:host([hidden]) {
+	static styles = css`
+		:host {
+			display: block;
+			position: relative;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-scroll-wrapper-container {
+			box-sizing: border-box;
+			overflow-y: var(--d2l-scroll-wrapper-overflow-y, visible);
+		}
+		:host([h-scrollbar]) .d2l-scroll-wrapper-container {
+			border-inline: 1px dashed var(--d2l-theme-border-color-standard);
+		}
+		:host([h-scrollbar][hide-actions]) .d2l-scroll-wrapper-container {
+			border-inline: none;
+		}
+		:host([scrollbar-left]) .d2l-scroll-wrapper-container {
+			border-inline-start: none;
+		}
+		:host([scrollbar-right]) .d2l-scroll-wrapper-container {
+			border-inline-end: none;
+		}
+
+		.d2l-scroll-wrapper-button-left {
+			inset-inline-start: -10px;
+		}
+		.d2l-scroll-wrapper-button-right {
+			inset-inline-end: -10px;
+		}
+
+		.d2l-scroll-wrapper-actions {
+			position: -webkit-sticky;
+			position: sticky;
+			top: var(--d2l-table-sticky-top, 0);
+			z-index: 5;
+		}
+
+		.d2l-scroll-wrapper-button {
+			background-color: var(--d2l-theme-background-color-interactive-faint-default);
+			border: 1px solid var(--d2l-theme-border-color-standard);
+			border-radius: 50%;
+			box-shadow: var(--d2l-theme-shadow-floating);
+			cursor: pointer;
+			display: inline-block;
+			height: 18px;
+			line-height: 0;
+			padding: 10px;
+			position: absolute;
+			top: 4px;
+			width: 18px;
+		}
+		.d2l-scroll-wrapper-button:hover {
+			background-color: var(--d2l-theme-background-color-interactive-faint-hover);
+		}
+		:host([scrollbar-right]) .d2l-scroll-wrapper-button-right {
+			display: none;
+		}
+		:host([scrollbar-left]) .d2l-scroll-wrapper-button-left {
+			display: none;
+		}
+
+		@media print {
+			.d2l-scroll-wrapper-actions {
 				display: none;
 			}
 			.d2l-scroll-wrapper-container {
-				box-sizing: border-box;
-				overflow-y: var(--d2l-scroll-wrapper-overflow-y, visible);
+				border: none !important;
+				box-sizing: content-box !important;
+				overflow: visible !important;
 			}
-			:host([h-scrollbar]) .d2l-scroll-wrapper-container {
-				border-inline: 1px dashed var(--d2l-theme-border-color-standard);
-			}
-			:host([h-scrollbar][hide-actions]) .d2l-scroll-wrapper-container {
-				border-inline: none;
-			}
-			:host([scrollbar-left]) .d2l-scroll-wrapper-container {
-				border-inline-start: none;
-			}
-			:host([scrollbar-right]) .d2l-scroll-wrapper-container {
-				border-inline-end: none;
-			}
-
-			.d2l-scroll-wrapper-button-left {
-				inset-inline-start: -10px;
-			}
-			.d2l-scroll-wrapper-button-right {
-				inset-inline-end: -10px;
-			}
-
-			.d2l-scroll-wrapper-actions {
-				position: -webkit-sticky;
-				position: sticky;
-				top: var(--d2l-table-sticky-top, 0);
-				z-index: 5;
-			}
-
-			.d2l-scroll-wrapper-button {
-				background-color: var(--d2l-theme-background-color-interactive-faint-default);
-				border: 1px solid var(--d2l-theme-border-color-standard);
-				border-radius: 50%;
-				box-shadow: var(--d2l-theme-shadow-floating);
-				cursor: pointer;
-				display: inline-block;
-				height: 18px;
-				line-height: 0;
-				padding: 10px;
-				position: absolute;
-				top: 4px;
-				width: 18px;
-			}
-			.d2l-scroll-wrapper-button:hover {
-				background-color: var(--d2l-theme-background-color-interactive-faint-hover);
-			}
-			:host([scrollbar-right]) .d2l-scroll-wrapper-button-right {
-				display: none;
-			}
-			:host([scrollbar-left]) .d2l-scroll-wrapper-button-left {
-				display: none;
-			}
-
-			@media print {
-				.d2l-scroll-wrapper-actions {
-					display: none;
-				}
-				.d2l-scroll-wrapper-container {
-					border: none !important;
-					box-sizing: content-box !important;
-					overflow: visible !important;
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/selection/README.md
+++ b/components/selection/README.md
@@ -19,13 +19,11 @@ The `SelectionMixin` defines the `selection-single` attribute that consumers can
   import { SelectionMixin } from '@brightspace-ui/core/components/selection/selection-mixin.js';
 
   class DemoSelection extends SelectionMixin(LitElement) {
-    static get styles() {
-      return css`
-        :host {
-          display: block;
-        }
-      `;
-    }
+    static styles = css`
+      :host {
+        display: block;
+      }
+    `;
     render() {
       return html`
         <slot></slot>

--- a/components/selection/demo/demo-selection.js
+++ b/components/selection/demo/demo-selection.js
@@ -3,13 +3,11 @@ import { PageableMixin } from '../../paging/pageable-mixin.js';
 import { SelectionMixin } from '../selection-mixin.js';
 
 class DemoBase extends LitElement {
-	static get styles() {
-		return css`
+	static styles = css`
 			:host {
 				display: block;
 			}
 		`;
-	}
 	render() {
 		return html`
 			<slot></slot>

--- a/components/selection/selection-action-dropdown.js
+++ b/components/selection/selection-action-dropdown.js
@@ -13,19 +13,15 @@ import { SelectionActionMixin } from './selection-action-mixin.js';
  */
 class ActionDropdown extends FocusMixin(SelectionActionMixin(DropdownOpenerMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Text for the dropdown opener button
 			 * @type {string}
 			 */
-			text: { type: String }
-		};
-	}
+		text: { type: String }
+	};
 
-	static get styles() {
-		return dropdownOpenerStyles;
-	}
+	static styles = dropdownOpenerStyles;
 
 	static get focusElementSelector() {
 		return 'd2l-button-subtle';

--- a/components/selection/selection-action-menu-item.js
+++ b/components/selection/selection-action-menu-item.js
@@ -13,9 +13,8 @@ import { SelectionInfo } from './selection-mixin.js';
  */
 class ActionMenuItem extends SelectionActionMixin(MenuItemMixin(LitElement)) {
 
-	static get styles() {
-		return [ menuItemStyles,
-			css`
+	static styles = [ menuItemStyles,
+		css`
 				:host {
 					align-items: center;
 					display: flex;
@@ -26,8 +25,7 @@ class ActionMenuItem extends SelectionActionMixin(MenuItemMixin(LitElement)) {
 					margin-inline-start: 6px;
 				}
 			`
-		];
-	}
+	];
 
 	connectedCallback() {
 		super.connectedCallback();

--- a/components/selection/selection-action-mixin.js
+++ b/components/selection/selection-action-mixin.js
@@ -5,21 +5,19 @@ import { SelectionObserverMixin } from './selection-observer-mixin.js';
 
 export const SelectionActionMixin = superclass => class extends LocalizeCoreElement(SelectionObserverMixin(superclass)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables bulk actions in the list or table controls once the selection limit is reached, but does not prevent further selection
 			 * @type {number}
 			 */
-			maxSelectionCount: { type: Number, attribute: 'max-selection-count' },
-			/**
+		maxSelectionCount: { type: Number, attribute: 'max-selection-count' },
+		/**
 			 * Whether the action requires one or more selected items
 			 * @type {boolean}
 			 */
-			requiresSelection: { type: Boolean, attribute: 'requires-selection', reflect: true },
-			_disabledTooltip: { state: true }
-		};
-	}
+		requiresSelection: { type: Boolean, attribute: 'requires-selection', reflect: true },
+		_disabledTooltip: { state: true }
+	};
 
 	constructor() {
 		super();

--- a/components/selection/selection-action.js
+++ b/components/selection/selection-action.js
@@ -13,31 +13,27 @@ import { SelectionInfo } from './selection-mixin.js';
  */
 class Action extends FocusMixin(SelectionActionMixin(ButtonMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Preset icon key (e.g. `tier1:gear`)
 			 * @type {string}
 			 */
-			icon: { type: String, reflect: true },
-			/**
+		icon: { type: String, reflect: true },
+		/**
 			 * REQUIRED: The text for the action
 			 * @type {string}
 			 */
-			text: { type: String, reflect: true }
-		};
-	}
+		text: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	static get focusElementSelector() {
 		return 'd2l-button-subtle';

--- a/components/selection/selection-controls.js
+++ b/components/selection/selection-controls.js
@@ -17,103 +17,99 @@ import { SelectionObserverMixin } from './selection-observer-mixin.js';
  */
 export class SelectionControls extends PageableSubscriberMixin(SelectionObserverMixin(LocalizeCoreElement(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether to render select-all and selection summary
 			 * @type {boolean}
 			 */
-			noSelection: { type: Boolean, attribute: 'no-selection' },
-			/**
+		noSelection: { type: Boolean, attribute: 'no-selection' },
+		/**
 			 * ADVANCED: Text to display if no items are selected (overrides pageable counts)
 			 * @type {string}
 			 */
-			noSelectionText: { type: String, attribute: 'no-selection-text' },
-			/**
+		noSelectionText: { type: String, attribute: 'no-selection-text' },
+		/**
 			 * Disables sticky positioning for the controls
 			 * @type {boolean}
 			 */
-			noSticky: { type: Boolean, attribute: 'no-sticky', reflect: true },
-			/**
+		noSticky: { type: Boolean, attribute: 'no-sticky', reflect: true },
+		/**
 			 * Whether all pages can be selected
 			 * @type {boolean}
 			 */
-			selectAllPagesAllowed: { type: Boolean, attribute: 'select-all-pages-allowed' },
-			_hasActions: { state: true },
-			_noSelectionText: { state: true },
-			_scrolled: { type: Boolean, reflect: true }
-		};
-	}
+		selectAllPagesAllowed: { type: Boolean, attribute: 'select-all-pages-allowed' },
+		_hasActions: { state: true },
+		_noSelectionText: { state: true },
+		_scrolled: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-				position: sticky;
-				top: 0;
+	static styles = css`
+		:host {
+			display: block;
+			position: sticky;
+			top: 0;
+		}
+		:host([no-sticky]) {
+			position: static;
+		}
+		@media (prefers-reduced-motion: no-preference) {
+			.d2l-selection-controls-shadow {
+				transition: box-shadow 200ms ease-out;
 			}
-			:host([no-sticky]) {
-				position: static;
-			}
-			@media (prefers-reduced-motion: no-preference) {
-				.d2l-selection-controls-shadow {
-					transition: box-shadow 200ms ease-out;
-				}
-			}
-			:host([_scrolled]) .d2l-selection-controls-shadow {
-				background-color: var(--d2l-selection-controls-background-color, var(--d2l-theme-background-color-base));
-				bottom: -4px;
-				box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
-				clip: rect(30px, auto, 200px, auto);
-				display: var(--d2l-selection-controls-shadow-display, block);
-				height: 40px;
-				margin: 0 calc(-1*var(--d2l-selection-controls-padding, 0px));
-				padding: 0 var(--d2l-selection-controls-padding, 0);
-				position: absolute;
-				width: 100%;
-				z-index: -1;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-selection-controls-container {
-				align-items: center;
-				background-color: var(--d2l-selection-controls-background-color, var(--d2l-theme-background-color-base));
-				display: flex;
-				margin: 6px calc(-1*var(--d2l-selection-controls-padding, 0px));
-				min-height: 54px;
-				padding: 0 var(--d2l-selection-controls-padding, 0);
-			}
-			:host([no-sticky]) .d2l-selection-controls-container {
-				background-color: transparent;
-			}
-			.d2l-selection-controls-container-slim {
-				min-height: 36px;
-			}
-			d2l-selection-select-all, d2l-selection-summary {
-				flex: none;
-			}
-			d2l-selection-select-all + d2l-selection-summary {
-				margin-inline-start: 0.9rem;
-			}
-			d2l-selection-select-all-pages {
-				flex: none;
-				margin-inline-start: 0.45rem;
-			}
-			.d2l-selection-controls-actions {
-				--d2l-overflow-group-justify-content: flex-end;
-				flex: auto;
-				margin-inline-end: var(--d2l-selection-controls-offset, 0);
-				text-align: end;
-			}
-			.d2l-sticky-edge {
-				left: 0;
-				position: absolute;
-				right: 0;
-				top: -1px;
-			}
-		`;
-	}
+		}
+		:host([_scrolled]) .d2l-selection-controls-shadow {
+			background-color: var(--d2l-selection-controls-background-color, var(--d2l-theme-background-color-base));
+			bottom: -4px;
+			box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
+			clip: rect(30px, auto, 200px, auto);
+			display: var(--d2l-selection-controls-shadow-display, block);
+			height: 40px;
+			margin: 0 calc(-1*var(--d2l-selection-controls-padding, 0px));
+			padding: 0 var(--d2l-selection-controls-padding, 0);
+			position: absolute;
+			width: 100%;
+			z-index: -1;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-selection-controls-container {
+			align-items: center;
+			background-color: var(--d2l-selection-controls-background-color, var(--d2l-theme-background-color-base));
+			display: flex;
+			margin: 6px calc(-1*var(--d2l-selection-controls-padding, 0px));
+			min-height: 54px;
+			padding: 0 var(--d2l-selection-controls-padding, 0);
+		}
+		:host([no-sticky]) .d2l-selection-controls-container {
+			background-color: transparent;
+		}
+		.d2l-selection-controls-container-slim {
+			min-height: 36px;
+		}
+		d2l-selection-select-all, d2l-selection-summary {
+			flex: none;
+		}
+		d2l-selection-select-all + d2l-selection-summary {
+			margin-inline-start: 0.9rem;
+		}
+		d2l-selection-select-all-pages {
+			flex: none;
+			margin-inline-start: 0.45rem;
+		}
+		.d2l-selection-controls-actions {
+			--d2l-overflow-group-justify-content: flex-end;
+			flex: auto;
+			margin-inline-end: var(--d2l-selection-controls-offset, 0);
+			text-align: end;
+		}
+		.d2l-sticky-edge {
+			left: 0;
+			position: absolute;
+			right: 0;
+			top: -1px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/selection/selection-input.js
+++ b/components/selection/selection-input.js
@@ -19,50 +19,46 @@ const keyCodes = {
  */
 class Input extends SkeletonMixin(LabelledMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * State of the input
 			 * @type {boolean}
 			 */
-			selected: { type: Boolean, reflect: true },
-			/**
+		selected: { type: Boolean, reflect: true },
+		/**
 			 * Disables the input
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
+		disabled: { type: Boolean, reflect: true },
+		/**
 			 * Tooltip text when disabled
 			 * @type {string}
 			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			/**
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		/**
 			 * Private. Force hovering state of input
 			 * @ignore
 			 * @type {boolean}
 			 */
-			hovering: { type: Boolean },
-			/**
+		hovering: { type: Boolean },
+		/**
 			 * REQUIRED: Key for the selectable
 			 * @type {string}
 			 */
-			key: { type: String },
-			_indeterminate: { type: Boolean },
-			_provider: { type: Object }
-		};
-	}
+		key: { type: String },
+		_indeterminate: { type: Boolean },
+		_provider: { type: Object }
+	};
 
-	static get styles() {
-		return [ super.styles, radioStyles, css`
-			:host {
-				display: inline-block;
-				line-height: normal;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`];
-	}
+	static styles = [ super.styles, radioStyles, css`
+		:host {
+			display: inline-block;
+			line-height: normal;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/selection/selection-mixin.js
+++ b/components/selection/selection-mixin.js
@@ -51,19 +51,17 @@ export class SelectionInfo {
 
 export const SelectionMixin = superclass => class extends CollectionMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			selectionNoInputArrowKeyBehaviour: { type: Boolean, attribute: 'selection-no-input-arrow-key-behavior' },
-			/**
+		selectionNoInputArrowKeyBehaviour: { type: Boolean, attribute: 'selection-no-input-arrow-key-behavior' },
+		/**
 			 * Whether to render with single selection behaviour. If `selection-single` is specified, the nested `d2l-selection-input` elements will render radios instead of checkboxes, and the selection component will maintain a single selected item.
 			 * @type {boolean}
 			 */
-			selectionSingle: { type: Boolean, attribute: 'selection-single' }
-		};
-	}
+		selectionSingle: { type: Boolean, attribute: 'selection-single' }
+	};
 
 	constructor() {
 		super();

--- a/components/selection/selection-observer-mixin.js
+++ b/components/selection/selection-observer-mixin.js
@@ -3,22 +3,20 @@ import { SelectionInfo } from './selection-mixin.js';
 
 export const SelectionObserverMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Id of the `SelectionMixin` component this component wants to observe (if not located within that component)
 			 * @type {string}
 			 */
-			selectionFor: { type: String, reflect: true, attribute: 'selection-for' },
-			/**
+		selectionFor: { type: String, reflect: true, attribute: 'selection-for' },
+		/**
 			 * The selection info (set by the selection component)
 			 * @ignore
 			 * @type {object}
 			 */
-			selectionInfo: { type: Object },
-			_provider: { type: Object, attribute: false }
-		};
-	}
+		selectionInfo: { type: Object },
+		_provider: { type: Object, attribute: false }
+	};
 
 	constructor() {
 		super();

--- a/components/selection/selection-select-all-pages.js
+++ b/components/selection/selection-select-all-pages.js
@@ -12,16 +12,14 @@ import { SelectionObserverMixin } from './selection-observer-mixin.js';
  */
 class SelectAllPages extends FocusMixin(LocalizeCoreElement(SelectionObserverMixin(LitElement))) {
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	static get focusElementSelector() {
 		return 'd2l-button-subtle';

--- a/components/selection/selection-select-all.js
+++ b/components/selection/selection-select-all.js
@@ -12,27 +12,23 @@ import { SelectionObserverMixin } from './selection-observer-mixin.js';
  */
 class SelectAll extends FocusMixin(LocalizeCoreElement(SelectionObserverMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Disables the select all checkbox
 			 * @type {boolean}
 			 */
-			disabled: { type: Boolean }
-		};
-	}
+		disabled: { type: Boolean }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-				line-height: normal;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+			line-height: normal;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/selection/selection-summary.js
+++ b/components/selection/selection-summary.js
@@ -11,29 +11,25 @@ import { SelectionObserverMixin } from './selection-observer-mixin.js';
  */
 class Summary extends LocalizeCoreElement(SelectionObserverMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Text to display if no items are selected
 			 * @type {string}
 			 */
-			noSelectionText: { type: String, attribute: 'no-selection-text' }
-		};
-	}
+		noSelectionText: { type: String, attribute: 'no-selection-text' }
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			p {
-				margin: 0;
-			}
-		`];
-	}
+	static styles = [bodyCompactStyles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		p {
+			margin: 0;
+		}
+	`];
 
 	render() {
 		if (!this._summary) {

--- a/components/selection/test/selection-component.js
+++ b/components/selection/test/selection-component.js
@@ -4,13 +4,11 @@ import { SelectionMixin } from '../selection-mixin.js';
 import { SelectionObserverMixin } from '../selection-observer-mixin.js';
 
 class TestBase extends LitElement {
-	static get styles() {
-		return css`
+	static styles = css`
 			:host {
 				display: block;
 			}
 		`;
-	}
 	render() {
 		return html`
 			<slot></slot>

--- a/components/skeleton/README.md
+++ b/components/skeleton/README.md
@@ -23,9 +23,7 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 
 class MyElement extends SkeletonMixin(LitElement) {
 
-  static get styles() {
-    return [ super.styles, ... ];
-  }
+  static styles = [ super.styles, ... ];
 
 }
 ```
@@ -63,9 +61,7 @@ import { selectStyles } from '@brightspace-ui/core/components/inputs/input-selec
 import { SkeletonMixin } from '@brightspace-ui/core/skeleton/skeleton-mixin.js';
 
 class MyElement extends SkeletonMixin(LitElement) {
-  static get styles() {
-    return [super.styles, selectStyles];
-  }
+  static styles = [super.styles, selectStyles];
   render() {
     return html`
       <div class="d2l-skeletize">

--- a/components/skeleton/demo/skeleton-group-nested-test.js
+++ b/components/skeleton/demo/skeleton-group-nested-test.js
@@ -8,15 +8,12 @@ import { css, html, LitElement } from 'lit';
 import { SkeletonGroupMixin } from '../skeleton-group-mixin.js';
 
 class SkeletonTestNestedGroup extends SkeletonGroupMixin(LitElement) {
-	static get properties() {
-		return {
-			_skeletonParent: { state: true },
-			_skeletonContainer: { state: true },
-			_skeletonHeading: { state: true },
-		};
-	}
-	static get styles() {
-		return css`
+	static properties = {
+		_skeletonParent: { state: true },
+		_skeletonContainer: { state: true },
+		_skeletonHeading: { state: true },
+	};
+	static styles = css`
 			.controls {
 				align-items: center;
 				display: flex;
@@ -24,7 +21,6 @@ class SkeletonTestNestedGroup extends SkeletonGroupMixin(LitElement) {
 				margin-bottom: 0.6rem;
 			}
 		`;
-	}
 
 	constructor() {
 		super();

--- a/components/skeleton/demo/skeleton-group-test-wrapper.js
+++ b/components/skeleton/demo/skeleton-group-test-wrapper.js
@@ -2,15 +2,13 @@ import { css, html, LitElement } from 'lit';
 import { SkeletonGroupMixin } from '../skeleton-group-mixin.js';
 
 class SkeletonGroupTestWrapper extends SkeletonGroupMixin(LitElement) {
-	static get styles() {
-		return css`
+	static styles = css`
 			:host {
 				display: flex;
 				flex-direction: column;
 				gap: 0.3rem;
 			}
 		`;
-	}
 	render() {
 		return html`<slot></slot>`;
 	}

--- a/components/skeleton/demo/skeleton-group-test.js
+++ b/components/skeleton/demo/skeleton-group-test.js
@@ -5,14 +5,11 @@ import { css, html, LitElement } from 'lit';
 import { SkeletonGroupMixin } from '../skeleton-group-mixin.js';
 
 class SkeletonTestGroup extends LitElement {
-	static get properties() {
-		return {
-			_items: { state: true },
-			_loadAsGroup: { state: true },
-		};
-	}
-	static get styles() {
-		return css`
+	static properties = {
+		_items: { state: true },
+		_loadAsGroup: { state: true },
+	};
+	static styles = css`
 			.controls {
 				align-items: center;
 				display: flex;
@@ -24,7 +21,6 @@ class SkeletonTestGroup extends LitElement {
 				margin-bottom: 0.6rem;
 			}
 		`;
-	}
 
 	constructor() {
 		super();

--- a/components/skeleton/demo/skeleton-test-box.js
+++ b/components/skeleton/demo/skeleton-test-box.js
@@ -4,25 +4,23 @@ import { SkeletonMixin } from '../skeleton-mixin.js';
 
 export class SkeletonTestBox extends SkeletonMixin(LitElement) {
 
-	static get styles() {
-		return [
-			super.styles,
-			css`
-				:host {
-					display: block;
-				}
-				.d2l-demo-box {
-					background-color: var(--d2l-color-fluorite-plus-2);
-					border: 1px solid var(--d2l-color-fluorite);
-					border-radius: 4px;
-					color: var(--d2l-color-fluorite);
-					height: 100px;
-					padding: 10px;
-					width: 300px;
-				}
-			`
-		];
-	}
+	static styles = [
+		super.styles,
+		css`
+			:host {
+				display: block;
+			}
+			.d2l-demo-box {
+				background-color: var(--d2l-color-fluorite-plus-2);
+				border: 1px solid var(--d2l-color-fluorite);
+				border-radius: 4px;
+				color: var(--d2l-color-fluorite);
+				height: 100px;
+				padding: 10px;
+				width: 300px;
+			}
+		`
+	];
 
 	render() {
 		return html`

--- a/components/skeleton/demo/skeleton-test-container.js
+++ b/components/skeleton/demo/skeleton-test-container.js
@@ -6,30 +6,28 @@ import { SkeletonGroupMixin } from '../skeleton-group-mixin.js';
 
 export class SkeletonTestContainer extends SkeletonGroupMixin(LitElement) {
 
-	static get styles() {
-		return [
-			super.styles,
-			bodyCompactStyles,
-			css`
-				:host {
-					display: block;
-				}
-				.d2l-demo-box {
-					background-color: var(--d2l-color-fluorite-plus-2);
-					border: 3px solid var(--d2l-color-fluorite);
-					border-radius: 4px;
-					color: var(--d2l-color-fluorite);
-					height: 100px;
-					padding: 10px;
-					width: 300px;
-				}
-				span {
-					display: block;
-					margin: 10px 0;
-				}
-			`
-		];
-	}
+	static styles = [
+		super.styles,
+		bodyCompactStyles,
+		css`
+			:host {
+				display: block;
+			}
+			.d2l-demo-box {
+				background-color: var(--d2l-color-fluorite-plus-2);
+				border: 3px solid var(--d2l-color-fluorite);
+				border-radius: 4px;
+				color: var(--d2l-color-fluorite);
+				height: 100px;
+				padding: 10px;
+				width: 300px;
+			}
+			span {
+				display: block;
+				margin: 10px 0;
+			}
+		`
+	];
 
 	render() {
 		return html`

--- a/components/skeleton/demo/skeleton-test-heading.js
+++ b/components/skeleton/demo/skeleton-test-heading.js
@@ -4,27 +4,23 @@ import { SkeletonMixin } from '../skeleton-mixin.js';
 
 export class SkeletonTestHeading extends SkeletonMixin(LitElement) {
 
-	static get properties() {
-		return {
-			level: { type: Number },
-			width: { type: Number }
-		};
-	}
+	static properties = {
+		level: { type: Number },
+		width: { type: Number }
+	};
 
-	static get styles() {
-		return [
-			super.styles,
-			heading1Styles,
-			heading2Styles,
-			heading3Styles,
-			heading4Styles,
-			css`
+	static styles = [
+		super.styles,
+		heading1Styles,
+		heading2Styles,
+		heading3Styles,
+		heading4Styles,
+		css`
 				:host {
 					display: block;
 				}
 			`
-		];
-	}
+	];
 
 	render() {
 		const width = this.width !== undefined ? ` d2l-skeletize-${this.width}` : '';

--- a/components/skeleton/demo/skeleton-test-link.js
+++ b/components/skeleton/demo/skeleton-test-link.js
@@ -5,24 +5,20 @@ import { SkeletonMixin } from '../skeleton-mixin.js';
 
 export class SkeletonTestLink extends SkeletonMixin(LitElement) {
 
-	static get properties() {
-		return {
-			type: { type: String },
-			width: { type: Number }
-		};
-	}
+	static properties = {
+		type: { type: String },
+		width: { type: Number }
+	};
 
-	static get styles() {
-		return [
-			super.styles,
-			linkStyles,
-			css`
+	static styles = [
+		super.styles,
+		linkStyles,
+		css`
 				:host {
 					display: block;
 				}
 			`
-		];
-	}
+	];
 
 	constructor() {
 		super();

--- a/components/skeleton/demo/skeleton-test-paragraph.js
+++ b/components/skeleton/demo/skeleton-test-paragraph.js
@@ -5,27 +5,23 @@ import { SkeletonMixin } from '../skeleton-mixin.js';
 
 export class SkeletonTestParagraph extends SkeletonMixin(LitElement) {
 
-	static get properties() {
-		return {
-			lines: { type: Number },
-			type: { type: String }
-		};
-	}
+	static properties = {
+		lines: { type: Number },
+		type: { type: String }
+	};
 
-	static get styles() {
-		return [
-			super.styles,
-			bodyStandardStyles,
-			bodyCompactStyles,
-			bodySmallStyles,
-			labelStyles,
-			css`
+	static styles = [
+		super.styles,
+		bodyStandardStyles,
+		bodyCompactStyles,
+		bodySmallStyles,
+		labelStyles,
+		css`
 				:host {
 					display: block;
 				}
 			`
-		];
-	}
+	];
 
 	constructor() {
 		super();

--- a/components/skeleton/demo/skeleton-test-stack.js
+++ b/components/skeleton/demo/skeleton-test-stack.js
@@ -4,10 +4,9 @@ import { SkeletonMixin } from '../skeleton-mixin.js';
 
 export class SkeletonTestStack extends SkeletonMixin(LitElement) {
 
-	static get styles() {
-		return [
-			super.styles,
-			css`
+	static styles = [
+		super.styles,
+		css`
 				:host {
 					display: block;
 				}
@@ -24,8 +23,7 @@ export class SkeletonTestStack extends SkeletonMixin(LitElement) {
 					z-index: 500;
 				}
 			`
-		];
-	}
+	];
 
 	render() {
 		return html`

--- a/components/skeleton/demo/skeleton-test-width.js
+++ b/components/skeleton/demo/skeleton-test-width.js
@@ -3,12 +3,10 @@ import { SkeletonMixin } from '../skeleton-mixin.js';
 
 export class SkeletonTestWidth extends SkeletonMixin(LitElement) {
 
-	static get styles() {
-		return [
-			super.styles,
-			css`:host { display: block; }`
-		];
-	}
+	static styles = [
+		super.styles,
+		css`:host { display: block; }`
+	];
 
 	render() {
 		const sizes = [...Array(19).keys()].map(i => (i + 1) * 5);

--- a/components/skeleton/skeleton-group-mixin.js
+++ b/components/skeleton/skeleton-group-mixin.js
@@ -4,11 +4,9 @@ import { SubscriberRegistryController } from '../../controllers/subscriber/subsc
 
 export const SkeletonGroupMixin = dedupeMixin(superclass => class extends SkeletonMixin(superclass) {
 
-	static get properties() {
-		return {
-			_anySubscribersWithSkeletonActive : { state: true },
-		};
-	}
+	static properties = {
+		_anySubscribersWithSkeletonActive : { state: true },
+	};
 
 	constructor() {
 		super();

--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -166,15 +166,13 @@ export const skeletonStyles = css`
 
 export const SkeletonMixin = dedupeMixin(superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * Render the component as a [skeleton loader](https://github.com/BrightspaceUI/core/tree/main/components/skeleton).
-			 * @type {boolean}
-			 */
-			skeleton: { reflect: true, type: Boolean },
-		};
-	}
+	static properties = {
+		/**
+		 * Render the component as a [skeleton loader](https://github.com/BrightspaceUI/core/tree/main/components/skeleton).
+		 * @type {boolean}
+		 */
+		skeleton: { reflect: true, type: Boolean },
+	};
 
 	static get styles() {
 		const styles = [ skeletonStyles ];

--- a/components/skip-nav/skip-nav-custom.js
+++ b/components/skip-nav/skip-nav-custom.js
@@ -7,44 +7,40 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class SkipNavCustom extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: REQUIRED: Text for the link
 			 * @type {string}
 			 */
-			text: { required: true, type: String }
-		};
-	}
+		text: { required: true, type: String }
+	};
 
-	static get styles() {
-		return css`
-			a {
-				inset-inline-start: -10000px;
-				overflow: hidden;
-				position: absolute;
-				width: 1px;
-			}
-			a:active,
-			a:focus {
-				background-color: rgba(0, 0, 0, 0.7);
-				border: 1px solid rgba(0, 0, 0, 0.8);
-				color: #ffffff;
-				cursor: pointer;
-				display: block;
-				font-weight: bold;
-				inset-block-start: 0;
-				inset-inline-start: 25%;
-				margin: 0 auto;
-				outline: none;
-				padding: 0.3em;
-				text-align: center;
-				text-decoration: none;
-				width: 50%;
-				z-index: 10000;
-			}
-		`;
-	}
+	static styles = css`
+		a {
+			inset-inline-start: -10000px;
+			overflow: hidden;
+			position: absolute;
+			width: 1px;
+		}
+		a:active,
+		a:focus {
+			background-color: rgba(0, 0, 0, 0.7);
+			border: 1px solid rgba(0, 0, 0, 0.8);
+			color: #ffffff;
+			cursor: pointer;
+			display: block;
+			font-weight: bold;
+			inset-block-start: 0;
+			inset-inline-start: 25%;
+			margin: 0 auto;
+			outline: none;
+			padding: 0.3em;
+			text-align: center;
+			text-decoration: none;
+			width: 50%;
+			z-index: 10000;
+		}
+	`;
 
 	static get focusElementSelector() {
 		return 'a';

--- a/components/sorting/sort.js
+++ b/components/sorting/sort.js
@@ -24,19 +24,17 @@ class Sort extends FocusMixin(LocalizeCoreElement(LitElement)) {
 		_selectedItemValue: { state: true },
 	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			::slotted(:not(d2l-sort-item)) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		::slotted(:not(d2l-sort-item)) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/status-indicator/status-indicator.js
+++ b/components/status-indicator/status-indicator.js
@@ -6,88 +6,84 @@ import { css, html, LitElement } from 'lit';
  */
 class StatusIndicator extends LitElement {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * State of status indicator to display
 			 * @type {'default'|'success'|'alert'|'none'}
 			 */
-			state: {
-				type: String,
-				reflect: true
-			},
-			/**
+		state: {
+			type: String,
+			reflect: true
+		},
+		/**
 			 * REQUIRED: The text that is displayed within the status indicator
 			 * @type {string}
 			 */
-			text: {
-				type: String
-			},
-			/**
+		text: {
+			type: String
+		},
+		/**
 			 * Use when the status is very important and needs to have a lot of prominence
 			 * @type {boolean}
 			 */
-			bold: {
-				type: Boolean,
-				reflect: true
-			}
-		};
-	}
+		bold: {
+			type: Boolean,
+			reflect: true
+		}
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				border-color: var(--d2l-color-celestine);
-				border-radius: 0.6rem;
-				border-style: solid;
-				border-width: 1px;
-				color: var(--d2l-color-celestine);
-				cursor: default;
-				display: inline-block;
-				font-size: 0.6rem;
-				font-weight: bold;
-				line-height: 1;
-				overflow: hidden;
-				padding: 2px 10px 2px 10px;
-				text-overflow: ellipsis;
-				text-transform: capitalize;
-				vertical-align: middle;
-				white-space: nowrap;
-			}
+	static styles = css`
+		:host {
+			border-color: var(--d2l-color-celestine);
+			border-radius: 0.6rem;
+			border-style: solid;
+			border-width: 1px;
+			color: var(--d2l-color-celestine);
+			cursor: default;
+			display: inline-block;
+			font-size: 0.6rem;
+			font-weight: bold;
+			line-height: 1;
+			overflow: hidden;
+			padding: 2px 10px 2px 10px;
+			text-overflow: ellipsis;
+			text-transform: capitalize;
+			vertical-align: middle;
+			white-space: nowrap;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
-			:host([state="success"]) {
-				border-color: var(--d2l-color-olivine-minus-1);
-				color: var(--d2l-color-olivine-minus-1);
-			}
-			:host([state="alert"]) {
-				border-color: var(--d2l-color-cinnabar);
-				color: var(--d2l-color-cinnabar);
-			}
-			:host([state="none"]),
-			:host([state="null"]) {
-				border-color: var(--d2l-color-tungsten);
-				color: var(--d2l-color-tungsten);
-			}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([state="success"]) {
+			border-color: var(--d2l-color-olivine-minus-1);
+			color: var(--d2l-color-olivine-minus-1);
+		}
+		:host([state="alert"]) {
+			border-color: var(--d2l-color-cinnabar);
+			color: var(--d2l-color-cinnabar);
+		}
+		:host([state="none"]),
+		:host([state="null"]) {
+			border-color: var(--d2l-color-tungsten);
+			color: var(--d2l-color-tungsten);
+		}
 
-			:host([bold]) {
-				background-color: var(--d2l-color-celestine);
-				color: white;
-			}
-			:host([bold][state="success"]) {
-				background-color: var(--d2l-color-olivine-minus-1);
-			}
-			:host([bold][state="alert"]) {
-				background-color: var(--d2l-color-cinnabar);
-			}
-			:host([bold][state="none"]),
-			:host([bold][state="null"]) {
-				background-color: var(--d2l-color-tungsten);
-			}
-		`;
-	}
+		:host([bold]) {
+			background-color: var(--d2l-color-celestine);
+			color: white;
+		}
+		:host([bold][state="success"]) {
+			background-color: var(--d2l-color-olivine-minus-1);
+		}
+		:host([bold][state="alert"]) {
+			background-color: var(--d2l-color-cinnabar);
+		}
+		:host([bold][state="none"]),
+		:host([bold][state="null"]) {
+			background-color: var(--d2l-color-tungsten);
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/switch/switch-mixin.js
+++ b/components/switch/switch-mixin.js
@@ -9,158 +9,154 @@ import { RtlMixin } from '../../mixins/rtl/rtl-mixin.js';
 
 export const SwitchMixin = superclass => class extends FocusMixin(RtlMixin(superclass)) {
 
-	static get properties() {
-		return {
-			/**
-			 * Disables the switch from being toggled.
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Active state.
-			 * @type {boolean}
-			 */
-			on: { type: Boolean, reflect: true },
-			/**
-			 * @ignore - Need to add documentation in each component that uses this mixin.
-			 */
-			text: { type: String, reflect: true },
-			/**
-			 * Determines where text should be positioned relative to the switch.
-			 * @type {'start'|'end'|'hidden'}
-			 * @default end
-			 */
-			textPosition: { type: String, attribute: 'text-position', reflect: true },
-			_hovering: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the switch from being toggled.
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Active state.
+		 * @type {boolean}
+		 */
+		on: { type: Boolean, reflect: true },
+		/**
+		 * @ignore - Need to add documentation in each component that uses this mixin.
+		 */
+		text: { type: String, reflect: true },
+		/**
+		 * Determines where text should be positioned relative to the switch.
+		 * @type {'start'|'end'|'hidden'}
+		 * @default end
+		 */
+		textPosition: { type: String, attribute: 'text-position', reflect: true },
+		_hovering: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-				user-select: none;
-				white-space: nowrap;
-			}
-			:host([hidden]) {
-				display: none;
-			}
+	static styles = css`
+		:host {
+			display: inline-block;
+			user-select: none;
+			white-space: nowrap;
+		}
+		:host([hidden]) {
+			display: none;
+		}
 
-			.d2l-switch-container {
-				--d2l-focus-ring-offset: 0;
-				background-color: var(--d2l-switch-container-background-color, var(--d2l-theme-background-color-base));
-				border-radius: 1rem;
-				box-sizing: border-box;
-				cursor: default;
-				display: inline-block;
-				font-size: 0;
-				line-height: 0;
-				outline-style: none;
-				padding: 0.1rem;
-				vertical-align: middle;
+		.d2l-switch-container {
+			--d2l-focus-ring-offset: 0;
+			background-color: var(--d2l-switch-container-background-color, var(--d2l-theme-background-color-base));
+			border-radius: 1rem;
+			box-sizing: border-box;
+			cursor: default;
+			display: inline-block;
+			font-size: 0;
+			line-height: 0;
+			outline-style: none;
+			padding: 0.1rem;
+			vertical-align: middle;
+		}
+		${getFocusRingStyles('.d2l-switch-container', { extraStyles: css`position: relative;` })}
+		:host([disabled]) .d2l-switch-container {
+			cursor: default;
+			opacity: var(--d2l-theme-opacity-disabled-control);
+		}
+		:host([disabled]) .d2l-switch-container:hover > .d2l-switch-inner,
+		:host([disabled]) .d2l-switch-inner:hover,
+		:host([disabled]) .switch-hover {
+			outline: none;
+		}
+		.d2l-switch-inner {
+			border: 1px solid var(--d2l-theme-border-color-emphasized);
+			border-radius: 0.8rem;
+			box-sizing: border-box;
+			padding: 0.3rem;
+			position: relative;
+			width: 3rem;
+		}
+		:host([on]) .d2l-switch-inner {
+			background-color: var(--d2l-theme-background-color-interactive-highlighted);
+		}
+		.d2l-switch-toggle {
+			position: relative;
+			transition: transform 150ms ease-out;
+		}
+		.d2l-switch-toggle > div {
+			background-color: var(--d2l-theme-background-color-base);
+			border: 1px solid var(--d2l-theme-border-color-emphasized);
+			border-radius: 0.6rem;
+			box-sizing: border-box;
+			display: inline-block;
+			height: 1.1rem;
+			left: -0.1rem;
+			position: absolute;
+			top: -0.95rem;
+			width: 1.1rem;
+		}
+		:host([on]) .d2l-switch-toggle > div {
+			left: 0.1rem;
+		}
+		:host([dir="rtl"][on]) .d2l-switch-toggle > div {
+			right: 0.3rem;
+		}
+		:host([dir="rtl"]) .d2l-switch-toggle > div {
+			left: auto;
+			right: -0.1rem;
+		}
+		:host([on]) .d2l-switch-toggle {
+			transform: translateX(1.2rem);
+		}
+		:host([dir="rtl"][on]) .d2l-switch-toggle {
+			right: -0.2rem;
+			transform: translateX(-1.2rem);
+		}
+		d2l-icon, d2l-icon-custom {
+			height: 0.8rem;
+			width: 0.8rem;
+		}
+		.d2l-switch-icon-on, .d2l-switch-icon-off {
+			display: inline-block;
+			transform: scale(1);
+			transition: transform 150ms ease-out;
+		}
+		.d2l-switch-icon-on {
+			margin-right: 0.65rem;
+		}
+		:host([dir="rtl"]) .d2l-switch-icon-on {
+			margin-left: 0.65rem;
+			margin-right: 0;
+		}
+		:host([on]) .d2l-switch-icon-on > d2l-icon,
+		:host([on]) .d2l-switch-icon-on > d2l-icon-custom {
+			color: var(--d2l-theme-icon-color-active);
+		}
+		:host([on]) .d2l-switch-icon-off {
+			transform: scale(0.35);
+		}
+		:host(:not([on])) .d2l-switch-icon-on {
+			color: var(--d2l-theme-icon-color-active);
+			transform: scale(0.35);
+		}
+		.d2l-switch-text {
+			cursor: default;
+			font-size: 0.8rem;
+			font-weight: 400;
+		}
+		:host([text-position="hidden"]) .d2l-switch-text {
+			display: none;
+		}
+		.d2l-switch-inner:hover, .switch-hover {
+			outline: 2px solid var(--d2l-theme-border-color-focus);
+			outline-offset: -2px;
+		}
+		@media (prefers-reduced-motion: reduce) {
+			.d2l-switch-toggle,
+			.d2l-switch-icon-on,
+			.d2l-switch-icon-off {
+				transition: none;
 			}
-			${getFocusRingStyles('.d2l-switch-container', { extraStyles: css`position: relative;` })}
-			:host([disabled]) .d2l-switch-container {
-				cursor: default;
-				opacity: var(--d2l-theme-opacity-disabled-control);
-			}
-			:host([disabled]) .d2l-switch-container:hover > .d2l-switch-inner,
-			:host([disabled]) .d2l-switch-inner:hover,
-			:host([disabled]) .switch-hover {
-				outline: none;
-			}
-			.d2l-switch-inner {
-				border: 1px solid var(--d2l-theme-border-color-emphasized);
-				border-radius: 0.8rem;
-				box-sizing: border-box;
-				padding: 0.3rem;
-				position: relative;
-				width: 3rem;
-			}
-			:host([on]) .d2l-switch-inner {
-				background-color: var(--d2l-theme-background-color-interactive-highlighted);
-			}
-			.d2l-switch-toggle {
-				position: relative;
-				transition: transform 150ms ease-out;
-			}
-			.d2l-switch-toggle > div {
-				background-color: var(--d2l-theme-background-color-base);
-				border: 1px solid var(--d2l-theme-border-color-emphasized);
-				border-radius: 0.6rem;
-				box-sizing: border-box;
-				display: inline-block;
-				height: 1.1rem;
-				left: -0.1rem;
-				position: absolute;
-				top: -0.95rem;
-				width: 1.1rem;
-			}
-			:host([on]) .d2l-switch-toggle > div {
-				left: 0.1rem;
-			}
-			:host([dir="rtl"][on]) .d2l-switch-toggle > div {
-				right: 0.3rem;
-			}
-			:host([dir="rtl"]) .d2l-switch-toggle > div {
-				left: auto;
-				right: -0.1rem;
-			}
-			:host([on]) .d2l-switch-toggle {
-				transform: translateX(1.2rem);
-			}
-			:host([dir="rtl"][on]) .d2l-switch-toggle {
-				right: -0.2rem;
-				transform: translateX(-1.2rem);
-			}
-			d2l-icon, d2l-icon-custom {
-				height: 0.8rem;
-				width: 0.8rem;
-			}
-			.d2l-switch-icon-on, .d2l-switch-icon-off {
-				display: inline-block;
-				transform: scale(1);
-				transition: transform 150ms ease-out;
-			}
-			.d2l-switch-icon-on {
-				margin-right: 0.65rem;
-			}
-			:host([dir="rtl"]) .d2l-switch-icon-on {
-				margin-left: 0.65rem;
-				margin-right: 0;
-			}
-			:host([on]) .d2l-switch-icon-on > d2l-icon,
-			:host([on]) .d2l-switch-icon-on > d2l-icon-custom {
-				color: var(--d2l-theme-icon-color-active);
-			}
-			:host([on]) .d2l-switch-icon-off {
-				transform: scale(0.35);
-			}
-			:host(:not([on])) .d2l-switch-icon-on {
-				color: var(--d2l-theme-icon-color-active);
-				transform: scale(0.35);
-			}
-			.d2l-switch-text {
-				cursor: default;
-				font-size: 0.8rem;
-				font-weight: 400;
-			}
-			:host([text-position="hidden"]) .d2l-switch-text {
-				display: none;
-			}
-			.d2l-switch-inner:hover, .switch-hover {
-				outline: 2px solid var(--d2l-theme-border-color-focus);
-				outline-offset: -2px;
-			}
-			@media (prefers-reduced-motion: reduce) {
-				.d2l-switch-toggle,
-				.d2l-switch-icon-on,
-				.d2l-switch-icon-off {
-					transition: none;
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/switch/switch-visibility.js
+++ b/components/switch/switch-visibility.js
@@ -12,22 +12,18 @@ import { SwitchMixin } from './switch-mixin.js';
  */
 class VisibilitySwitch extends LocalizeCoreElement(SwitchMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			_hasConditions: { state: true }
-		};
-	}
+	static properties = {
+		_hasConditions: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			d2l-tooltip-help {
-				display: none;
-			}
-			d2l-tooltip-help.switch-visibility-conditions-show {
-				display: inline;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		d2l-tooltip-help {
+			display: none;
+		}
+		d2l-tooltip-help.switch-visibility-conditions-show {
+			display: inline;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/switch/switch.js
+++ b/components/switch/switch.js
@@ -11,13 +11,11 @@ import { SwitchMixin } from './switch-mixin.js';
  */
 class Switch extends SwitchMixin(LitElement) {
 
-	static get styles() {
-		return [super.styles, css`
-			.d2l-switch-icon-off > d2l-icon-custom {
-				color: var(--d2l-theme-icon-color-standard);
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		.d2l-switch-icon-off > d2l-icon-custom {
+			color: var(--d2l-theme-icon-color-standard);
+		}
+	`];
 
 	get offIcon() {
 		return html`

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -65,9 +65,7 @@ The `d2l-table-wrapper` element can be combined with table styles to apply defau
 
   class SampleTable extends LitElement {
 
-    static get styles() {
-      return tableStyles;
-    }
+    static styles = tableStyles;
 
     render() {
       const type = this.type === 'light' ? 'light' : 'default';
@@ -147,15 +145,11 @@ For the example below:
 
   class MySortableTableElem extends LitElement {
 
-    static get properties() {
-      return {
-        _sortDesc: { attribute: false, type: Boolean }
-      };
-    }
+    static properties = {
+      _sortDesc: { attribute: false, type: Boolean }
+    };
 
-    static get styles() {
-      return tableStyles;
-    }
+    static styles = tableStyles;
 
     constructor() {
       super();
@@ -290,15 +284,11 @@ When a single column is responsible for sorting in multiple facets (e.g., first 
     { firstname: 'Christopher', lastname: 'Martinez', grade: 83 }
   ];
   class MyComplexSortableTableElem extends LitElement {
-    static get properties() {
-      return {
-        _desc: { state: true },
-        _field: { state: true }
-      };
-    }
-    static get styles() {
-      return tableStyles;
-    }
+    static properties = {
+      _desc: { state: true },
+      _field: { state: true }
+    };
+    static styles = tableStyles;
     constructor() {
       super();
       this._data = data();
@@ -382,16 +372,12 @@ To enable selection, add `d2l-selection-input` components in the selection colum
 
   class SampleTableWithSelectionInputs extends LitElement {
 
-    static get properties() {
-      return {
-        selectionSingle: { type: Boolean, attribute: 'selection-single' },
-        _data: { state: true }
-      }
-    }
+    static properties = {
+      selectionSingle: { type: Boolean, attribute: 'selection-single' },
+      _data: { state: true }
+    };
 
-    static get styles() {
-      return tableStyles;
-    }
+    static styles = tableStyles;
 
     constructor() {
       super();
@@ -494,15 +480,11 @@ The `d2l-table-controls` component can be placed in the `d2l-table-wrapper`'s `c
 
   class SampleTableWithControls extends LitElement {
 
-    static get properties() {
-      return {
-        _data: { state: true }
-      }
-    }
+    static properties = {
+      _data: { state: true }
+    };
 
-    static get styles() {
-      return tableStyles;
-    }
+    static styles = tableStyles;
 
     constructor() {
       super();

--- a/components/table/demo/table-test.js
+++ b/components/table/demo/table-test.js
@@ -39,38 +39,34 @@ const formatter = new Intl.NumberFormat('en-US');
 
 class TestTable extends DemoPassthroughMixin(TableWrapper, 'd2l-table-wrapper') {
 
-	static get properties() {
-		return {
-			paging: { type: Boolean, reflect: true },
-			multiLine: { type: Boolean, attribute: 'multi-line' },
-			resetOnSort: { type: Boolean, attribute: 'reset-on-sort' },
-			showButtons: { type: Boolean, attribute: 'show-buttons' },
-			stickyControls: { attribute: 'sticky-controls', type: Boolean, reflect: true },
-			visibleBackground: { attribute: 'visible-background', type: Boolean, reflect: true },
-			_data: { state: true },
-			_sortField: { state: true },
-			_sortDesc: { state: true }
-		};
-	}
+	static properties = {
+		paging: { type: Boolean, reflect: true },
+		multiLine: { type: Boolean, attribute: 'multi-line' },
+		resetOnSort: { type: Boolean, attribute: 'reset-on-sort' },
+		showButtons: { type: Boolean, attribute: 'show-buttons' },
+		stickyControls: { attribute: 'sticky-controls', type: Boolean, reflect: true },
+		visibleBackground: { attribute: 'visible-background', type: Boolean, reflect: true },
+		_data: { state: true },
+		_sortField: { state: true },
+		_sortDesc: { state: true }
+	};
 
-	static get styles() {
-		return [tableStyles, css`
-			:host {
-				display: block;
-			}
-			:host([visible-background]) {
-				--d2l-table-controls-background-color: #dddddd;
-			}
-			.d2l-table > * > tr > :has(d2l-button-icon),
-			.d2l-table > * > tr > :has(d2l-dropdown-context-menu) {
-				padding-block: 0;
-			}
-			.d2l-table > * > tr > :has(d2l-table-col-sort-button) d2l-button-icon,
-			.d2l-table > * > tr > :has(d2l-table-col-sort-button) d2l-dropdown-context-menu {
-				vertical-align: top;
-			}
-		`];
-	}
+	static styles = [tableStyles, css`
+		:host {
+			display: block;
+		}
+		:host([visible-background]) {
+			--d2l-table-controls-background-color: #dddddd;
+		}
+		.d2l-table > * > tr > :has(d2l-button-icon),
+		.d2l-table > * > tr > :has(d2l-dropdown-context-menu) {
+			padding-block: 0;
+		}
+		.d2l-table > * > tr > :has(d2l-table-col-sort-button) d2l-button-icon,
+		.d2l-table > * > tr > :has(d2l-table-col-sort-button) d2l-dropdown-context-menu {
+			vertical-align: top;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/table/table-col-sort-button-item.js
+++ b/components/table/table-col-sort-button-item.js
@@ -11,9 +11,7 @@ import { menuItemSelectableStyles } from '../menu/menu-item-selectable-styles.js
  */
 class TableColSortButtonItem extends MenuItemRadioMixin(LitElement) {
 
-	static get styles() {
-		return menuItemSelectableStyles;
-	}
+	static styles = menuItemSelectableStyles;
 
 	firstUpdated() {
 		super.firstUpdated();

--- a/components/table/table-col-sort-button.js
+++ b/components/table/table-col-sort-button.js
@@ -19,115 +19,111 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 export class TableColSortButton extends LocalizeCoreElement(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Whether sort direction is descending
 			 * @type {boolean}
 			 */
-			desc: {
-				reflect: true,
-				type: Boolean
-			},
-			/**
+		desc: {
+			reflect: true,
+			type: Boolean
+		},
+		/**
 			 * Column is not currently sorted. Hides the ascending/descending sort icon.
 			 * @type {boolean}
 			 */
-			nosort: {
-				reflect: true,
-				type: Boolean
-			},
-			/**
+		nosort: {
+			reflect: true,
+			type: Boolean
+		},
+		/**
 			 * Position of the button content
 			 * @type {'start'|'center'|'end'}
 			 */
-			position: {
-				reflect: true,
-				type: String
-			},
-			/**
+		position: {
+			reflect: true,
+			type: String
+		},
+		/**
 			 * ACCESSIBILITY: The type of data in the column (e.g., 'words'). Used to set the title.
 			 *  @type {'words'|'numbers'|'dates'|'unknown'}
 			 */
-			sourceType: {
-				attribute: 'source-type',
-				type: String
-			},
-			_hasDropdownItems: { state: true },
-			_selectedMenuItemText: { state: true },
-			_label: { state: true },
-		};
-	}
+		sourceType: {
+			attribute: 'source-type',
+			type: String
+		},
+		_hasDropdownItems: { state: true },
+		_selectedMenuItemText: { state: true },
+		_label: { state: true },
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				--d2l-table-col-sort-button-additional-padding-inline-end: 0px; /* stylelint-disable-line length-zero-no-unit */
-				--d2l-table-col-sort-button-additional-padding-inline-start: 0px; /* stylelint-disable-line length-zero-no-unit */
-				--d2l-table-col-sort-button-width: calc(100% - var(--d2l-table-cell-col-sort-button-size-offset, 4px));
-			}
-			:host([nosort]) {
-				--d2l-table-col-sort-button-additional-padding-inline-end: calc(0.6rem + 18px);
-			}
-			:host > :first-child {
-				width: var(--d2l-table-col-sort-button-width);
-			}
-			:host([nosort][position="center"]) {
-				--d2l-table-col-sort-button-additional-padding-inline-end: calc(0.5 * (0.6rem + 18px) + var(--d2l-table-cell-col-sort-button-size-offset, 4px));
-				--d2l-table-col-sort-button-additional-padding-inline-start: calc(0.5 * (0.6rem + 18px) - var(--d2l-table-cell-col-sort-button-size-offset, 4px));
-			}
-			:host([nosort][position="end"]) {
-				--d2l-table-col-sort-button-additional-padding-inline-end: 0px; /* stylelint-disable-line length-zero-no-unit */
-				--d2l-table-col-sort-button-additional-padding-inline-start: calc(0.6rem + 18px);
-			}
-			:host([position="center"]) button {
-				justify-content: center;
-			}
-			:host([position="end"]) button {
-				justify-content: end;
-			}
-			button {
-				align-items: center;
-				background-color: transparent;
-				border: none;
-				border-radius: 4px;
-				color: inherit;
-				cursor: pointer;
-				display: inline-flex;
-				font-family: inherit;
-				font-size: inherit;
-				letter-spacing: inherit;
-				line-height: 0.9rem;
-				margin-block: 0 var(--d2l-table-cell-col-sort-button-size-offset, 4px);
-				margin-inline: 0 var(--d2l-table-cell-col-sort-button-size-offset, 4px);
-				padding: calc(var(--d2l-table-cell-padding) - var(--d2l-table-cell-col-sort-button-size-offset, 4px));
-				padding-inline-end: calc(var(--d2l-table-cell-padding) - var(--d2l-table-cell-col-sort-button-size-offset, 4px) + var(--d2l-table-col-sort-button-additional-padding-inline-end));
-				padding-inline-start: calc(var(--d2l-table-cell-padding) - var(--d2l-table-cell-col-sort-button-size-offset, 4px) + var(--d2l-table-col-sort-button-additional-padding-inline-start));
-				text-align: start;
-				text-decoration: none;
-				width: 100%;
-			}
-			button::-moz-focus-inner {
-				border: 0;
-			}
-			button:disabled {
-				opacity: 0.5;
-			}
-			button:hover {
-				background-color: var(--d2l-color-gypsum);
-			}
-			${getFocusRingStyles('button', { extraStyles: css`box-shadow: 0 0 0 2px #ffffff;` })}
-			d2l-icon {
-				margin-inline-start: 0.6rem;
-			}
-			::slotted(*[slot="items"]) {
-				display: none;
-			}
-			::slotted(d2l-table-col-sort-button-item[slot="items"]) {
-				display: flex;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			--d2l-table-col-sort-button-additional-padding-inline-end: 0px; /* stylelint-disable-line length-zero-no-unit */
+			--d2l-table-col-sort-button-additional-padding-inline-start: 0px; /* stylelint-disable-line length-zero-no-unit */
+			--d2l-table-col-sort-button-width: calc(100% - var(--d2l-table-cell-col-sort-button-size-offset, 4px));
+		}
+		:host([nosort]) {
+			--d2l-table-col-sort-button-additional-padding-inline-end: calc(0.6rem + 18px);
+		}
+		:host > :first-child {
+			width: var(--d2l-table-col-sort-button-width);
+		}
+		:host([nosort][position="center"]) {
+			--d2l-table-col-sort-button-additional-padding-inline-end: calc(0.5 * (0.6rem + 18px) + var(--d2l-table-cell-col-sort-button-size-offset, 4px));
+			--d2l-table-col-sort-button-additional-padding-inline-start: calc(0.5 * (0.6rem + 18px) - var(--d2l-table-cell-col-sort-button-size-offset, 4px));
+		}
+		:host([nosort][position="end"]) {
+			--d2l-table-col-sort-button-additional-padding-inline-end: 0px; /* stylelint-disable-line length-zero-no-unit */
+			--d2l-table-col-sort-button-additional-padding-inline-start: calc(0.6rem + 18px);
+		}
+		:host([position="center"]) button {
+			justify-content: center;
+		}
+		:host([position="end"]) button {
+			justify-content: end;
+		}
+		button {
+			align-items: center;
+			background-color: transparent;
+			border: none;
+			border-radius: 4px;
+			color: inherit;
+			cursor: pointer;
+			display: inline-flex;
+			font-family: inherit;
+			font-size: inherit;
+			letter-spacing: inherit;
+			line-height: 0.9rem;
+			margin-block: 0 var(--d2l-table-cell-col-sort-button-size-offset, 4px);
+			margin-inline: 0 var(--d2l-table-cell-col-sort-button-size-offset, 4px);
+			padding: calc(var(--d2l-table-cell-padding) - var(--d2l-table-cell-col-sort-button-size-offset, 4px));
+			padding-inline-end: calc(var(--d2l-table-cell-padding) - var(--d2l-table-cell-col-sort-button-size-offset, 4px) + var(--d2l-table-col-sort-button-additional-padding-inline-end));
+			padding-inline-start: calc(var(--d2l-table-cell-padding) - var(--d2l-table-cell-col-sort-button-size-offset, 4px) + var(--d2l-table-col-sort-button-additional-padding-inline-start));
+			text-align: start;
+			text-decoration: none;
+			width: 100%;
+		}
+		button::-moz-focus-inner {
+			border: 0;
+		}
+		button:disabled {
+			opacity: 0.5;
+		}
+		button:hover {
+			background-color: var(--d2l-color-gypsum);
+		}
+		${getFocusRingStyles('button', { extraStyles: css`box-shadow: 0 0 0 2px #ffffff;` })}
+		d2l-icon {
+			margin-inline-start: 0.6rem;
+		}
+		::slotted(*[slot="items"]) {
+			display: none;
+		}
+		::slotted(d2l-table-col-sort-button-item[slot="items"]) {
+			display: flex;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/table/table-controls.js
+++ b/components/table/table-controls.js
@@ -5,28 +5,24 @@ import { SelectionControls } from '../selection/selection-controls.js';
  * Controls for table components containing a selection summary and selection actions.
  */
 class TableControls extends SelectionControls {
-	static get properties() {
-		return {
-			/**
-			 * Whether to render the selection summary
-			 * @type {boolean}
-			 */
-			noSelection: { type: Boolean, attribute: 'no-selection' }
-		};
-	}
+	static properties = {
+		/**
+		 * Whether to render the selection summary
+		 * @type {boolean}
+		 */
+		noSelection: { type: Boolean, attribute: 'no-selection' }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				--d2l-selection-controls-background-color: var(--d2l-table-controls-background-color);
-				--d2l-selection-controls-shadow-display: var(--d2l-table-controls-shadow-display);
-				z-index: 6; /* Must be greater than d2l-table-wrapper and d2l-scroll-wrapper */
-			}
-			:host([no-sticky]) {
-				z-index: auto;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			--d2l-selection-controls-background-color: var(--d2l-table-controls-background-color);
+			--d2l-selection-controls-shadow-display: var(--d2l-table-controls-shadow-display);
+			z-index: 6; /* Must be greater than d2l-table-wrapper and d2l-scroll-wrapper */
+		}
+		:host([no-sticky]) {
+			z-index: auto;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -268,136 +268,132 @@ const SELECTORS = {
  */
 export class TableWrapper extends PropertyRequiredMixin(PageableMixin(SelectionMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
-			 * Hides the column borders on "default" table type
-			 * @type {boolean}
-			 */
-			noColumnBorder: {
-				attribute: 'no-column-border',
-				reflect: true,
-				type: Boolean
+	static properties = {
+		/**
+		 * Hides the column borders on "default" table type
+		 * @type {boolean}
+		 */
+		noColumnBorder: {
+			attribute: 'no-column-border',
+			reflect: true,
+			type: Boolean
+		},
+		/**
+		 * Whether the header row is sticky. Useful for long tables to "stick" the header row in place as the user scrolls.
+		 * @type {boolean}
+		 */
+		stickyHeaders: {
+			attribute: 'sticky-headers',
+			reflect: true,
+			type: Boolean
+		},
+		/**
+		 * When used in combo with `sticky-headers`, whether to additionally wrap the table in a scroll-wrapper. Requires sticky headers to be in a separate thead.
+		 * @type {boolean}
+		 */
+		stickyHeadersScrollWrapper: {
+			attribute: 'sticky-headers-scroll-wrapper',
+			reflect: true,
+			type: Boolean
+		},
+		_stickyWidth: { state: true },
+		/**
+		 * Type of table style to apply. The "light" style has fewer borders and tighter padding.
+		 * @type {'default'|'light'}
+		 */
+		type: {
+			reflect: true,
+			type: String
+		},
+		_controlsScrolled: { state: true },
+		_noScrollWidth: {
+			attribute: '_no-scroll-width',
+			reflect: true,
+			type: Boolean,
+		},
+		/**
+		 * The state of data in the table. Set to 'clean' when the data represents the user's latest selections, 'dirty' when the data does not represent the user's latest selections, and 'loading' if the data is being actively refreshed
+		 * @type {'clean'|'dirty'|'loading'}
+		 */
+		dataState: {
+			reflect: true,
+			type: String
+		},
+		/**
+		 * The text displayed on the dirty state overlay when the 'dirty' dataState is set.
+		 * @type {string}
+		 */
+		dirtyText: {
+			reflect: true,
+			attribute: 'dirty-text',
+			required: {
+				dependentProps: ['dataState'],
+				validator: (_value, elem, hasValue) => hasValue || elem.dataState !== 'dirty'
 			},
-			/**
-			 * Whether the header row is sticky. Useful for long tables to "stick" the header row in place as the user scrolls.
-			 * @type {boolean}
-			 */
-			stickyHeaders: {
-				attribute: 'sticky-headers',
-				reflect: true,
-				type: Boolean
+			type: String
+		},
+		/**
+		 * The text displayed on the button dirty state overlay when the 'dirty' dataState is set.
+		 * @type {string}
+		 */
+		dirtyButtonText: {
+			reflect: true,
+			attribute: 'dirty-button-text',
+			required: {
+				dependentProps: ['dataState'],
+				validator: (_value, elem, hasValue) => hasValue || elem.dataState !== 'dirty'
 			},
-			/**
-			 * When used in combo with `sticky-headers`, whether to additionally wrap the table in a scroll-wrapper. Requires sticky headers to be in a separate thead.
-			 * @type {boolean}
-			 */
-			stickyHeadersScrollWrapper: {
-				attribute: 'sticky-headers-scroll-wrapper',
-				reflect: true,
-				type: Boolean
-			},
-			_stickyWidth: { state: true },
-			/**
-			 * Type of table style to apply. The "light" style has fewer borders and tighter padding.
-			 * @type {'default'|'light'}
-			 */
-			type: {
-				reflect: true,
-				type: String
-			},
-			_controlsScrolled: { state: true },
-			_noScrollWidth: {
-				attribute: '_no-scroll-width',
-				reflect: true,
-				type: Boolean,
-			},
-			/**
-			 * The state of data in the table. Set to 'clean' when the data represents the user's latest selections, 'dirty' when the data does not represent the user's latest selections, and 'loading' if the data is being actively refreshed
-			 * @type {'clean'|'dirty'|'loading'}
-			 */
-			dataState: {
-				reflect: true,
-				type: String
-			},
-			/**
-			 * The text displayed on the dirty state overlay when the 'dirty' dataState is set.
-			 * @type {string}
-			 */
-			dirtyText: {
-				reflect: true,
-				attribute: 'dirty-text',
-				required: {
-					dependentProps: ['dataState'],
-					validator: (_value, elem, hasValue) => hasValue || elem.dataState !== 'dirty'
-				},
-				type: String
-			},
-			/**
-			 * The text displayed on the button dirty state overlay when the 'dirty' dataState is set.
-			 * @type {string}
-			 */
-			dirtyButtonText: {
-				reflect: true,
-				attribute: 'dirty-button-text',
-				required: {
-					dependentProps: ['dataState'],
-					validator: (_value, elem, hasValue) => hasValue || elem.dataState !== 'dirty'
-				},
-				type: String
-			}
-		};
-	}
+			type: String
+		}
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				--d2l-table-border: 1px solid var(--d2l-table-border-color);
-				--d2l-table-border-color: var(--d2l-color-mica);
-				--d2l-table-border-radius: 0.3rem;
-				--d2l-table-border-radius-sticky-offset: calc(1px - var(--d2l-table-border-radius));
-				--d2l-table-cell-overall-height: 46px;
-				--d2l-table-cell-height: calc(var(--d2l-table-cell-overall-height) - 2 * var(--d2l-table-cell-padding));
-				--d2l-table-cell-padding: 0.7rem;
-				--d2l-table-cell-padding-alt: calc(0.7rem - 1px) 0.7rem 0.7rem 0.7rem;
-				--d2l-table-cell-col-sort-button-size-offset: 4px;
-				--d2l-table-header-background-color: var(--d2l-color-regolith);
-				--d2l-table-row-border-color-selected: var(--d2l-color-celestine);
-				--d2l-table-row-background-color-selected: var(--d2l-color-celestine-plus-2);
-				display: block;
-				width: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([type="light"]) {
-				--d2l-table-border-radius: 0rem; /* stylelint-disable-line length-zero-no-unit */
-				--d2l-table-border-radius-sticky-offset: 0rem; /* stylelint-disable-line length-zero-no-unit */
-				--d2l-table-border-color: var(--d2l-color-gypsum);
-				--d2l-table-header-background-color: #ffffff;
-			}
-			:host([sticky-headers]) {
-				--d2l-table-controls-shadow-display: none;
-			}
-			.d2l-sticky-headers-backdrop {
-				position: sticky;
-				top: calc(var(--d2l-table-sticky-top, 0px) + var(--d2l-table-border-radius));
-				width: 100%;
-				z-index: 2; /* Must sit under d2l-table sticky-headers but over sticky columns and regular cells */
-			}
-			.d2l-sticky-headers-backdrop::after {
-				background-color: var(--d2l-table-controls-background-color, white);
-				bottom: 0;
-				content: "";
-				position: absolute;
-				top: calc(-7px - var(--d2l-table-border-radius)); /* 6px for the d2l-table-controls margin-bottom, 1px overlap to fix zoom issues */
-				width: 100%;
-			}
-			slot[name="pager"]::slotted(*) {
-				margin-top: 12px;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			--d2l-table-border: 1px solid var(--d2l-table-border-color);
+			--d2l-table-border-color: var(--d2l-color-mica);
+			--d2l-table-border-radius: 0.3rem;
+			--d2l-table-border-radius-sticky-offset: calc(1px - var(--d2l-table-border-radius));
+			--d2l-table-cell-overall-height: 46px;
+			--d2l-table-cell-height: calc(var(--d2l-table-cell-overall-height) - 2 * var(--d2l-table-cell-padding));
+			--d2l-table-cell-padding: 0.7rem;
+			--d2l-table-cell-padding-alt: calc(0.7rem - 1px) 0.7rem 0.7rem 0.7rem;
+			--d2l-table-cell-col-sort-button-size-offset: 4px;
+			--d2l-table-header-background-color: var(--d2l-color-regolith);
+			--d2l-table-row-border-color-selected: var(--d2l-color-celestine);
+			--d2l-table-row-background-color-selected: var(--d2l-color-celestine-plus-2);
+			display: block;
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([type="light"]) {
+			--d2l-table-border-radius: 0rem; /* stylelint-disable-line length-zero-no-unit */
+			--d2l-table-border-radius-sticky-offset: 0rem; /* stylelint-disable-line length-zero-no-unit */
+			--d2l-table-border-color: var(--d2l-color-gypsum);
+			--d2l-table-header-background-color: #ffffff;
+		}
+		:host([sticky-headers]) {
+			--d2l-table-controls-shadow-display: none;
+		}
+		.d2l-sticky-headers-backdrop {
+			position: sticky;
+			top: calc(var(--d2l-table-sticky-top, 0px) + var(--d2l-table-border-radius));
+			width: 100%;
+			z-index: 2; /* Must sit under d2l-table sticky-headers but over sticky columns and regular cells */
+		}
+		.d2l-sticky-headers-backdrop::after {
+			background-color: var(--d2l-table-controls-background-color, white);
+			bottom: 0;
+			content: "";
+			position: absolute;
+			top: calc(-7px - var(--d2l-table-border-radius)); /* 6px for the d2l-table-controls margin-bottom, 1px overlap to fix zoom issues */
+			width: 100%;
+		}
+		slot[name="pager"]::slotted(*) {
+			margin-top: 12px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/table/test/table.test.js
+++ b/components/table/test/table.test.js
@@ -35,19 +35,15 @@ describe('d2l-table-wrapper', () => {
 
 		const tagName = defineCE(
 			class extends LitElement {
-				static get properties() {
-					return {
-						stickyHeaders: { type: Boolean, reflect: true, attribute: 'sticky-headers' }
-					};
-				}
-				static get styles() {
-					return [tableStyles, css`
-						:host {
-							display: block;
-							width: 150px;
-						}
-					`];
-				}
+				static properties = {
+					stickyHeaders: { type: Boolean, reflect: true, attribute: 'sticky-headers' }
+				};
+				static styles = [tableStyles, css`
+					:host {
+						display: block;
+						width: 150px;
+					}
+				`];
 				render() {
 					return html`
 						<d2l-table-wrapper sticky-headers sticky-headers-scroll-wrapper>
@@ -100,21 +96,19 @@ describe('d2l-table-wrapper', () => {
 
 		const tagName = defineCE(
 			class extends LitElement {
-				static get styles() {
-					return [tableStyles, css`
-						:host {
-							display: block;
-							width: 400px;
-						}
-						.large-sticky {
-							min-width: 300px;
-						}
-						:host([td-size="larger"]) th.large-sticky,
-						:host([td-size="smaller"]) td.large-sticky {
-							min-width: 200px;
-						}
-					`];
-				}
+				static styles = [tableStyles, css`
+					:host {
+						display: block;
+						width: 400px;
+					}
+					.large-sticky {
+						min-width: 300px;
+					}
+					:host([td-size="larger"]) th.large-sticky,
+					:host([td-size="smaller"]) td.large-sticky {
+						min-width: 200px;
+					}
+				`];
 				render() {
 					return html`
 						<d2l-table-wrapper sticky-headers sticky-headers-scroll-wrapper>
@@ -160,11 +154,9 @@ describe('d2l-table-wrapper', () => {
 		let element, wrapper;
 		const tagName = defineCE(
 			class extends LitElement {
-				static get properties() {
-					return {
-						loadedCount: { status: true }
-					};
-				}
+				static properties = {
+					loadedCount: { status: true }
+				};
 				constructor() {
 					super();
 					this.loadedCount = 5;

--- a/components/table/test/table.vdiff.js
+++ b/components/table/test/table.vdiff.js
@@ -205,7 +205,7 @@ async function createTableFixtureShared(type, rtl, tableContents, opts = {}) {
 	const tableClasses = { 'd2l-table': true, 'vdiff-target': opts.stickyHeaders };
 	const tag = defineCE(
 		class extends LitElement {
-			static get styles() { return [tableStyles]; }
+			static styles = [tableStyles];
 			render() {
 				const wrapper = html`
 					<d2l-table-wrapper

--- a/components/tabs/demo/tabs-array.js
+++ b/components/tabs/demo/tabs-array.js
@@ -5,11 +5,9 @@ import { html, LitElement } from 'lit';
 
 class TabsArray extends LitElement {
 
-	static get properties() {
-		return {
-			_tabs: { type: Array }
-		};
-	}
+	static properties = {
+		_tabs: { type: Array }
+	};
 
 	constructor() {
 		super();

--- a/components/tabs/tab-internal.js
+++ b/components/tabs/tab-internal.js
@@ -13,85 +13,81 @@ const keyCodes = {
 // remove file with GAUD-8299-core-tabs-use-new-structure flag clean up
 class Tab extends SkeletonMixin(LitElement) {
 
-	static get properties() {
-		return {
-			ariaSelected: { type: String, reflect: true, attribute: 'aria-selected' },
-			controlsPanel: { type: String, reflect: true, attribute: 'controls-panel' },
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
-			text: { type: String }
-		};
-	}
+	static properties = {
+		ariaSelected: { type: String, reflect: true, attribute: 'aria-selected' },
+		controlsPanel: { type: String, reflect: true, attribute: 'controls-panel' },
+		// eslint-disable-next-line lit/no-native-attributes
+		role: { type: String, reflect: true },
+		text: { type: String }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				box-sizing: border-box;
-				display: inline-block;
-				max-width: 200px;
-				outline: none;
-				position: relative;
-				vertical-align: middle;
-			}
-			.d2l-tab-text {
-				--d2l-focus-ring-offset: 0;
-				margin: 0.5rem;
-				padding: 0.1rem;
-				${overflowEllipsisDeclarations}
-			}
-			:host([skeleton]) .d2l-tab-text.d2l-skeletize::before {
-				bottom: 0.15rem;
-				top: 0.15rem;
-			}
-			:host(:first-child) .d2l-tab-text {
-				margin-inline-start: 0;
-			}
+	static styles = [super.styles, css`
+		:host {
+			box-sizing: border-box;
+			display: inline-block;
+			max-width: 200px;
+			outline: none;
+			position: relative;
+			vertical-align: middle;
+		}
+		.d2l-tab-text {
+			--d2l-focus-ring-offset: 0;
+			margin: 0.5rem;
+			padding: 0.1rem;
+			${overflowEllipsisDeclarations}
+		}
+		:host([skeleton]) .d2l-tab-text.d2l-skeletize::before {
+			bottom: 0.15rem;
+			top: 0.15rem;
+		}
+		:host(:first-child) .d2l-tab-text {
+			margin-inline-start: 0;
+		}
+		.d2l-tab-selected-indicator {
+			border-top: 4px solid var(--d2l-theme-brand-color-primary-default);
+			border-top-left-radius: 4px;
+			border-top-right-radius: 4px;
+			bottom: 0;
+			display: none;
+			margin: 1px 0.6rem 0 0.6rem;
+			position: absolute;
+			-webkit-transition: box-shadow 0.2s;
+			transition: box-shadow 0.2s;
+			width: calc(100% - 1.2rem);
+		}
+		:host([skeleton]) .d2l-tab-selected-indicator {
+			position: absolute; /* make sure skeleton styles do not override this */
+		}
+		.d2l-tab-text-skeletize-override {
+			min-width: 50px;
+		}
+		:host(:first-child) .d2l-tab-selected-indicator {
+			margin-inline-start: 0;
+			width: calc(100% - 0.6rem);
+		}
+		${getFocusRingStyles(pseudoClass => `:host(:${pseudoClass}) > .d2l-tab-text`, { extraStyles: css`border-radius: 0.3rem; color: var(--d2l-theme-text-color-interactive-default);` })}
+		:host([aria-selected="true"]:focus) {
+			text-decoration: none;
+		}
+		:host(:hover) {
+			color: var(--d2l-theme-text-color-interactive-default);
+			cursor: pointer;
+		}
+		:host([aria-selected="true"]:hover) {
+			color: inherit;
+			cursor: default;
+		}
+		:host([aria-selected="true"]) .d2l-tab-selected-indicator {
+			display: block;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
 			.d2l-tab-selected-indicator {
-				border-top: 4px solid var(--d2l-theme-brand-color-primary-default);
-				border-top-left-radius: 4px;
-				border-top-right-radius: 4px;
-				bottom: 0;
-				display: none;
-				margin: 1px 0.6rem 0 0.6rem;
-				position: absolute;
-				-webkit-transition: box-shadow 0.2s;
-				transition: box-shadow 0.2s;
-				width: calc(100% - 1.2rem);
+				-webkit-transition: none;
+				transition: none;
 			}
-			:host([skeleton]) .d2l-tab-selected-indicator {
-				position: absolute; /* make sure skeleton styles do not override this */
-			}
-			.d2l-tab-text-skeletize-override {
-				min-width: 50px;
-			}
-			:host(:first-child) .d2l-tab-selected-indicator {
-				margin-inline-start: 0;
-				width: calc(100% - 0.6rem);
-			}
-			${getFocusRingStyles(pseudoClass => `:host(:${pseudoClass}) > .d2l-tab-text`, { extraStyles: css`border-radius: 0.3rem; color: var(--d2l-theme-text-color-interactive-default);` })}
-			:host([aria-selected="true"]:focus) {
-				text-decoration: none;
-			}
-			:host(:hover) {
-				color: var(--d2l-theme-text-color-interactive-default);
-				cursor: pointer;
-			}
-			:host([aria-selected="true"]:hover) {
-				color: inherit;
-				cursor: default;
-			}
-			:host([aria-selected="true"]) .d2l-tab-selected-indicator {
-				display: block;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				.d2l-tab-selected-indicator {
-					-webkit-transition: none;
-					transition: none;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -10,30 +10,28 @@ const keyCodes = {
 
 export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			hidden: { type: Boolean, reflect: true },
-			/**
-			 * Use to select the tab. Only one tab can be selected at a time.
-			 * @type {boolean}
-			 */
-			selected: { type: Boolean, reflect: true },
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
-			/**
-			 * @ignore
-			 */
-			tabIndex: { type: Number, reflect: true, attribute: 'tabindex' },
-			_clicked: { type: Boolean, reflect: true },
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		hidden: { type: Boolean, reflect: true },
+		/**
+		 * Use to select the tab. Only one tab can be selected at a time.
+		 * @type {boolean}
+		 */
+		selected: { type: Boolean, reflect: true },
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		role: { type: String, reflect: true },
+		/**
+		 * @ignore
+		 */
+		tabIndex: { type: Number, reflect: true, attribute: 'tabindex' },
+		_clicked: { type: Boolean, reflect: true },
+	};
 
 	static get styles() {
 		const styles = [ css`

--- a/components/tabs/tab-panel-mixin.js
+++ b/components/tabs/tab-panel-mixin.js
@@ -4,58 +4,54 @@ import { getUseNewTabsStructureFlag } from './tabs.js';
 
 export const TabPanelMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: Id of the tab that labels this panel
-			 * @type {string}
-			 */
-			labelledBy: { type: String, attribute: 'labelled-by', reflect: true },
-			/**
-			 * Opt out of default padding/whitespace around the panel
-			 * @type {boolean}
-			 */
-			noPadding: { type: Boolean, attribute: 'no-padding', reflect: true },
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
-			/**
-			 * DEPRECATED: Use to select the tab. Do NOT set if using the d2l-tab/d2l-tab-panel implementation.
-			 * Remove with GAUD-8299-core-tabs-use-new-structure flag clean up.
-			 * @type {boolean}
-			 */
-			selected: { type: Boolean, reflect: true },
-			/**
-			 * DEPRECATED: The text used for the tab, as well as labelling the panel. Required if not using d2l-tab/d2l-tab-panel implementation.
-			 * Remove with GAUD-8299-core-tabs-use-new-structure flag clean up.
-			 * @type {string}
-			 */
-			text: { type: String },
-			_selected: { type: Boolean, attribute: '_selected', reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: Id of the tab that labels this panel
+		 * @type {string}
+		 */
+		labelledBy: { type: String, attribute: 'labelled-by', reflect: true },
+		/**
+		 * Opt out of default padding/whitespace around the panel
+		 * @type {boolean}
+		 */
+		noPadding: { type: Boolean, attribute: 'no-padding', reflect: true },
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		role: { type: String, reflect: true },
+		/**
+		 * DEPRECATED: Use to select the tab. Do NOT set if using the d2l-tab/d2l-tab-panel implementation.
+		 * Remove with GAUD-8299-core-tabs-use-new-structure flag clean up.
+		 * @type {boolean}
+		 */
+		selected: { type: Boolean, reflect: true },
+		/**
+		 * DEPRECATED: The text used for the tab, as well as labelling the panel. Required if not using d2l-tab/d2l-tab-panel implementation.
+		 * Remove with GAUD-8299-core-tabs-use-new-structure flag clean up.
+		 * @type {string}
+		 */
+		text: { type: String },
+		_selected: { type: Boolean, attribute: '_selected', reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				box-sizing: border-box;
-				display: none;
-				margin: 1.2rem 0 0 0;
-			}
-			:host([no-padding]) {
-				margin: 0;
-			}
-			/* clean up with GAUD-8299-core-tabs-use-new-structure flag clean up */
-			:host([selected]) {
-				display: block;
-			}
-			:host([_selected]) {
-				display: block;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			box-sizing: border-box;
+			display: none;
+			margin: 1.2rem 0 0 0;
+		}
+		:host([no-padding]) {
+			margin: 0;
+		}
+		/* clean up with GAUD-8299-core-tabs-use-new-structure flag clean up */
+		:host([selected]) {
+			display: block;
+		}
+		:host([_selected]) {
+			display: block;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -18,15 +18,13 @@ const focusRingStyles = getFocusRingStyles(
  */
 class Tab extends TabMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: REQUIRED: The text used for the tab and for labelling the corresponding panel
 			 * @type {string}
 			 */
-			text: { type: String }
-		};
-	}
+		text: { type: String }
+	};
 
 	static get styles() {
 		const styles = [ css`

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -37,196 +37,192 @@ function getOffsetLeft(tab, tabRect) {
  */
 class Tabs extends LocalizeCoreElement(ArrowKeysMixin(SkeletonMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Limit the number of tabs to initially display
 			 * @type {number}
 			 */
-			maxToShow: { type: Number, attribute: 'max-to-show' },
-			/**
+		maxToShow: { type: Number, attribute: 'max-to-show' },
+		/**
 			 * REQUIRED: ACCESSIBILITY: Accessible text for the tablist
 			 * @type {string}
 			 */
-			text: { type: String },
-			_allowScrollNext: { type: Boolean },
-			_allowScrollPrevious: { type: Boolean },
-			_defaultSlotBehavior: { state: true },
-			_maxWidth: { type: Number },
-			_scrollCollapsed: { type: Boolean },
-			_state: { type: String },
-			_tabInfos: { type: Array },
-			_translationValue: {}
-		};
-	}
+		text: { type: String },
+		_allowScrollNext: { type: Boolean },
+		_allowScrollPrevious: { type: Boolean },
+		_defaultSlotBehavior: { state: true },
+		_maxWidth: { type: Number },
+		_scrollCollapsed: { type: Boolean },
+		_state: { type: String },
+		_tabInfos: { type: Array },
+		_translationValue: {}
+	};
 
-	static get styles() {
-		return [super.styles, bodyCompactStyles, css`
-			:host {
-				--d2l-tabs-background-color: var(--d2l-theme-background-color-base);
-				box-sizing: border-box;
-				display: block;
-				margin-bottom: 1.2rem;
-			}
+	static styles = [super.styles, bodyCompactStyles, css`
+		:host {
+			--d2l-tabs-background-color: var(--d2l-theme-background-color-base);
+			box-sizing: border-box;
+			display: block;
+			margin-bottom: 1.2rem;
+		}
+		.d2l-tabs-layout {
+			border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
+			display: none;
+			max-height: 0;
+			opacity: 0;
+			transform: translateY(-10px);
+			-webkit-transition: max-height 200ms ease-out, transform 200ms ease-out, opacity 200ms ease-out;
+			transition: max-height 200ms ease-out, transform 200ms ease-out, opacity 200ms ease-out;
+			width: 100%;
+		}
+		.d2l-tabs-layout-anim {
+			display: flex;
+		}
+		.d2l-tabs-layout-shown {
+			display: flex;
+			max-height: 60px;
+			opacity: 1;
+			transform: none;
+		}
+		.d2l-tabs-container {
+			box-sizing: border-box;
+			flex: auto;
+			margin-left: -3px;
+			padding-left: 3px;
+			position: relative;
+			-webkit-transition: max-width 200ms ease-in;
+			transition: max-width 200ms ease-in;
+			${getOverflowDeclarations({ textOverflow: 'clip' })}
+		}
+		.d2l-tabs-container-ext {
+			flex: none;
+			padding-inline: 4px 0;
+		}
+		.d2l-tabs-container-list {
+			display: flex;
+			position: relative;
+			-webkit-transition: transform 200ms ease-out;
+			transition: transform 200ms ease-out;
+			white-space: nowrap;
+		}
+		.d2l-tabs-scroll-previous-container,
+		.d2l-tabs-scroll-next-container {
+			background-color: var(--d2l-tabs-background-color);
+			box-shadow: 0 0 12px 18px var(--d2l-tabs-background-color);
+			clip-path: rect(0% 200% 100% -100%);
+			display: none;
+			height: 100%;
+			position: absolute;
+			top: 0;
+			z-index: 1;
+		}
+		.d2l-tabs-scroll-previous-container {
+			inset-inline-start: 0;
+			margin-inline: 4px 0;
+		}
+		.d2l-tabs-container[data-allow-scroll-previous] > .d2l-tabs-scroll-previous-container {
+			display: inline-block;
+		}
+		.d2l-tabs-scroll-next-container {
+			inset-inline-end: 0;
+			margin-inline: 0 4px;
+		}
+		.d2l-tabs-container[data-allow-scroll-next] > .d2l-tabs-scroll-next-container {
+			display: inline-block;
+		}
+		.d2l-tabs-scroll-button {
+			background-color: transparent;
+			border: 1px solid transparent;
+			border-radius: 15px;
+			box-sizing: border-box;
+			cursor: pointer;
+			display: inline-block;
+			height: 30px;
+			margin: 0;
+			outline: none;
+			padding: 0;
+			transform: translateY(10px);
+			width: 30px;
+		}
+		.d2l-tabs-scroll-button[disabled] {
+			cursor: default;
+			opacity: 0.5;
+		}
+		.d2l-tabs-scroll-button::-moz-focus-inner {
+			border: 0;
+		}
+		.d2l-tabs-scroll-button[disabled]:hover,
+		.d2l-tabs-scroll-button[disabled]:${unsafeCSS(getFocusPseudoClass())} {
+			background-color: transparent;
+		}
+		.d2l-tabs-scroll-button:hover,
+		.d2l-tabs-scroll-button:${unsafeCSS(getFocusPseudoClass())} {
+			background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
+		}
+		${getFocusRingStyles('.d2l-tabs-scroll-button')}
+		:host([skeleton]) .d2l-tabs-scroll-button {
+			visibility: hidden;
+		}
+		.d2l-panels-container-no-whitespace ::slotted(*) {
+			margin-top: 0;
+			-webkit-transition: margin-top 200ms ease-out;
+			transition: margin-top 200ms ease-out;
+		}
+
+		d2l-tab-internal, ::slotted([role="tab"]) {
+			-webkit-transition: max-width 200ms ease-out, opacity 200ms ease-out, transform 200ms ease-out;
+			transition: max-width 200ms ease-out, opacity 200ms ease-out, transform 200ms ease-out;
+		}
+		d2l-tab-internal[data-state="adding"],
+		d2l-tab-internal[data-state="removing"],
+		::slotted([role="tab"][data-state="adding"]),
+		::slotted([role="tab"][data-state="removing"]) {
+			max-width: 0;
+			opacity: 0;
+			transform: translateY(20px);
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+
 			.d2l-tabs-layout {
-				border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
-				display: none;
-				max-height: 0;
-				opacity: 0;
-				transform: translateY(-10px);
-				-webkit-transition: max-height 200ms ease-out, transform 200ms ease-out, opacity 200ms ease-out;
-				transition: max-height 200ms ease-out, transform 200ms ease-out, opacity 200ms ease-out;
-				width: 100%;
-			}
-			.d2l-tabs-layout-anim {
-				display: flex;
-			}
-			.d2l-tabs-layout-shown {
-				display: flex;
-				max-height: 60px;
-				opacity: 1;
-				transform: none;
+				-webkit-transition: none;
+				transition: none;
 			}
 			.d2l-tabs-container {
-				box-sizing: border-box;
-				flex: auto;
-				margin-left: -3px;
-				padding-left: 3px;
-				position: relative;
-				-webkit-transition: max-width 200ms ease-in;
-				transition: max-width 200ms ease-in;
-				${getOverflowDeclarations({ textOverflow: 'clip' })}
-			}
-			.d2l-tabs-container-ext {
-				flex: none;
-				padding-inline: 4px 0;
+				-webkit-transition: none;
+				transition: none;
 			}
 			.d2l-tabs-container-list {
-				display: flex;
-				position: relative;
-				-webkit-transition: transform 200ms ease-out;
-				transition: transform 200ms ease-out;
-				white-space: nowrap;
-			}
-			.d2l-tabs-scroll-previous-container,
-			.d2l-tabs-scroll-next-container {
-				background-color: var(--d2l-tabs-background-color);
-				box-shadow: 0 0 12px 18px var(--d2l-tabs-background-color);
-				clip-path: rect(0% 200% 100% -100%);
-				display: none;
-				height: 100%;
-				position: absolute;
-				top: 0;
-				z-index: 1;
-			}
-			.d2l-tabs-scroll-previous-container {
-				inset-inline-start: 0;
-				margin-inline: 4px 0;
-			}
-			.d2l-tabs-container[data-allow-scroll-previous] > .d2l-tabs-scroll-previous-container {
-				display: inline-block;
-			}
-			.d2l-tabs-scroll-next-container {
-				inset-inline-end: 0;
-				margin-inline: 0 4px;
-			}
-			.d2l-tabs-container[data-allow-scroll-next] > .d2l-tabs-scroll-next-container {
-				display: inline-block;
-			}
-			.d2l-tabs-scroll-button {
-				background-color: transparent;
-				border: 1px solid transparent;
-				border-radius: 15px;
-				box-sizing: border-box;
-				cursor: pointer;
-				display: inline-block;
-				height: 30px;
-				margin: 0;
-				outline: none;
-				padding: 0;
-				transform: translateY(10px);
-				width: 30px;
-			}
-			.d2l-tabs-scroll-button[disabled] {
-				cursor: default;
-				opacity: 0.5;
-			}
-			.d2l-tabs-scroll-button::-moz-focus-inner {
-				border: 0;
-			}
-			.d2l-tabs-scroll-button[disabled]:hover,
-			.d2l-tabs-scroll-button[disabled]:${unsafeCSS(getFocusPseudoClass())} {
-				background-color: transparent;
-			}
-			.d2l-tabs-scroll-button:hover,
-			.d2l-tabs-scroll-button:${unsafeCSS(getFocusPseudoClass())} {
-				background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
-			}
-			${getFocusRingStyles('.d2l-tabs-scroll-button')}
-			:host([skeleton]) .d2l-tabs-scroll-button {
-				visibility: hidden;
+				-webkit-transition: none;
+				transition: none;
 			}
 			.d2l-panels-container-no-whitespace ::slotted(*) {
-				margin-top: 0;
-				-webkit-transition: margin-top 200ms ease-out;
-				transition: margin-top 200ms ease-out;
+				-webkit-transition: none;
+				transition: none;
 			}
-
 			d2l-tab-internal, ::slotted([role="tab"]) {
-				-webkit-transition: max-width 200ms ease-out, opacity 200ms ease-out, transform 200ms ease-out;
-				transition: max-width 200ms ease-out, opacity 200ms ease-out, transform 200ms ease-out;
-			}
-			d2l-tab-internal[data-state="adding"],
-			d2l-tab-internal[data-state="removing"],
-			::slotted([role="tab"][data-state="adding"]),
-			::slotted([role="tab"][data-state="removing"]) {
-				max-width: 0;
-				opacity: 0;
-				transform: translateY(20px);
+				-webkit-transition: none;
+				transition: none;
 			}
 
-			@media (prefers-reduced-motion: reduce) {
+		}
 
-				.d2l-tabs-layout {
-					-webkit-transition: none;
-					transition: none;
-				}
-				.d2l-tabs-container {
-					-webkit-transition: none;
-					transition: none;
-				}
-				.d2l-tabs-container-list {
-					-webkit-transition: none;
-					transition: none;
-				}
-				.d2l-panels-container-no-whitespace ::slotted(*) {
-					-webkit-transition: none;
-					transition: none;
-				}
-				d2l-tab-internal, ::slotted([role="tab"]) {
-					-webkit-transition: none;
-					transition: none;
-				}
-
+		@media (prefers-contrast: more) {
+			.d2l-tabs-scroll-previous-container,
+			.d2l-tabs-scroll-next-container {
+				margin-inline: 0;
+				padding-inline: 4px;
 			}
-
-			@media (prefers-contrast: more) {
-				.d2l-tabs-scroll-previous-container,
-				.d2l-tabs-scroll-next-container {
-					margin-inline: 0;
-					padding-inline: 4px;
-				}
-				.d2l-tabs-scroll-next-container {
-					border-inline-start: 1px solid var(--d2l-theme-border-color-subtle);
-					padding-inline-start: 11px;
-				}
-				.d2l-tabs-scroll-previous-container {
-					border-inline-end: 1px solid var(--d2l-theme-border-color-subtle);
-					padding-inline-end: 11px;
-				}
+			.d2l-tabs-scroll-next-container {
+				border-inline-start: 1px solid var(--d2l-theme-border-color-subtle);
+				padding-inline-start: 11px;
 			}
-		`];
-	}
+			.d2l-tabs-scroll-previous-container {
+				border-inline-end: 1px solid var(--d2l-theme-border-color-subtle);
+				padding-inline-end: 11px;
+			}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/tag-list/tag-list-item-mixin.js
+++ b/components/tag-list/tag-list-item-mixin.js
@@ -44,117 +44,113 @@ const focusSelector = isHasSelectorSupported() && isFocusVisibleSupported() ?
 
 export const TagListItemMixin = superclass => class extends LocalizeCoreElement(PropertyRequiredMixin(superclass)) {
 
-	static get properties() {
-		return {
-			/**
-			 * Enables the option to clear a tag list item. The `d2l-tag-list-item-clear` event will be dispatched when the user selects to delete the item. The consumer must handle the actual item deletion.
-			 * @type {boolean}
-			 */
-			clearable: { type: Boolean },
-			/**
-			 * REQUIRED if clearable. Acts as a unique identifier for the tag
-			 * @type {string}
-			 */
-			key: { type: String },
-			/**
-			 * @ignore
-			 */
-			keyboardTooltipItem: { type: Boolean, attribute: 'keyboard-tooltip-item' },
-			/**
-			 * @ignore
-			 */
-			_plainText: {
-				state: true,
-				required: {
-					message: (_value, elem) => `TagListItemMixin: "${elem.tagName.toLowerCase()}" called "_renderTag()" with empty "plainText" option`
-				}
-			},
-			_displayKeyboardTooltip: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Enables the option to clear a tag list item. The `d2l-tag-list-item-clear` event will be dispatched when the user selects to delete the item. The consumer must handle the actual item deletion.
+		 * @type {boolean}
+		 */
+		clearable: { type: Boolean },
+		/**
+		 * REQUIRED if clearable. Acts as a unique identifier for the tag
+		 * @type {string}
+		 */
+		key: { type: String },
+		/**
+		 * @ignore
+		 */
+		keyboardTooltipItem: { type: Boolean, attribute: 'keyboard-tooltip-item' },
+		/**
+		 * @ignore
+		 */
+		_plainText: {
+			state: true,
+			required: {
+				message: (_value, elem) => `TagListItemMixin: "${elem.tagName.toLowerCase()}" called "_renderTag()" with empty "plainText" option`
+			}
+		},
+		_displayKeyboardTooltip: { state: true }
+	};
 
-	static get styles() {
-		return [labelStyles, heading4Styles, css`
-			:host {
-				display: grid;
-				max-width: 100%;
-				outline: none;
-			}
-			:host([hidden]) {
-				display: none;
-			}
+	static styles = [labelStyles, heading4Styles, css`
+		:host {
+			display: grid;
+			max-width: 100%;
+			outline: none;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.tag-list-item-container {
+			--d2l-focus-ring-offset: -2px;
+			align-items: center;
+			background-color: var(--d2l-theme-background-color-interactive-faint-default);
+			border-radius: 6px;
+			box-shadow: var(--d2l-theme-shadow-attached);
+			box-sizing: border-box;
+			color: var(--d2l-theme-text-color-static-standard);
+			cursor: pointer;
+			display: flex;
+			line-height: 1rem;
+			max-width: 320px;
+			min-width: 0;
+			outline: 1px solid var(--d2l-theme-border-color-subtle);
+			outline-offset: -1px;
+			transition: background-color 0.2s ease-out, box-shadow 0.2s ease-out;
+			white-space: nowrap;
+		}
+		.tag-list-item-container.tag-list-item-container-clearable {
+			padding-inline-end: 0.2rem;
+		}
+		.tag-list-item-content {
+			outline: none;
+			overflow: hidden;
+			padding: 0.25rem 0.6rem;
+			text-overflow: ellipsis;
+		}
+		${getFocusRingStyles(() => focusSelector)}
+		:host(:hover) .tag-list-item-container,
+		${unsafeCSS(focusSelector)} {
+			background-color: var(--d2l-theme-background-color-interactive-faint-hover);
+		}
+		:host(:hover) .tag-list-item-container:not(${unsafeCSS(focusSelector)}) {
+			outline-color: var(--d2l-theme-border-color-standard);
+		}
+
+		@media (prefers-reduced-motion: reduce) {
 			.tag-list-item-container {
-				--d2l-focus-ring-offset: -2px;
-				align-items: center;
-				background-color: var(--d2l-theme-background-color-interactive-faint-default);
-				border-radius: 6px;
-				box-shadow: var(--d2l-theme-shadow-attached);
-				box-sizing: border-box;
-				color: var(--d2l-theme-text-color-static-standard);
-				cursor: pointer;
-				display: flex;
-				line-height: 1rem;
-				max-width: 320px;
-				min-width: 0;
-				outline: 1px solid var(--d2l-theme-border-color-subtle);
-				outline-offset: -1px;
-				transition: background-color 0.2s ease-out, box-shadow 0.2s ease-out;
-				white-space: nowrap;
+				transition: none;
 			}
-			.tag-list-item-container.tag-list-item-container-clearable {
-				padding-inline-end: 0.2rem;
+		}
+		.d2l-tag-list-item-clear-button {
+			margin-inline-start: calc(-0.6rem + 3px);
+		}
+		d2l-button-icon {
+			--d2l-button-icon-fill-color: var(--d2l-color-chromite);
+			--d2l-button-icon-min-height: 1.2rem;
+			--d2l-button-icon-min-width: 1.2rem;
+		}
+		d2l-button-icon:hover {
+			--d2l-button-icon-fill-color: var(--d2l-theme-icon-color-standard);
+		}
+		d2l-tooltip ul {
+			list-style: none;
+			margin-bottom: 0;
+			margin-top: 0.2rem;
+			padding: 0;
+		}
+		.d2l-tag-list-item-tooltip-title-key {
+			font-weight: 600;
+		}
+		.d2l-heading-4 {
+			margin: 0 0 0.5rem 0;
+		}
+		@media (prefers-contrast: more) {
+			:host(:hover) .tag-list-item-container {
+				outline-offset: -2px;
+				outline-width: 2px;
 			}
-			.tag-list-item-content {
-				outline: none;
-				overflow: hidden;
-				padding: 0.25rem 0.6rem;
-				text-overflow: ellipsis;
-			}
-			${getFocusRingStyles(() => focusSelector)}
-			:host(:hover) .tag-list-item-container,
-			${unsafeCSS(focusSelector)} {
-				background-color: var(--d2l-theme-background-color-interactive-faint-hover);
-			}
-			:host(:hover) .tag-list-item-container:not(${unsafeCSS(focusSelector)}) {
-				outline-color: var(--d2l-theme-border-color-standard);
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				.tag-list-item-container {
-					transition: none;
-				}
-			}
-			.d2l-tag-list-item-clear-button {
-				margin-inline-start: calc(-0.6rem + 3px);
-			}
-			d2l-button-icon {
-				--d2l-button-icon-fill-color: var(--d2l-color-chromite);
-				--d2l-button-icon-min-height: 1.2rem;
-				--d2l-button-icon-min-width: 1.2rem;
-			}
-			d2l-button-icon:hover {
-				--d2l-button-icon-fill-color: var(--d2l-theme-icon-color-standard);
-			}
-			d2l-tooltip ul {
-				list-style: none;
-				margin-bottom: 0;
-				margin-top: 0.2rem;
-				padding: 0;
-			}
-			.d2l-tag-list-item-tooltip-title-key {
-				font-weight: 600;
-			}
-			.d2l-heading-4 {
-				margin: 0 0 0.5rem 0;
-			}
-			@media (prefers-contrast: more) {
-				:host(:hover) .tag-list-item-container {
-					outline-offset: -2px;
-					outline-width: 2px;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/tag-list/tag-list-item.js
+++ b/components/tag-list/tag-list-item.js
@@ -3,21 +3,19 @@ import { TagListItemMixin } from './tag-list-item-mixin.js';
 
 class TagListItem extends TagListItemMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Text to display
 			 * @type {string}
 			 */
-			text: { type: String },
-			/**
+		text: { type: String },
+		/**
 			 * Optional: Text to display in tooltip.
 			 * Tooltip will also include text property value if truncated.
 			 * @type {string}
 			 */
-			description: { type: String }
-		};
-	}
+		description: { type: String }
+	};
 
 	render() {
 		return this._renderTag(this.text, {

--- a/components/tag-list/tag-list.js
+++ b/components/tag-list/tag-list.js
@@ -32,64 +32,60 @@ async function filterAsync(arr, callback) {
 
 class TagList extends LocalizeCoreElement(InteractiveMixin(ArrowKeysMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Enables the option to clear all inner tag list items. The `d2l-tag-list-item-clear` event will be dispatched for each list item when the user selects to Clear All. The consumer must handle the actual item deletion.
 			 * @type {boolean}
 			 */
-			clearable: { type: Boolean },
-			/**
+		clearable: { type: Boolean },
+		/**
 			 * ADVANCED: When an item is `clearable`, optionally add a timeout before the focus happens on clear. This is useful if the consumer has some operations that will reload the list items prior to wanting focus to occur.
 			 * @type {number}
 			 */
-			clearFocusTimeout: { type: Number, attribute: 'clear-focus-timeout' },
-			/**
+		clearFocusTimeout: { type: Number, attribute: 'clear-focus-timeout' },
+		/**
 			 * REQUIRED: A description of the tag list for additional accessibility context
 			 * @type {string}
 			 */
-			description: { type: String },
-			_chompIndex: { type: Number },
-			_contentReady: { type: Boolean },
-			_lines: { type: Number },
-			_showHiddenTags: { type: Boolean }
-		};
-	}
+		description: { type: String },
+		_chompIndex: { type: Number },
+		_contentReady: { type: Boolean },
+		_lines: { type: Number },
+		_showHiddenTags: { type: Boolean }
+	};
 
-	static get styles() {
-		return [...super.styles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.tag-list-container {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 6px;
-				padding: 0;
-			}
-			::slotted([data-is-chomped]) {
-				display: none !important;
-			}
-			.d2l-tag-list-hidden-button {
-				position: absolute;
-				visibility: hidden;
-			}
-			.d2l-tag-list-clear-button {
-				position: absolute;
-				visibility: hidden;
-			}
-			.d2l-tag-list-clear-button.d2l-tag-list-clear-button-visible {
-				position: static;
-				visibility: visible;
-			}
-			.tag-list-hidden {
-				visibility: hidden;
-			}
-		`];
-	}
+	static styles = [...super.styles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.tag-list-container {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 6px;
+			padding: 0;
+		}
+		::slotted([data-is-chomped]) {
+			display: none !important;
+		}
+		.d2l-tag-list-hidden-button {
+			position: absolute;
+			visibility: hidden;
+		}
+		.d2l-tag-list-clear-button {
+			position: absolute;
+			visibility: hidden;
+		}
+		.d2l-tag-list-clear-button.d2l-tag-list-clear-button-visible {
+			position: static;
+			visibility: visible;
+		}
+		.tag-list-hidden {
+			visibility: hidden;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/tag-list/test/tag-list-item-mixin-consumer.js
+++ b/components/tag-list/test/tag-list-item-mixin-consumer.js
@@ -5,35 +5,31 @@ import { TagListItemMixin } from '../tag-list-item-mixin.js';
 
 class TagListItemMixinConsumer extends TagListItemMixin(LitElement) {
 
-	static get properties() {
-		return {
-			name: { type: String }
-		};
-	}
+	static properties = {
+		name: { type: String }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			.color-block {
-				background-color: purple;
-				border-radius: 6px;
-				display: inline-block;
-				height: 1.2rem;
-				inset-inline-start: 0.15rem;
-				position: absolute;
-				top: 50%;
-				transform: translate(0, -50%);
-				width: 1.2rem;
-			}
-			.text {
-				padding-inline-start: calc(1.55rem - 0.6rem);
-				vertical-align: middle;
-			}
-			d2l-dropdown {
-				min-width: 0;
-				position: relative;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		.color-block {
+			background-color: purple;
+			border-radius: 6px;
+			display: inline-block;
+			height: 1.2rem;
+			inset-inline-start: 0.15rem;
+			position: absolute;
+			top: 50%;
+			transform: translate(0, -50%);
+			width: 1.2rem;
+		}
+		.text {
+			padding-inline-start: calc(1.55rem - 0.6rem);
+			vertical-align: middle;
+		}
+		d2l-dropdown {
+			min-width: 0;
+			position: relative;
+		}
+	`];
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);

--- a/components/tooltip/tooltip-help.js
+++ b/components/tooltip/tooltip-help.js
@@ -16,79 +16,75 @@ import { SlottedIconMixin } from '../icons/slotted-icon-mixin.js';
  */
 class TooltipHelp extends SlottedIconMixin(SkeletonMixin(FocusMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Allows this component to inherit certain font properties
 			 * @type {boolean}
 			 */
-			inheritFontStyle: { type: Boolean, attribute: 'inherit-font-style' },
-			/**
+		inheritFontStyle: { type: Boolean, attribute: 'inherit-font-style' },
+		/**
 			 * ADVANCED: Force the internal tooltip to open in a certain direction. If no position is provided, the tooltip will open in the first position that has enough space for it in the order: bottom, top, right, left.
 			 * @type {'top'|'bottom'|'left'|'right'}
 			 */
-			position: { type: String },
-			/**
+		position: { type: String },
+		/**
 			 * @ignore
 			 */
-			showing: { type: Boolean, reflect: true },
-			/**
+		showing: { type: Boolean, reflect: true },
+		/**
 			 * REQUIRED: Text that will render as the Help Tooltip opener
 			 * @type {string}
 			 */
-			text: { type: String }
-		};
-	}
+		text: { type: String }
+	};
 
-	static get styles() {
-		return [super.styles, bodySmallStyles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			#d2l-tooltip-help-text {
-				--d2l-focus-ring-offset: 0.05rem;
-				align-items: baseline;
-				background: none;
-				border: none;
-				column-gap: 0.3rem;
-				cursor: inherit;
-				display: inline-flex;
-				font-family: inherit;
-				padding: 0;
-				text-align: start;
-				text-decoration-line: underline;
-				text-decoration-style: dashed;
-				text-decoration-thickness: 1px;
-				text-underline-offset: 0.1rem;
-			}
-			d2l-icon,
-			slot[name="icon"]::slotted(d2l-icon-custom) {
-				align-self: center;
-			}
+	static styles = [super.styles, bodySmallStyles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		#d2l-tooltip-help-text {
+			--d2l-focus-ring-offset: 0.05rem;
+			align-items: baseline;
+			background: none;
+			border: none;
+			column-gap: 0.3rem;
+			cursor: inherit;
+			display: inline-flex;
+			font-family: inherit;
+			padding: 0;
+			text-align: start;
+			text-decoration-line: underline;
+			text-decoration-style: dashed;
+			text-decoration-thickness: 1px;
+			text-underline-offset: 0.1rem;
+		}
+		d2l-icon,
+		slot[name="icon"]::slotted(d2l-icon-custom) {
+			align-self: center;
+		}
 
-			${getFocusRingStyles('#d2l-tooltip-help-text', { extraStyles: css`border-radius: 0.05rem; text-underline-offset: 0.1rem;` })}
-			:host([inherit-font-style]) #d2l-tooltip-help-text {
-				color: inherit;
-				font-size: inherit;
-				font-weight: inherit;
-				letter-spacing: inherit;
-				line-height: inherit;
-				margin: inherit;
-			}
-			d2l-tooltip {
-				cursor: text;
-			}
-			:host([skeleton]) #d2l-tooltip-help-text.d2l-skeletize {
-				text-decoration: none;
-			}
-			:host([skeleton]) slot[name="icon"]::slotted(d2l-icon-custom) {
-				display: none;
-			}
-		`];
-	}
+		${getFocusRingStyles('#d2l-tooltip-help-text', { extraStyles: css`border-radius: 0.05rem; text-underline-offset: 0.1rem;` })}
+		:host([inherit-font-style]) #d2l-tooltip-help-text {
+			color: inherit;
+			font-size: inherit;
+			font-weight: inherit;
+			letter-spacing: inherit;
+			line-height: inherit;
+			margin: inherit;
+		}
+		d2l-tooltip {
+			cursor: text;
+		}
+		:host([skeleton]) #d2l-tooltip-help-text.d2l-skeletize {
+			text-decoration: none;
+		}
+		:host([skeleton]) slot[name="icon"]::slotted(d2l-icon-custom) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -58,115 +58,111 @@ let activeTooltip = null;
  */
 class Tooltip extends PopoverMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Align the tooltip with either the start or end of its target. If not set, the tooltip will attempt be centered.
-			 * @type {'start'|'end'}
-			 */
-			align: { type: String, reflect: true },
-			/**
-			 * ADVANCED: Announce the tooltip innerText when applicable (for use with custom elements)
-			 * @type {boolean}
-			 */
-			announced: { type: Boolean },
-			/**
-			 * ADVANCED: Causes the tooltip to close when its target is clicked
-			 * @type {boolean}
-			 */
-			closeOnClick: { type: Boolean, attribute: 'close-on-click' },
-			/**
-			 * Provide a delay in milliseconds to prevent the tooltip from opening immediately when hovered. This delay will only apply to hover, not focus.
-			 * @type {number}
-			 */
-			delay: { type: Number },
-			/**
-			 * ADVANCED: Disables focus lock so the tooltip will automatically close when no longer hovered even if it still has focus
-			 * @type {boolean}
-			 */
-			disableFocusLock: { type: Boolean, attribute: 'disable-focus-lock' },
-			/**
-			 * REQUIRED: The "id" of the tooltip's target element. Both elements must be within the same shadow root. If not provided, the tooltip's parent element will be used as its target.
-			 * @type {string}
-			 */
-			for: { type: String },
-			/**
-			 * ADVANCED: Force the tooltip to stay open as long as it remains "true"
-			 * @type {boolean}
-			 */
-			forceShow: { type: Boolean, attribute: 'force-show' },
-			/**
-			 * ADVANCED: Accessibility type for the tooltip to specify whether it is the primary label for the target or a secondary descriptor.
-			 * @type {'label'|'descriptor'}
-			 */
-			forType: { type: String, attribute: 'for-type' },
-			/**
-			 * Adjust the size of the gap between the tooltip and its target (px)
-			 * @type {number}
-			 */
-			offset: { type: Number },
-			/**
-			 * ADVANCED: Force the tooltip to open in a certain direction. If no position is provided, the tooltip will open in the first position that has enough space for it in the order: bottom, top, right, left.
-			 * @type {'top'|'bottom'|'left'|'right'}
-			 */
-			positionLocation: { type: String, attribute: 'position' },
-			/**
-			 * @ignore
-			 */
-			showing: { type: Boolean, reflect: true },
-			/**
-			 * ADVANCED: Only show the tooltip if we detect the target element is truncated
-			 * @type {boolean}
-			 */
-			showTruncatedOnly: { type: Boolean, attribute: 'show-truncated-only' },
-			/**
-			 * The style of the tooltip based on the type of information it displays
-			 * @type {'info'|'error'}
-			 */
-			state: { type: String, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Align the tooltip with either the start or end of its target. If not set, the tooltip will attempt be centered.
+		 * @type {'start'|'end'}
+		 */
+		align: { type: String, reflect: true },
+		/**
+		 * ADVANCED: Announce the tooltip innerText when applicable (for use with custom elements)
+		 * @type {boolean}
+		 */
+		announced: { type: Boolean },
+		/**
+		 * ADVANCED: Causes the tooltip to close when its target is clicked
+		 * @type {boolean}
+		 */
+		closeOnClick: { type: Boolean, attribute: 'close-on-click' },
+		/**
+		 * Provide a delay in milliseconds to prevent the tooltip from opening immediately when hovered. This delay will only apply to hover, not focus.
+		 * @type {number}
+		 */
+		delay: { type: Number },
+		/**
+		 * ADVANCED: Disables focus lock so the tooltip will automatically close when no longer hovered even if it still has focus
+		 * @type {boolean}
+		 */
+		disableFocusLock: { type: Boolean, attribute: 'disable-focus-lock' },
+		/**
+		 * REQUIRED: The "id" of the tooltip's target element. Both elements must be within the same shadow root. If not provided, the tooltip's parent element will be used as its target.
+		 * @type {string}
+		 */
+		for: { type: String },
+		/**
+		 * ADVANCED: Force the tooltip to stay open as long as it remains "true"
+		 * @type {boolean}
+		 */
+		forceShow: { type: Boolean, attribute: 'force-show' },
+		/**
+		 * ADVANCED: Accessibility type for the tooltip to specify whether it is the primary label for the target or a secondary descriptor.
+		 * @type {'label'|'descriptor'}
+		 */
+		forType: { type: String, attribute: 'for-type' },
+		/**
+		 * Adjust the size of the gap between the tooltip and its target (px)
+		 * @type {number}
+		 */
+		offset: { type: Number },
+		/**
+		 * ADVANCED: Force the tooltip to open in a certain direction. If no position is provided, the tooltip will open in the first position that has enough space for it in the order: bottom, top, right, left.
+		 * @type {'top'|'bottom'|'left'|'right'}
+		 */
+		positionLocation: { type: String, attribute: 'position' },
+		/**
+		 * @ignore
+		 */
+		showing: { type: Boolean, reflect: true },
+		/**
+		 * ADVANCED: Only show the tooltip if we detect the target element is truncated
+		 * @type {boolean}
+		 */
+		showTruncatedOnly: { type: Boolean, attribute: 'show-truncated-only' },
+		/**
+		 * The style of the tooltip based on the type of information it displays
+		 * @type {'info'|'error'}
+		 */
+		state: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [super.styles, bodySmallStyles, css`
-			:host {
-				--d2l-tooltip-background-color: var(--d2l-color-ferrite); /* Deprecated, use state attribute instead */
-				--d2l-tooltip-border-color: var(--d2l-color-ferrite); /* Deprecated, use state attribute instead */
-				--d2l-tooltip-outline-color: rgba(255, 255, 255, 0.32);
-				--d2l-popover-background-color: var(--d2l-tooltip-background-color);
-				--d2l-popover-border-color: var(--d2l-tooltip-border-color);
-				--d2l-popover-border-radius: 0.3rem;
-				--d2l-popover-outline-color: var(--d2l-tooltip-outline-color);
-				--d2l-popover-outline-width: 1px;
-			}
-			:host([state="error"]) {
-				--d2l-tooltip-background-color: var(--d2l-color-cinnabar);
-				--d2l-tooltip-border-color: var(--d2l-color-cinnabar);
-			}
+	static styles = [super.styles, bodySmallStyles, css`
+		:host {
+			--d2l-tooltip-background-color: var(--d2l-color-ferrite); /* Deprecated, use state attribute instead */
+			--d2l-tooltip-border-color: var(--d2l-color-ferrite); /* Deprecated, use state attribute instead */
+			--d2l-tooltip-outline-color: rgba(255, 255, 255, 0.32);
+			--d2l-popover-background-color: var(--d2l-tooltip-background-color);
+			--d2l-popover-border-color: var(--d2l-tooltip-border-color);
+			--d2l-popover-border-radius: 0.3rem;
+			--d2l-popover-outline-color: var(--d2l-tooltip-outline-color);
+			--d2l-popover-outline-width: 1px;
+		}
+		:host([state="error"]) {
+			--d2l-tooltip-background-color: var(--d2l-color-cinnabar);
+			--d2l-tooltip-border-color: var(--d2l-color-cinnabar);
+		}
+		.d2l-tooltip-content {
+			box-sizing: border-box;
+			color: white;
+			max-width: 17.5rem;
+			min-height: 1.85rem;
+			min-width: 2.1rem;
+			overflow: hidden;
+			overflow-wrap: anywhere;
+			padding-block: ${10 - contentBorderSize}px ${11 - contentBorderSize}px;
+			padding-inline: ${contentHorizontalPadding - contentBorderSize}px;
+			white-space: normal;
+		}
+		::slotted(ul),
+		::slotted(ol) {
+			padding-inline-start: 1rem;
+		}
+		@media (max-width: 615px) {
 			.d2l-tooltip-content {
-				box-sizing: border-box;
-				color: white;
-				max-width: 17.5rem;
-				min-height: 1.85rem;
-				min-width: 2.1rem;
-				overflow: hidden;
-				overflow-wrap: anywhere;
-				padding-block: ${10 - contentBorderSize}px ${11 - contentBorderSize}px;
-				padding-inline: ${contentHorizontalPadding - contentBorderSize}px;
-				white-space: normal;
+				padding-bottom: ${12 - contentBorderSize}px;
+				padding-top: ${12 - contentBorderSize}px;
 			}
-			::slotted(ul),
-			::slotted(ol) {
-				padding-inline-start: 1rem;
-			}
-			@media (max-width: 615px) {
-				.d2l-tooltip-content {
-					padding-bottom: ${12 - contentBorderSize}px;
-					padding-top: ${12 - contentBorderSize}px;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/typography/README.md
+++ b/components/typography/README.md
@@ -52,13 +52,11 @@ import { heading2Styles } from '@brightspace-ui/core/components/typography/style
 
 class MyComponent extends LitElement {
 
-  static get styles() {
-    return [ heading2Styles, css`
-      :host {
-        display: inline-block;
-      }
-    ` ];
-  }
+  static styles = [heading2Styles, css`
+    :host {
+      display: inline-block;
+    }
+  `];
 
   render() {
     return html `<h1 class="d2l-heading-2"> ... </h1>`;

--- a/components/validation/validation-custom-mixin.js
+++ b/components/validation/validation-custom-mixin.js
@@ -2,12 +2,10 @@ import { isCustomFormElement } from '../form/form-helper.js';
 
 export const ValidationCustomMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			failureText: { type: String, attribute: 'failure-text' },
-			for: { type: String }
-		};
-	}
+	static properties = {
+		failureText: { type: String, attribute: 'failure-text' },
+		for: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/view-switcher/demo/demo-table-view.js
+++ b/components/view-switcher/demo/demo-table-view.js
@@ -2,13 +2,11 @@ import { css, html, LitElement } from 'lit';
 import { tableStyles } from '../../table/table-wrapper.js';
 
 class TableView extends LitElement {
-	static get styles() {
-		return [tableStyles, css`
-			:host([hidden]) {
-				display: none;
-			}
-		`];
-	}
+	static styles = [tableStyles, css`
+		:host([hidden]) {
+			display: none;
+		}
+	`];
 
 	render() {
 		return html`

--- a/components/view-switcher/view-switcher-button.js
+++ b/components/view-switcher/view-switcher-button.js
@@ -12,57 +12,53 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class ViewSwitcherButton extends PropertyRequiredMixin(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * REQUIRED: Key for the button
 			 * @type {string}
 			 */
-			key: { type: String, required: true },
-			/**
+		key: { type: String, required: true },
+		/**
 			 * REQUIRED: Text for the button
 			 * @type {string}
 			 */
-			text: { type: String, required: true },
-			/**
+		text: { type: String, required: true },
+		/**
 			 * Indicates if the item is selected
 			 * @type {boolean}
 			 */
-			selected: { type: Boolean, reflect: true },
-		};
-	}
+		selected: { type: Boolean, reflect: true },
+	};
 
-	static get styles() {
-		return [labelStyles, buttonStyles, css`
-			/* Firefox includes a hidden border which messes up button dimensions */
-			button::-moz-focus-inner {
-				border: 0;
-			}
+	static styles = [labelStyles, buttonStyles, css`
+		/* Firefox includes a hidden border which messes up button dimensions */
+		button::-moz-focus-inner {
+			border: 0;
+		}
 
-			button {
-				background-color: transparent;
-				border-radius: 0.2rem;
-				display: block;
-				font-family: inherit;
-				min-height: auto;
-				padding-block: 0.3rem;
-				padding-inline: 1rem;
-			}
+		button {
+			background-color: transparent;
+			border-radius: 0.2rem;
+			display: block;
+			font-family: inherit;
+			min-height: auto;
+			padding-block: 0.3rem;
+			padding-inline: 1rem;
+		}
 
-			button:hover {
-				background-color: var(--d2l-color-mica);
-			}
+		button:hover {
+			background-color: var(--d2l-color-mica);
+		}
 
-			button:${unsafeCSS(getFocusPseudoClass())} {
-				box-shadow: 0 0 0 2px #ffffff;
-			}
+		button:${unsafeCSS(getFocusPseudoClass())} {
+			box-shadow: 0 0 0 2px #ffffff;
+		}
 
-			:host([selected]) button {
-				background-color: var(--d2l-color-tungsten);
-				color: #ffffff;
-			}
-		`];
-	}
+		:host([selected]) button {
+			background-color: var(--d2l-color-tungsten);
+			color: #ffffff;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/view-switcher/view-switcher.js
+++ b/components/view-switcher/view-switcher.js
@@ -7,36 +7,32 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 class ViewSwitcher extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: Label for the switcher
 			 * @type {string}
 			 */
-			label: { type: String, required: true },
-			_count: { state: true }
-		};
-	}
+		label: { type: String, required: true },
+		_count: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.container {
-				align-items: center;
-				background-color: var(--d2l-color-gypsum);
-				border-radius: 0.3rem;
-				box-sizing: border-box;
-				display: flex;
-				gap: 0.3rem;
-				padding: 0.3rem;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.container {
+			align-items: center;
+			background-color: var(--d2l-color-gypsum);
+			border-radius: 0.3rem;
+			box-sizing: border-box;
+			display: flex;
+			gap: 0.3rem;
+			padding: 0.3rem;
+		}
+	`;
 	constructor() {
 		super();
 		this._count = 0;

--- a/controllers/subscriber/README.md
+++ b/controllers/subscriber/README.md
@@ -51,11 +51,9 @@ Like the `SubscriberRegistryController`, these `*subscriberController`s take opt
 import { EventSubscriberController, IdSubscriberController } from '@brightspace-ui/core/controllers/subscriber/subscriberControllers.js';
 
 class GeneralViewer extends LitElement {
-	static get properties() {
-		return {
-			_subscribedChannels: { type: Object }
-		};
-	}
+	static properties = {
+		_subscribedChannels: { type: Object }
+	};
 
 	constructor() {
 		super();
@@ -80,12 +78,10 @@ class GeneralViewer extends LitElement {
 }
 
 class YoungerViewer extends LitElement {
-	static get properties() {
-		return {
-			for: { type: String },
-			_subscribedChannels: { type: Object }
-		};
-	}
+	static properties = {
+		for: { type: String },
+		_subscribedChannels: { type: Object }
+	};
 
 	constructor() {
 		super();

--- a/controllers/subscriber/test/subscriberControllers.test.js
+++ b/controllers/subscriber/test/subscriberControllers.test.js
@@ -43,11 +43,9 @@ const registries = defineCE(
 );
 
 const generateSubscriber = (type, name) => class extends LitElement {
-	static get properties() {
-		return {
-			for: { type: String }
-		};
-	}
+	static properties = {
+		for: { type: String }
+	};
 	constructor() {
 		super();
 
@@ -92,7 +90,7 @@ const indirectSlotRegistries = defineCE(class extends LitElement {
 });
 
 const delayedRegistries = defineCE(class extends LitElement {
-	static get properties() { return { _ready: { state: true } }; }
+	static properties = { _ready: { state: true } };
 	constructor() {
 		super();
 		this._ready = false;

--- a/directives/animate/demo/animate-test.js
+++ b/directives/animate/demo/animate-test.js
@@ -7,15 +7,12 @@ import { hide, show } from '../animate.js';
 
 export class AnimateTest extends LitElement {
 
-	static get properties() {
-		return {
-			_listVisibility: { type: Boolean, reflect: false },
-			_renderCount: { type: Number, reflect: false }
-		};
-	}
+	static properties = {
+		_listVisibility: { type: Boolean, reflect: false },
+		_renderCount: { type: Number, reflect: false }
+	};
 
-	static get styles() {
-		return css`
+	static styles = css`
 			:host {
 				display: block;
 			}
@@ -24,7 +21,6 @@ export class AnimateTest extends LitElement {
 				max-width: 400px;
 			}
 		`;
-	}
 
 	constructor() {
 		super();

--- a/directives/animate/test/animate.test.js
+++ b/directives/animate/test/animate.test.js
@@ -5,11 +5,9 @@ import { getComposedActiveElement } from '../../../helpers/focus.js';
 
 class FocusTestElem extends LitElement {
 
-	static get properties() {
-		return {
-			animate: { type: Boolean }
-		};
-	}
+	static properties = {
+		animate: { type: Boolean }
+	};
 
 	render() {
 		const animateValue = this.animate ? hide() : undefined;

--- a/helpers/demo/announce-test.js
+++ b/helpers/demo/announce-test.js
@@ -5,8 +5,7 @@ import { announce } from '../announce.js';
 
 class AnnounceTest extends LitElement {
 
-	static get styles() {
-		return css`
+	static styles = css`
 			:host {
 				display: block;
 				width: 400px;
@@ -15,7 +14,6 @@ class AnnounceTest extends LitElement {
 				margin-bottom: 10px;
 			}
 		`;
-	}
 
 	render() {
 		return html`

--- a/helpers/demo/dismissible-test.js
+++ b/helpers/demo/dismissible-test.js
@@ -4,26 +4,22 @@ import { css, html, LitElement } from 'lit';
 
 class DismissibleTest extends LitElement {
 
-	static get properties() {
-		return {
-			opened: { type: Boolean, reflect: true }
-		};
-	}
+	static properties = {
+		opened: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				background-color: #ffffff;
-				border: 1px solid var(--d2l-color-chromite);
-				display: none;
-				padding: 1rem;
-				position: absolute;
-			}
-			:host([opened]) {
-				display: block;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			background-color: #ffffff;
+			border: 1px solid var(--d2l-color-chromite);
+			display: none;
+			padding: 1rem;
+			position: absolute;
+		}
+		:host([opened]) {
+			display: block;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/helpers/demo/prism.html
+++ b/helpers/demo/prism.html
@@ -14,18 +14,14 @@
 			import { classMap } from 'lit/directives/class-map.js';
 
 			class DemoPrism extends LitElement {
-				static get properties() {
-					return {
-						dark: { type: Boolean, reflect: true }
-					};
-				}
-				static get styles() {
-					return [codeStyles, css`
-						:host {
-							display: block;
-						}
-					`];
-				}
+				static properties = {
+					dark: { type: Boolean, reflect: true }
+				};
+				static styles = [codeStyles, css`
+					:host {
+						display: block;
+					}
+				`];
 				render() {
 					const classes = { 'd2l-code': true, 'd2l-code-dark': this.dark, 'line-numbers': true };
 					return html`

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -32,18 +32,14 @@ const testElemTag = defineCE(
 );
 const offsetParentWrapperTag = defineCE(
 	class extends LitElement {
-		static get properties() {
-			return {
-				wrapperId: { type: String, attribute: 'wrapper-id' }
-			};
-		}
-		static get styles() {
-			return css`
-				#expected {
-					position: relative;
-				}
-			`;
-		}
+		static properties = {
+			wrapperId: { type: String, attribute: 'wrapper-id' }
+		};
+		static styles = css`
+			#expected {
+				position: relative;
+			}
+		`;
 		constructor() {
 			super();
 			this.wrapperId = 'notExpected';

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
 import { html, LitElement } from 'lit';
 
 export class BuildInfo extends LitElement {
-	static get properties() {
-		return {
-			_buildDate: { state: true },
-			_buildVersion: { state: true },
-		};
-	}
+	static properties = {
+		_buildDate: { state: true },
+		_buildVersion: { state: true },
+	};
 
 	constructor() {
 		super();

--- a/mixins/arrow-keys/arrow-keys-mixin.js
+++ b/mixins/arrow-keys/arrow-keys-mixin.js
@@ -11,18 +11,16 @@ const keyCodes = Object.freeze({
 
 export const ArrowKeysMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			arrowKeysDirection: { type: String, attribute: 'arrow-keys-direction' },
-			/**
-			 * @ignore
-			 */
-			arrowKeysNoWrap: { type: Boolean, attribute: 'arrow-keys-no-wrap' }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		arrowKeysDirection: { type: String, attribute: 'arrow-keys-direction' },
+		/**
+		 * @ignore
+		 */
+		arrowKeysNoWrap: { type: Boolean, attribute: 'arrow-keys-no-wrap' }
+	};
 
 	constructor() {
 		super();

--- a/mixins/arrow-keys/demo/arrow-keys-test.js
+++ b/mixins/arrow-keys/demo/arrow-keys-test.js
@@ -4,22 +4,20 @@ import { ArrowKeysMixin } from '../arrow-keys-mixin.js';
 
 export class ArrowKeysTest extends ArrowKeysMixin(LitElement) {
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			.d2l-arrowkeys-focusable {
-				border: 2px solid var(--d2l-color-ferrite);
-				border-radius: 4px;
-				display: inline-block;
-				padding: 1rem;
-			}
-			.d2l-arrowkeys-focusable:focus {
-				border: 2px solid var(--d2l-color-celestine);
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		.d2l-arrowkeys-focusable {
+			border: 2px solid var(--d2l-color-ferrite);
+			border-radius: 4px;
+			display: inline-block;
+			padding: 1rem;
+		}
+		.d2l-arrowkeys-focusable:focus {
+			border: 2px solid var(--d2l-color-celestine);
+		}
+	`;
 
 	render() {
 		const inner = html`

--- a/mixins/async-container/async-container-mixin.js
+++ b/mixins/async-container/async-container-mixin.js
@@ -7,18 +7,16 @@ export const asyncStates = {
 
 export const AsyncContainerMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			asyncPendingDelay: { type: Number, attribute: 'async-pending-delay' },
-			/**
+		asyncPendingDelay: { type: Number, attribute: 'async-pending-delay' },
+		/**
 			 * @ignore
 			 */
-			asyncState: { type: String }
-		};
-	}
+		asyncState: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/mixins/async-container/demo/async-item.js
+++ b/mixins/async-container/demo/async-item.js
@@ -4,32 +4,28 @@ import { InitialStateError, runAsync } from '../../../directives/run-async/run-a
 
 class AsyncItem extends LitElement {
 
-	static get properties() {
-		return {
-			delay: { type: Number },
-			key: { type: String },
-			manual: { type: Boolean },
-			throwError: { type: Boolean, attribute: 'throw-error' }
-		};
-	}
+	static properties = {
+		delay: { type: Number },
+		key: { type: String },
+		manual: { type: Boolean },
+		throwError: { type: Boolean, attribute: 'throw-error' }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			div {
-				background-color: var(--d2l-color-celestine);
-				border: 1px solid var(--d2l-color-galena);
-				border-radius: 0.4rem;
-				color: white;
-				height: 100px;
-				padding: 0.3rem;
-				text-align: center;
-				width: 100px;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		div {
+			background-color: var(--d2l-color-celestine);
+			border: 1px solid var(--d2l-color-galena);
+			border-radius: 0.4rem;
+			color: white;
+			height: 100px;
+			padding: 0.3rem;
+			text-align: center;
+			width: 100px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/mixins/collection/collection-mixin.js
+++ b/mixins/collection/collection-mixin.js
@@ -1,14 +1,12 @@
 export const CollectionMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Total number of items. If not specified, features like select-all-pages will be disabled.
 			 * @type {number}
 			 */
-			itemCount: { type: Number, attribute: 'item-count', reflect: true },
-		};
-	}
+		itemCount: { type: Number, attribute: 'item-count', reflect: true },
+	};
 
 	constructor() {
 		super();

--- a/mixins/interactive/interactive-mixin.js
+++ b/mixins/interactive/interactive-mixin.js
@@ -16,20 +16,16 @@ export function isInteractiveDescendant(node) {
 
 export const InteractiveMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
-	static get properties() {
-		return {
-			_focusingToggle: { state: true },
-			_hasInteractiveAncestor: { state: true },
-			_interactive: { state: true }
-		};
-	}
+	static properties = {
+		_focusingToggle: { state: true },
+		_hasInteractiveAncestor: { state: true },
+		_interactive: { state: true }
+	};
 
-	static get styles() {
-		return [offscreenStyles, getFocusRingStyles(
-			() => '.interactive-focusing-toggle',
-			{ extraStyles: css`border-radius: 6px;` }
-		)];
-	}
+	static styles = [offscreenStyles, getFocusRingStyles(
+		() => '.interactive-focusing-toggle',
+		{ extraStyles: css`border-radius: 6px;` }
+	)];
 
 	constructor() {
 		super();

--- a/mixins/labelled/README.md
+++ b/mixins/labelled/README.md
@@ -26,11 +26,9 @@ Optionally, to enable custom elements to act as labels, extend the `LabelMixin` 
 import { LabelMixin } from '@brightspace-ui/core/mixins/labelled/labelled-mixin.js';
 
 class CustomLabel extends LabelMixin(LitElement) {
-  static get properties() {
-    return {
-      text: { type: String }
-    };
-  }
+  static properties = {
+    text: { type: String }
+  };
   render() {
     return html`
       <span>${this.text}</span>

--- a/mixins/labelled/demo/labelled-mixin.html
+++ b/mixins/labelled/demo/labelled-mixin.html
@@ -10,16 +10,14 @@
 			import { ifDefined } from 'lit/directives/if-defined.js';
 
 			class DemoInput extends LabelledMixin(LitElement) {
-				static get styles() {
-					return css`
-						:host {
-							disply: inline-block;
-						}
-						d2l-input-checkbox {
-							margin-bottom: 0;
-						}
-					`;
-				}
+				static styles = css`
+					:host {
+						disply: inline-block;
+					}
+					d2l-input-checkbox {
+						margin-bottom: 0;
+					}
+				`;
 				render() {
 					return html`
 						<d2l-input-checkbox label="${ifDefined(this.label)}" label-hidden></d2l-input-checkbox>
@@ -29,18 +27,14 @@
 			customElements.define('d2l-demo-input', DemoInput);
 
 			class DemoText extends LabelMixin(LitElement) {
-				static get properties() {
-					return {
-						text: { type: String }
-					};
-				}
-				static get styles() {
-					return css`
-						:host {
-							disply: inline-block;
-						}
-					`;
-				}
+				static properties = {
+					text: { type: String }
+				};
+				static styles = css`
+					:host {
+						disply: inline-block;
+					}
+				`;
 				constructor() {
 					super();
 					this.text = '';

--- a/mixins/labelled/labelled-mixin.js
+++ b/mixins/labelled/labelled-mixin.js
@@ -48,11 +48,9 @@ const waitForElement = async(contextElement, selector, timeout) => {
 
 export const LabelMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			_label: { type: String, reflect: true }
-		};
-	}
+	static properties = {
+		_label: { type: String, reflect: true }
+	};
 
 	connectedCallback() {
 		super.connectedCallback();
@@ -77,33 +75,31 @@ export const LabelMixin = superclass => class extends superclass {
 
 export const LabelledMixin = superclass => class extends PropertyRequiredMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * ACCESSIBILITY: The id of element that provides the label for this element. Use when another visible element should act as the label.
 			 * @type {string}
 			 */
-			labelledBy: { type: String, reflect: true, attribute: 'labelled-by' },
-			/**
+		labelledBy: { type: String, reflect: true, attribute: 'labelled-by' },
+		/**
 			 * ACCESSIBILITY: REQUIRED: Explicitly defined label for the element
 			 * @type {string}
 			 */
-			label: {
-				type: String,
-				required: {
-					message: (_value, elem, defaultMessage) => {
-						if (!elem.labelledBy) return defaultMessage;
-						return `LabelledMixin: "${elem.tagName.toLowerCase()}" is labelled-by="${elem.labelledBy}", but its label is empty`;
-					},
-					validator: (_value, elem, hasValue) => {
-						if (!elem.labelRequired || hasValue) return true;
-						if (!elem.labelledBy) return false;
-						return elem._labelElem !== null;
-					}
+		label: {
+			type: String,
+			required: {
+				message: (_value, elem, defaultMessage) => {
+					if (!elem.labelledBy) return defaultMessage;
+					return `LabelledMixin: "${elem.tagName.toLowerCase()}" is labelled-by="${elem.labelledBy}", but its label is empty`;
+				},
+				validator: (_value, elem, hasValue) => {
+					if (!elem.labelRequired || hasValue) return true;
+					if (!elem.labelledBy) return false;
+					return elem._labelElem !== null;
 				}
 			}
-		};
-	}
+		}
+	};
 
 	constructor() {
 		super();

--- a/mixins/labelled/test/label-mixin.test.js
+++ b/mixins/labelled/test/label-mixin.test.js
@@ -16,11 +16,9 @@ const labelledTag = defineCE(
 
 const labelTag = defineCE(
 	class extends LabelMixin(LitElement) {
-		static get properties() {
-			return {
-				text: { type: String }
-			};
-		}
+		static properties = {
+			text: { type: String }
+		};
 		render() {
 			return html`
 				<span>${this.text}</span>

--- a/mixins/localize/demo/localize-mixin-greeting.js
+++ b/mixins/localize/demo/localize-mixin-greeting.js
@@ -3,11 +3,9 @@ import { LocalizeMixin } from '../localize-mixin.js';
 
 class Greeting extends LocalizeMixin(LitElement) {
 
-	static get properties() {
-		return {
-			name: {	type: String }
-		};
-	}
+	static properties = {
+		name: {	type: String }
+	};
 
 	static get localizeConfig() {
 		const langResources = {

--- a/mixins/localize/test/localize-mixin.test.js
+++ b/mixins/localize/test/localize-mixin.test.js
@@ -207,13 +207,11 @@ const multiMixinTagConsolidated = defineCE(
 );
 
 class StaticEl extends _LocalizeMixinBase(LitElement) {
-	static get properties() {
-		return {
-			name: {
-				type: String
-			}
-		};
-	}
+	static properties = {
+		name: {
+			type: String
+		}
+	};
 	static langResources = {
 		'en': {
 			'hello': 'Hello {name}',

--- a/mixins/provider/README.md
+++ b/mixins/provider/README.md
@@ -30,13 +30,11 @@ NB: due to its reliance on DOM events, `requestInstance()` needs to be called af
 import { RequesterMixin } from '@brightspace-ui/core/mixins/provider/provider-mixin.js'
 
 class InterestingFactUI extends RequesterMixin(LitElement) {
-	static get properties() {
-		return {
-			_factString: { type: String },
-			_factObjectString: { type: String },
-			_factFunctionString: { type: String }
-		};
-	}
+	static properties = {
+		_factString: { type: String },
+		_factObjectString: { type: String },
+		_factFunctionString: { type: String }
+	};
 
 	render() {
 		return html`

--- a/mixins/rtl/README.md
+++ b/mixins/rtl/README.md
@@ -11,12 +11,10 @@ Apply the mixin and define RTL styles.
 ```js
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl/rtl-mixin.js';
 class MyComponent extends RtlMixin(LitElement) {
-  static get styles() {
-    return css`
-      :host([dir="rtl"]) .some-elem {
-        /* some RTL styles */
-      }
-    `;
-  }
+  static styles = css`
+    :host([dir="rtl"]) .some-elem {
+      /* some RTL styles */
+    }
+  `;
 }
 ```

--- a/mixins/rtl/rtl-mixin.js
+++ b/mixins/rtl/rtl-mixin.js
@@ -3,15 +3,13 @@ import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 
 export const RtlMixin = dedupeMixin(superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			dir: { type: String, reflect: true }
-		};
-	}
+		// eslint-disable-next-line lit/no-native-attributes
+		dir: { type: String, reflect: true }
+	};
 
 	constructor() {
 		super();

--- a/mixins/theme/theme-mixin.js
+++ b/mixins/theme/theme-mixin.js
@@ -7,13 +7,11 @@
  */
 export const ThemeMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * @ignore
 			 */
-			theme: { reflect: true, type: String }
-		};
-	}
+		theme: { reflect: true, type: String }
+	};
 
 };

--- a/mixins/visible-on-ancestor/README.md
+++ b/mixins/visible-on-ancestor/README.md
@@ -9,9 +9,9 @@ Apply the mixin and include the required `visibleOnAncestorStyles`.
 ```js
 import { VisibleOnAncestorMixin, visibleOnAncestorStyles } from '@brightspace-ui/core/mixins/visible-on-ancestor/visible-on-ancestor-mixin.js';
 class MyComponent extends VisibleOnAncestorMixin(LitElement) {
-  static get styles() {
-    return [ visibleOnAncestorStyles, css`/* MyComponent styles */` ];
-  }
+  static styles = [visibleOnAncestorStyles, css`
+    /* MyComponent styles */
+  `];
 }
 ```
 

--- a/mixins/visible-on-ancestor/visible-on-ancestor-mixin.js
+++ b/mixins/visible-on-ancestor/visible-on-ancestor-mixin.js
@@ -41,19 +41,17 @@ export const visibleOnAncestorStyles = css`
 
 export const VisibleOnAncestorMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			animationType: { type: String, reflect: true, attribute: 'animation-type' },
-			/**
-			 * @ignore
-			 */
-			visibleOnAncestor: { type: Boolean, reflect: true, attribute: 'visible-on-ancestor' },
-			__voaState: { type: String, reflect: true, attribute: '__voa-state' }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		animationType: { type: String, reflect: true, attribute: 'animation-type' },
+		/**
+		 * @ignore
+		 */
+		visibleOnAncestor: { type: Boolean, reflect: true, attribute: 'visible-on-ancestor' },
+		__voaState: { type: String, reflect: true, attribute: '__voa-state' }
+	};
 
 	constructor() {
 		super();

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -554,431 +554,427 @@ class MobileTouchResizer extends Resizer {
  */
 class TemplatePrimarySecondary extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
+	static properties = {
+		/**
 			 * Controls whether the primary and secondary panels have shaded backgrounds
 			 * @type {'primary'|'secondary'|'none'}
 			 */
-			backgroundShading: { type: String, attribute: 'background-shading' },
-			/**
+		backgroundShading: { type: String, attribute: 'background-shading' },
+		/**
 			 * Controls how the primary panel's contents overflow
 			 * @type {'default'|'hidden'}
 			 */
-			primaryOverflow: { attribute: 'primary-overflow', reflect: true, type: String },
-			/**
+		primaryOverflow: { attribute: 'primary-overflow', reflect: true, type: String },
+		/**
 			 * Whether the panels are user resizable. This only applies to desktop users,
 			 * mobile users will always be able to resize.
 			 * @type {boolean}
 			 */
-			resizable: { type: Boolean, reflect: true },
-			/**
+		resizable: { type: Boolean, reflect: true },
+		/**
 			 * When set to true, the secondary panel will be displayed on the left (or the
 			 * right in RTL) in the desktop view. This attribute has no effect on the mobile view.
 			 * @type {boolean}
 			 */
-			secondaryFirst: { type: Boolean, attribute: 'secondary-first', reflect: true },
-			/**
+		secondaryFirst: { type: Boolean, attribute: 'secondary-first', reflect: true },
+		/**
 			 * The key used to persist the divider's position to local storage. This key
 			 * should not be shared between pages so that users can save different divider
 			 * positions on different pages. If no key is provided, the template will fall
 			 * back its default size.
 			 * @type {string}
 			 */
-			storageKey: { type: String, attribute: 'storage-key' },
-			/**
+		storageKey: { type: String, attribute: 'storage-key' },
+		/**
 			 * Whether content fills the screen or not
 			 * @type {'fullscreen'|'normal'}
 			 */
-			widthType: { type: String, attribute: 'width-type', reflect: true },
-			/**
+		widthType: { type: String, attribute: 'width-type', reflect: true },
+		/**
 			 * Whether to render an encompassing form over all panels
 			 * @type {boolean}
 			 */
-			hasForm: { type: Boolean, attribute: 'has-form' },
-			_formErrorSummary: { type: Array },
-			_hasFooter: { type: Boolean, attribute: false },
-			_isCollapsed: { type: Boolean, attribute: false },
-			_isExpanded: { type: Boolean, attribute: false },
-			_isMobile: { type: Boolean, attribute: false },
-			_size: { type: Number, attribute: false },
-			_sizeAsPercent: { state: true }
-		};
-	}
+		hasForm: { type: Boolean, attribute: 'has-form' },
+		_formErrorSummary: { type: Array },
+		_hasFooter: { type: Boolean, attribute: false },
+		_isCollapsed: { type: Boolean, attribute: false },
+		_isExpanded: { type: Boolean, attribute: false },
+		_isMobile: { type: Boolean, attribute: false },
+		_size: { type: Number, attribute: false },
+		_sizeAsPercent: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host,
-			:host > d2l-form {
-				bottom: 0;
-				left: 0;
-				overflow: hidden;
-				position: absolute;
-				right: 0;
-				top: 0;
-			}
+	static styles = css`
+		:host,
+		:host > d2l-form {
+			bottom: 0;
+			left: 0;
+			overflow: hidden;
+			position: absolute;
+			right: 0;
+			top: 0;
+		}
 
-			:host([hidden]) {
-				display: none;
+		:host([hidden]) {
+			display: none;
+		}
+		:host([width-type="normal"]) .d2l-template-primary-secondary-content,
+		:host([width-type="normal"]) .d2l-template-primary-secondary-footer {
+			margin: 0 auto;
+			max-width: 1230px;
+			width: 100%;
+		}
+		.d2l-template-primary-secondary-container {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			width: 100%;
+		}
+		.d2l-template-primary-secondary-content {
+			display: flex;
+			height: 100%;
+			overflow: hidden;
+		}
+
+		main {
+			flex: 2 0 0;
+			overflow-x: hidden;
+			transition: none;
+		}
+		main d2l-form-error-summary {
+			margin-inline: var(--d2l-template-primary-secondary-form-error-inline-margin, 20px);
+		}
+
+		:host([resizable]) main {
+			flex: 1 0 0;
+		}
+		:host([primary-overflow="hidden"]) main {
+			overflow: hidden;
+		}
+		.d2l-template-primary-secondary-secondary-container {
+			flex: 1 0 0;
+			min-width: ${desktopMinSize}px;
+			overflow: hidden;
+		}
+		:host([resizable]) .d2l-template-primary-secondary-secondary-container {
+			flex: none;
+			min-width: 0;
+		}
+		[data-animate-resize] .d2l-template-primary-secondary-secondary-container {
+			transition: width 400ms cubic-bezier(0, 0.7, 0.5, 1), height 400ms cubic-bezier(0, 0.7, 0.5, 1);
+		}
+		.d2l-template-primary-secondary-divider-shadow {
+			display: none;
+		}
+		aside {
+			height: 100%;
+			min-width: ${desktopMinSize}px;
+			overflow-x: hidden;
+			overflow-y: scroll;
+			width: 100%;
+		}
+
+		/* prevent margin colapse on slotted children */
+		aside::before,
+		aside::after {
+			content: " ";
+			display: table;
+		}
+		[data-background-shading="primary"] > main,
+		[data-background-shading="secondary"] > .d2l-template-primary-secondary-secondary-container {
+			background-color: var(--d2l-color-gypsum);
+		}
+		:host([resizable]) [data-is-collapsed] aside {
+			visibility: hidden;
+		}
+		:host([resizable]:not([secondary-first])) aside {
+			float: inline-start;
+		}
+		.d2l-template-primary-secondary-divider,
+		.d2l-template-primary-secondary-divider-not-resizable {
+			background-color: var(--d2l-color-mica);
+			flex: none;
+			outline: none;
+			position: relative;
+			width: 1px;
+			z-index: 1;
+		}
+		.d2l-template-primary-secondary-divider-handle {
+			display: none;
+			position: absolute;
+			top: calc(50%);
+			width: 100%;
+		}
+		:host([resizable]) .d2l-template-primary-secondary-divider {
+			background-color: var(--d2l-color-gypsum);
+			cursor: ew-resize;
+			width: 0.45rem;
+		}
+		:host([resizable]) [data-is-expanded] .d2l-template-primary-secondary-divider {
+			cursor: var(--d2l-cursor-resize-inline-end, e-resize);
+		}
+		:host([resizable]) [data-is-collapsed] .d2l-template-primary-secondary-divider {
+			cursor: var(--d2l-cursor-resize-inline-start, w-resize);
+		}
+		:host([resizable]) .d2l-template-primary-secondary-divider-handle {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+		}
+		:host([resizable]) [data-background-shading="secondary"] .d2l-template-primary-secondary-divider {
+			box-shadow: calc(1px * var(--d2l-length-factor, 1)) 0 0 0 rgba(0, 0, 0, 0.15);
+		}
+		:host([resizable]) [data-background-shading="primary"] .d2l-template-primary-secondary-divider {
+			box-shadow: calc(-1px * var(--d2l-length-factor, 1)) 0 0 0 rgba(0, 0, 0, 0.15);
+		}
+		.d2l-template-primary-secondary-divider-handle-desktop {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+			position: absolute;
+		}
+		.d2l-template-primary-secondary-divider-handle-left,
+		.d2l-template-primary-secondary-divider-handle-right {
+			color: var(--d2l-color-celestine);
+			display: none;
+			position: absolute;
+		}
+		.d2l-template-primary-secondary-divider-handle-left {
+			inset-inline-start: -1rem;
+		}
+		.d2l-template-primary-secondary-divider-handle-right {
+			inset-inline-end: -1rem;
+		}
+		.d2l-template-primary-secondary-divider-handle-line {
+			display: flex;
+			height: 0.9rem;
+			justify-content: space-between;
+			width: 0.25rem;
+		}
+		.d2l-template-primary-secondary-divider-handle-line::before,
+		.d2l-template-primary-secondary-divider-handle-line::after {
+			background-color: var(--d2l-color-galena);
+			border-radius: 0.05rem;
+			content: "";
+			display: inline-block;
+			width: 0.1rem;
+		}
+		.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-right,
+		.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-left {
+			display: block;
+		}
+		:host(:not([secondary-first])) [data-is-expanded] .d2l-template-primary-secondary-divider-handle-left,
+		:host([secondary-first]) [data-is-expanded] .d2l-template-primary-secondary-divider-handle-right {
+			display: none;
+		}
+		d2l-icon {
+			display: none;
+		}
+
+		footer {
+			background-color: white;
+			box-shadow: 0 -2px 4px rgba(32, 33, 34, 0.2); /* ferrite */
+			padding: 0.75rem 1rem;
+			z-index: 1; /* ensures the footer box-shadow is over main areas with background colours set */
+		}
+		header {
+			z-index: 14; /* ensures the header box-shadow is over main areas with background colours set, and opt-in on top of sticky header */
+		}
+
+		:host([resizable]) .d2l-template-primary-secondary-divider:focus,
+		:host([resizable]) .d2l-template-primary-secondary-divider:hover {
+			background-color: var(--d2l-color-mica);
+			box-shadow: none;
+		}
+		:host([resizable]) .d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} {
+			background-color: var(--d2l-color-celestine);
+		}
+		.d2l-template-primary-secondary-divider:focus .d2l-template-primary-secondary-divider-handle-line::before,
+		.d2l-template-primary-secondary-divider:focus .d2l-template-primary-secondary-divider-handle-line::after,
+		.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-line::before,
+		.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-line::after {
+			background-color: var(--d2l-color-ferrite);
+		}
+		.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-line::before,
+		.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-line::after {
+			background-color: white;
+		}
+
+		.d2l-template-primary-secondary-divider,
+		.d2l-template-primary-secondary-divider-handle-mobile,
+		.d2l-template-primary-secondary-divider-handle-line::before,
+		.d2l-template-primary-secondary-divider-handle-line::after {
+			transition: background-color 100ms, box-shadow 100ms;
+		}
+		.d2l-template-primary-secondary-divider:hover,
+		.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-mobile,
+		.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-line::before,
+		.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-line::after {
+			transition-delay: 100ms;
+		}
+
+		.d2l-template-scroll::-webkit-scrollbar {
+			width: 8px;
+		}
+
+		.d2l-template-scroll::-webkit-scrollbar-track {
+			background: rgba(255, 255, 255, 0.4);
+		}
+
+		.d2l-template-scroll::-webkit-scrollbar-thumb {
+			background: var(--d2l-color-galena);
+			border-radius: 4px;
+		}
+
+		.d2l-template-scroll::-webkit-scrollbar-thumb:hover {
+			background: var(--d2l-color-tungsten);
+		}
+
+		/* For Firefox */
+		.d2l-template-scroll {
+			scrollbar-color: var(--d2l-color-galena) rgba(255, 255, 255, 0.4);
+			scrollbar-width: thin;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			.d2l-template-primary-secondary-divider,
+			.d2l-template-primary-secondary-divider-handle-line::before,
+			.d2l-template-primary-secondary-divider-handle-line::after,
+			.d2l-template-primary-secondary-divider-handle-mobile {
+				transition: none;
 			}
-			:host([width-type="normal"]) .d2l-template-primary-secondary-content,
-			:host([width-type="normal"]) .d2l-template-primary-secondary-footer {
-				margin: 0 auto;
-				max-width: 1230px;
-				width: 100%;
-			}
-			.d2l-template-primary-secondary-container {
-				display: flex;
-				flex-direction: column;
-				height: 100%;
-				width: 100%;
-			}
+		}
+		@media only screen and (max-width: 767px) {
+
 			.d2l-template-primary-secondary-content {
-				display: flex;
-				height: 100%;
-				overflow: hidden;
+				flex-direction: column;
 			}
 
 			main {
-				flex: 2 0 0;
-				overflow-x: hidden;
-				transition: none;
-			}
-			main d2l-form-error-summary {
-				margin-inline: var(--d2l-template-primary-secondary-form-error-inline-margin, 20px);
-			}
-
-			:host([resizable]) main {
 				flex: 1 0 0;
-			}
-			:host([primary-overflow="hidden"]) main {
-				overflow: hidden;
 			}
 			.d2l-template-primary-secondary-secondary-container {
-				flex: 1 0 0;
-				min-width: ${desktopMinSize}px;
-				overflow: hidden;
-			}
-			:host([resizable]) .d2l-template-primary-secondary-secondary-container {
 				flex: none;
-				min-width: 0;
 			}
-			[data-animate-resize] .d2l-template-primary-secondary-secondary-container {
-				transition: width 400ms cubic-bezier(0, 0.7, 0.5, 1), height 400ms cubic-bezier(0, 0.7, 0.5, 1);
+			aside,
+			.d2l-template-primary-secondary-secondary-container {
+				min-width: auto;
 			}
-			.d2l-template-primary-secondary-divider-shadow {
+			[data-is-collapsed] aside {
 				display: none;
 			}
-			aside {
-				height: 100%;
-				min-width: ${desktopMinSize}px;
-				overflow-x: hidden;
-				overflow-y: scroll;
+
+			.d2l-template-primary-secondary-divider-handle-desktop {
+				display: none;
+			}
+			/* Attribute selector is only used to increase specificity */
+			:host([resizable]) .d2l-template-primary-secondary-divider,
+			:host(:not([resizable])) .d2l-template-primary-secondary-divider {
+				background-color: var(--d2l-color-celestine);
+				cursor: ns-resize;
+				height: 0.1rem;
 				width: 100%;
 			}
+			:host([resizable]) [data-is-collapsed] .d2l-template-primary-secondary-divider,
+			:host(:not([resizable])) [data-is-collapsed] .d2l-template-primary-secondary-divider {
+				cursor: n-resize;
+			}
+			:host([resizable]) [data-is-expanded] .d2l-template-primary-secondary-divider,
+			:host(:not([resizable])) [data-is-expanded] .d2l-template-primary-secondary-divider {
+				cursor: s-resize;
+			}
 
-			/* prevent margin colapse on slotted children */
-			aside::before,
-			aside::after {
-				content: " ";
-				display: table;
-			}
-			[data-background-shading="primary"] > main,
-			[data-background-shading="secondary"] > .d2l-template-primary-secondary-secondary-container {
-				background-color: var(--d2l-color-gypsum);
-			}
-			:host([resizable]) [data-is-collapsed] aside {
-				visibility: hidden;
-			}
-			:host([resizable]:not([secondary-first])) aside {
-				float: inline-start;
-			}
-			.d2l-template-primary-secondary-divider,
-			.d2l-template-primary-secondary-divider-not-resizable {
-				background-color: var(--d2l-color-mica);
-				flex: none;
-				outline: none;
-				position: relative;
-				width: 1px;
-				z-index: 1;
+			/* Attribute selector is only used to increase specificity */
+			:host([resizable]) .d2l-template-primary-secondary-divider:hover,
+			:host(:not([resizable])) .d2l-template-primary-secondary-divider:hover,
+			:host([resizable]) .d2l-template-primary-secondary-divider:focus,
+			:host(:not([resizable])) .d2l-template-primary-secondary-divider:focus {
+				background-color: var(--d2l-color-celestine-minus-1);
 			}
 			.d2l-template-primary-secondary-divider-handle {
-				display: none;
-				position: absolute;
-				top: calc(50%);
-				width: 100%;
-			}
-			:host([resizable]) .d2l-template-primary-secondary-divider {
-				background-color: var(--d2l-color-gypsum);
-				cursor: ew-resize;
-				width: 0.45rem;
-			}
-			:host([resizable]) [data-is-expanded] .d2l-template-primary-secondary-divider {
-				cursor: var(--d2l-cursor-resize-inline-end, e-resize);
-			}
-			:host([resizable]) [data-is-collapsed] .d2l-template-primary-secondary-divider {
-				cursor: var(--d2l-cursor-resize-inline-start, w-resize);
-			}
-			:host([resizable]) .d2l-template-primary-secondary-divider-handle {
-				align-items: center;
-				display: flex;
-				justify-content: center;
-			}
-			:host([resizable]) [data-background-shading="secondary"] .d2l-template-primary-secondary-divider {
-				box-shadow: calc(1px * var(--d2l-length-factor, 1)) 0 0 0 rgba(0, 0, 0, 0.15);
-			}
-			:host([resizable]) [data-background-shading="primary"] .d2l-template-primary-secondary-divider {
-				box-shadow: calc(-1px * var(--d2l-length-factor, 1)) 0 0 0 rgba(0, 0, 0, 0.15);
-			}
-			.d2l-template-primary-secondary-divider-handle-desktop {
-				align-items: center;
-				display: flex;
-				justify-content: center;
-				position: absolute;
-			}
-			.d2l-template-primary-secondary-divider-handle-left,
-			.d2l-template-primary-secondary-divider-handle-right {
-				color: var(--d2l-color-celestine);
-				display: none;
-				position: absolute;
-			}
-			.d2l-template-primary-secondary-divider-handle-left {
-				inset-inline-start: -1rem;
-			}
-			.d2l-template-primary-secondary-divider-handle-right {
-				inset-inline-end: -1rem;
-			}
-			.d2l-template-primary-secondary-divider-handle-line {
-				display: flex;
-				height: 0.9rem;
-				justify-content: space-between;
-				width: 0.25rem;
-			}
-			.d2l-template-primary-secondary-divider-handle-line::before,
-			.d2l-template-primary-secondary-divider-handle-line::after {
-				background-color: var(--d2l-color-galena);
-				border-radius: 0.05rem;
-				content: "";
-				display: inline-block;
-				width: 0.1rem;
-			}
-			.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-right,
-			.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-left {
+				border-radius: 0;
+				bottom: 0.1rem;
 				display: block;
+				inset-inline-end: calc(17px + 0.2rem);
+				overflow: hidden;
+				top: auto;
 			}
-			:host(:not([secondary-first])) [data-is-expanded] .d2l-template-primary-secondary-divider-handle-left,
-			:host([secondary-first]) [data-is-expanded] .d2l-template-primary-secondary-divider-handle-right {
-				display: none;
+			.d2l-template-primary-secondary-divider-handle-mobile {
+				align-items: center;
+				background-color: var(--d2l-color-celestine);
+				border-radius: 0.25rem 0.25rem 0 0;
+				bottom: 0;
+				display: flex;
+				justify-content: center;
+				position: absolute;
+				right: 0;
+			}
+			.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-mobile,
+			.d2l-template-primary-secondary-divider:focus .d2l-template-primary-secondary-divider-handle-mobile {
+				background-color: var(--d2l-color-celestine-minus-1);
+			}
+			.d2l-template-primary-secondary-divider-handle,
+			.d2l-template-primary-secondary-divider-handle-mobile {
+				height: 1rem;
+				width: 2.2rem;
+			}
+			.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle {
+				box-shadow: none;
+				height: 1.2rem;
+				inset-inline-end: 17px;
+				width: 2.6rem;
 			}
 			d2l-icon {
+				color: white;
+				display: block;
+			}
+			${getFocusRingStyles(pseudoClass => `.d2l-template-primary-secondary-divider:${pseudoClass} .d2l-template-primary-secondary-divider-handle-mobile`, { extraStyles: css`right: 0.2rem; box-shadow: 0 0 0 2px #ffffff;` })}
+			.d2l-template-primary-secondary-divider-shadow {
+				box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.25);
+				display: block;
+				height: 100%;
+				position: absolute;
+				width: 100%;
+				z-index: -1;
+			}
+		}
+
+		@media print {
+			:host {
+				overflow: visible;
+				position: relative;
+			}
+
+			.d2l-template-primary-secondary-content {
+				flex-direction: column;
+			}
+
+			.d2l-template-primary-secondary-content,
+			.d2l-template-primary-secondary-content > main,
+			.d2l-template-primary-secondary-secondary-container {
+				overflow: visible;
+			}
+
+			.d2l-template-primary-secondary-content > main {
+				background: none;
+			}
+
+			.d2l-template-primary-secondary-divider-not-resizable,
+			.d2l-template-primary-secondary-divider {
 				display: none;
 			}
 
-			footer {
-				background-color: white;
-				box-shadow: 0 -2px 4px rgba(32, 33, 34, 0.2); /* ferrite */
-				padding: 0.75rem 1rem;
-				z-index: 1; /* ensures the footer box-shadow is over main areas with background colours set */
-			}
-			header {
-				z-index: 14; /* ensures the header box-shadow is over main areas with background colours set, and opt-in on top of sticky header */
-			}
-
-			:host([resizable]) .d2l-template-primary-secondary-divider:focus,
-			:host([resizable]) .d2l-template-primary-secondary-divider:hover {
-				background-color: var(--d2l-color-mica);
+			.d2l-template-primary-secondary-container > footer {
 				box-shadow: none;
-			}
-			:host([resizable]) .d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} {
-				background-color: var(--d2l-color-celestine);
-			}
-			.d2l-template-primary-secondary-divider:focus .d2l-template-primary-secondary-divider-handle-line::before,
-			.d2l-template-primary-secondary-divider:focus .d2l-template-primary-secondary-divider-handle-line::after,
-			.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-line::before,
-			.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-line::after {
-				background-color: var(--d2l-color-ferrite);
-			}
-			.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-line::before,
-			.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle-line::after {
-				background-color: white;
+				padding: 0;
 			}
 
-			.d2l-template-primary-secondary-divider,
-			.d2l-template-primary-secondary-divider-handle-mobile,
-			.d2l-template-primary-secondary-divider-handle-line::before,
-			.d2l-template-primary-secondary-divider-handle-line::after {
-				transition: background-color 100ms, box-shadow 100ms;
+			.d2l-template-primary-secondary-container,
+			.d2l-template-primary-secondary-content {
+				height: auto;
 			}
-			.d2l-template-primary-secondary-divider:hover,
-			.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-mobile,
-			.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-line::before,
-			.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-line::after {
-				transition-delay: 100ms;
-			}
-
-			.d2l-template-scroll::-webkit-scrollbar {
-				width: 8px;
-			}
-
-			.d2l-template-scroll::-webkit-scrollbar-track {
-				background: rgba(255, 255, 255, 0.4);
-			}
-
-			.d2l-template-scroll::-webkit-scrollbar-thumb {
-				background: var(--d2l-color-galena);
-				border-radius: 4px;
-			}
-
-			.d2l-template-scroll::-webkit-scrollbar-thumb:hover {
-				background: var(--d2l-color-tungsten);
-			}
-
-			/* For Firefox */
-			.d2l-template-scroll {
-				scrollbar-color: var(--d2l-color-galena) rgba(255, 255, 255, 0.4);
-				scrollbar-width: thin;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				.d2l-template-primary-secondary-divider,
-				.d2l-template-primary-secondary-divider-handle-line::before,
-				.d2l-template-primary-secondary-divider-handle-line::after,
-				.d2l-template-primary-secondary-divider-handle-mobile {
-					transition: none;
-				}
-			}
-			@media only screen and (max-width: 767px) {
-
-				.d2l-template-primary-secondary-content {
-					flex-direction: column;
-				}
-
-				main {
-					flex: 1 0 0;
-				}
-				.d2l-template-primary-secondary-secondary-container {
-					flex: none;
-				}
-				aside,
-				.d2l-template-primary-secondary-secondary-container {
-					min-width: auto;
-				}
-				[data-is-collapsed] aside {
-					display: none;
-				}
-
-				.d2l-template-primary-secondary-divider-handle-desktop {
-					display: none;
-				}
-				/* Attribute selector is only used to increase specificity */
-				:host([resizable]) .d2l-template-primary-secondary-divider,
-				:host(:not([resizable])) .d2l-template-primary-secondary-divider {
-					background-color: var(--d2l-color-celestine);
-					cursor: ns-resize;
-					height: 0.1rem;
-					width: 100%;
-				}
-				:host([resizable]) [data-is-collapsed] .d2l-template-primary-secondary-divider,
-				:host(:not([resizable])) [data-is-collapsed] .d2l-template-primary-secondary-divider {
-					cursor: n-resize;
-				}
-				:host([resizable]) [data-is-expanded] .d2l-template-primary-secondary-divider,
-				:host(:not([resizable])) [data-is-expanded] .d2l-template-primary-secondary-divider {
-					cursor: s-resize;
-				}
-
-				/* Attribute selector is only used to increase specificity */
-				:host([resizable]) .d2l-template-primary-secondary-divider:hover,
-				:host(:not([resizable])) .d2l-template-primary-secondary-divider:hover,
-				:host([resizable]) .d2l-template-primary-secondary-divider:focus,
-				:host(:not([resizable])) .d2l-template-primary-secondary-divider:focus {
-					background-color: var(--d2l-color-celestine-minus-1);
-				}
-				.d2l-template-primary-secondary-divider-handle {
-					border-radius: 0;
-					bottom: 0.1rem;
-					display: block;
-					inset-inline-end: calc(17px + 0.2rem);
-					overflow: hidden;
-					top: auto;
-				}
-				.d2l-template-primary-secondary-divider-handle-mobile {
-					align-items: center;
-					background-color: var(--d2l-color-celestine);
-					border-radius: 0.25rem 0.25rem 0 0;
-					bottom: 0;
-					display: flex;
-					justify-content: center;
-					position: absolute;
-					right: 0;
-				}
-				.d2l-template-primary-secondary-divider:hover .d2l-template-primary-secondary-divider-handle-mobile,
-				.d2l-template-primary-secondary-divider:focus .d2l-template-primary-secondary-divider-handle-mobile {
-					background-color: var(--d2l-color-celestine-minus-1);
-				}
-				.d2l-template-primary-secondary-divider-handle,
-				.d2l-template-primary-secondary-divider-handle-mobile {
-					height: 1rem;
-					width: 2.2rem;
-				}
-				.d2l-template-primary-secondary-divider:${unsafeCSS(getFocusPseudoClass())} .d2l-template-primary-secondary-divider-handle {
-					box-shadow: none;
-					height: 1.2rem;
-					inset-inline-end: 17px;
-					width: 2.6rem;
-				}
-				d2l-icon {
-					color: white;
-					display: block;
-				}
-				${getFocusRingStyles(pseudoClass => `.d2l-template-primary-secondary-divider:${pseudoClass} .d2l-template-primary-secondary-divider-handle-mobile`, { extraStyles: css`right: 0.2rem; box-shadow: 0 0 0 2px #ffffff;` })}
-				.d2l-template-primary-secondary-divider-shadow {
-					box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.25);
-					display: block;
-					height: 100%;
-					position: absolute;
-					width: 100%;
-					z-index: -1;
-				}
-			}
-
-			@media print {
-				:host {
-					overflow: visible;
-					position: relative;
-				}
-
-				.d2l-template-primary-secondary-content {
-					flex-direction: column;
-				}
-
-				.d2l-template-primary-secondary-content,
-				.d2l-template-primary-secondary-content > main,
-				.d2l-template-primary-secondary-secondary-container {
-					overflow: visible;
-				}
-
-				.d2l-template-primary-secondary-content > main {
-					background: none;
-				}
-
-				.d2l-template-primary-secondary-divider-not-resizable,
-				.d2l-template-primary-secondary-divider {
-					display: none;
-				}
-
-				.d2l-template-primary-secondary-container > footer {
-					box-shadow: none;
-					padding: 0;
-				}
-
-				.d2l-template-primary-secondary-container,
-				.d2l-template-primary-secondary-content {
-					height: auto;
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();


### PR DESCRIPTION
Ignore this for now, still fiddling to try and get it right.

I used a custom copilot agent to automatically convert this:

```javascript
static get properties() {
  return {
    ...
  };
}
```

To this:
```javascript
static properties = {
  ...
};
```

And the same for `styles`, although there were a few [complex cases like this](https://github.com/BrightspaceUI/core/blob/8d5ab19367915c1b98d14cfa6780294d77dc0dae/components/inputs/input-inline-help.js#L24) that it left alone.

I don't know that this is the type of PR we necessarily want to review with a fine-toothed comb, since our linting and other tests should catch problems. But if you do review it line-by-line, it will 100% need to be reviewed with whitespace OFF.