### PR TITLE
GAUD-10267: use modern static properties (Part 1)

### DIFF
--- a/components/alert/alert-toast.js
+++ b/components/alert/alert-toast.js
@@ -38,119 +38,115 @@ let ALERT_HAS_HOVER = false; // if this alert or sibling alert is hovered on
  */
 class AlertToast extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * Text that is displayed within the alert's action button. If no text is provided the button is not displayed.
-			 * @type {string}
-			 */
-			buttonText: { type: String, attribute: 'button-text' },
+	static properties = {
+		/**
+		 * Text that is displayed within the alert's action button. If no text is provided the button is not displayed.
+		 * @type {string}
+		 */
+		buttonText: { type: String, attribute: 'button-text' },
 
-			/**
-			 * Hide the close button to prevent users from manually closing the alert
-			 * @type {boolean}
-			 */
-			hideCloseButton: { type: Boolean, attribute: 'hide-close-button' },
+		/**
+		 * Hide the close button to prevent users from manually closing the alert
+		 * @type {boolean}
+		 */
+		hideCloseButton: { type: Boolean, attribute: 'hide-close-button' },
 
-			/**
-			 * Prevents the alert from automatically closing 4 seconds after opening
-			 * @type {boolean}
-			 */
-			noAutoClose: { type: Boolean, attribute: 'no-auto-close' },
+		/**
+		 * Prevents the alert from automatically closing 4 seconds after opening
+		 * @type {boolean}
+		 */
+		noAutoClose: { type: Boolean, attribute: 'no-auto-close' },
 
-			/**
-			 * Open or close the toast alert
-			 * @type {boolean}
-			 */
-			open: { type: Boolean, reflect: true },
+		/**
+		 * Open or close the toast alert
+		 * @type {boolean}
+		 */
+		open: { type: Boolean, reflect: true },
 
-			/**
-			 * The text that is displayed below the main alert message
-			 * @type {string}
-			 */
-			subtext: { type: String },
+		/**
+		 * The text that is displayed below the main alert message
+		 * @type {string}
+		 */
+		subtext: { type: String },
 
-			/**
-			 * Type of the alert being displayed
-			 * @type {'default'|'critical'|'success'|'warning'}
-			 * @default "default"
-			 */
-			type: { type: String, reflect: true },
-			_closeClicked: { state: true },
-			_numAlertsBelow: { state: true },
-			_smallWidth: { state: true },
-			_state: { type: String },
-			_totalSiblingHeightBelow: { state: true }
-		};
-	}
+		/**
+		 * Type of the alert being displayed
+		 * @type {'default'|'critical'|'success'|'warning'}
+		 * @default "default"
+		 */
+		type: { type: String, reflect: true },
+		_closeClicked: { state: true },
+		_numAlertsBelow: { state: true },
+		_smallWidth: { state: true },
+		_state: { type: String },
+		_totalSiblingHeightBelow: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
+	static styles = css`
+		:host {
+			display: block;
+		}
 
+		.d2l-alert-toast-container {
+			border-radius: 0.3rem;
+			box-shadow: 0 0.1rem 0.6rem 0 rgba(0, 0, 0, 0.1);
+			display: none;
+			left: 0;
+			margin: 0 auto 1.5rem;
+			max-width: 600px;
+			position: fixed;
+			right: 0;
+			width: 100%;
+			z-index: 10000;
+		}
+
+		.d2l-alert-toast-container:not([data-state="closed"]) {
+			display: block;
+		}
+
+		.d2l-alert-toast-container[data-state="opening"],
+		.d2l-alert-toast-container.d2l-alert-toast-container-lowest[data-state="closing"] {
+			transition-duration: 600ms;
+			transition-property: opacity, transform;
+			transition-timing-function: ease;
+		}
+		.d2l-alert-toast-container[data-state="closing"] {
+			transition: opacity 200ms ease;
+		}
+
+		.d2l-alert-toast-container.d2l-alert-toast-container-close-clicked[data-state="closing"] {
+			transition-duration: 200ms;
+		}
+
+		.d2l-alert-toast-container[data-state="preopening"],
+		.d2l-alert-toast-container[data-state="closing"] {
+			opacity: 0;
+		}
+		.d2l-alert-toast-container[data-state="preopening"],
+		.d2l-alert-toast-container.d2l-alert-toast-container-lowest[data-state="closing"] {
+			transform: translateY(calc(100% + 1.5rem));
+		}
+
+		.d2l-alert-toast-container[data-state="opening"] {
+			opacity: 1;
+			transform: translateY(0);
+		}
+
+		.d2l-alert-toast-container[data-state="sliding"] {
+			transition: bottom 600ms ease;
+		}
+
+		d2l-alert {
+			animation: none;
+		}
+
+		@media (max-width: 615px) {
 			.d2l-alert-toast-container {
-				border-radius: 0.3rem;
-				box-shadow: 0 0.1rem 0.6rem 0 rgba(0, 0, 0, 0.1);
-				display: none;
-				left: 0;
-				margin: 0 auto 1.5rem;
-				max-width: 600px;
-				position: fixed;
-				right: 0;
-				width: 100%;
-				z-index: 10000;
+				margin-bottom: 12px;
+				width: calc(100% - 16px);
 			}
-
-			.d2l-alert-toast-container:not([data-state="closed"]) {
-				display: block;
-			}
-
-			.d2l-alert-toast-container[data-state="opening"],
-			.d2l-alert-toast-container.d2l-alert-toast-container-lowest[data-state="closing"] {
-				transition-duration: 600ms;
-				transition-property: opacity, transform;
-				transition-timing-function: ease;
-			}
-			.d2l-alert-toast-container[data-state="closing"] {
-				transition: opacity 200ms ease;
-			}
-
-			.d2l-alert-toast-container.d2l-alert-toast-container-close-clicked[data-state="closing"] {
-				transition-duration: 200ms;
-			}
-
-			.d2l-alert-toast-container[data-state="preopening"],
-			.d2l-alert-toast-container[data-state="closing"] {
-				opacity: 0;
-			}
-			.d2l-alert-toast-container[data-state="preopening"],
-			.d2l-alert-toast-container.d2l-alert-toast-container-lowest[data-state="closing"] {
-				transform: translateY(calc(100% + 1.5rem));
-			}
-
-			.d2l-alert-toast-container[data-state="opening"] {
-				opacity: 1;
-				transform: translateY(0);
-			}
-
-			.d2l-alert-toast-container[data-state="sliding"] {
-				transition: bottom 600ms ease;
-			}
-
-			d2l-alert {
-				animation: none;
-			}
-
-			@media (max-width: 615px) {
-				.d2l-alert-toast-container {
-					margin-bottom: 12px;
-					width: calc(100% - 16px);
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/alert/alert.js
+++ b/components/alert/alert.js
@@ -14,134 +14,130 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 class Alert extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Text that is displayed within the alert's action button. If no text is provided the button is not displayed.
-			 * @type {string}
-			 */
-			buttonText: { type: String, attribute: 'button-text' },
+	static properties = {
+		/**
+		 * Text that is displayed within the alert's action button. If no text is provided the button is not displayed.
+		 * @type {string}
+		 */
+		buttonText: { type: String, attribute: 'button-text' },
 
-			/**
-			 * Gives the alert a close button that will close the alert when clicked
-			 * @type {boolean}
-			 */
-			hasCloseButton: { type: Boolean, attribute: 'has-close-button' },
+		/**
+		 * Gives the alert a close button that will close the alert when clicked
+		 * @type {boolean}
+		 */
+		hasCloseButton: { type: Boolean, attribute: 'has-close-button' },
 
-			/**
-			 * Opt out of default padding/whitespace around the alert
-			 * @type {boolean}
-			 */
-			noPadding: { type: Boolean, attribute: 'no-padding', reflect: true },
+		/**
+		 * Opt out of default padding/whitespace around the alert
+		 * @type {boolean}
+		 */
+		noPadding: { type: Boolean, attribute: 'no-padding', reflect: true },
 
-			/**
-			 * The text that is displayed below the main alert message
-			 * @type {string}
-			 */
-			subtext: { type: String },
+		/**
+		 * The text that is displayed below the main alert message
+		 * @type {string}
+		 */
+		subtext: { type: String },
 
-			/**
-			 * Type of the alert being displayed
-			 * @type {'default'|'critical'|'success'|'warning'}
-			 */
-			type: { type: String, reflect: true }
-		};
-	}
-	static get styles() {
-		return [bodyCompactStyles, bodyStandardStyles, css`
+		/**
+		 * Type of the alert being displayed
+		 * @type {'default'|'critical'|'success'|'warning'}
+		 */
+		type: { type: String, reflect: true }
+	};
+	static styles = [bodyCompactStyles, bodyStandardStyles, css`
 
-			:host {
-				animation: 600ms ease drop-in;
-				background: var(--d2l-theme-background-color-base);
-				border: 1px solid var(--d2l-theme-border-color-standard);
-				border-inline-start-width: 0.3rem;
-				border-radius: 0.3rem;
-				box-sizing: border-box;
-				display: flex;
-				flex: 1;
-				max-width: 710px;
-				position: relative;
-				width: 100%;
-			}
+		:host {
+			animation: 600ms ease drop-in;
+			background: var(--d2l-theme-background-color-base);
+			border: 1px solid var(--d2l-theme-border-color-standard);
+			border-inline-start-width: 0.3rem;
+			border-radius: 0.3rem;
+			box-sizing: border-box;
+			display: flex;
+			flex: 1;
+			max-width: 710px;
+			position: relative;
+			width: 100%;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
-			:host([type="critical"]),
-			:host([type="error"]) {
-				border-inline-start-color: var(--d2l-theme-status-color-error);
-			}
-			:host([type="warning"]) {
-				border-inline-start-color: var(--d2l-theme-status-color-warning);
-			}
-			:host([type="default"]),
-			:host([type="call-to-action"]) {
-				border-inline-start-color: var(--d2l-theme-status-color-default);
-			}
-			:host([type="success"]) {
-				border-inline-start-color: var(--d2l-theme-status-color-success);
-			}
+		:host([type="critical"]),
+		:host([type="error"]) {
+			border-inline-start-color: var(--d2l-theme-status-color-error);
+		}
+		:host([type="warning"]) {
+			border-inline-start-color: var(--d2l-theme-status-color-warning);
+		}
+		:host([type="default"]),
+		:host([type="call-to-action"]) {
+			border-inline-start-color: var(--d2l-theme-status-color-default);
+		}
+		:host([type="success"]) {
+			border-inline-start-color: var(--d2l-theme-status-color-success);
+		}
 
+		.d2l-alert-text {
+			flex: 1;
+			padding-block: 0.9rem;
+			padding-inline-end: 1.5rem;
+			padding-inline-start: 1.2rem;
+			position: relative;
+		}
+		.d2l-alert-text-with-actions {
+			padding-inline-end: 0.9rem;
+		}
+
+		:host([no-padding]) .d2l-alert-text,
+		:host([no-padding]) .d2l-alert-text-with-actions {
+			padding-block: 0;
+			padding-inline-end: 0;
+			padding-inline-start: 0;
+		}
+
+		.d2l-alert-subtext {
+			margin: 0.5rem 0 0;
+		}
+
+		.d2l-alert-action {
+			margin-block: 0.6rem;
+			margin-inline-end: 0.6rem;
+			margin-inline-start: 0;
+		}
+		:host([no-padding]) .d2l-alert-action {
+			margin: 0;
+		}
+
+		@media (max-width: 615px) {
 			.d2l-alert-text {
 				flex: 1;
-				padding-block: 0.9rem;
-				padding-inline-end: 1.5rem;
-				padding-inline-start: 1.2rem;
 				position: relative;
 			}
-			.d2l-alert-text-with-actions {
-				padding-inline-end: 0.9rem;
-			}
-
-			:host([no-padding]) .d2l-alert-text,
-			:host([no-padding]) .d2l-alert-text-with-actions {
-				padding-block: 0;
-				padding-inline-end: 0;
-				padding-inline-start: 0;
-			}
-
-			.d2l-alert-subtext {
-				margin: 0.5rem 0 0;
-			}
-
 			.d2l-alert-action {
-				margin-block: 0.6rem;
-				margin-inline-end: 0.6rem;
-				margin-inline-start: 0;
+				margin: 0.45rem;
 			}
-			:host([no-padding]) .d2l-alert-action {
-				margin: 0;
-			}
+		}
 
-			@media (max-width: 615px) {
-				.d2l-alert-text {
-					flex: 1;
-					position: relative;
-				}
-				.d2l-alert-action {
-					margin: 0.45rem;
-				}
+		@keyframes drop-in {
+			from {
+				opacity: 0;
+				transform: translate(0, -10px);
 			}
+			to {
+				opacity: 1;
+				transform: translate(0, 0);
+			}
+		}
 
-			@keyframes drop-in {
-				from {
-					opacity: 0;
-					transform: translate(0, -10px);
-				}
-				to {
-					opacity: 1;
-					transform: translate(0, 0);
-				}
+		@media (prefers-reduced-motion: reduce) {
+			:host {
+				animation: none;
 			}
-
-			@media (prefers-reduced-motion: reduce) {
-				:host {
-					animation: none;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/backdrop/backdrop-dirty-overlay.js
+++ b/components/backdrop/backdrop-dirty-overlay.js
@@ -34,25 +34,21 @@ const overlayStyles = css`
  */
 class BackdropDirtyOverlay extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * The text displayed on the dirty state overlay.
-			 * @type {string}
-			 */
-			description: { type: String, required: true },
+	static properties = {
+		/**
+		 * The text displayed on the dirty state overlay.
+		 * @type {string}
+		 */
+		description: { type: String, required: true },
 
-			/**
-			 * The text displayed on the button of the dirty state overlay when the 'dirty' dataState is set.
-			 * @type {string}
-			 */
-			action: { type: String, required: true }
-		};
-	}
+		/**
+		 * The text displayed on the button of the dirty state overlay when the 'dirty' dataState is set.
+		 * @type {string}
+		 */
+		action: { type: String, required: true }
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, overlayStyles, getFocusRingStyles('.d2l-backdrop-dirty-overlay')];
-	}
+	static styles = [bodyCompactStyles, overlayStyles, getFocusRingStyles('.d2l-backdrop-dirty-overlay')];
 
 	render() {
 		return html`

--- a/components/backdrop/backdrop-loading.js
+++ b/components/backdrop/backdrop-loading.js
@@ -22,120 +22,116 @@ const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
  */
 class LoadingBackdrop extends PropertyRequiredMixin(LocalizeCoreElement(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * The state of data in the element being overlaid. Set to 'clean' when the data represents the user's latest selections, 'dirty' when the data does not represent the user's latest selections, and 'loading' if the data is being actively refreshed
-			 * @type {'clean'|'dirty'|'loading'}
-			 */
-			dataState: {
-				reflect: true,
-				type: String
-			},
-			/**
-			 * Used to identify content that the backdrop should make inert
-			 * @type {string}
-			 */
-			for: { type: String, required: true },
-			/**
-			 * The text displayed on the dirty state overlay when the 'dirty' dataState is set.
-			 * @type {string}
-			 */
-			dirtyText: {
-				reflect: true,
-				attribute: 'dirty-text',
-				type: String
-			},
-			/**
-			 * The text displayed on the button of the dirty state overlay when the 'dirty' dataState is set.
-			 * @type {string}
-			 */
-			dirtyButtonText: {
-				reflect: true,
-				attribute: 'dirty-button-text',
-				type: String
-			},
-			_state: { type: String, reflect: true },
-			_spinnerTop: { state: true },
-			_ariaContent: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * The state of data in the element being overlaid. Set to 'clean' when the data represents the user's latest selections, 'dirty' when the data does not represent the user's latest selections, and 'loading' if the data is being actively refreshed
+		 * @type {'clean'|'dirty'|'loading'}
+		 */
+		dataState: {
+			reflect: true,
+			type: String
+		},
+		/**
+		 * Used to identify content that the backdrop should make inert
+		 * @type {string}
+		 */
+		for: { type: String, required: true },
+		/**
+		 * The text displayed on the dirty state overlay when the 'dirty' dataState is set.
+		 * @type {string}
+		 */
+		dirtyText: {
+			reflect: true,
+			attribute: 'dirty-text',
+			type: String
+		},
+		/**
+		 * The text displayed on the button of the dirty state overlay when the 'dirty' dataState is set.
+		 * @type {string}
+		 */
+		dirtyButtonText: {
+			reflect: true,
+			attribute: 'dirty-button-text',
+			type: String
+		},
+		_state: { type: String, reflect: true },
+		_spinnerTop: { state: true },
+		_ariaContent: { state: true }
+	};
 
-	static get styles() {
-		return [css`
-			#visible {
-				display: none;
-			}
+	static styles = [css`
+		#visible {
+			display: none;
+		}
 
-			:host([_state="showing"]),
-			:host([_state="shown"]),
-			:host([_state="hiding"]),
-			:host([_state="showing"]) #visible,
-			:host([_state="shown"]) #visible,
-			:host([_state="hiding"]) #visible {
-				display: flex;
-				height: 100%;
-				justify-content: center;
-				position: absolute;
-				top: 0;
-				width: 100%;
-				z-index: 999;
-			}
+		:host([_state="showing"]),
+		:host([_state="shown"]),
+		:host([_state="hiding"]),
+		:host([_state="showing"]) #visible,
+		:host([_state="shown"]) #visible,
+		:host([_state="hiding"]) #visible {
+			display: flex;
+			height: 100%;
+			justify-content: center;
+			position: absolute;
+			top: 0;
+			width: 100%;
+			z-index: 999;
+		}
 
-			.backdrop {
-				background-color: var(--d2l-theme-backdrop-background-color);
-				height: 100%;
-				opacity: 0;
-				position: absolute;
-				top: 0;
-				width: 100%;
-			}
-			:host([_state="shown"]) .backdrop {
-				opacity: var(--d2l-theme-backdrop-opacity);
-				transition: opacity ${FADE_DURATION_MS}ms ease-in;
-			}
-			:host([_state="hiding"]) .backdrop {
-				transition: opacity ${FADE_DURATION_MS}ms ease-out;
-			}
+		.backdrop {
+			background-color: var(--d2l-theme-backdrop-background-color);
+			height: 100%;
+			opacity: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
+		:host([_state="shown"]) .backdrop {
+			opacity: var(--d2l-theme-backdrop-opacity);
+			transition: opacity ${FADE_DURATION_MS}ms ease-in;
+		}
+		:host([_state="hiding"]) .backdrop {
+			transition: opacity ${FADE_DURATION_MS}ms ease-out;
+		}
 
-			d2l-loading-spinner {
-				opacity: 0;
-				position: absolute;
-			}
-			:host([_state="shown"]) d2l-loading-spinner {
-				opacity: 1;
-				transition: opacity ${FADE_DURATION_MS}ms ease-in ${SPINNER_DELAY_MS}ms;
-			}
-			:host([_state="shown"][dataState="dirty"]) d2l-loading-spinner,
-			:host([_state="hiding"]) d2l-loading-spinner {
-				opacity: 0;
-				transition: opacity ${FADE_DURATION_MS}ms ease-out;
-			}
+		d2l-loading-spinner {
+			opacity: 0;
+			position: absolute;
+		}
+		:host([_state="shown"]) d2l-loading-spinner {
+			opacity: 1;
+			transition: opacity ${FADE_DURATION_MS}ms ease-in ${SPINNER_DELAY_MS}ms;
+		}
+		:host([_state="shown"][dataState="dirty"]) d2l-loading-spinner,
+		:host([_state="hiding"]) d2l-loading-spinner {
+			opacity: 0;
+			transition: opacity ${FADE_DURATION_MS}ms ease-out;
+		}
 
-			d2l-backdrop-dirty-overlay {
-				background-color: var(--d2l-theme-backdrop-dialog-color);
-				height: fit-content;
-				justify-content: center;
-				opacity: 0;
-				position: relative;
-				top: 0;
-				z-index: 1000;
-			}
-			:host([_state="shown"]) d2l-backdrop-dirty-overlay {
-				opacity: 1;
-				transition: opacity ${FADE_DURATION_MS}ms ease-in;
-			}
-			:host([_state="shown"][dataState="loading"]) d2l-backdrop-dirty-overlay,
-			:host([_state="hiding"]) d2l-backdrop-dirty-overlay {
-				opacity: 0;
-				transition: opacity ${FADE_DURATION_MS}ms ease-out;
-			}
+		d2l-backdrop-dirty-overlay {
+			background-color: var(--d2l-theme-backdrop-dialog-color);
+			height: fit-content;
+			justify-content: center;
+			opacity: 0;
+			position: relative;
+			top: 0;
+			z-index: 1000;
+		}
+		:host([_state="shown"]) d2l-backdrop-dirty-overlay {
+			opacity: 1;
+			transition: opacity ${FADE_DURATION_MS}ms ease-in;
+		}
+		:host([_state="shown"][dataState="loading"]) d2l-backdrop-dirty-overlay,
+		:host([_state="hiding"]) d2l-backdrop-dirty-overlay {
+			opacity: 0;
+			transition: opacity ${FADE_DURATION_MS}ms ease-out;
+		}
 
-			@media (prefers-reduced-motion: reduce) {
-				* { transition: none; }
-			}
-		`];
-	}
+		@media (prefers-reduced-motion: reduce) {
+			* { transition: none; }
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -20,64 +20,60 @@ let scrollOverflow = null;
  */
 class Backdrop extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: id of the target element to display backdrop behind
-			 * @type {string}
-			 */
-			forTarget: { type: String, attribute: 'for-target' },
+	static properties = {
+		/**
+		 * REQUIRED: id of the target element to display backdrop behind
+		 * @type {string}
+		 */
+		forTarget: { type: String, attribute: 'for-target' },
 
-			/**
-			 * Disables the fade-out transition while the backdrop is being hidden
-			 * @type {boolean}
-			 */
-			noAnimateHide: { type: Boolean, attribute: 'no-animate-hide' },
+		/**
+		 * Disables the fade-out transition while the backdrop is being hidden
+		 * @type {boolean}
+		 */
+		noAnimateHide: { type: Boolean, attribute: 'no-animate-hide' },
 
-			/**
-			 * Used to control whether the backdrop is shown
-			 * @type {boolean}
-			 */
-			shown: { type: Boolean },
-			_state: { type: String, reflect: true }
-		};
-	}
+		/**
+		 * Used to control whether the backdrop is shown
+		 * @type {boolean}
+		 */
+		shown: { type: Boolean },
+		_state: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [ css`
-			:host {
-				background-color: var(--d2l-theme-backdrop-background-color);
-				height: 0;
-				left: 0;
-				opacity: 0;
-				position: fixed;
-				top: 0;
-				transition: opacity ${TRANSITION_DURATION}ms ease-in;
-				width: 0;
-				z-index: 999;
-			}
+	static styles = [ css`
+		:host {
+			background-color: var(--d2l-theme-backdrop-background-color);
+			height: 0;
+			left: 0;
+			opacity: 0;
+			position: fixed;
+			top: 0;
+			transition: opacity ${TRANSITION_DURATION}ms ease-in;
+			width: 0;
+			z-index: 999;
+		}
+		:host([slow-transition]) {
+			transition: opacity 1200ms ease-in;
+		}
+		:host([_state="showing"]) {
+			opacity: var(--d2l-theme-backdrop-opacity);
+		}
+		:host([_state="showing"]),
+		:host([_state="hiding"]) {
+			height: 100%;
+			width: 100%;
+		}
+		:host([_state=null][no-animate-hide]) {
+			transition: none;
+		}
+		@media (prefers-reduced-motion: reduce) {
+			:host,
 			:host([slow-transition]) {
-				transition: opacity 1200ms ease-in;
-			}
-			:host([_state="showing"]) {
-				opacity: var(--d2l-theme-backdrop-opacity);
-			}
-			:host([_state="showing"]),
-			:host([_state="hiding"]) {
-				height: 100%;
-				width: 100%;
-			}
-			:host([_state=null][no-animate-hide]) {
 				transition: none;
 			}
-			@media (prefers-reduced-motion: reduce) {
-				:host,
-				:host([slow-transition]) {
-					transition: none;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/breadcrumbs/breadcrumb-current-page.js
+++ b/components/breadcrumbs/breadcrumb-current-page.js
@@ -5,30 +5,26 @@ import { css, html, LitElement } from 'lit';
  */
 class BreadcrumbCurrentPage extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			_role: { type: 'string', attribute: 'role', reflect: true },
-			/**
-			 * REQUIRED: The title of the current page
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		_role: { type: 'string', attribute: 'role', reflect: true },
+		/**
+		 * REQUIRED: The title of the current page
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/breadcrumbs/breadcrumb.js
+++ b/components/breadcrumbs/breadcrumb.js
@@ -10,61 +10,57 @@ import { linkStyles } from '../link/link.js';
  */
 class Breadcrumb extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			_compact: { attribute: 'data-compact', reflect: true, type: Boolean },
-			/**
-			 * @ignore
-			 */
-			_role: { type: 'string', attribute: 'role', reflect: true },
-			/**
-			 * The Url that breadcrumb is pointing to
-			 * @type {string}
-			 */
-			href: { type: String, reflect: true },
-			/**
-			 * The target of breadcrumb link
-			 * @type {string}
-			 */
-			target: { type: String, reflect: true },
-			/**
-			 * REQUIRED: The text of the breadcrumb link
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true },
-			/**
-			 * ACCESSIBILITY: ARIA label for the breadcrumb, used if `text` does not provide enough context for screen reader users
-			 * @type {string}
-			 */
-			ariaLabel: { attribute: 'aria-label', type: String, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		_compact: { attribute: 'data-compact', reflect: true, type: Boolean },
+		/**
+		 * @ignore
+		 */
+		_role: { type: 'string', attribute: 'role', reflect: true },
+		/**
+		 * The Url that breadcrumb is pointing to
+		 * @type {string}
+		 */
+		href: { type: String, reflect: true },
+		/**
+		 * The target of breadcrumb link
+		 * @type {string}
+		 */
+		target: { type: String, reflect: true },
+		/**
+		 * REQUIRED: The text of the breadcrumb link
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true },
+		/**
+		 * ACCESSIBILITY: ARIA label for the breadcrumb, used if `text` does not provide enough context for screen reader users
+		 * @type {string}
+		 */
+		ariaLabel: { attribute: 'aria-label', type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [linkStyles, css`
-			:host {
-				align-items: center;
-				display: inline-flex;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([data-compact]) {
-				flex-direction: row-reverse;
-			}
-			d2l-icon {
-				height: 8px;
-				padding-inline: 8px 3px;
-				width: 8px;
-			}
-			d2l-icon[icon="tier1:chevron-left"] {
-				padding-inline: 0 8px;
-			}
-		`];
-	}
+	static styles = [linkStyles, css`
+		:host {
+			align-items: center;
+			display: inline-flex;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([data-compact]) {
+			flex-direction: row-reverse;
+		}
+		d2l-icon {
+			height: 8px;
+			padding-inline: 8px 3px;
+			width: 8px;
+		}
+		d2l-icon[icon="tier1:chevron-left"] {
+			padding-inline: 0 8px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/breadcrumbs/breadcrumbs.js
+++ b/components/breadcrumbs/breadcrumbs.js
@@ -9,45 +9,41 @@ import { overflowEllipsisDeclarations } from '../../helpers/overflow.js';
  */
 class Breadcrumbs extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Renders in compact mode, displaying only the last item
-			 * @type {boolean}
-			 */
-			compact: { type: Boolean, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Renders in compact mode, displaying only the last item
+		 * @type {boolean}
+		 */
+		compact: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				clip-path: rect(-1em 100% calc(100% + 1em) -1em);
-				display: block;
-				font-size: 0.7rem;
-				line-height: 1.05rem;
-				${overflowEllipsisDeclarations}
-				overflow-y: clip;
-				position: relative;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host::after {
-				background: linear-gradient(to var(--d2l-inline-end, right), rgba(255, 255, 255, 0), rgb(251, 252, 252));
-				content: "";
-				inset-block: 0;
-				inset-inline-end: 0;
-				pointer-events: none;
-				position: absolute;
-				width: 10px;
-			}
-			:host([compact]) ::slotted(d2l-breadcrumb:not(:last-of-type)),
-			:host([compact]) ::slotted(d2l-breadcrumb-current-page) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			clip-path: rect(-1em 100% calc(100% + 1em) -1em);
+			display: block;
+			font-size: 0.7rem;
+			line-height: 1.05rem;
+			${overflowEllipsisDeclarations}
+			overflow-y: clip;
+			position: relative;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host::after {
+			background: linear-gradient(to var(--d2l-inline-end, right), rgba(255, 255, 255, 0), rgb(251, 252, 252));
+			content: "";
+			inset-block: 0;
+			inset-inline-end: 0;
+			pointer-events: none;
+			position: absolute;
+			width: 10px;
+		}
+		:host([compact]) ::slotted(d2l-breadcrumb:not(:last-of-type)),
+		:host([compact]) ::slotted(d2l-breadcrumb-current-page) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/button/button-add.js
+++ b/components/button/button-add.js
@@ -19,138 +19,134 @@ const MODE = {
  * A component for quickly adding items to a specific locaiton.
  */
 class ButtonAdd extends PropertyRequiredMixin(FocusMixin(LocalizeCoreElement(LitElement))) {
-	static get properties() {
-		return {
-			/**
-			 * Display mode of the component. Defaults to `icon` (plus icon is always visible). Other options are `icon-and-text` (plus icon and text are always visible), and `icon-when-interacted` (plus icon is only visible when hover or focus).
-			 * @type {'icon'|'icon-and-text'|'icon-when-interacted'}
-			 */
-			mode: { type: String, reflect: true },
-			/**
-			 * ACCESSIBILITY: The text associated with the button. When mode is `icon-and-text` this text is displayed next to the icon, otherwise this text is in a tooltip.
-			 * @type {string}
-			 */
-			text: { type: String, required: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Display mode of the component. Defaults to `icon` (plus icon is always visible). Other options are `icon-and-text` (plus icon and text are always visible), and `icon-when-interacted` (plus icon is only visible when hover or focus).
+		 * @type {'icon'|'icon-and-text'|'icon-when-interacted'}
+		 */
+		mode: { type: String, reflect: true },
+		/**
+		 * ACCESSIBILITY: The text associated with the button. When mode is `icon-and-text` this text is displayed next to the icon, otherwise this text is in a tooltip.
+		 * @type {string}
+		 */
+		text: { type: String, required: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				--d2l-button-add-animation-delay: 0ms;
-				--d2l-button-add-animation-duration: 200ms;
-				--d2l-button-add-hover-focus-color: var(--d2l-color-celestine-minus-1);
-				--d2l-button-add-line-color: var(--d2l-color-mica);
-				--d2l-button-add-line-height: 1px;
-				--d2l-button-add-hover-focus-line-height: 2px;
-			}
-			:host([mode="icon-when-interacted"]) {
-				--d2l-button-add-animation-delay: 50ms;
-			}
-			button {
-				align-items: center;
-				background-color: transparent;
-				border: 0;
-				box-shadow: none;
-				cursor: pointer;
-				display: flex;
-				font-family: inherit;
-				height: 11px;
-				justify-content: center;
-				margin: 6.5px 0; /* (d2l-button-add-icon-text height - line height) / 2 */
-				outline: none;
-				padding: 0;
-				position: relative;
-				user-select: none;
-				white-space: nowrap;
-				width: 100%;
-				z-index: 1; /* needed for button-add to have expected hover behaviour in list (hover from below, tooltip position) */
-			}
-			:host([mode="icon-and-text"]) button {
-				margin: calc((1.5rem - 11px) / 2) 0; /* (d2l-button-add-icon-text height - line height) / 2 */
-			}
+	static styles = css`
+		:host {
+			--d2l-button-add-animation-delay: 0ms;
+			--d2l-button-add-animation-duration: 200ms;
+			--d2l-button-add-hover-focus-color: var(--d2l-color-celestine-minus-1);
+			--d2l-button-add-line-color: var(--d2l-color-mica);
+			--d2l-button-add-line-height: 1px;
+			--d2l-button-add-hover-focus-line-height: 2px;
+		}
+		:host([mode="icon-when-interacted"]) {
+			--d2l-button-add-animation-delay: 50ms;
+		}
+		button {
+			align-items: center;
+			background-color: transparent;
+			border: 0;
+			box-shadow: none;
+			cursor: pointer;
+			display: flex;
+			font-family: inherit;
+			height: 11px;
+			justify-content: center;
+			margin: 6.5px 0; /* (d2l-button-add-icon-text height - line height) / 2 */
+			outline: none;
+			padding: 0;
+			position: relative;
+			user-select: none;
+			white-space: nowrap;
+			width: 100%;
+			z-index: 1; /* needed for button-add to have expected hover behaviour in list (hover from below, tooltip position) */
+		}
+		:host([mode="icon-and-text"]) button {
+			margin: calc((1.5rem - 11px) / 2) 0; /* (d2l-button-add-icon-text height - line height) / 2 */
+		}
 
-			.line {
-				background: var(--d2l-button-add-line-color);
-				height: var(--d2l-button-add-line-height);
-				margin: 5px 0;
-				width: 100%;
-			}
+		.line {
+			background: var(--d2l-button-add-line-color);
+			height: var(--d2l-button-add-line-height);
+			margin: 5px 0;
+			width: 100%;
+		}
 
+		button:hover .line,
+		button:focus .line {
+			background: var(--d2l-button-add-hover-focus-color);
+			height: var(--d2l-button-add-hover-focus-line-height);
+		}
+		button:hover d2l-button-add-icon-text,
+		button:focus d2l-button-add-icon-text {
+			--d2l-button-add-icon-text-color: var(--d2l-button-add-hover-focus-color);
+		}
+		:host([mode="icon-when-interacted"]) button:hover .line {
+			transition-delay: var(--d2l-button-add-animation-delay);
+		}
+
+		:host([mode="icon-when-interacted"]) button:not(:focus):not(:hover) d2l-button-add-icon-text {
+			position: absolute;
+		}
+		:host([mode="icon-when-interacted"]) button:hover d2l-button-add-icon-text,
+		:host([mode="icon-when-interacted"]) button:focus d2l-button-add-icon-text {
+			animation: position-change-animation var(--d2l-button-add-animation-delay); /* add delay in changing position to avoid flash of missing icon space */
+		}
+		@keyframes position-change-animation {
+			0% { position: absolute; }
+			100% { position: static; }
+		}
+		${getFocusRingStyles(pseudoClass => `button:${pseudoClass} d2l-button-add-icon-text`, { extraStyles: css`background-color: white; border-radius: 0.3rem;` })}
+		:host([mode="icon-when-interacted"]) button:${unsafeCSS(getFocusPseudoClass())} d2l-button-add-icon-text,
+		:host([mode="icon"]) button:${unsafeCSS(getFocusPseudoClass())} d2l-button-add-icon-text {
+			border-radius: 0.2rem;
+			padding: 0.15rem;
+		}
+
+		@media (prefers-reduced-motion: no-preference) {
 			button:hover .line,
 			button:focus .line {
-				background: var(--d2l-button-add-hover-focus-color);
-				height: var(--d2l-button-add-hover-focus-line-height);
+				animation: line-start-animation var(--d2l-button-add-animation-duration) ease-in var(--d2l-button-add-animation-delay) 1 forwards;
+				transition: all var(--d2l-button-add-animation-duration) ease-in var(--d2l-button-add-animation-delay);
 			}
-			button:hover d2l-button-add-icon-text,
-			button:focus d2l-button-add-icon-text {
-				--d2l-button-add-icon-text-color: var(--d2l-button-add-hover-focus-color);
-			}
-			:host([mode="icon-when-interacted"]) button:hover .line {
-				transition-delay: var(--d2l-button-add-animation-delay);
+			button:hover .line-end,
+			button:focus .line-end {
+				animation-name: line-end-animation;
 			}
 
-			:host([mode="icon-when-interacted"]) button:not(:focus):not(:hover) d2l-button-add-icon-text {
-				position: absolute;
-			}
-			:host([mode="icon-when-interacted"]) button:hover d2l-button-add-icon-text,
-			:host([mode="icon-when-interacted"]) button:focus d2l-button-add-icon-text {
-				animation: position-change-animation var(--d2l-button-add-animation-delay); /* add delay in changing position to avoid flash of missing icon space */
-			}
-			@keyframes position-change-animation {
-				0% { position: absolute; }
-				100% { position: static; }
-			}
-			${getFocusRingStyles(pseudoClass => `button:${pseudoClass} d2l-button-add-icon-text`, { extraStyles: css`background-color: white; border-radius: 0.3rem;` })}
-			:host([mode="icon-when-interacted"]) button:${unsafeCSS(getFocusPseudoClass())} d2l-button-add-icon-text,
-			:host([mode="icon"]) button:${unsafeCSS(getFocusPseudoClass())} d2l-button-add-icon-text {
-				border-radius: 0.2rem;
-				padding: 0.15rem;
-			}
-
-			@media (prefers-reduced-motion: no-preference) {
-				button:hover .line,
-				button:focus .line {
-					animation: line-start-animation var(--d2l-button-add-animation-duration) ease-in var(--d2l-button-add-animation-delay) 1 forwards;
-					transition: all var(--d2l-button-add-animation-duration) ease-in var(--d2l-button-add-animation-delay);
+			@keyframes line-start-animation {
+				0% {
+					background: linear-gradient(to var(--d2l-inline-end, right), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-start, left) center / 113%;
+					opacity: 10%;
 				}
-				button:hover .line-end,
-				button:focus .line-end {
-					animation-name: line-end-animation;
-				}
-
-				@keyframes line-start-animation {
-					0% {
-						background: linear-gradient(to var(--d2l-inline-end, right), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-start, left) center / 113%;
-						opacity: 10%;
-					}
-					100% {
-						background: linear-gradient(to var(--d2l-inline-end, right), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-start, left) center / 113%; /* safari */
-						background-position: var(--d2l-inline-end, right);
-					}
-				}
-				@keyframes line-end-animation {
-					0% {
-						background: linear-gradient(to var(--d2l-inline-start, left), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-end, right) center / 113%;
-						opacity: 10%;
-					}
-					100% {
-						background: linear-gradient(to var(--d2l-inline-start, left), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-end, right) center / 113%; /* safari */
-						background-position: var(--d2l-inline-start, left);
-					}
+				100% {
+					background: linear-gradient(to var(--d2l-inline-end, right), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-start, left) center / 113%; /* safari */
+					background-position: var(--d2l-inline-end, right);
 				}
 			}
-			@media (prefers-contrast: more) {
-				.line {
-					background-color: ButtonBorder;
+			@keyframes line-end-animation {
+				0% {
+					background: linear-gradient(to var(--d2l-inline-start, left), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-end, right) center / 113%;
+					opacity: 10%;
 				}
-				button:hover .line,
-				button:focus .line {
-					background-color: Highlight !important;
+				100% {
+					background: linear-gradient(to var(--d2l-inline-start, left), var(--d2l-button-add-line-color) 0%, var(--d2l-button-add-line-color) 11%, var(--d2l-button-add-hover-focus-color) 11%) var(--d2l-inline-end, right) center / 113%; /* safari */
+					background-position: var(--d2l-inline-start, left);
 				}
 			}
-		`;
-	}
+		}
+		@media (prefers-contrast: more) {
+			.line {
+				background-color: ButtonBorder;
+			}
+			button:hover .line,
+			button:focus .line {
+				background-color: Highlight !important;
+			}
+		}
+	`;
 
 	constructor() {
 		super();
@@ -194,49 +190,45 @@ customElements.define('d2l-button-add', ButtonAdd);
  * @ignore
  */
 class ButtonAddIconText extends VisibleOnAncestorMixin(LitElement) {
-	static get properties() {
-		return {
-			text: { type: String }
-		};
-	}
+	static properties = {
+		text: { type: String }
+	};
 
-	static get styles() {
-		return [visibleOnAncestorStyles, css`
-			:host {
-				--d2l-focus-ring-offset: 0;
-				--d2l-focus-ring-color: var(--d2l-button-add-hover-focus-color);
-				--d2l-button-add-icon-text-color: var(--d2l-color-galena);
-				align-items: center;
-				display: flex;
-				stroke: var(--d2l-button-add-icon-text-color);
-				stroke-width: 2;
-			}
-			:host([visible-on-ancestor]),
-			:host([text]) {
-				--d2l-button-add-icon-text-color: var(--d2l-color-celestine);
-			}
-			:host([text]) {
-				color: var(--d2l-button-add-icon-text-color);
-				height: 1.5rem;
-				padding: 0 0.3rem;
-			}
+	static styles = [visibleOnAncestorStyles, css`
+		:host {
+			--d2l-focus-ring-offset: 0;
+			--d2l-focus-ring-color: var(--d2l-button-add-hover-focus-color);
+			--d2l-button-add-icon-text-color: var(--d2l-color-galena);
+			align-items: center;
+			display: flex;
+			stroke: var(--d2l-button-add-icon-text-color);
+			stroke-width: 2;
+		}
+		:host([visible-on-ancestor]),
+		:host([text]) {
+			--d2l-button-add-icon-text-color: var(--d2l-color-celestine);
+		}
+		:host([text]) {
+			color: var(--d2l-button-add-icon-text-color);
+			height: 1.5rem;
+			padding: 0 0.3rem;
+		}
 
-			:host([text]) svg {
-				padding-inline-end: 0.2rem;
-			}
-			:host(:not([text])) svg {
-				margin: -0.15rem; /** hover/click target */
-				padding: 0.15rem; /** hover/click target */
-			}
+		:host([text]) svg {
+			padding-inline-end: 0.2rem;
+		}
+		:host(:not([text])) svg {
+			margin: -0.15rem; /** hover/click target */
+			padding: 0.15rem; /** hover/click target */
+		}
 
-			span {
-				font-size: 0.7rem;
-				font-weight: 700;
-				letter-spacing: 0.2px;
-				line-height: 1rem;
-			}`
-		];
-	}
+		span {
+			font-size: 0.7rem;
+			font-weight: 700;
+			letter-spacing: 0.2px;
+			line-height: 1rem;
+		}`
+	];
 
 	render() {
 		return html`

--- a/components/button/button-copy-mixin.js
+++ b/components/button/button-copy-mixin.js
@@ -4,17 +4,15 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 
 export const ButtonCopyMixin = (superclass) => class extends LocalizeCoreElement(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Disables the button
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			_recentCopySuccessful: { state: true },
-			_toastState: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the button
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		_recentCopySuccessful: { state: true },
+		_toastState: { state: true }
+	};
 
 	constructor() {
 		super();

--- a/components/button/button-copy.js
+++ b/components/button/button-copy.js
@@ -8,26 +8,22 @@ import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
  */
 class ButtonCopy extends FocusMixin(ButtonCopyMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * Description of the content being copied to clipboard
-			 * @type {string}
-			 */
-			text: { type: String },
-		};
-	}
+	static properties = {
+		/**
+		 * Description of the content being copied to clipboard
+		 * @type {string}
+		 */
+		text: { type: String },
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	static get focusElementSelector() {
 		return 'd2l-button-icon';

--- a/components/button/button-icon.js
+++ b/components/button/button-icon.js
@@ -17,122 +17,118 @@ import { ThemeMixin } from '../../mixins/theme/theme-mixin.js';
  */
 class ButtonIcon extends SlottedIconMixin(PropertyRequiredMixin(ThemeMixin(ButtonMixin(VisibleOnAncestorMixin(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
-			 * @type {string}
-			 */
-			description: { type: String },
+	static properties = {
+		/**
+		 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
+		 * @type {string}
+		 */
+		description: { type: String },
 
-			/**
-			 * Aligns the leading edge of text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
-			 * @type {'text'|'text-end'|''}
-			 */
-			hAlign: { type: String, reflect: true, attribute: 'h-align' },
+		/**
+		 * Aligns the leading edge of text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
+		 * @type {'text'|'text-end'|''}
+		 */
+		hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
-			/**
-			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true, required: true },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Accessible text for the button
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true, required: true },
 
-			/**
-			 * Indicates to display translucent (e.g., on rich backgrounds)
-			 * @type {boolean}
-			 */
-			translucent: { type: Boolean, reflect: true }
-		};
-	}
+		/**
+		 * Indicates to display translucent (e.g., on rich backgrounds)
+		 * @type {boolean}
+		 */
+		translucent: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return [super.styles, buttonStyles, visibleOnAncestorStyles,
-			css`
-				:host {
-					--d2l-button-icon-background-color-default: var(--d2l-theme-background-color-interactive-tertiary-default);
-					--d2l-button-icon-background-color-hover-default: var(--d2l-theme-background-color-interactive-tertiary-hover);
-					--d2l-button-icon-border-radius-default: 0.3rem;
-					--d2l-button-icon-min-height-default: calc(2rem + 2px);
-					--d2l-button-icon-min-width-default: calc(2rem + 2px);
-					--d2l-button-icon-h-align: calc(((2rem + 2px - 0.9rem) / 2) * -1);
-					display: inline-block;
-					line-height: 0;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([translucent]) {
-					--d2l-button-icon-background-color-default: var(--d2l-theme-background-color-interactive-translucent-default);
-					--d2l-button-icon-background-color-hover-default: var(--d2l-theme-background-color-interactive-translucent-hover);
-					--d2l-focus-ring-color: var(--d2l-theme-icon-color-inverted);
-					--d2l-focus-ring-offset: -4px;
-					--d2l-button-icon-fill-color: var(--d2l-theme-icon-color-inverted);
-					--d2l-button-icon-fill-color-hover: var(--d2l-theme-icon-color-inverted);
-				}
-				:host([theme="dark"]) {
-					--d2l-button-icon-background-color-default: transparent;
-					--d2l-button-icon-background-color-hover-default: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
-					--d2l-button-icon-fill-color: var(--d2l-color-sylvite);
-					--d2l-button-icon-fill-color-hover: var(--d2l-color-sylvite);
-					--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
-				}
+	static styles = [super.styles, buttonStyles, visibleOnAncestorStyles,
+		css`
+			:host {
+				--d2l-button-icon-background-color-default: var(--d2l-theme-background-color-interactive-tertiary-default);
+				--d2l-button-icon-background-color-hover-default: var(--d2l-theme-background-color-interactive-tertiary-hover);
+				--d2l-button-icon-border-radius-default: 0.3rem;
+				--d2l-button-icon-min-height-default: calc(2rem + 2px);
+				--d2l-button-icon-min-width-default: calc(2rem + 2px);
+				--d2l-button-icon-h-align: calc(((2rem + 2px - 0.9rem) / 2) * -1);
+				display: inline-block;
+				line-height: 0;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([translucent]) {
+				--d2l-button-icon-background-color-default: var(--d2l-theme-background-color-interactive-translucent-default);
+				--d2l-button-icon-background-color-hover-default: var(--d2l-theme-background-color-interactive-translucent-hover);
+				--d2l-focus-ring-color: var(--d2l-theme-icon-color-inverted);
+				--d2l-focus-ring-offset: -4px;
+				--d2l-button-icon-fill-color: var(--d2l-theme-icon-color-inverted);
+				--d2l-button-icon-fill-color-hover: var(--d2l-theme-icon-color-inverted);
+			}
+			:host([theme="dark"]) {
+				--d2l-button-icon-background-color-default: transparent;
+				--d2l-button-icon-background-color-hover-default: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
+				--d2l-button-icon-fill-color: var(--d2l-color-sylvite);
+				--d2l-button-icon-fill-color-hover: var(--d2l-color-sylvite);
+				--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
+			}
 
-				button {
-					background-color: var(--d2l-button-icon-background-color, var(--d2l-button-icon-background-color-default));
-					border-color: transparent;
-					border-radius: var(--d2l-button-icon-border-radius, var(--d2l-button-icon-border-radius-default));
-					font-family: inherit;
-					min-height: var(--d2l-button-icon-min-height, var(--d2l-button-icon-min-height-default));
-					min-width: var(--d2l-button-icon-min-width, var(--d2l-button-icon-min-width-default));
-					padding: 0;
-					position: relative;
-				}
+			button {
+				background-color: var(--d2l-button-icon-background-color, var(--d2l-button-icon-background-color-default));
+				border-color: transparent;
+				border-radius: var(--d2l-button-icon-border-radius, var(--d2l-button-icon-border-radius-default));
+				font-family: inherit;
+				min-height: var(--d2l-button-icon-min-height, var(--d2l-button-icon-min-height-default));
+				min-width: var(--d2l-button-icon-min-width, var(--d2l-button-icon-min-width-default));
+				padding: 0;
+				position: relative;
+			}
 
-				:host([h-align="text"]) button {
-					inset-inline-start: var(--d2l-button-icon-h-align);
-				}
-				:host([h-align="text-end"]) button {
-					inset-inline-end: var(--d2l-button-icon-h-align);
-				}
+			:host([h-align="text"]) button {
+				inset-inline-start: var(--d2l-button-icon-h-align);
+			}
+			:host([h-align="text-end"]) button {
+				inset-inline-end: var(--d2l-button-icon-h-align);
+			}
 
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
+			/* Firefox includes a hidden border which messes up button dimensions */
+			button::-moz-focus-inner {
+				border: 0;
+			}
 
-				button:hover:not([disabled]),
-				button:focus:not([disabled]),
-				:host([active]) button:not([disabled]) {
-					--d2l-button-icon-fill-color: var(--d2l-button-icon-fill-color-hover, var(--d2l-theme-icon-color-standard));
-					background-color: var(--d2l-button-icon-background-color-hover, var(--d2l-button-icon-background-color-hover-default));
-				}
+			button:hover:not([disabled]),
+			button:focus:not([disabled]),
+			:host([active]) button:not([disabled]) {
+				--d2l-button-icon-fill-color: var(--d2l-button-icon-fill-color-hover, var(--d2l-theme-icon-color-standard));
+				background-color: var(--d2l-button-icon-background-color-hover, var(--d2l-button-icon-background-color-hover-default));
+			}
 
-				d2l-icon,
-				slot[name="icon"]::slotted(d2l-icon-custom) {
-					color: var(--d2l-button-icon-fill-color, var(--d2l-theme-icon-color-standard));
-				}
+			d2l-icon,
+			slot[name="icon"]::slotted(d2l-icon-custom) {
+				color: var(--d2l-button-icon-fill-color, var(--d2l-theme-icon-color-standard));
+			}
 
+			:host([translucent]) button {
+				transition-duration: 0.2s, 0.2s;
+				transition-property: background-color, box-shadow;
+			}
+			:host([translucent][visible-on-ancestor]) button {
+				transition-duration: 0.4s, 0.4s;
+			}
+
+			:host([disabled]) button {
+				cursor: default;
+				opacity: var(--d2l-theme-opacity-disabled-control);
+			}
+
+			@media (prefers-reduced-motion: reduce) {
 				:host([translucent]) button {
-					transition-duration: 0.2s, 0.2s;
-					transition-property: background-color, box-shadow;
+					transition: none;
 				}
-				:host([translucent][visible-on-ancestor]) button {
-					transition-duration: 0.4s, 0.4s;
-				}
-
-				:host([disabled]) button {
-					cursor: default;
-					opacity: var(--d2l-theme-opacity-disabled-control);
-				}
-
-				@media (prefers-reduced-motion: reduce) {
-					:host([translucent]) button {
-						transition: none;
-					}
-				}
-			`
-		];
-	}
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -2,72 +2,74 @@ import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 
 export const ButtonMixin = superclass => class extends FocusMixin(superclass) {
 
-	static properties = {
-		/**
-		 * @ignore
-		 */
-		ariaExpanded: { type: String, reflect: true, attribute: 'aria-expanded' },
-		/**
-		 * @ignore
-		 */
-		ariaHaspopup: { type: String, reflect: true, attribute: 'aria-haspopup' },
-		/**
-		 * @ignore
-		 */
-		ariaLabel: { type: String, reflect: true, attribute: 'aria-label' },
-		/**
-		 * @ignore
-		 */
-		// eslint-disable-next-line lit/no-native-attributes
-		autofocus: { type: Boolean, reflect: true },
-		/**
-		 * Wether the controlled element is expanded. Replaces 'aria-expanded'
-		 * @type {'true' | 'false'}
-		 */
-		expanded: { type: String, reflect: true, attribute: 'expanded' },
-		/**
-		 * Disables the button
-		 * @type {boolean}
-		 */
-		disabled: { type: Boolean, reflect: true },
-		/**
-		 * Tooltip text when disabled
-		 * @type {string}
-		 */
-		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-		/**
-		 * @ignore
-		 */
-		form: { type: String, reflect: true },
-		/**
-		 * @ignore
-		 */
-		formaction: { type: String, reflect: true },
-		/**
-		 * @ignore
-		 */
-		formenctype: { type: String, reflect: true },
-		/**
-		 * @ignore
-		 */
-		formmethod: { type: String, reflect: true },
-		/**
-		 * @ignore
-		 */
-		formnovalidate: { type: String, reflect: true },
-		/**
-		 * @ignore
-		 */
-		formtarget: { type: String, reflect: true },
-		/**
-		 * @ignore
-		 */
-		name: { type: String, reflect: true },
-		/**
-		 * @ignore
-		 */
-		type: { type: String, reflect: true }
-	};
+	static get properties() {
+		return {
+			/**
+			 * @ignore
+			 */
+			ariaExpanded: { type: String, reflect: true, attribute: 'aria-expanded' },
+			/**
+			 * @ignore
+			 */
+			ariaHaspopup: { type: String, reflect: true, attribute: 'aria-haspopup' },
+			/**
+			 * @ignore
+			 */
+			ariaLabel: { type: String, reflect: true, attribute: 'aria-label' },
+			/**
+			 * @ignore
+			 */
+			// eslint-disable-next-line lit/no-native-attributes
+			autofocus: { type: Boolean, reflect: true },
+			/**
+			 * Wether the controlled element is expanded. Replaces 'aria-expanded'
+			 * @type {'true' | 'false'}
+			 */
+			expanded: { type: String, reflect: true, attribute: 'expanded' },
+			/**
+			 * Disables the button
+			 * @type {boolean}
+			 */
+			disabled: { type: Boolean, reflect: true },
+			/**
+			 * Tooltip text when disabled
+			 * @type {string}
+			 */
+			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+			/**
+			 * @ignore
+			 */
+			form: { type: String, reflect: true },
+			/**
+			 * @ignore
+			 */
+			formaction: { type: String, reflect: true },
+			/**
+			 * @ignore
+			 */
+			formenctype: { type: String, reflect: true },
+			/**
+			 * @ignore
+			 */
+			formmethod: { type: String, reflect: true },
+			/**
+			 * @ignore
+			 */
+			formnovalidate: { type: String, reflect: true },
+			/**
+			 * @ignore
+			 */
+			formtarget: { type: String, reflect: true },
+			/**
+			 * @ignore
+			 */
+			name: { type: String, reflect: true },
+			/**
+			 * @ignore
+			 */
+			type: { type: String, reflect: true }
+		};
+	}
 
 	constructor() {
 		super();

--- a/components/button/button-mixin.js
+++ b/components/button/button-mixin.js
@@ -2,74 +2,72 @@ import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
 
 export const ButtonMixin = superclass => class extends FocusMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			ariaExpanded: { type: String, reflect: true, attribute: 'aria-expanded' },
-			/**
-			 * @ignore
-			 */
-			ariaHaspopup: { type: String, reflect: true, attribute: 'aria-haspopup' },
-			/**
-			 * @ignore
-			 */
-			ariaLabel: { type: String, reflect: true, attribute: 'aria-label' },
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean, reflect: true },
-			/**
-			 * Wether the controlled element is expanded. Replaces 'aria-expanded'
-			 * @type {'true' | 'false'}
-			 */
-			expanded: { type: String, reflect: true, attribute: 'expanded' },
-			/**
-			 * Disables the button
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Tooltip text when disabled
-			 * @type {string}
-			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			/**
-			 * @ignore
-			 */
-			form: { type: String, reflect: true },
-			/**
-			 * @ignore
-			 */
-			formaction: { type: String, reflect: true },
-			/**
-			 * @ignore
-			 */
-			formenctype: { type: String, reflect: true },
-			/**
-			 * @ignore
-			 */
-			formmethod: { type: String, reflect: true },
-			/**
-			 * @ignore
-			 */
-			formnovalidate: { type: String, reflect: true },
-			/**
-			 * @ignore
-			 */
-			formtarget: { type: String, reflect: true },
-			/**
-			 * @ignore
-			 */
-			name: { type: String, reflect: true },
-			/**
-			 * @ignore
-			 */
-			type: { type: String, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		ariaExpanded: { type: String, reflect: true, attribute: 'aria-expanded' },
+		/**
+		 * @ignore
+		 */
+		ariaHaspopup: { type: String, reflect: true, attribute: 'aria-haspopup' },
+		/**
+		 * @ignore
+		 */
+		ariaLabel: { type: String, reflect: true, attribute: 'aria-label' },
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean, reflect: true },
+		/**
+		 * Wether the controlled element is expanded. Replaces 'aria-expanded'
+		 * @type {'true' | 'false'}
+		 */
+		expanded: { type: String, reflect: true, attribute: 'expanded' },
+		/**
+		 * Disables the button
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Tooltip text when disabled
+		 * @type {string}
+		 */
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		/**
+		 * @ignore
+		 */
+		form: { type: String, reflect: true },
+		/**
+		 * @ignore
+		 */
+		formaction: { type: String, reflect: true },
+		/**
+		 * @ignore
+		 */
+		formenctype: { type: String, reflect: true },
+		/**
+		 * @ignore
+		 */
+		formmethod: { type: String, reflect: true },
+		/**
+		 * @ignore
+		 */
+		formnovalidate: { type: String, reflect: true },
+		/**
+		 * @ignore
+		 */
+		formtarget: { type: String, reflect: true },
+		/**
+		 * @ignore
+		 */
+		name: { type: String, reflect: true },
+		/**
+		 * @ignore
+		 */
+		type: { type: String, reflect: true }
+	};
 
 	constructor() {
 		super();

--- a/components/button/button-move.js
+++ b/components/button/button-move.js
@@ -34,168 +34,164 @@ export const moveActions = Object.freeze({
  */
 class ButtonMove extends ThemeMixin(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
-			 * @type {string}
-			 */
-			description: { type: String },
-			/**
-			 * Disables the down interaction
-			 * @type {boolean}
-			 */
-			disabledDown: { type: Boolean, attribute: 'disabled-down', reflect: true },
-			/**
-			 * Disables the end interaction
-			 * @type {boolean}
-			 */
-			disabledEnd: { type: Boolean, attribute: 'disabled-end', reflect: true },
-			/**
-			 * Disables the home interaction
-			 * @type {boolean}
-			 */
-			disabledHome: { type: Boolean, attribute: 'disabled-home', reflect: true },
-			/**
-			 * Disables the left interaction
-			 * @type {boolean}
-			 */
-			disabledLeft: { type: Boolean, attribute: 'disabled-left', reflect: true },
-			/**
-			 * Disables the right interaction
-			 * @type {boolean}
-			 */
-			disabledRight: { type: Boolean, attribute: 'disabled-right', reflect: true },
-			/**
-			 * Disables the up interaction
-			 * @type {boolean}
-			 */
-			disabledUp: { type: Boolean, attribute: 'disabled-up', reflect: true },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Accessible text for the button
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true },
-			/**
-			 * Renders the buttons in a side by side orientation
-			 * @type {boolean}
-			 */
-			sideToSide: { type: Boolean, attribute: 'side-to-side', reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
+		 * @type {string}
+		 */
+		description: { type: String },
+		/**
+		 * Disables the down interaction
+		 * @type {boolean}
+		 */
+		disabledDown: { type: Boolean, attribute: 'disabled-down', reflect: true },
+		/**
+		 * Disables the end interaction
+		 * @type {boolean}
+		 */
+		disabledEnd: { type: Boolean, attribute: 'disabled-end', reflect: true },
+		/**
+		 * Disables the home interaction
+		 * @type {boolean}
+		 */
+		disabledHome: { type: Boolean, attribute: 'disabled-home', reflect: true },
+		/**
+		 * Disables the left interaction
+		 * @type {boolean}
+		 */
+		disabledLeft: { type: Boolean, attribute: 'disabled-left', reflect: true },
+		/**
+		 * Disables the right interaction
+		 * @type {boolean}
+		 */
+		disabledRight: { type: Boolean, attribute: 'disabled-right', reflect: true },
+		/**
+		 * Disables the up interaction
+		 * @type {boolean}
+		 */
+		disabledUp: { type: Boolean, attribute: 'disabled-up', reflect: true },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Accessible text for the button
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true },
+		/**
+		 * Renders the buttons in a side by side orientation
+		 * @type {boolean}
+		 */
+		sideToSide: { type: Boolean, attribute: 'side-to-side', reflect: true }
+	};
 
-	static get styles() {
-		return [ buttonStyles,
-			css`
-				:host {
-					--d2l-button-move-background-color-focus: #ffffff;
-					--d2l-button-move-icon-background-color-hover: var(--d2l-color-mica);
-					--d2l-icon-fill-color: var(--d2l-color-tungsten);
-					display: inline-block;
-					line-height: 0;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([theme="dark"]) {
-					--d2l-button-move-background-color-focus: #000000;
-					--d2l-button-move-icon-background-color-hover: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
-					--d2l-icon-fill-color: var(--d2l-color-sylvite);
-					--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
-				}
-				button {
-					background-color: transparent;
-					display: flex;
-					flex-direction: column;
-					gap: 2px;
-					margin: 0;
-					min-height: auto;
-					padding: 0;
-					position: relative;
-					width: 0.9rem;
-				}
-				d2l-icon {
-					border-radius: 0.1rem;
-					height: 0.85rem;
-					width: 0.9rem;
-				}
-				button:focus {
-					background-color: var(--d2l-button-move-background-color-focus);
-				}
-				button:hover > d2l-icon,
-				button:focus > d2l-icon {
-					background-color: var(--d2l-button-move-icon-background-color-hover);
-				}
-				.up-icon {
-					border-top-left-radius: 0.3rem;
-					border-top-right-radius: 0.3rem;
-				}
-				.down-icon {
-					border-bottom-left-radius: 0.3rem;
-					border-bottom-right-radius: 0.3rem;
-				}
-				.layer {
-					display: flex;
-					flex-direction: column;
-					height: calc(1.2rem * 2);
-					inset-inline-start: -0.2rem;
-					position: absolute;
-					top: -0.35rem;
-					width: 1.3rem;
-				}
-				.up-layer,
-				.down-layer {
-					height: 1.2rem;
-					position: relative;
-					width: 1.25rem;
-				}
+	static styles = [ buttonStyles,
+		css`
+			:host {
+				--d2l-button-move-background-color-focus: #ffffff;
+				--d2l-button-move-icon-background-color-hover: var(--d2l-color-mica);
+				--d2l-icon-fill-color: var(--d2l-color-tungsten);
+				display: inline-block;
+				line-height: 0;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([theme="dark"]) {
+				--d2l-button-move-background-color-focus: #000000;
+				--d2l-button-move-icon-background-color-hover: rgba(51, 53, 54, 0.9); /* tungsten @70% @90% */
+				--d2l-icon-fill-color: var(--d2l-color-sylvite);
+				--d2l-focus-ring-color: var(--d2l-color-celestine-plus-1);
+			}
+			button {
+				background-color: transparent;
+				display: flex;
+				flex-direction: column;
+				gap: 2px;
+				margin: 0;
+				min-height: auto;
+				padding: 0;
+				position: relative;
+				width: 0.9rem;
+			}
+			d2l-icon {
+				border-radius: 0.1rem;
+				height: 0.85rem;
+				width: 0.9rem;
+			}
+			button:focus {
+				background-color: var(--d2l-button-move-background-color-focus);
+			}
+			button:hover > d2l-icon,
+			button:focus > d2l-icon {
+				background-color: var(--d2l-button-move-icon-background-color-hover);
+			}
+			.up-icon {
+				border-top-left-radius: 0.3rem;
+				border-top-right-radius: 0.3rem;
+			}
+			.down-icon {
+				border-bottom-left-radius: 0.3rem;
+				border-bottom-right-radius: 0.3rem;
+			}
+			.layer {
+				display: flex;
+				flex-direction: column;
+				height: calc(1.2rem * 2);
+				inset-inline-start: -0.2rem;
+				position: absolute;
+				top: -0.35rem;
+				width: 1.3rem;
+			}
+			.up-layer,
+			.down-layer {
+				height: 1.2rem;
+				position: relative;
+				width: 1.25rem;
+			}
 
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
-				button[disabled]:hover > d2l-icon {
-					background-color: transparent;
-				}
-				:host([disabled-up]) .up-icon,
-				:host([disabled-down]) .down-icon {
-					opacity: 0.5;
-				}
-				:host([disabled-up]) .up-layer,
-				:host([disabled-down]) .down-layer {
-					cursor: default;
-				}
+			/* Firefox includes a hidden border which messes up button dimensions */
+			button::-moz-focus-inner {
+				border: 0;
+			}
+			button[disabled]:hover > d2l-icon {
+				background-color: transparent;
+			}
+			:host([disabled-up]) .up-icon,
+			:host([disabled-down]) .down-icon {
+				opacity: 0.5;
+			}
+			:host([disabled-up]) .up-layer,
+			:host([disabled-down]) .down-layer {
+				cursor: default;
+			}
 
-				:host([side-to-side]) button {
-					align-items: center;
-					flex-direction: row;
-					height: 1.2rem;
-					width: calc(calc(1.2rem + 1px) * 2);
-				}
+			:host([side-to-side]) button {
+				align-items: center;
+				flex-direction: row;
+				height: 1.2rem;
+				width: calc(calc(1.2rem + 1px) * 2);
+			}
 
-				:host([side-to-side]) .layer {
-					flex-direction: row;
-					gap: 2px;
-					height: 1.2rem;
-					inset-inline-start: 0;
-					top: 0;
-					width: calc(calc(1.2rem + 1px) * 2);
-				}
+			:host([side-to-side]) .layer {
+				flex-direction: row;
+				gap: 2px;
+				height: 1.2rem;
+				inset-inline-start: 0;
+				top: 0;
+				width: calc(calc(1.2rem + 1px) * 2);
+			}
 
-				:host([side-to-side]) d2l-icon {
-					height: 1.2rem;
-					/* Arrows need to be rotated in opposite direction for RTL */
-					transform: rotate(calc(-90deg * var(--d2l-length-factor)));
-					width: 1.2rem;
-				}
-			`
-		];
-	}
+			:host([side-to-side]) d2l-icon {
+				height: 1.2rem;
+				/* Arrows need to be rotated in opposite direction for RTL */
+				transform: rotate(calc(-90deg * var(--d2l-length-factor)));
+				width: 1.2rem;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/button/button-split-item.js
+++ b/components/button/button-split-item.js
@@ -8,27 +8,23 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class ButtonSplitItem extends PropertyRequiredMixin(MenuItemMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: Key of the action
-			 * @type {string}
-			 */
-			key: { type: String, required: true }
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: Key of the action
+		 * @type {string}
+		 */
+		key: { type: String, required: true }
+	};
 
-	static get styles() {
-		return [ menuItemStyles,
-			css`
-				:host {
-					align-items: center;
-					display: flex;
-					padding: 0.75rem 1rem;
-				}
-			`
-		];
-	}
+	static styles = [ menuItemStyles,
+		css`
+			:host {
+				align-items: center;
+				display: flex;
+				padding: 0.75rem 1rem;
+			}
+		`
+	];
 
 	render() {
 		return html`

--- a/components/button/button-split.js
+++ b/components/button/button-split.js
@@ -16,80 +16,76 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class ButtonSplit extends FocusMixin(PropertyRequiredMixin(LocalizeCoreElement(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: A description to be added to the main action button for accessibility when text does not provide enough context
-			 * @type {string}
-			 */
-			description: { type: String },
-			/**
-			 * Disables the main action and dropdown opener buttons
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Tooltip text when disabled
-			 * @type {string}
-			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			/**
-			 * REQUIRED: Key of the main action
-			 * @type {string}
-			 */
-			key: { type: String, required: true },
-			/**
-			 * Styles the buttons as a primary buttons
-			 * @type {boolean}
-			 */
-			primary: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Accessible text for the main action button
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true, required: true },
-			_focusVisibleElem: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * ACCESSIBILITY: A description to be added to the main action button for accessibility when text does not provide enough context
+		 * @type {string}
+		 */
+		description: { type: String },
+		/**
+		 * Disables the main action and dropdown opener buttons
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Tooltip text when disabled
+		 * @type {string}
+		 */
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		/**
+		 * REQUIRED: Key of the main action
+		 * @type {string}
+		 */
+		key: { type: String, required: true },
+		/**
+		 * Styles the buttons as a primary buttons
+		 * @type {boolean}
+		 */
+		primary: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Accessible text for the main action button
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true, required: true },
+		_focusVisibleElem: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.container {
-				display: flex;
-				gap: 2px;
-			}
-			.main-action {
-				--d2l-button-start-end-radius: 0;
-				--d2l-button-end-end-radius: 0;
-			}
-			.d2l-dropdown-opener {
-				--d2l-button-start-start-radius: 0;
-				--d2l-button-end-start-radius: 0;
-				--d2l-button-padding-inline-end: 0.6rem;
-				--d2l-button-padding-inline-start: 0.6rem;
-			}
-			.d2l-dropdown-opener[primary] > d2l-icon {
-				color: #ffffff;
-			}
-			::slotted(:not(d2l-button-split-item)) {
-				display: none;
-			}
-			.main-action-focus-visible .d2l-dropdown-opener {
-				--d2l-button-padding-inline-start: calc(0.6rem - 4px);
-				margin-inline-start: 4px;
-			}
-			.menu-opener-focus-visible .main-action {
-				--d2l-button-padding-inline-end: calc(1.5rem - 4px);
-				margin-inline-end: 4px;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.container {
+			display: flex;
+			gap: 2px;
+		}
+		.main-action {
+			--d2l-button-start-end-radius: 0;
+			--d2l-button-end-end-radius: 0;
+		}
+		.d2l-dropdown-opener {
+			--d2l-button-start-start-radius: 0;
+			--d2l-button-end-start-radius: 0;
+			--d2l-button-padding-inline-end: 0.6rem;
+			--d2l-button-padding-inline-start: 0.6rem;
+		}
+		.d2l-dropdown-opener[primary] > d2l-icon {
+			color: #ffffff;
+		}
+		::slotted(:not(d2l-button-split-item)) {
+			display: none;
+		}
+		.main-action-focus-visible .d2l-dropdown-opener {
+			--d2l-button-padding-inline-start: calc(0.6rem - 4px);
+			margin-inline-start: 4px;
+		}
+		.menu-opener-focus-visible .main-action {
+			--d2l-button-padding-inline-end: calc(1.5rem - 4px);
+			margin-inline-end: 4px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/button/button-subtle-copy.js
+++ b/components/button/button-subtle-copy.js
@@ -7,25 +7,23 @@ import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
  * A button component that copies to the clipboard, using the "subtle" button style.
  */
 class ButtonSubtleCopy extends FocusMixin(ButtonCopyMixin(LitElement)) {
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
-			 * @type {string}
-			 */
-			description: { type: String },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Text for the button
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true },
-			/**
-			 * Whether to render the slimmer version of the button
-			 * @type {boolean}
-			 */
-			slim: { type: Boolean, reflect: true },
-		};
-	}
+	static properties = {
+		/**
+		 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
+		 * @type {string}
+		 */
+		description: { type: String },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Text for the button
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true },
+		/**
+		 * Whether to render the slimmer version of the button
+		 * @type {boolean}
+		 */
+		slim: { type: Boolean, reflect: true },
+	};
 
 	static get focusElementSelector() {
 		return 'd2l-button-subtle';

--- a/components/button/button-subtle.js
+++ b/components/button/button-subtle.js
@@ -16,155 +16,151 @@ import { SlottedIconMixin } from '../icons/slotted-icon-mixin.js';
  */
 class ButtonSubtle extends SlottedIconMixin(ButtonMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
-			 * @type {string}
-			 */
-			description: { type: String },
+	static properties = {
+		/**
+		 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
+		 * @type {string}
+		 */
+		description: { type: String },
 
-			/**
-			 * Aligns the leading edge of text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
-			 * @type {'text'|'text-end'|''}
-			 */
-			hAlign: { type: String, reflect: true, attribute: 'h-align' },
+		/**
+		 * Aligns the leading edge of text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
+		 * @type {'text'|'text-end'|''}
+		 */
+		hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
-			/**
-			 * Indicates that the icon should be rendered on right
-			 * @type {boolean}
-			 */
-			iconRight: { type: Boolean, reflect: true, attribute: 'icon-right' },
+		/**
+		 * Indicates that the icon should be rendered on right
+		 * @type {boolean}
+		 */
+		iconRight: { type: Boolean, reflect: true, attribute: 'icon-right' },
 
-			/**
-			 * Whether to render the slimmer version of the button
-			 * @type {boolean}
-			 */
-			slim: { type: Boolean, reflect: true },
+		/**
+		 * Whether to render the slimmer version of the button
+		 * @type {boolean}
+		 */
+		slim: { type: Boolean, reflect: true },
 
-			/**
-			 * ACCESSIBILITY: REQUIRED: Text for the button
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true }
-		};
-	}
+		/**
+		 * ACCESSIBILITY: REQUIRED: Text for the button
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [super.styles, labelStyles, buttonStyles,
-			css`
-				:host {
-					--d2l-count-badge-background-color: var(--d2l-theme-background-color-interactive-primary-default);
-					--d2l-count-badge-foreground-color: var(--d2l-theme-text-color-static-inverted);
-					display: inline-block;
-				}
+	static styles = [super.styles, labelStyles, buttonStyles,
+		css`
+			:host {
+				--d2l-count-badge-background-color: var(--d2l-theme-background-color-interactive-primary-default);
+				--d2l-count-badge-foreground-color: var(--d2l-theme-text-color-static-inverted);
+				display: inline-block;
+			}
 
-				:host([hidden]) {
-					display: none;
-				}
+			:host([hidden]) {
+				display: none;
+			}
 
-				button {
-					--d2l-button-subtle-padding-inline-start: 0.6rem;
-					--d2l-button-subtle-padding-inline-end: 0.6rem;
-					align-items: center;
-					background-color: var(--d2l-theme-background-color-interactive-tertiary-default);
-					border-color: transparent;
-					column-gap: 0.3rem;
-					display: inline-flex;
-					font-family: inherit;
-					padding-block-end: 0;
-					padding-block-start: 0;
-					padding-inline-end: var(--d2l-button-subtle-padding-inline-end);
-					padding-inline-start: var(--d2l-button-subtle-padding-inline-start);
-					position: relative;
-				}
+			button {
+				--d2l-button-subtle-padding-inline-start: 0.6rem;
+				--d2l-button-subtle-padding-inline-end: 0.6rem;
+				align-items: center;
+				background-color: var(--d2l-theme-background-color-interactive-tertiary-default);
+				border-color: transparent;
+				column-gap: 0.3rem;
+				display: inline-flex;
+				font-family: inherit;
+				padding-block-end: 0;
+				padding-block-start: 0;
+				padding-inline-end: var(--d2l-button-subtle-padding-inline-end);
+				padding-inline-start: var(--d2l-button-subtle-padding-inline-start);
+				position: relative;
+			}
 
-				:host([slim]) button {
-					--d2l-button-subtle-padding-inline-start: 0.5rem;
-					--d2l-button-subtle-padding-inline-end: 0.5rem;
-					min-height: 1.5rem;
-				}
+			:host([slim]) button {
+				--d2l-button-subtle-padding-inline-start: 0.5rem;
+				--d2l-button-subtle-padding-inline-end: 0.5rem;
+				min-height: 1.5rem;
+			}
 
-				:host([slim]) button.d2l-button-subtle-has-icon {
-					--d2l-button-subtle-padding-inline-start: 0.4rem;
-					--d2l-button-subtle-padding-inline-end: 0.5rem;
-				}
+			:host([slim]) button.d2l-button-subtle-has-icon {
+				--d2l-button-subtle-padding-inline-start: 0.4rem;
+				--d2l-button-subtle-padding-inline-end: 0.5rem;
+			}
 
-				:host([slim][icon-right]) button.d2l-button-subtle-has-icon {
-					--d2l-button-subtle-padding-inline-start: 0.5rem;
-					--d2l-button-subtle-padding-inline-end: 0.4rem;
-				}
+			:host([slim][icon-right]) button.d2l-button-subtle-has-icon {
+				--d2l-button-subtle-padding-inline-start: 0.5rem;
+				--d2l-button-subtle-padding-inline-end: 0.4rem;
+			}
 
-				:host([h-align="text"]) button {
-					inset-inline-start: calc(var(--d2l-button-subtle-padding-inline-start) * -1);
-				}
-				:host([h-align="text-end"]) button {
-					inset-inline-end: calc(var(--d2l-button-subtle-padding-inline-end) * -1);
-				}
+			:host([h-align="text"]) button {
+				inset-inline-start: calc(var(--d2l-button-subtle-padding-inline-start) * -1);
+			}
+			:host([h-align="text-end"]) button {
+				inset-inline-end: calc(var(--d2l-button-subtle-padding-inline-end) * -1);
+			}
 
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
+			/* Firefox includes a hidden border which messes up button dimensions */
+			button::-moz-focus-inner {
+				border: 0;
+			}
 
-				button[disabled]:hover,
-				button[disabled]:focus,
-				:host([active]) button[disabled] {
-					background-color: var(--d2l-theme-background-color-interactive-tertiary-default);
-				}
+			button[disabled]:hover,
+			button[disabled]:focus,
+			:host([active]) button[disabled] {
+				background-color: var(--d2l-theme-background-color-interactive-tertiary-default);
+			}
 
-				button:hover,
-				button:focus,
-				:host([active]) button {
-					background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
-				}
+			button:hover,
+			button:focus,
+			:host([active]) button {
+				background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
+			}
 
-				.d2l-button-subtle-content {
-					color: var(--d2l-theme-text-color-interactive-default);
-				}
+			.d2l-button-subtle-content {
+				color: var(--d2l-theme-text-color-interactive-default);
+			}
 
-				button:hover:not([disabled]) .d2l-button-subtle-content,
-				button:focus:not([disabled]) .d2l-button-subtle-content,
-				:host([active]:not([disabled])) button .d2l-button-subtle-content {
-					color: var(--d2l-theme-text-color-interactive-hover);
-				}
+			button:hover:not([disabled]) .d2l-button-subtle-content,
+			button:focus:not([disabled]) .d2l-button-subtle-content,
+			:host([active]:not([disabled])) button .d2l-button-subtle-content {
+				color: var(--d2l-theme-text-color-interactive-hover);
+			}
 
-				button:hover:not([disabled]),
-				button:focus:not([disabled]),
-				:host([active]:not([disabled])) {
-					--d2l-count-badge-background-color: var(--d2l-theme-text-color-interactive-hover);
-				}
+			button:hover:not([disabled]),
+			button:focus:not([disabled]),
+			:host([active]:not([disabled])) {
+				--d2l-count-badge-background-color: var(--d2l-theme-text-color-interactive-hover);
+			}
 
-				.property-icon,
-				slot[name="icon"]::slotted(d2l-icon-custom) {
-					color: var(--d2l-theme-text-color-interactive-default);
-				}
+			.property-icon,
+			slot[name="icon"]::slotted(d2l-icon-custom) {
+				color: var(--d2l-theme-text-color-interactive-default);
+			}
 
-				button:hover:not([disabled]) .property-icon,
-				button:focus:not([disabled]) .property-icon,
-				:host([active]:not([disabled])) button .property-icon,
-				button:hover:not([disabled]) slot[name="icon"]::slotted(d2l-icon-custom),
-				button:focus:not([disabled]) slot[name="icon"]::slotted(d2l-icon-custom),
-				:host([active]:not([disabled])) slot[name="icon"]::slotted(d2l-icon-custom) {
-					color: var(--d2l-theme-text-color-interactive-hover);
-				}
+			button:hover:not([disabled]) .property-icon,
+			button:focus:not([disabled]) .property-icon,
+			:host([active]:not([disabled])) button .property-icon,
+			button:hover:not([disabled]) slot[name="icon"]::slotted(d2l-icon-custom),
+			button:focus:not([disabled]) slot[name="icon"]::slotted(d2l-icon-custom),
+			:host([active]:not([disabled])) slot[name="icon"]::slotted(d2l-icon-custom) {
+				color: var(--d2l-theme-text-color-interactive-hover);
+			}
 
-				:host([icon-right]) .property-icon,
-				:host([icon-right]) slot[name="icon"]::slotted(d2l-icon-custom) {
-					order: 1;
-				}
+			:host([icon-right]) .property-icon,
+			:host([icon-right]) slot[name="icon"]::slotted(d2l-icon-custom) {
+				order: 1;
+			}
 
-				.d2l-button-subtle-content-wrapper slot {
-					color: var(--d2l-theme-text-color-static-standard);
-				}
+			.d2l-button-subtle-content-wrapper slot {
+				color: var(--d2l-theme-text-color-static-standard);
+			}
 
-				:host([disabled]) button {
-					cursor: default;
-					opacity: var(--d2l-theme-opacity-disabled-control);
-				}
-			`
-		];
-	}
+			:host([disabled]) button {
+				cursor: default;
+				opacity: var(--d2l-theme-opacity-disabled-control);
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/button/button-toggle.js
+++ b/components/button/button-toggle.js
@@ -6,35 +6,31 @@ import { css, html, LitElement } from 'lit';
  */
 class ButtonToggle extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * Pressed state
-			 * @type {boolean}
-			 */
-			pressed: { type: Boolean, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Pressed state
+		 * @type {boolean}
+		 */
+		pressed: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			::slotted(:not(d2l-button-icon, d2l-button-subtle)),
-			:host slot[name="pressed"],
-			:host([pressed]) slot[name="not-pressed"] {
-				display: none;
-			}
-			:host slot[name="not-pressed"],
-			:host([pressed]) slot[name="pressed"] {
-				display: contents;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		::slotted(:not(d2l-button-icon, d2l-button-subtle)),
+		:host slot[name="pressed"],
+		:host([pressed]) slot[name="not-pressed"] {
+			display: none;
+		}
+		:host slot[name="not-pressed"],
+		:host([pressed]) slot[name="pressed"] {
+			display: contents;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -13,88 +13,84 @@ import { labelStyles } from '../typography/styles.js';
  */
 class Button extends ButtonMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
-			 * @type {string}
-			 */
-			description: { type: String },
+	static properties = {
+		/**
+		 * ACCESSIBILITY: A description to be added to the button for accessibility when text on button does not provide enough context
+		 * @type {string}
+		 */
+		description: { type: String },
 
-			/**
-			 * Styles the button as a primary button
-			 * @type {boolean}
-			 */
-			primary: { type: Boolean, reflect: true }
-		};
-	}
+		/**
+		 * Styles the button as a primary button
+		 * @type {boolean}
+		 */
+		primary: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return [ labelStyles, buttonStyles,
-			css`
-				:host {
-					display: inline-block;
-				}
-				:host([hidden]) {
-					display: none;
-				}
+	static styles = [ labelStyles, buttonStyles,
+		css`
+			:host {
+				display: inline-block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
 
-				button {
-					font-family: inherit;
-					padding-block-end: 0;
-					padding-block-start: 0;
-					padding-inline-end: var(--d2l-button-padding-inline-end, 1.5rem);
-					padding-inline-start: var(--d2l-button-padding-inline-start, 1.5rem);
-					width: 100%;
-				}
+			button {
+				font-family: inherit;
+				padding-block-end: 0;
+				padding-block-start: 0;
+				padding-inline-end: var(--d2l-button-padding-inline-end, 1.5rem);
+				padding-inline-start: var(--d2l-button-padding-inline-start, 1.5rem);
+				width: 100%;
+			}
 
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
+			/* Firefox includes a hidden border which messes up button dimensions */
+			button::-moz-focus-inner {
+				border: 0;
+			}
 
-				button,
-				button[disabled]:hover,
-				button[disabled]:focus,
-				:host([active]) button[disabled] {
-					background-color: var(--d2l-theme-background-color-interactive-secondary-default);
-					color: var(--d2l-theme-text-color-static-standard);
-				}
+			button,
+			button[disabled]:hover,
+			button[disabled]:focus,
+			:host([active]) button[disabled] {
+				background-color: var(--d2l-theme-background-color-interactive-secondary-default);
+				color: var(--d2l-theme-text-color-static-standard);
+			}
 
-				button:hover,
-				button:focus,
-				:host([active]) button {
-					background-color: var(--d2l-theme-background-color-interactive-secondary-hover);
-				}
+			button:hover,
+			button:focus,
+			:host([active]) button {
+				background-color: var(--d2l-theme-background-color-interactive-secondary-hover);
+			}
 
-				:host([disabled]) button {
-					cursor: default;
-					position: relative;
-				}
-				:host([disabled]) button::before {
-					background-color: var(--d2l-theme-background-color-base);
-					border-radius: inherit;
-					content: "";
-					inset: 0;
-					opacity: var(--d2l-theme-opacity-disabled-control);
-					position: absolute;
-				}
+			:host([disabled]) button {
+				cursor: default;
+				position: relative;
+			}
+			:host([disabled]) button::before {
+				background-color: var(--d2l-theme-background-color-base);
+				border-radius: inherit;
+				content: "";
+				inset: 0;
+				opacity: var(--d2l-theme-opacity-disabled-control);
+				position: absolute;
+			}
 
-				:host([primary]) button,
-				:host([primary]) button[disabled]:hover,
-				:host([primary]) button[disabled]:focus,
-				:host([primary][active]) button[disabled] {
-					background-color: var(--d2l-theme-background-color-interactive-primary-default);
-					color: var(--d2l-theme-text-color-static-inverted);
-				}
-				:host([primary]) button:hover,
-				:host([primary]) button:focus,
-				:host([primary][active]) button {
-					background-color: var(--d2l-theme-background-color-interactive-primary-hover);
-				}
-			`
-		];
-	}
+			:host([primary]) button,
+			:host([primary]) button[disabled]:hover,
+			:host([primary]) button[disabled]:focus,
+			:host([primary][active]) button[disabled] {
+				background-color: var(--d2l-theme-background-color-interactive-primary-default);
+				color: var(--d2l-theme-text-color-static-inverted);
+			}
+			:host([primary]) button:hover,
+			:host([primary]) button:focus,
+			:host([primary][active]) button {
+				background-color: var(--d2l-theme-background-color-interactive-primary-hover);
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -16,84 +16,80 @@ const MINIMUM_TARGET_SIZE = 24;
  */
 class FloatingButtons extends LoadingCompleteMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Indicates to display buttons as always floating
-			 * @type {boolean}
-			 */
-			alwaysFloat: { type: Boolean, attribute: 'always-float', reflect: true },
-			_containerMarginLeft: { attribute: false, type: String },
-			_containerMarginRight: { attribute: false, type: String },
-			_floating: { type: Boolean, reflect: true },
-			_innerContainerLeft: { attribute: false, type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Indicates to display buttons as always floating
+		 * @type {boolean}
+		 */
+		alwaysFloat: { type: Boolean, attribute: 'always-float', reflect: true },
+		_containerMarginLeft: { attribute: false, type: String },
+		_containerMarginRight: { attribute: false, type: String },
+		_floating: { type: Boolean, reflect: true },
+		_innerContainerLeft: { attribute: false, type: String }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				box-sizing: border-box;
-				display: block;
-			}
+	static styles = css`
+		:host {
+			box-sizing: border-box;
+			display: block;
+		}
 
-			:host([_floating]) {
-				bottom: -10px;
-				left: 0;
-				position: -webkit-sticky;
-				position: sticky;
-				right: 0;
-				z-index: 997;
-			}
+		:host([_floating]) {
+			bottom: -10px;
+			left: 0;
+			position: -webkit-sticky;
+			position: sticky;
+			right: 0;
+			z-index: 997;
+		}
 
-			:host([_floating][always-float]) {
-				bottom: 0;
-			}
+		:host([_floating][always-float]) {
+			bottom: 0;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
-			.d2l-floating-buttons-container {
-				border-top: 1px solid transparent;
-				display: block;
-			}
+		.d2l-floating-buttons-container {
+			border-top: 1px solid transparent;
+			display: block;
+		}
 
-			:host([_floating]) .d2l-floating-buttons-container {
-				background-color: #ffffff;
-				background-color: rgba(255, 255, 255, 0.88);
-				border-top-color: var(--d2l-color-mica);
-				box-shadow: 0 -2px 4px rgba(32, 33, 34, 0.2); /* ferrite */
-			}
+		:host([_floating]) .d2l-floating-buttons-container {
+			background-color: #ffffff;
+			background-color: rgba(255, 255, 255, 0.88);
+			border-top-color: var(--d2l-color-mica);
+			box-shadow: 0 -2px 4px rgba(32, 33, 34, 0.2); /* ferrite */
+		}
 
+		:host([_floating]:not([always-float])) .d2l-floating-buttons-container {
+			transform: translate(0, -10px);
+			transition: transform 500ms, border-top-color 500ms, background-color 500ms;
+		}
+
+		.d2l-floating-buttons-inner-container {
+			padding: 0.75rem 0 0 0;
+			position: relative;
+		}
+
+		.d2l-floating-buttons-inner-container ::slotted(d2l-button),
+		.d2l-floating-buttons-inner-container ::slotted(button),
+		.d2l-floating-buttons-inner-container ::slotted(.d2l-button) {
+			margin-inline-end: 0.75rem !important;
+			margin-bottom: 0.75rem !important;
+		}
+
+		.d2l-floating-buttons-inner-container ::slotted(d2l-overflow-group) {
+			padding-bottom: 0.75rem !important;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
 			:host([_floating]:not([always-float])) .d2l-floating-buttons-container {
-				transform: translate(0, -10px);
-				transition: transform 500ms, border-top-color 500ms, background-color 500ms;
+				transition: none;
 			}
-
-			.d2l-floating-buttons-inner-container {
-				padding: 0.75rem 0 0 0;
-				position: relative;
-			}
-
-			.d2l-floating-buttons-inner-container ::slotted(d2l-button),
-			.d2l-floating-buttons-inner-container ::slotted(button),
-			.d2l-floating-buttons-inner-container ::slotted(.d2l-button) {
-				margin-inline-end: 0.75rem !important;
-				margin-bottom: 0.75rem !important;
-			}
-
-			.d2l-floating-buttons-inner-container ::slotted(d2l-overflow-group) {
-				padding-bottom: 0.75rem !important;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				:host([_floating]:not([always-float])) .d2l-floating-buttons-container {
-					transition: none;
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -149,304 +149,300 @@ export function getPrevMonth(month) {
  */
 class Calendar extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Additional info for each day (ex. events on [{"date": "2024-09-19"}])
-			 * @type {Array}
-			 */
-			dayInfos: { type: Array, attribute: 'day-infos' },
-			/**
-			 * Unique label text for calendar (necessary if multiple calendars on page)
-			 * @type {string}
-			 */
-			label: { attribute: 'label', reflect: true, type: String },
-			/**
-			 * ADVANCED: Initial date to override the logic for determining default date to initially show
-			 * @type {string}
-			 */
-			initialValue: { attribute: 'initial-value', type: String },
-			/**
-			 * Maximum valid date that could be selected by a user
-			 * @type {string}
-			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
-			 * Minimum valid date that could be selected by a user
-			 * @type {string}
-			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
-			 * Currently selected date
-			 * @type {string}
-			 */
-			selectedValue: { type: String, attribute: 'selected-value' },
-			/**
-			 * ACCESSIBILITY: Summary of the calendar used by screen reader users for identifying the calendar and/or summarizing its purpose
-			 * @type {string}
-			 */
-			summary: { type: String },
-			_dialog: { type: Boolean },
-			_focusDate: { type: Object },
-			_isInitialFocusDate: { type: Boolean },
-			_monthNav: { type: String },
-			_shownMonth: { type: Number },
-			_shownYear: { type: Number }
-		};
-	}
+	static properties = {
+		/**
+		 * Additional info for each day (ex. events on [{"date": "2024-09-19"}])
+		 * @type {Array}
+		 */
+		dayInfos: { type: Array, attribute: 'day-infos' },
+		/**
+		 * Unique label text for calendar (necessary if multiple calendars on page)
+		 * @type {string}
+		 */
+		label: { attribute: 'label', reflect: true, type: String },
+		/**
+		 * ADVANCED: Initial date to override the logic for determining default date to initially show
+		 * @type {string}
+		 */
+		initialValue: { attribute: 'initial-value', type: String },
+		/**
+		 * Maximum valid date that could be selected by a user
+		 * @type {string}
+		 */
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
+		 * Minimum valid date that could be selected by a user
+		 * @type {string}
+		 */
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
+		 * Currently selected date
+		 * @type {string}
+		 */
+		selectedValue: { type: String, attribute: 'selected-value' },
+		/**
+		 * ACCESSIBILITY: Summary of the calendar used by screen reader users for identifying the calendar and/or summarizing its purpose
+		 * @type {string}
+		 */
+		summary: { type: String },
+		_dialog: { type: Boolean },
+		_focusDate: { type: Object },
+		_isInitialFocusDate: { type: Boolean },
+		_monthNav: { type: String },
+		_shownMonth: { type: Number },
+		_shownYear: { type: Number }
+	};
 
-	static get styles() {
-		return [bodySmallStyles, heading4Styles, offscreenStyles, css`
-			:host {
-				display: block;
-				min-width: 14rem;
-			}
+	static styles = [bodySmallStyles, heading4Styles, offscreenStyles, css`
+		:host {
+			display: block;
+			min-width: 14rem;
+		}
 
-			table {
-				border-collapse: collapse;
-				border-spacing: 0;
-				table-layout: fixed;
-				width: 100%;
-			}
+		table {
+			border-collapse: collapse;
+			border-spacing: 0;
+			table-layout: fixed;
+			width: 100%;
+		}
 
-			th {
-				border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
-				padding-bottom: 0.6rem;
-				padding-top: 0.3rem;
-				text-align: center;
-			}
+		th {
+			border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
+			padding-bottom: 0.6rem;
+			padding-top: 0.3rem;
+			text-align: center;
+		}
 
-			abbr {
-				text-decoration: none;
-			}
+		abbr {
+			text-decoration: none;
+		}
 
-			tbody > tr:first-child button {
-				margin-top: 0.3rem;
-			}
+		tbody > tr:first-child button {
+			margin-top: 0.3rem;
+		}
 
-			.d2l-calendar {
-				border-radius: 4px;
-			}
+		.d2l-calendar {
+			border-radius: 4px;
+		}
 
-			.d2l-calendar-title {
-				align-items: center;
-				display: flex;
-				justify-content: space-between;
-			}
+		.d2l-calendar-title {
+			align-items: center;
+			display: flex;
+			justify-content: space-between;
+		}
 
-			.d2l-calendar-title .d2l-heading-4 {
-				height: 100%;
-				margin: 0;
-				opacity: 0;
-			}
+		.d2l-calendar-title .d2l-heading-4 {
+			height: 100%;
+			margin: 0;
+			opacity: 0;
+		}
 
-			.d2l-calendar-next .d2l-calendar-title .d2l-heading-4 {
-				padding-left: 20px;
-				padding-right: 0;
-			}
+		.d2l-calendar-next .d2l-calendar-title .d2l-heading-4 {
+			padding-left: 20px;
+			padding-right: 0;
+		}
 
-			.d2l-calendar-prev .d2l-calendar-title .d2l-heading-4 {
-				padding-left: 0;
-				padding-right: 20px;
-			}
+		.d2l-calendar-prev .d2l-calendar-title .d2l-heading-4 {
+			padding-left: 0;
+			padding-right: 20px;
+		}
 
-			.d2l-calendar-next-updown .d2l-calendar-title .d2l-heading-4 {
-				padding-bottom: 0;
-				padding-top: 20px;
-			}
+		.d2l-calendar-next-updown .d2l-calendar-title .d2l-heading-4 {
+			padding-bottom: 0;
+			padding-top: 20px;
+		}
 
-			.d2l-calendar-prev-updown .d2l-calendar-title .d2l-heading-4 {
-				padding-bottom: 20px;
-				padding-top: 0;
-			}
+		.d2l-calendar-prev-updown .d2l-calendar-title .d2l-heading-4 {
+			padding-bottom: 20px;
+			padding-top: 0;
+		}
 
+		.d2l-calendar-date {
+			align-items: center;
+			background-color: var(--d2l-theme-background-color-base);
+			border-radius: 0.3rem;
+			border-style: none;
+			box-sizing: content-box;
+			color: var(--d2l-theme-text-color-static-standard);
+			cursor: pointer;
+			display: flex;
+			font-family: inherit;
+			font-size: 0.8rem;
+			height: calc(2rem - 6px);
+			justify-content: center;
+			letter-spacing: inherit;
+			line-height: inherit;
+			margin-left: auto;
+			margin-right: auto;
+			opacity: 0;
+			outline-offset: -1px;
+			padding: 3px;
+			position: relative;
+			text-align: center;
+			-webkit-user-select: none;
+			-moz-user-select: none;
+			-ms-user-select: none;
+			user-select: none;
+			width: calc(2rem - 6px);
+		}
+
+		.d2l-calendar-date::-moz-focus-inner {
+			border: 0;
+		}
+
+		.d2l-calendar-date:disabled {
+			cursor: not-allowed;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			.d2l-calendar-title .d2l-heading-4,
 			.d2l-calendar-date {
-				align-items: center;
-				background-color: var(--d2l-theme-background-color-base);
-				border-radius: 0.3rem;
-				border-style: none;
-				box-sizing: content-box;
-				color: var(--d2l-theme-text-color-static-standard);
-				cursor: pointer;
-				display: flex;
-				font-family: inherit;
-				font-size: 0.8rem;
-				height: calc(2rem - 6px);
-				justify-content: center;
-				letter-spacing: inherit;
-				line-height: inherit;
-				margin-left: auto;
-				margin-right: auto;
-				opacity: 0;
-				outline-offset: -1px;
-				padding: 3px;
-				position: relative;
-				text-align: center;
-				-webkit-user-select: none;
-				-moz-user-select: none;
-				-ms-user-select: none;
-				user-select: none;
-				width: calc(2rem - 6px);
-			}
-
-			.d2l-calendar-date::-moz-focus-inner {
-				border: 0;
+				opacity: 1;
 			}
 
 			.d2l-calendar-date:disabled {
-				cursor: not-allowed;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				.d2l-calendar-title .d2l-heading-4,
-				.d2l-calendar-date {
-					opacity: 1;
-				}
-
-				.d2l-calendar-date:disabled {
-					opacity: var(--d2l-theme-opacity-disabled-control);
-				}
-			}
-
-			.d2l-calendar-next .d2l-calendar-date {
-				left: 10px;
-			}
-
-			.d2l-calendar-next-updown .d2l-calendar-date {
-				top: 10px;
-			}
-
-			.d2l-calendar-prev .d2l-calendar-date {
-				left: -10px;
-			}
-
-			.d2l-calendar-prev-updown .d2l-calendar-date {
-				top: -10px;
-			}
-
-			.d2l-calendar-animating .d2l-calendar-title .d2l-heading-4,
-			.d2l-calendar-animating .d2l-calendar-date {
-				opacity: 1;
-				transition-duration: 200ms;
-				transition-property: opacity, transform;
-				transition-timing-function: ease-out;
-			}
-
-			.d2l-calendar-animating .d2l-calendar-date:disabled {
 				opacity: var(--d2l-theme-opacity-disabled-control);
 			}
+		}
 
-			.d2l-calendar-next .d2l-heading-4,
-			.d2l-calendar-next .d2l-calendar-date {
-				transform: translateX(-10px);
+		.d2l-calendar-next .d2l-calendar-date {
+			left: 10px;
+		}
+
+		.d2l-calendar-next-updown .d2l-calendar-date {
+			top: 10px;
+		}
+
+		.d2l-calendar-prev .d2l-calendar-date {
+			left: -10px;
+		}
+
+		.d2l-calendar-prev-updown .d2l-calendar-date {
+			top: -10px;
+		}
+
+		.d2l-calendar-animating .d2l-calendar-title .d2l-heading-4,
+		.d2l-calendar-animating .d2l-calendar-date {
+			opacity: 1;
+			transition-duration: 200ms;
+			transition-property: opacity, transform;
+			transition-timing-function: ease-out;
+		}
+
+		.d2l-calendar-animating .d2l-calendar-date:disabled {
+			opacity: var(--d2l-theme-opacity-disabled-control);
+		}
+
+		.d2l-calendar-next .d2l-heading-4,
+		.d2l-calendar-next .d2l-calendar-date {
+			transform: translateX(-10px);
+		}
+
+		.d2l-calendar-next-updown .d2l-heading-4,
+		.d2l-calendar-next-updown .d2l-calendar-date {
+			transform: translateY(-10px);
+		}
+
+		.d2l-calendar-prev .d2l-heading-4,
+		.d2l-calendar-prev .d2l-calendar-date {
+			transform: translateX(10px);
+		}
+
+		.d2l-calendar-prev-updown .d2l-heading-4,
+		.d2l-calendar-prev-updown .d2l-calendar-date {
+			transform: translateY(10px);
+		}
+
+		.d2l-calendar-date:enabled:not(.d2l-calendar-date-selected):hover,
+		.d2l-calendar-date:enabled:not(.d2l-calendar-date-selected).d2l-calendar-date-hover {
+			background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
+		}
+
+		td, .d2l-calendar-date:${unsafeCSS(getFocusPseudoClass())} {
+			outline: none;
+		}
+
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date:not(:disabled) {
+			outline: 2px solid var(--d2l-theme-border-color-focus);
+		}
+
+		@keyframes initial-focus {
+			from {
+				outline: 0 solid var(--d2l-theme-border-color-focus);
+				padding: 0;
 			}
+		}
 
-			.d2l-calendar-next-updown .d2l-heading-4,
-			.d2l-calendar-next-updown .d2l-calendar-date {
-				transform: translateY(-10px);
-			}
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-initial {
+			animation: 200ms ease-in initial-focus;
+		}
 
-			.d2l-calendar-prev .d2l-heading-4,
-			.d2l-calendar-prev .d2l-calendar-date {
-				transform: translateX(10px);
-			}
-
-			.d2l-calendar-prev-updown .d2l-heading-4,
-			.d2l-calendar-prev-updown .d2l-calendar-date {
-				transform: translateY(10px);
-			}
-
-			.d2l-calendar-date:enabled:not(.d2l-calendar-date-selected):hover,
-			.d2l-calendar-date:enabled:not(.d2l-calendar-date-selected).d2l-calendar-date-hover {
-				background-color: var(--d2l-theme-background-color-interactive-tertiary-hover);
-			}
-
-			td, .d2l-calendar-date:${unsafeCSS(getFocusPseudoClass())} {
-				outline: none;
-			}
-
-			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date:not(:disabled) {
-				outline: 2px solid var(--d2l-theme-border-color-focus);
-			}
-
-			@keyframes initial-focus {
-				from {
-					outline: 0 solid var(--d2l-theme-border-color-focus);
-					padding: 0;
-				}
-			}
-
-			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-initial {
-				animation: 200ms ease-in initial-focus;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-initial,
-				td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-initial.d2l-calendar-date-day-info::after {
-					animation: none;
-				}
-			}
-
-			.d2l-calendar-date.d2l-calendar-date-selected {
-				background-color: var(--d2l-theme-background-color-interactive-highlighted);
-				outline: 1px solid var(--d2l-theme-border-color-focus);
-			}
-
-			.d2l-calendar-date.d2l-calendar-date-selected:disabled {
-				background-color: var(--d2l-theme-background-color-base);
-				color: var(--d2l-theme-text-color-static-disabled);
-				opacity: 1;
-				outline: none;
-			}
-
-			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-selected:disabled {
-				outline: 2px solid var(--d2l-theme-border-color-focus);
-			}
-
-			.d2l-calendar-date.d2l-calendar-date-today,
-			.d2l-calendar-date.d2l-calendar-date-selected:enabled {
-				font-size: 1rem;
-				font-weight: 700;
-			}
-
-			@keyframes initial-focus-day-info {
-				from {
-					bottom: 1px;
-				}
-			}
-
+		@media (prefers-reduced-motion: reduce) {
+			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-initial,
 			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-initial.d2l-calendar-date-day-info::after {
-				animation: 200ms ease-in initial-focus-day-info;
+				animation: none;
 			}
+		}
 
+		.d2l-calendar-date.d2l-calendar-date-selected {
+			background-color: var(--d2l-theme-background-color-interactive-highlighted);
+			outline: 1px solid var(--d2l-theme-border-color-focus);
+		}
+
+		.d2l-calendar-date.d2l-calendar-date-selected:disabled {
+			background-color: var(--d2l-theme-background-color-base);
+			color: var(--d2l-theme-text-color-static-disabled);
+			opacity: 1;
+			outline: none;
+		}
+
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date.d2l-calendar-date-selected:disabled {
+			outline: 2px solid var(--d2l-theme-border-color-focus);
+		}
+
+		.d2l-calendar-date.d2l-calendar-date-today,
+		.d2l-calendar-date.d2l-calendar-date-selected:enabled {
+			font-size: 1rem;
+			font-weight: 700;
+		}
+
+		@keyframes initial-focus-day-info {
+			from {
+				bottom: 1px;
+			}
+		}
+
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-initial.d2l-calendar-date-day-info::after {
+			animation: 200ms ease-in initial-focus-day-info;
+		}
+
+		.d2l-calendar-date-day-info::after {
+			background-color: var(--d2l-theme-brand-color-primary-default);
+			border-radius: 3px;
+			bottom: 4px;
+			content: "";
+			display: inline-block;
+			height: 6px;
+			position: absolute;
+			width: 6px;
+		}
+
+		.d2l-calendar-date-selected.d2l-calendar-date-day-info::after,
+		td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-day-info::after {
+			bottom: 3px;
+		}
+		@media (prefers-contrast: more) {
 			.d2l-calendar-date-day-info::after {
-				background-color: var(--d2l-theme-brand-color-primary-default);
-				border-radius: 3px;
-				bottom: 4px;
-				content: "";
-				display: inline-block;
-				height: 6px;
-				position: absolute;
-				width: 6px;
+				background-color: FieldText;
+				forced-color-adjust: none;
 			}
 
-			.d2l-calendar-date-selected.d2l-calendar-date-day-info::after,
-			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date-day-info::after {
-				bottom: 3px;
+			td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date {
+				outline-color: Highlight !important;
 			}
-			@media (prefers-contrast: more) {
-				.d2l-calendar-date-day-info::after {
-					background-color: FieldText;
-					forced-color-adjust: none;
-				}
+		}
 
-				td:${unsafeCSS(getFocusPseudoClass())} .d2l-calendar-date {
-					outline-color: Highlight !important;
-				}
-			}
-
-		`];
-	}
+	`];
 
 	constructor() {
 		super();

--- a/components/card/card-content-meta.js
+++ b/components/card/card-content-meta.js
@@ -7,21 +7,19 @@ import { css, html, LitElement } from 'lit';
  */
 class CardContentMeta extends LitElement {
 
-	static get styles() {
-		return css`
-			:host {
-				box-sizing: border-box;
-				color: var(--d2l-color-tungsten);
-				display: inline-block;
-				font-size: 0.7rem;
-				font-weight: 400;
-				line-height: 1rem;
-			}
-			:host span {
-				display: inline-block; /* extra inline-block helps reset display context to opt-out of underline */
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			box-sizing: border-box;
+			color: var(--d2l-color-tungsten);
+			display: inline-block;
+			font-size: 0.7rem;
+			font-weight: 400;
+			line-height: 1rem;
+		}
+		:host span {
+			display: inline-block; /* extra inline-block helps reset display context to opt-out of underline */
+		}
+	`;
 
 	render() {
 		return html`<span><slot></slot></span>`;

--- a/components/card/card-content-title.js
+++ b/components/card/card-content-title.js
@@ -6,17 +6,15 @@ import { css, html, LitElement } from 'lit';
  */
 class CardContentTitle extends LitElement {
 
-	static get styles() {
-		return css`
-			:host {
-				box-sizing: border-box;
-				display: block;
-				font-size: 0.95rem;
-				font-weight: 400;
-				line-height: 1.4rem;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			box-sizing: border-box;
+			display: block;
+			font-size: 0.95rem;
+			font-weight: 400;
+			line-height: 1.4rem;
+		}
+	`;
 
 	render() {
 		return html`<slot></slot>`;

--- a/components/card/card-footer-link.js
+++ b/components/card/card-footer-link.js
@@ -12,87 +12,83 @@ import { offscreenStyles } from '../offscreen/offscreen.js';
  */
 class CardFooterLink extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Download a URL instead of navigating to it
-			 * @type {boolean}
-			 */
-			download: { type: Boolean, reflect: true },
-			/**
-			 * URL or URL fragment of the link
-			 * @type {string}
-			 */
-			href: { type: String, reflect: true },
-			/**
-			 * Indicates the human language of the linked resource; purely advisory, with no built-in functionality
-			 * @type {string}
-			 */
-			hreflang: { type: String, reflect: true },
-			/**
-			 * REQUIRED: Preset icon key (e.g. "tier1:gear"). Must be a tier 1 icon.
-			 * @type {string}
-			 */
-			icon: { type: String, reflect: true },
-			/**
-			 * Specifies the relationship of the target object to the link object
-			 * @type {string}
-			 */
-			rel: { type: String, reflect: true },
-			/**
-			 * Secondary count to display as a count bubble on the icon
-			 * @type {number}
-			 */
-			secondaryCount: { type: Number, attribute: 'secondary-count', reflect: true },
-			/**
-			 * Maximum digits to display in the secondary count. Defaults to no limit
-			 * @type {number}
-			 */
-			secondaryCountMaxDigits: { type: Number, attribute: 'secondary-count-max-digits' },
-			/**
-			 * Controls the style of the secondary count bubble
-			 * @type {'count'|'notification'}
-			 */
-			secondaryCountType: { type: String, attribute: 'secondary-count-type', reflect: true },
-			/**
-			 * Where to display the linked URL
-			 * @type {string}
-			 */
-			target: { type: String, reflect: true },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Accessible text for the link
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true },
-			/**
-			 * Specifies the media type in the form of a MIME type for the linked URL; purely advisory, with no built-in functionality
-			 * @type {string}
-			 */
-			type: { type: String, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Download a URL instead of navigating to it
+		 * @type {boolean}
+		 */
+		download: { type: Boolean, reflect: true },
+		/**
+		 * URL or URL fragment of the link
+		 * @type {string}
+		 */
+		href: { type: String, reflect: true },
+		/**
+		 * Indicates the human language of the linked resource; purely advisory, with no built-in functionality
+		 * @type {string}
+		 */
+		hreflang: { type: String, reflect: true },
+		/**
+		 * REQUIRED: Preset icon key (e.g. "tier1:gear"). Must be a tier 1 icon.
+		 * @type {string}
+		 */
+		icon: { type: String, reflect: true },
+		/**
+		 * Specifies the relationship of the target object to the link object
+		 * @type {string}
+		 */
+		rel: { type: String, reflect: true },
+		/**
+		 * Secondary count to display as a count bubble on the icon
+		 * @type {number}
+		 */
+		secondaryCount: { type: Number, attribute: 'secondary-count', reflect: true },
+		/**
+		 * Maximum digits to display in the secondary count. Defaults to no limit
+		 * @type {number}
+		 */
+		secondaryCountMaxDigits: { type: Number, attribute: 'secondary-count-max-digits' },
+		/**
+		 * Controls the style of the secondary count bubble
+		 * @type {'count'|'notification'}
+		 */
+		secondaryCountType: { type: String, attribute: 'secondary-count-type', reflect: true },
+		/**
+		 * Where to display the linked URL
+		 * @type {string}
+		 */
+		target: { type: String, reflect: true },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Accessible text for the link
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true },
+		/**
+		 * Specifies the media type in the form of a MIME type for the linked URL; purely advisory, with no built-in functionality
+		 * @type {string}
+		 */
+		type: { type: String, reflect: true }
+	};
 
-	static get styles() {
-		return [offscreenStyles, css`
-			:host {
-				display: inline-block;
-				position: relative;
-			}
-			:host[hidden] {
-				display: none;
-			}
-			a {
-				box-sizing: border-box;
-				display: inline-block;
-				height: 100%;
-				outline: none;
-				width: 100%;
-			}
-			d2l-count-badge-icon {
-				text-align: initial;
-			}
-		`];
-	}
+	static styles = [offscreenStyles, css`
+		:host {
+			display: inline-block;
+			position: relative;
+		}
+		:host[hidden] {
+			display: none;
+		}
+		a {
+			box-sizing: border-box;
+			display: inline-block;
+			height: 100%;
+			outline: none;
+			width: 100%;
+		}
+		d2l-count-badge-icon {
+			text-align: initial;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/card/card-loading-shimmer.js
+++ b/components/card/card-loading-shimmer.js
@@ -7,49 +7,45 @@ import { css, html, LitElement } from 'lit';
  */
 class CardLoadingShimmer extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether the header content is being loaded
-			 * @type {boolean}
-			 */
-			loading: { type: Boolean }
-		};
-	}
+	static properties = {
+		/**
+		 * Whether the header content is being loaded
+		 * @type {boolean}
+		 */
+		loading: { type: Boolean }
+	};
 
-	static get styles() {
-		return css`
-			:host([hidden]) {
-				display: none;
-			}
+	static styles = css`
+		:host([hidden]) {
+			display: none;
+		}
 
-			.d2l-card-loading-indicator {
-				background-color: var(--d2l-color-regolith);
-				border-radius: 7px 7px 0 0;
-				box-shadow: inset 0 -1px 0 0 var(--d2l-color-gypsum);
-				height: inherit;
-				overflow: hidden;
-				position: relative;
-			}
+		.d2l-card-loading-indicator {
+			background-color: var(--d2l-color-regolith);
+			border-radius: 7px 7px 0 0;
+			box-shadow: inset 0 -1px 0 0 var(--d2l-color-gypsum);
+			height: inherit;
+			overflow: hidden;
+			position: relative;
+		}
 
-			.d2l-card-loading-indicator::after {
-				animation: loadingShimmer 1.5s ease-in-out infinite;
-				background: linear-gradient(90deg, rgba(249, 250, 251, 0.1), rgba(114, 119, 122, 0.1), rgba(249, 250, 251, 0.1));
-				background-color: var(--d2l-color-regolith);
-				content: "";
-				height: 100%;
-				left: 0;
-				position: absolute;
-				top: 0;
-				width: 100%;
-			}
+		.d2l-card-loading-indicator::after {
+			animation: loadingShimmer 1.5s ease-in-out infinite;
+			background: linear-gradient(90deg, rgba(249, 250, 251, 0.1), rgba(114, 119, 122, 0.1), rgba(249, 250, 251, 0.1));
+			background-color: var(--d2l-color-regolith);
+			content: "";
+			height: 100%;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
 
-			@keyframes loadingShimmer {
-				0% { transform: translate3d(-100%, 0, 0); }
-				100% { transform: translate3d(100%, 0, 0); }
-			}
-		`;
-	}
+		@keyframes loadingShimmer {
+			0% { transform: translate3d(-100%, 0, 0); }
+			100% { transform: translate3d(100%, 0, 0); }
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -16,209 +16,205 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class Card extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * Style the card's content and footer as centered horizontally
-			 * @type {boolean}
-			 */
-			alignCenter: { type: Boolean, attribute: 'align-center', reflect: true },
-			/**
-			 * Download a URL instead of navigating to it
-			 * @type {boolean}
-			 */
-			download: { type: Boolean, reflect: true },
-			/**
-			 * Location for the primary action/navigation
-			 * @type {string}
-			 */
-			href: { type: String, reflect: true },
-			/**
-			 * Indicates the human language of the linked resource; purely advisory, with no built-in functionality
-			 * @type {string}
-			 */
-			hreflang: { type: String, reflect: true },
-			/**
-			 * Specifies the relationship of the target object to the link object
-			 * @type {string}
-			 */
-			rel: { type: String, reflect: true },
-			/**
-			 * Subtle aesthetic on non-white backgrounds
-			 * @type {boolean}
-			 */
-			subtle: { type: Boolean, reflect: true },
-			/**
-			 * Where to display the linked URL
-			 * @type {string}
-			 */
-			target: { type: String, reflect: true },
-			/**
-			 * ACCESSIBILITY: Accessible text for the card; required if `href` is set
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true },
-			/**
-			 * Specifies the media type in the form of a MIME type for the linked URL; purely advisory, with no built-in functionality
-			 * @type {string}
-			 */
-			type: { type: String, reflect: true },
-			_active: { type: Boolean, reflect: true },
-			_dropdownActionOpen: { type: Boolean, attribute: '_dropdown-action-open', reflect: true },
-			_hover: { type: Boolean },
-			_badgeMarginTop: { type: String },
-			_footerHidden: { type: Boolean },
-			_tooltipShowing: { type: Boolean, attribute: '_tooltip_showing', reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Style the card's content and footer as centered horizontally
+		 * @type {boolean}
+		 */
+		alignCenter: { type: Boolean, attribute: 'align-center', reflect: true },
+		/**
+		 * Download a URL instead of navigating to it
+		 * @type {boolean}
+		 */
+		download: { type: Boolean, reflect: true },
+		/**
+		 * Location for the primary action/navigation
+		 * @type {string}
+		 */
+		href: { type: String, reflect: true },
+		/**
+		 * Indicates the human language of the linked resource; purely advisory, with no built-in functionality
+		 * @type {string}
+		 */
+		hreflang: { type: String, reflect: true },
+		/**
+		 * Specifies the relationship of the target object to the link object
+		 * @type {string}
+		 */
+		rel: { type: String, reflect: true },
+		/**
+		 * Subtle aesthetic on non-white backgrounds
+		 * @type {boolean}
+		 */
+		subtle: { type: Boolean, reflect: true },
+		/**
+		 * Where to display the linked URL
+		 * @type {string}
+		 */
+		target: { type: String, reflect: true },
+		/**
+		 * ACCESSIBILITY: Accessible text for the card; required if `href` is set
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true },
+		/**
+		 * Specifies the media type in the form of a MIME type for the linked URL; purely advisory, with no built-in functionality
+		 * @type {string}
+		 */
+		type: { type: String, reflect: true },
+		_active: { type: Boolean, reflect: true },
+		_dropdownActionOpen: { type: Boolean, attribute: '_dropdown-action-open', reflect: true },
+		_hover: { type: Boolean },
+		_badgeMarginTop: { type: String },
+		_footerHidden: { type: Boolean },
+		_tooltipShowing: { type: Boolean, attribute: '_tooltip_showing', reflect: true }
+	};
 
-	static get styles() {
-		return [offscreenStyles, css`
+	static styles = [offscreenStyles, css`
+		:host {
+			background-color: #ffffff;
+			border: 1px solid var(--d2l-color-gypsum);
+			border-radius: 6px;
+			box-sizing: border-box;
+			display: inline-block;
+			position: relative;
+			z-index: 0;
+		}
+		.d2l-card-container {
+			align-items: flex-start; /* required so that footer will not stretch to 100% width */
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			position: relative;
+		}
+		.d2l-card-link-container {
+			flex-basis: auto;
+			flex-grow: 1;
+			flex-shrink: 1;
+			width: 100%; /* required for Legacy-Edge and FF when align-items: flex-start is specified */
+		}
+		.d2l-card-link-text {
+			display: inline-block;
+		}
+		.d2l-card-header {
+			border-start-end-radius: 6px;
+			border-start-start-radius: 6px;
+			overflow: hidden;
+		}
+
+		a {
+			bottom: -1px;
+			display: block;
+			left: -1px;
+			outline: none;
+			position: absolute;
+			right: -1px;
+			top: -1px;
+			z-index: 1;
+		}
+		:host([subtle]) a {
+			bottom: 0;
+			left: 0;
+			right: 0;
+			top: 0;
+		}
+
+		:host(:hover) a {
+			bottom: -5px;
+		}
+		:host([subtle]:hover) a {
+			bottom: -4px;
+		}
+
+		.d2l-card-content {
+			padding: 1.2rem 0.8rem 0 0.8rem;
+		}
+		:host([align-center]) .d2l-card-content {
+			text-align: center;
+		}
+
+		:host([align-center]) .d2l-card-badge {
+			display: flex;
+			justify-content: center;
+		}
+
+		.d2l-card-footer-hidden .d2l-card-content {
+			padding-bottom: 1.2rem;
+		}
+		.d2l-card-actions {
+			inset-inline-end: 0.6rem;
+			position: absolute;
+			top: 0.6rem;
+			/* this must be higher than footer z-index so dropdowns will be on top */
+			z-index: 3;
+		}
+		.d2l-card-actions ::slotted(*) {
+			margin-inline-start: 0.3rem;
+		}
+		.d2l-card-badge {
+			line-height: 0;
+			padding: 0 0.8rem;
+		}
+		.d2l-card-footer {
+			box-sizing: border-box;
+			flex: none;
+			padding: 1.2rem 0.8rem 0.6rem 0.8rem;
+			pointer-events: none;
+			width: 100%;
+			z-index: 2;
+		}
+		:host([align-center]) .d2l-card-footer {
+			text-align: center;
+		}
+
+		.d2l-card-footer ::slotted([slot="footer"]) {
+			pointer-events: all;
+		}
+
+		.d2l-card-footer-hidden .d2l-card-footer {
+			box-sizing: content-box;
+			height: auto;
+		}
+
+		:host([subtle]) {
+			border: none;
+		}
+		:host([subtle][href]) {
+			box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.03);
+		}
+		:host([href]:not([_active]):hover) {
+			box-shadow: 0 2px 14px 1px rgba(0, 0, 0, 0.06);
+		}
+		:host([subtle][href]:not([_active]):hover) {
+			box-shadow: 0 4px 18px 2px rgba(0, 0, 0, 0.06);
+		}
+		${getFocusRingStyles(() => ':host([_active])', { 'extraStyles': css`border-color: transparent;` })}
+		/* .d2l-card-link-container-hover is used to only color/underline when
+		hovering the anchor; these styles are not applied when hovering actions */
+		:host([href]) .d2l-card-link-container-hover,
+		:host([href][_active]) .d2l-card-content {
+			color: var(--d2l-color-celestine);
+			text-decoration: underline;
+		}
+		/* this is needed to ensure tooltip is not be clipped by adjacent cards */
+		:host([_tooltip_showing]) {
+			z-index: 1;
+		}
+		/* this is needed to ensure open menu will be ontop of adjacent cards */
+		:host([_dropdown-action-open]) {
+			z-index: 2;
+		}
+		@media (prefers-reduced-motion: no-preference) {
 			:host {
-				background-color: #ffffff;
-				border: 1px solid var(--d2l-color-gypsum);
-				border-radius: 6px;
-				box-sizing: border-box;
-				display: inline-block;
-				position: relative;
-				z-index: 0;
+				transition: box-shadow 0.2s;
 			}
-			.d2l-card-container {
-				align-items: flex-start; /* required so that footer will not stretch to 100% width */
-				display: flex;
-				flex-direction: column;
-				height: 100%;
-				position: relative;
-			}
-			.d2l-card-link-container {
-				flex-basis: auto;
-				flex-grow: 1;
-				flex-shrink: 1;
-				width: 100%; /* required for Legacy-Edge and FF when align-items: flex-start is specified */
-			}
-			.d2l-card-link-text {
-				display: inline-block;
-			}
-			.d2l-card-header {
-				border-start-end-radius: 6px;
-				border-start-start-radius: 6px;
-				overflow: hidden;
-			}
-
-			a {
-				bottom: -1px;
-				display: block;
-				left: -1px;
-				outline: none;
-				position: absolute;
-				right: -1px;
-				top: -1px;
-				z-index: 1;
-			}
-			:host([subtle]) a {
-				bottom: 0;
-				left: 0;
-				right: 0;
-				top: 0;
-			}
-
-			:host(:hover) a {
-				bottom: -5px;
-			}
-			:host([subtle]:hover) a {
-				bottom: -4px;
-			}
-
-			.d2l-card-content {
-				padding: 1.2rem 0.8rem 0 0.8rem;
-			}
-			:host([align-center]) .d2l-card-content {
-				text-align: center;
-			}
-
-			:host([align-center]) .d2l-card-badge {
-				display: flex;
-				justify-content: center;
-			}
-
-			.d2l-card-footer-hidden .d2l-card-content {
-				padding-bottom: 1.2rem;
-			}
-			.d2l-card-actions {
-				inset-inline-end: 0.6rem;
-				position: absolute;
-				top: 0.6rem;
-				/* this must be higher than footer z-index so dropdowns will be on top */
-				z-index: 3;
-			}
-			.d2l-card-actions ::slotted(*) {
-				margin-inline-start: 0.3rem;
-			}
-			.d2l-card-badge {
-				line-height: 0;
-				padding: 0 0.8rem;
-			}
-			.d2l-card-footer {
-				box-sizing: border-box;
-				flex: none;
-				padding: 1.2rem 0.8rem 0.6rem 0.8rem;
-				pointer-events: none;
-				width: 100%;
-				z-index: 2;
-			}
-			:host([align-center]) .d2l-card-footer {
-				text-align: center;
-			}
-
-			.d2l-card-footer ::slotted([slot="footer"]) {
-				pointer-events: all;
-			}
-
-			.d2l-card-footer-hidden .d2l-card-footer {
-				box-sizing: content-box;
-				height: auto;
-			}
-
+		}
+		@media (prefers-contrast: more) {
 			:host([subtle]) {
-				border: none;
+				border: 1px solid var(--d2l-color-gypsum);
 			}
-			:host([subtle][href]) {
-				box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.03);
-			}
-			:host([href]:not([_active]):hover) {
-				box-shadow: 0 2px 14px 1px rgba(0, 0, 0, 0.06);
-			}
-			:host([subtle][href]:not([_active]):hover) {
-				box-shadow: 0 4px 18px 2px rgba(0, 0, 0, 0.06);
-			}
-			${getFocusRingStyles(() => ':host([_active])', { 'extraStyles': css`border-color: transparent;` })}
-			/* .d2l-card-link-container-hover is used to only color/underline when
-			hovering the anchor; these styles are not applied when hovering actions */
-			:host([href]) .d2l-card-link-container-hover,
-			:host([href][_active]) .d2l-card-content {
-				color: var(--d2l-color-celestine);
-				text-decoration: underline;
-			}
-			/* this is needed to ensure tooltip is not be clipped by adjacent cards */
-			:host([_tooltip_showing]) {
-				z-index: 1;
-			}
-			/* this is needed to ensure open menu will be ontop of adjacent cards */
-			:host([_dropdown-action-open]) {
-				z-index: 2;
-			}
-			@media (prefers-reduced-motion: no-preference) {
-				:host {
-					transition: box-shadow 0.2s;
-				}
-			}
-			@media (prefers-contrast: more) {
-				:host([subtle]) {
-					border: 1px solid var(--d2l-color-gypsum);
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/collapsible-panel/collapsible-panel-group.js
+++ b/components/collapsible-panel/collapsible-panel-group.js
@@ -9,27 +9,23 @@ import { SubscriberRegistryController } from '../../controllers/subscriber/subsc
  */
 class CollapsiblePanelGroup extends SkeletonGroupMixin(LitElement) {
 
-	static get properties() {
-		return {
-			_spaced: { state: true }
-		};
-	}
+	static properties = {
+		_spaced: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host ::slotted(*) {
-				display: none;
-			}
-			:host ::slotted(d2l-collapsible-panel) {
-				display: unset;
-			}
-			.spaced {
-				display: flex;
-				flex-direction: column;
-				row-gap: 0.5rem;
-			}
-		`;
-	}
+	static styles = css`
+		:host ::slotted(*) {
+			display: none;
+		}
+		:host ::slotted(d2l-collapsible-panel) {
+			display: unset;
+		}
+		.spaced {
+			display: flex;
+			flex-direction: column;
+			row-gap: 0.5rem;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/collapsible-panel/collapsible-panel-summary-item.js
+++ b/components/collapsible-panel/collapsible-panel-summary-item.js
@@ -11,38 +11,34 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class CollapsiblePanelSummaryItem extends SkeletonMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * The number of lines to display before truncating text with an ellipsis. The text will not be truncated unless a value is specified.
-			 * @type {number}
-			 */
-			lines: { type: Number },
-			/**
-			 * REQUIRED: Text that is displayed
-			 * @type {string}
-			 */
-			text: { type: String },
-		};
-	}
+	static properties = {
+		/**
+		 * The number of lines to display before truncating text with an ellipsis. The text will not be truncated unless a value is specified.
+		 * @type {number}
+		 */
+		lines: { type: Number },
+		/**
+		 * REQUIRED: Text that is displayed
+		 * @type {string}
+		 */
+		text: { type: String },
+	};
 
-	static get styles() {
-		return [super.styles, bodySmallStyles, css`
-			:host {
-				color: var(--d2l-theme-text-color-static-faint);
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-body-small {
-				line-height: 1.2rem;
-			}
-			p.truncate {
-				${getOverflowDeclarations({ lines: 1 })}
-			}
-		`];
-	}
+	static styles = [super.styles, bodySmallStyles, css`
+		:host {
+			color: var(--d2l-theme-text-color-static-faint);
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-body-small {
+			line-height: 1.2rem;
+		}
+		p.truncate {
+			${getOverflowDeclarations({ lines: 1 })}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/collapsible-panel/collapsible-panel.js
+++ b/components/collapsible-panel/collapsible-panel.js
@@ -54,278 +54,274 @@ function addTabListener() {
  */
 class CollapsiblePanel extends SkeletonMixin(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: The title of the panel
-			 * @type {string}
-			 */
-			panelTitle: { attribute: 'panel-title', type: String, reflect: true },
-			/**
-			 * The semantic heading level (h1-h6)
-			 * @type {'1'|'2'|'3'|'4'|'5'|'6'}
-			 * @default "3"
-			 */
-			headingLevel: { attribute: 'heading-level', type: String, reflect: true },
-			/**
-			 * The heading style to use
-			 * @type {'1'|'2'|'3'|'4'}
-			 * @default "3"
-			 */
-			headingStyle: { attribute: 'heading-style', type: String, reflect: true },
-			/**
-			 * Whether or not the panel is expanded
-			 * @type {boolean}
-			 */
-			expanded: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: Label describing the contents of the header for screen reader users
-			 * @type {string}
-			 */
-			expandCollapseLabel: { attribute: 'expand-collapse-label', type: String, reflect: true },
-			/**
-			 * Type of collapsible panel
-			 * @type {'default'|'subtle'|'inline'}
-			 * @default "default"
-			 */
-			type: { type: String, reflect: true },
-			/**
-			 * Horizontal padding of the panel
-			 * @type {'default'|'large'}
-			 * @default "default"
-			 */
-			paddingType: { attribute: 'padding-type', type: String, reflect: true },
-			/**
-			 * Disables sticky positioning for the header
-			 * @type {boolean}
-			 */
-			noSticky: { attribute: 'no-sticky', type: Boolean },
-			_focused: { state: true },
-			_hasBefore: { state: true },
-			_hasSummary: { state: true },
-			_isLastPanelInGroup: { state: true },
-			_scrolled: { state: true },
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: The title of the panel
+		 * @type {string}
+		 */
+		panelTitle: { attribute: 'panel-title', type: String, reflect: true },
+		/**
+		 * The semantic heading level (h1-h6)
+		 * @type {'1'|'2'|'3'|'4'|'5'|'6'}
+		 * @default "3"
+		 */
+		headingLevel: { attribute: 'heading-level', type: String, reflect: true },
+		/**
+		 * The heading style to use
+		 * @type {'1'|'2'|'3'|'4'}
+		 * @default "3"
+		 */
+		headingStyle: { attribute: 'heading-style', type: String, reflect: true },
+		/**
+		 * Whether or not the panel is expanded
+		 * @type {boolean}
+		 */
+		expanded: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: Label describing the contents of the header for screen reader users
+		 * @type {string}
+		 */
+		expandCollapseLabel: { attribute: 'expand-collapse-label', type: String, reflect: true },
+		/**
+		 * Type of collapsible panel
+		 * @type {'default'|'subtle'|'inline'}
+		 * @default "default"
+		 */
+		type: { type: String, reflect: true },
+		/**
+		 * Horizontal padding of the panel
+		 * @type {'default'|'large'}
+		 * @default "default"
+		 */
+		paddingType: { attribute: 'padding-type', type: String, reflect: true },
+		/**
+		 * Disables sticky positioning for the header
+		 * @type {boolean}
+		 */
+		noSticky: { attribute: 'no-sticky', type: Boolean },
+		_focused: { state: true },
+		_hasBefore: { state: true },
+		_hasSummary: { state: true },
+		_isLastPanelInGroup: { state: true },
+		_scrolled: { state: true },
+	};
 
-	static get styles() {
-		return [super.styles, heading1Styles, heading2Styles, heading3Styles, heading4Styles, css`
-			:host {
-				--d2l-collapsible-panel-focus-outline: solid 2px var(--d2l-theme-border-color-focus);
-				--d2l-collapsible-panel-spacing-inline: 0.9rem;
-				--d2l-collapsible-panel-header-spacing: 0.6rem;
-				--d2l-collapsible-panel-transition-time: 0.2s;
-				--d2l-collapsible-panel-arrow-time: 0.5s;
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([padding-type="large"][type="inline"]) {
-				--d2l-collapsible-panel-spacing-inline: 2rem;
-			}
-			.d2l-collapsible-panel {
-				border: 1px solid var(--d2l-theme-border-color-standard);
-				border-radius: 0.4rem;
-			}
-			:host(:not([expanded]):not([skeleton])) .d2l-collapsible-panel {
-				cursor: pointer;
-			}
-			:host([type="subtle"]) .d2l-collapsible-panel {
-				background-color: var(--d2l-theme-background-color-base);
-				border: none;
-				box-shadow: var(--d2l-theme-shadow-attached);
-			}
-			:host([type="inline"]) .d2l-collapsible-panel {
-				border-left: none;
-				border-radius: 0;
-				border-right: none;
-				outline-offset: -2px;
-			}
-			:host([type="inline"]) .d2l-collapsible-panel.no-bottom-border {
-				border-bottom: none;
-			}
-			:host([heading-style="1"]) {
-				--d2l-collapsible-panel-header-spacing: 1.2rem;
-			}
-			:host([heading-style="4"]) {
-				--d2l-collapsible-panel-header-spacing: 0.3rem;
-			}
-			.d2l-collapsible-panel-before {
-				grid-row: 1/-1;
-			}
-			.d2l-collapsible-panel.has-before .d2l-collapsible-panel-before {
-				margin: 0.3rem 0;
-				margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
-			}
-			.d2l-collapsible-panel-header {
-				border-radius: 0.4rem;
-				cursor: pointer;
-				display: grid;
-				grid-template-columns: auto 1fr;
-				grid-template-rows: auto auto;
-				padding: var(--d2l-collapsible-panel-header-spacing) 0;
-			}
-			:host(:not([skeleton])) .d2l-collapsible-panel-header {
-				cursor: pointer;
-			}
-			:host([type="inline"]) .d2l-collapsible-panel-header {
-				border-radius: 0;
-				outline-offset: -2px;
-			}
-			.d2l-collapsible-panel.scrolled .d2l-collapsible-panel-header {
-				background-color: var(--d2l-theme-background-color-base);
-				box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
-				position: sticky;
-				top: 0;
-				z-index: 11; /* must be greater greater than list-items with open dropdowns or tooltips */
-			}
-			.d2l-collapsible-panel.focused.scrolled .d2l-collapsible-panel-header {
-				top: 2px;
-			}
-			.d2l-collapsible-panel-title {
-				flex: 1;
-				margin: 0.3rem;
-				margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
-				overflow-wrap: anywhere;
-				user-select: none;
-			}
-			.d2l-collapsible-panel.has-before .d2l-collapsible-panel-title {
-				margin-inline-start: 0.75rem;
-			}
+	static styles = [super.styles, heading1Styles, heading2Styles, heading3Styles, heading4Styles, css`
+		:host {
+			--d2l-collapsible-panel-focus-outline: solid 2px var(--d2l-theme-border-color-focus);
+			--d2l-collapsible-panel-spacing-inline: 0.9rem;
+			--d2l-collapsible-panel-header-spacing: 0.6rem;
+			--d2l-collapsible-panel-transition-time: 0.2s;
+			--d2l-collapsible-panel-arrow-time: 0.5s;
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([padding-type="large"][type="inline"]) {
+			--d2l-collapsible-panel-spacing-inline: 2rem;
+		}
+		.d2l-collapsible-panel {
+			border: 1px solid var(--d2l-theme-border-color-standard);
+			border-radius: 0.4rem;
+		}
+		:host(:not([expanded]):not([skeleton])) .d2l-collapsible-panel {
+			cursor: pointer;
+		}
+		:host([type="subtle"]) .d2l-collapsible-panel {
+			background-color: var(--d2l-theme-background-color-base);
+			border: none;
+			box-shadow: var(--d2l-theme-shadow-attached);
+		}
+		:host([type="inline"]) .d2l-collapsible-panel {
+			border-left: none;
+			border-radius: 0;
+			border-right: none;
+			outline-offset: -2px;
+		}
+		:host([type="inline"]) .d2l-collapsible-panel.no-bottom-border {
+			border-bottom: none;
+		}
+		:host([heading-style="1"]) {
+			--d2l-collapsible-panel-header-spacing: 1.2rem;
+		}
+		:host([heading-style="4"]) {
+			--d2l-collapsible-panel-header-spacing: 0.3rem;
+		}
+		.d2l-collapsible-panel-before {
+			grid-row: 1/-1;
+		}
+		.d2l-collapsible-panel.has-before .d2l-collapsible-panel-before {
+			margin: 0.3rem 0;
+			margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
+		}
+		.d2l-collapsible-panel-header {
+			border-radius: 0.4rem;
+			cursor: pointer;
+			display: grid;
+			grid-template-columns: auto 1fr;
+			grid-template-rows: auto auto;
+			padding: var(--d2l-collapsible-panel-header-spacing) 0;
+		}
+		:host(:not([skeleton])) .d2l-collapsible-panel-header {
+			cursor: pointer;
+		}
+		:host([type="inline"]) .d2l-collapsible-panel-header {
+			border-radius: 0;
+			outline-offset: -2px;
+		}
+		.d2l-collapsible-panel.scrolled .d2l-collapsible-panel-header {
+			background-color: var(--d2l-theme-background-color-base);
+			box-shadow: 0 8px 12px -9px rgba(0, 0, 0, 0.3);
+			position: sticky;
+			top: 0;
+			z-index: 11; /* must be greater greater than list-items with open dropdowns or tooltips */
+		}
+		.d2l-collapsible-panel.focused.scrolled .d2l-collapsible-panel-header {
+			top: 2px;
+		}
+		.d2l-collapsible-panel-title {
+			flex: 1;
+			margin: 0.3rem;
+			margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
+			overflow-wrap: anywhere;
+			user-select: none;
+		}
+		.d2l-collapsible-panel.has-before .d2l-collapsible-panel-title {
+			margin-inline-start: 0.75rem;
+		}
 
+		.d2l-collapsible-panel.focused,
+		:host([expanded]) .d2l-collapsible-panel.focused .d2l-collapsible-panel-header {
+			outline: var(--d2l-collapsible-panel-focus-outline);
+		}
+		@supports selector(:has(a, b)) {
 			.d2l-collapsible-panel.focused,
 			:host([expanded]) .d2l-collapsible-panel.focused .d2l-collapsible-panel-header {
+				outline: none;
+			}
+			.d2l-collapsible-panel.focused:has(:focus-visible),
+			:host([expanded]) .d2l-collapsible-panel.focused:has(:focus-visible) .d2l-collapsible-panel-header {
 				outline: var(--d2l-collapsible-panel-focus-outline);
 			}
-			@supports selector(:has(a, b)) {
-				.d2l-collapsible-panel.focused,
-				:host([expanded]) .d2l-collapsible-panel.focused .d2l-collapsible-panel-header {
-					outline: none;
-				}
-				.d2l-collapsible-panel.focused:has(:focus-visible),
-				:host([expanded]) .d2l-collapsible-panel.focused:has(:focus-visible) .d2l-collapsible-panel-header {
-					outline: var(--d2l-collapsible-panel-focus-outline);
-				}
-			}
-			:host([expanded]) .d2l-collapsible-panel {
-				outline: none;
-			}
+		}
+		:host([expanded]) .d2l-collapsible-panel {
+			outline: none;
+		}
 
-			.d2l-collapsible-panel-header-primary {
-				align-items: center;
-				display: flex;
-				justify-content: space-between;
-			}
-			.d2l-collapsible-panel-header-secondary {
-				display: flex;
-				margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
-				margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
-			}
-			.d2l-collapsible-panel.has-before .d2l-collapsible-panel-header-secondary {
-				margin-inline-start: 0.75rem;
-			}
-			.d2l-collapsible-panel-header-secondary ::slotted(*) {
-				cursor: default;
-			}
-			.d2l-collapsible-panel-header-actions {
-				align-self: self-start;
-				display: flex;
-				gap: 0.3rem;
-			}
-			.d2l-collapsible-panel-header-actions::after {
-				border-inline-end: 1px solid var(--d2l-theme-border-color-standard);
-				content: "";
-				display: flex;
-				margin: 0.3rem;
-			}
-			.d2l-collapsible-panel-opener {
-				background-color: transparent;
-				border: none;
-				color: inherit;
-				cursor: pointer;
-				font-family: inherit;
-				font-size: inherit;
-				font-weight: inherit;
-				letter-spacing: inherit;
-				line-height: inherit;
-				outline: none;
-				padding-block: 0;
-				padding-inline: 0;
-				text-align: inherit;
-			}
-			d2l-icon-custom {
-				align-self: self-start;
-				height: 0.9rem;
-				margin: 0.6rem;
-				margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
-				position: relative;
-				transform: var(--d2l-mirror-transform, ${document.dir === 'rtl' ? css`scale(-1, 1)` : css`none`}); /* stylelint-disable-line @stylistic/string-quotes, @stylistic/function-whitespace-after */
-				transform-origin: center;
-				width: 0.9rem;
+		.d2l-collapsible-panel-header-primary {
+			align-items: center;
+			display: flex;
+			justify-content: space-between;
+		}
+		.d2l-collapsible-panel-header-secondary {
+			display: flex;
+			margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
+			margin-inline-start: var(--d2l-collapsible-panel-spacing-inline);
+		}
+		.d2l-collapsible-panel.has-before .d2l-collapsible-panel-header-secondary {
+			margin-inline-start: 0.75rem;
+		}
+		.d2l-collapsible-panel-header-secondary ::slotted(*) {
+			cursor: default;
+		}
+		.d2l-collapsible-panel-header-actions {
+			align-self: self-start;
+			display: flex;
+			gap: 0.3rem;
+		}
+		.d2l-collapsible-panel-header-actions::after {
+			border-inline-end: 1px solid var(--d2l-theme-border-color-standard);
+			content: "";
+			display: flex;
+			margin: 0.3rem;
+		}
+		.d2l-collapsible-panel-opener {
+			background-color: transparent;
+			border: none;
+			color: inherit;
+			cursor: pointer;
+			font-family: inherit;
+			font-size: inherit;
+			font-weight: inherit;
+			letter-spacing: inherit;
+			line-height: inherit;
+			outline: none;
+			padding-block: 0;
+			padding-inline: 0;
+			text-align: inherit;
+		}
+		d2l-icon-custom {
+			align-self: self-start;
+			height: 0.9rem;
+			margin: 0.6rem;
+			margin-inline-end: var(--d2l-collapsible-panel-spacing-inline);
+			position: relative;
+			transform: var(--d2l-mirror-transform, ${document.dir === 'rtl' ? css`scale(-1, 1)` : css`none`}); /* stylelint-disable-line @stylistic/string-quotes, @stylistic/function-whitespace-after */
+			transform-origin: center;
+			width: 0.9rem;
+		}
+		d2l-icon-custom svg {
+			position: absolute;
+			transform-origin: 0.4rem;
+		}
+		:host([expanded]) d2l-icon-custom svg {
+			fill: currentColor;
+			transform: rotate(90deg);
+		}
+		@media (prefers-reduced-motion: no-preference) {
+			.d2l-collapsible-panel-divider {
+				transition: opacity var(--d2l-collapsible-panel-transition-time) ease-in-out;
 			}
 			d2l-icon-custom svg {
-				position: absolute;
-				transform-origin: 0.4rem;
+				animation: d2l-collapsible-panel-opener-close var(--d2l-collapsible-panel-arrow-time) ease-in-out;
 			}
 			:host([expanded]) d2l-icon-custom svg {
-				fill: currentColor;
-				transform: rotate(90deg);
+				animation: d2l-collapsible-panel-opener-open var(--d2l-collapsible-panel-arrow-time) ease-in-out;
 			}
-			@media (prefers-reduced-motion: no-preference) {
-				.d2l-collapsible-panel-divider {
-					transition: opacity var(--d2l-collapsible-panel-transition-time) ease-in-out;
-				}
-				d2l-icon-custom svg {
-					animation: d2l-collapsible-panel-opener-close var(--d2l-collapsible-panel-arrow-time) ease-in-out;
-				}
-				:host([expanded]) d2l-icon-custom svg {
-					animation: d2l-collapsible-panel-opener-open var(--d2l-collapsible-panel-arrow-time) ease-in-out;
-				}
-				/* stylelint-disable order/properties-alphabetical-order */
-				@keyframes d2l-collapsible-panel-opener-open {
-					0% { transform: rotate(0deg); }
-					25% { transform: rotate(105deg); animation-timing-function: ease-in-out; }
-					50% { transform: rotate(82deg); animation-timing-function: ease-in-out; }
-					75% { transform: rotate(93deg); animation-timing-function: ease-in-out; }
-					100% { transform: rotate(90deg); animation-timing-function: ease-in-out; }
-				}
-				@keyframes d2l-collapsible-panel-opener-close {
-					0% { transform: rotate(90deg); }
-					25% { transform: rotate(-15deg); animation-timing-function: ease-in-out; }
-					50% { transform: rotate(8deg); animation-timing-function: ease-in-out; }
-					75% { transform: rotate(-3deg); animation-timing-function: ease-in-out; }
-					100% { transform: rotate(0deg); animation-timing-function: ease-in-out; }
-				}
-				/* stylelint-enable */
+			/* stylelint-disable order/properties-alphabetical-order */
+			@keyframes d2l-collapsible-panel-opener-open {
+				0% { transform: rotate(0deg); }
+				25% { transform: rotate(105deg); animation-timing-function: ease-in-out; }
+				50% { transform: rotate(82deg); animation-timing-function: ease-in-out; }
+				75% { transform: rotate(93deg); animation-timing-function: ease-in-out; }
+				100% { transform: rotate(90deg); animation-timing-function: ease-in-out; }
 			}
-			.d2l-collapsible-panel-divider {
-				border-bottom: 1px solid var(--d2l-theme-border-color-standard);
-				margin-inline: var(--d2l-collapsible-panel-spacing-inline);
-				opacity: 1;
+			@keyframes d2l-collapsible-panel-opener-close {
+				0% { transform: rotate(90deg); }
+				25% { transform: rotate(-15deg); animation-timing-function: ease-in-out; }
+				50% { transform: rotate(8deg); animation-timing-function: ease-in-out; }
+				75% { transform: rotate(-3deg); animation-timing-function: ease-in-out; }
+				100% { transform: rotate(0deg); animation-timing-function: ease-in-out; }
 			}
-			:host([type=inline]) .d2l-collapsible-panel-divider {
-				opacity: 0;
-			}
-			:host(:not([expanded])) .d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-divider {
-				opacity: 0;
-			}
-			.d2l-collapsible-panel-summary,
-			.d2l-collapsible-panel-content {
-				padding: 0.9rem var(--d2l-collapsible-panel-spacing-inline);
-			}
-			:host([type=inline]) .d2l-collapsible-panel-summary,
-			:host([type=inline]) .d2l-collapsible-panel-content {
-				padding-top: 0;
-			}
-			:host([type="inline"]) .d2l-collapsible-panel-summary {
-				margin-top: -0.3rem;
-			}
-			.d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-summary {
-				display: none;
-			}
-		`];
-	}
+			/* stylelint-enable */
+		}
+		.d2l-collapsible-panel-divider {
+			border-bottom: 1px solid var(--d2l-theme-border-color-standard);
+			margin-inline: var(--d2l-collapsible-panel-spacing-inline);
+			opacity: 1;
+		}
+		:host([type=inline]) .d2l-collapsible-panel-divider {
+			opacity: 0;
+		}
+		:host(:not([expanded])) .d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-divider {
+			opacity: 0;
+		}
+		.d2l-collapsible-panel-summary,
+		.d2l-collapsible-panel-content {
+			padding: 0.9rem var(--d2l-collapsible-panel-spacing-inline);
+		}
+		:host([type=inline]) .d2l-collapsible-panel-summary,
+		:host([type=inline]) .d2l-collapsible-panel-content {
+			padding-top: 0;
+		}
+		:host([type="inline"]) .d2l-collapsible-panel-summary {
+			margin-top: -0.3rem;
+		}
+		.d2l-collapsible-panel:not(.has-summary) .d2l-collapsible-panel-summary {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/count-badge/count-badge-icon.js
+++ b/components/count-badge/count-badge-icon.js
@@ -9,21 +9,18 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 class CountBadgeIcon extends FocusMixin(CountBadgeMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: Preset icon key (e.g. "tier1:gear")
-			 * @type {string}
-			 */
-			icon: {
-				type: String,
-				reflect: true
-			}
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: Preset icon key (e.g. "tier1:gear")
+		 * @type {string}
+		 */
+		icon: {
+			type: String,
+			reflect: true
+		}
+	};
 
-	static get styles() {
-		return [super.styles, css`
+	static styles = [super.styles, css`
 		${getFocusRingStyles(pseudoClass => `:host([focus-ring]) d2l-icon, d2l-icon:${pseudoClass}`)}
 		:host {
 			display: inline-block;
@@ -52,8 +49,7 @@ class CountBadgeIcon extends FocusMixin(CountBadgeMixin(LitElement)) {
 			border: 2px solid transparent;
 			border-radius: 6px;
 		}
-		`];
-	}
+	`];
 
 	constructor() {
 		super();

--- a/components/count-badge/count-badge-mixin.js
+++ b/components/count-badge/count-badge-mixin.js
@@ -12,135 +12,131 @@ const maxBadgeDigits = 5;
 
 export const CountBadgeMixin = superclass => class extends LocalizeCoreElement(SkeletonMixin(superclass)) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: When `true`, changes to the badge will be announced to screen reader users
-			 * @type {boolean}
-			 */
-			announceChanges: {
-				type: Boolean,
-				attribute: 'announce-changes'
-			},
-			/**
-			 * Forces the focus ring around the badge
-			 * @type {boolean}
-			 */
-			forceFocusRing: {
-				type: Boolean,
-				attribute: 'focus-ring',
-				reflect: true
-			},
-			/**
-			 * ACCESSIBILITY: Adds a tooltip on the badge, which will be visible on hover and keyboard interaction
-			 * @type {boolean}
-			 */
-			hasTooltip: {
-				type: Boolean,
-				attribute: 'has-tooltip'
-			},
-			/**
-			 * Hides the count badge when `number` is zero
-			 * @type {boolean}
-			 */
-			hideZero: {
-				type: Boolean,
-				attribute: 'hide-zero'
-			},
-			/**
-			 * Specifies a digit limit, after which numbers are truncated. Defaults to two for "notification" type and five for "count" type.
-			 * @type {number}
-			 */
-			maxDigits: {
-				type: Number,
-				attribute: 'max-digits'
-			},
-			/**
-			 * REQUIRED: The number to be displayed on the badge; must be a positive integer
-			 * @type {number}
-			 */
-			number: {
-				type: Number,
-				attribute: 'number'
-			},
-			/**
-			 * The size of the badge
-			 * @type {'small'|'large'}
-			 */
-			size: {
-				type: String,
-				reflect: true,
-				attribute: 'size'
-			},
-			/**
-			 * ACCESSIBILITY: Adds a tab stop to the badge, which allows screen reader and keyboard users to easily tab to the badge
-			 * @type {boolean}
-			 */
-			tabStop: {
-				type: Boolean,
-				attribute: 'tab-stop'
-			},
-			/**
-			 * ACCESSIBILITY: REQUIRED: Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled
-			 * @type {string}
-			 */
-			text: {
-				type: String
-			},
-			/**
-			 * The type of the badge
-			 * @type {'count'|'notification'}
-			 */
-			type: {
-				type: String,
-				reflect: true,
-				attribute: 'type'
-			}
-		};
-	}
+	static properties = {
+		/**
+		 * ACCESSIBILITY: When `true`, changes to the badge will be announced to screen reader users
+		 * @type {boolean}
+		 */
+		announceChanges: {
+			type: Boolean,
+			attribute: 'announce-changes'
+		},
+		/**
+		 * Forces the focus ring around the badge
+		 * @type {boolean}
+		 */
+		forceFocusRing: {
+			type: Boolean,
+			attribute: 'focus-ring',
+			reflect: true
+		},
+		/**
+		 * ACCESSIBILITY: Adds a tooltip on the badge, which will be visible on hover and keyboard interaction
+		 * @type {boolean}
+		 */
+		hasTooltip: {
+			type: Boolean,
+			attribute: 'has-tooltip'
+		},
+		/**
+		 * Hides the count badge when `number` is zero
+		 * @type {boolean}
+		 */
+		hideZero: {
+			type: Boolean,
+			attribute: 'hide-zero'
+		},
+		/**
+		 * Specifies a digit limit, after which numbers are truncated. Defaults to two for "notification" type and five for "count" type.
+		 * @type {number}
+		 */
+		maxDigits: {
+			type: Number,
+			attribute: 'max-digits'
+		},
+		/**
+		 * REQUIRED: The number to be displayed on the badge; must be a positive integer
+		 * @type {number}
+		 */
+		number: {
+			type: Number,
+			attribute: 'number'
+		},
+		/**
+		 * The size of the badge
+		 * @type {'small'|'large'}
+		 */
+		size: {
+			type: String,
+			reflect: true,
+			attribute: 'size'
+		},
+		/**
+		 * ACCESSIBILITY: Adds a tab stop to the badge, which allows screen reader and keyboard users to easily tab to the badge
+		 * @type {boolean}
+		 */
+		tabStop: {
+			type: Boolean,
+			attribute: 'tab-stop'
+		},
+		/**
+		 * ACCESSIBILITY: REQUIRED: Descriptive text for the badge which will act as an accessible label and tooltip text when tooltips are enabled
+		 * @type {string}
+		 */
+		text: {
+			type: String
+		},
+		/**
+		 * The type of the badge
+		 * @type {'count'|'notification'}
+		 */
+		type: {
+			type: String,
+			reflect: true,
+			attribute: 'type'
+		}
+	};
 
-	static get styles() {
-		return [super.styles, offscreenStyles, css`
-			:host([hidden]) {
-				display: none;
-			}
+	static styles = [super.styles, offscreenStyles, css`
+		:host([hidden]) {
+			display: none;
+		}
 
-			:host {
-				display: inline-block;
-				min-width: 0.9rem;
-			}
+		:host {
+			display: inline-block;
+			min-width: 0.9rem;
+		}
 
-			.d2l-count-badge-number {
-				font-weight: bold;
-			}
+		.d2l-count-badge-number {
+			font-weight: bold;
+		}
 
-			:host([type="notification"]) .d2l-count-badge-number {
-				background-color: var(--d2l-theme-notification-background-color);
-				color: var(--d2l-theme-notification-text-color);
-			}
+		:host([type="notification"]) .d2l-count-badge-number {
+			background-color: var(--d2l-theme-notification-background-color);
+			color: var(--d2l-theme-notification-text-color);
+		}
 
-			:host([type="count"]) .d2l-count-badge-number {
-				background-color: var(--d2l-count-badge-background-color, var(--d2l-theme-badge-background-color));
-				color: var(--d2l-count-badge-foreground-color, var(--d2l-theme-badge-text-color));
-			}
+		:host([type="count"]) .d2l-count-badge-number {
+			background-color: var(--d2l-count-badge-background-color, var(--d2l-theme-badge-background-color));
+			color: var(--d2l-count-badge-foreground-color, var(--d2l-theme-badge-text-color));
+		}
 
-			:host([size="small"]) .d2l-count-badge-number {
-				border-radius: 0.55rem;
-				font-size: 0.6rem;
-				line-height: 0.9rem;
-				padding-left: 0.3rem;
-				padding-right: 0.3rem;
-			}
+		:host([size="small"]) .d2l-count-badge-number {
+			border-radius: 0.55rem;
+			font-size: 0.6rem;
+			line-height: 0.9rem;
+			padding-left: 0.3rem;
+			padding-right: 0.3rem;
+		}
 
-			:host([size="large"]) .d2l-count-badge-number {
-				border-radius: 0.7rem;
-				font-size: 0.8rem;
-				line-height: 1.2rem;
-				padding-left: 0.4rem;
-				padding-right: 0.4rem;
-			}
-		`];
-	}
+		:host([size="large"]) .d2l-count-badge-number {
+			border-radius: 0.7rem;
+			font-size: 0.8rem;
+			line-height: 1.2rem;
+			padding-left: 0.4rem;
+			padding-right: 0.4rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/count-badge/count-badge.js
+++ b/components/count-badge/count-badge.js
@@ -8,8 +8,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 class CountBadge extends FocusMixin(CountBadgeMixin(LitElement)) {
 
-	static get styles() {
-		return [super.styles, css`
+	static styles = [super.styles, css`
 		${getFocusRingStyles(pseudoClass => `:host([focus-ring]) .d2l-count-badge-wrapper, .d2l-count-badge-wrapper:${pseudoClass}`)}
 		.d2l-count-badge-wrapper {
 			--d2l-focus-ring-offset: 0;
@@ -23,8 +22,7 @@ class CountBadge extends FocusMixin(CountBadgeMixin(LitElement)) {
 		:host([size="large"]) .d2l-count-badge-wrapper {
 			border-radius: 0.8rem;
 		}
-		`];
-	}
+	`];
 
 	constructor() {
 		super();

--- a/components/description-list/description-list-wrapper.js
+++ b/components/description-list/description-list-wrapper.js
@@ -36,38 +36,34 @@ export const descriptionListStyles = [
  * @slot - Content to wrap
  */
 class DescriptionListWrapper extends LitElement {
-	static get properties() {
-		return {
-			/**
-			 * Width for component to use a stacked layout
-			 * @type {number}
-			 */
-			breakpoint: { type: Number, reflect: true },
-			/**
-			 * Force the component to always use a stacked layout; will override breakpoint attribute
-			 * @type {boolean}
-			 */
-			forceStacked: { type: Boolean, reflect: true, attribute: 'force-stacked' },
-			_stacked: { state: true },
-		};
-	}
+	static properties = {
+		/**
+		 * Width for component to use a stacked layout
+		 * @type {number}
+		 */
+		breakpoint: { type: Number, reflect: true },
+		/**
+		 * Force the component to always use a stacked layout; will override breakpoint attribute
+		 * @type {boolean}
+		 */
+		forceStacked: { type: Boolean, reflect: true, attribute: 'force-stacked' },
+		_stacked: { state: true },
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.stacked {
-				--d2l-dl-wrapper-dl-display: block;
-				--d2l-dl-wrapper-dt-max-width: none;
-				--d2l-dl-wrapper-dt-margin: 0 0 0.3rem 0;
-				--d2l-dl-wrapper-dd-margin: 0 0 0.9rem 0;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.stacked {
+			--d2l-dl-wrapper-dl-display: block;
+			--d2l-dl-wrapper-dt-max-width: none;
+			--d2l-dl-wrapper-dt-margin: 0 0 0.3rem 0;
+			--d2l-dl-wrapper-dd-margin: 0 0 0.9rem 0;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/dialog/dialog-confirm.js
+++ b/components/dialog/dialog-confirm.js
@@ -15,79 +15,75 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 class DialogConfirm extends LocalizeCoreElement(DialogMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether the dialog should indicate that its message is important to the user
-			 */
-			critical: { type: Boolean },
+	static properties = {
+		/**
+		 * Whether the dialog should indicate that its message is important to the user
+		 */
+		critical: { type: Boolean },
 
-			/**
-			 * REQUIRED: The text content for the confirmation dialog. Newline characters (`&#10;` in HTML or `\n` in JavaScript) will render as multiple paragraphs.
-			 * @type {string}
-			 */
-			text: { type: String }
-		};
-	}
+		/**
+		 * REQUIRED: The text content for the confirmation dialog. Newline characters (`&#10;` in HTML or `\n` in JavaScript) will render as multiple paragraphs.
+		 * @type {string}
+		 */
+		text: { type: String }
+	};
 
-	static get styles() {
-		return [ _generateResetStyles(':host'), dialogStyles, heading3Styles, css`
+	static styles = [_generateResetStyles(':host'), dialogStyles, heading3Styles, css`
 
+		.d2l-dialog-outer {
+			max-width: 420px;
+		}
+
+		.d2l-dialog-header > h2 {
+			margin: 0;
+			width: fit-content;
+		}
+
+		${getFocusRingStyles(pseudoClass => `.d2l-dialog-content:${pseudoClass} > div`, { extraStyles: css`
+
+			--d2l-focus-ring-offset: -1px; border-radius: 6px;`
+		})}
+		.d2l-dialog-content:focus,
+		.d2l-dialog-content:focus-visible {
+			outline: none;
+		}
+
+		.d2l-dialog-content {
+			padding-top: 30px;
+		}
+
+		.d2l-dialog-header + .d2l-dialog-content {
+			padding-top: 0;
+		}
+
+		.d2l-dialog-content p {
+			margin: 1rem 0;
+		}
+
+		.d2l-dialog-content p:first-child {
+			margin-top: 0;
+		}
+
+		.d2l-dialog-content p:last-child {
+			margin-bottom: 0;
+		}
+
+		@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+
+			dialog.d2l-dialog-outer,
 			.d2l-dialog-outer {
-				max-width: 420px;
-			}
-
-			.d2l-dialog-header > h2 {
-				margin: 0;
-				width: fit-content;
-			}
-
-			${getFocusRingStyles(pseudoClass => `.d2l-dialog-content:${pseudoClass} > div`, { extraStyles: css`
-
-				--d2l-focus-ring-offset: -1px; border-radius: 6px;`
-			})}
-			.d2l-dialog-content:focus,
-			.d2l-dialog-content:focus-visible {
-				outline: none;
+				bottom: 0;
+				margin: auto;
+				top: 0;
 			}
 
 			.d2l-dialog-content {
-				padding-top: 30px;
+				padding-top: 20px;
 			}
 
-			.d2l-dialog-header + .d2l-dialog-content {
-				padding-top: 0;
-			}
+		}
 
-			.d2l-dialog-content p {
-				margin: 1rem 0;
-			}
-
-			.d2l-dialog-content p:first-child {
-				margin-top: 0;
-			}
-
-			.d2l-dialog-content p:last-child {
-				margin-bottom: 0;
-			}
-
-			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
-
-				dialog.d2l-dialog-outer,
-				.d2l-dialog-outer {
-					bottom: 0;
-					margin: auto;
-					top: 0;
-				}
-
-				.d2l-dialog-content {
-					padding-top: 20px;
-				}
-
-			}
-
-		`];
-	}
+	`];
 
 	constructor() {
 		super();

--- a/components/dialog/dialog-fullscreen.js
+++ b/components/dialog/dialog-fullscreen.js
@@ -22,172 +22,168 @@ const mediaQueryList = window.matchMedia('(max-width: 615px), (max-height: 420px
  */
 class DialogFullscreen extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether to render a loading-spinner and wait for state changes via AsyncContainerMixin
-			 * @type {boolean}
-			 */
-			async: { type: Boolean },
-			/**
-			 * Render with no content padding
-			 * @type {boolean}
-			 */
-			noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
-			/**
-			 * REQUIRED: the title for the dialog
-			 */
-			titleText: { type: String, attribute: 'title-text', required: true },
-			/**
-			 * The preferred width (unit-less) for the dialog. Minimum 1170 (anything smaller will have no effect).
-			 */
-			width: { type: Number },
-			_autoSize: { state: true }, /* DE52039 This is only redefined here to suppress a lit-analyzer linting issue */
-			_hasFooterContent: { state: true },
-			_icon: { state: true },
-			_headerStyle: { state: true },
-		};
-	}
+	static properties = {
+		/**
+		 * Whether to render a loading-spinner and wait for state changes via AsyncContainerMixin
+		 * @type {boolean}
+		 */
+		async: { type: Boolean },
+		/**
+		 * Render with no content padding
+		 * @type {boolean}
+		 */
+		noPadding: { type: Boolean, reflect: true, attribute: 'no-padding' },
+		/**
+		 * REQUIRED: the title for the dialog
+		 */
+		titleText: { type: String, attribute: 'title-text', required: true },
+		/**
+		 * The preferred width (unit-less) for the dialog. Minimum 1170 (anything smaller will have no effect).
+		 */
+		width: { type: Number },
+		_autoSize: { state: true }, /* DE52039 This is only redefined here to suppress a lit-analyzer linting issue */
+		_hasFooterContent: { state: true },
+		_icon: { state: true },
+		_headerStyle: { state: true },
+	};
 
-	static get styles() {
-		return [ _generateResetStyles(':host'), dialogStyles, heading2Styles, heading3Styles, css`
+	static styles = [_generateResetStyles(':host'), dialogStyles, heading2Styles, heading3Styles, css`
 
-			.d2l-dialog-footer.d2l-footer-no-content {
-				display: none;
+		.d2l-dialog-footer.d2l-footer-no-content {
+			display: none;
+		}
+
+		.d2l-dialog-content-loading {
+			text-align: center;
+		}
+
+		.d2l-dialog-outer {
+			max-width: calc(100% - 3rem);
+		}
+
+		:host([no-padding]) .d2l-dialog-content {
+			--d2l-list-controls-padding: 0px; /* stylelint-disable-line length-zero-no-unit */
+			padding: 0;
+		}
+
+		@media (min-width: 616px) {
+
+			.d2l-dialog-header {
+				border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
+				padding-bottom: 0.9rem;
+				padding-top: 1rem;
 			}
 
-			.d2l-dialog-content-loading {
-				text-align: center;
+			.d2l-dialog-content > div {
+				/* required to properly calculate preferred height when there are bottom
+				margins at the end of the slotted content */
+				border-bottom: 1px solid transparent;
+				box-sizing: border-box;
+				height: calc(100% - 1rem);
+				padding-top: 1rem;
 			}
 
-			.d2l-dialog-outer {
-				max-width: calc(100% - 3rem);
+			:host([no-padding]) .d2l-dialog-content > div {
+				height: 100%;
+				padding-top: 0;
 			}
 
-			:host([no-padding]) .d2l-dialog-content {
-				--d2l-list-controls-padding: 0px; /* stylelint-disable-line length-zero-no-unit */
-				padding: 0;
+			.d2l-dialog-header > div > d2l-button-icon {
+				flex: none;
+				margin-block: -2px 0;
+				margin-inline: 0 -12px;
 			}
 
-			@media (min-width: 616px) {
+			dialog.d2l-dialog-outer,
+			div.d2l-dialog-outer {
+				animation: d2l-dialog-fullscreen-close 200ms ease-in;
+				border-radius: 8px;
+				margin: 1.5rem;
+				top: 0;
+				width: auto;
+			}
 
-				.d2l-dialog-header {
-					border-bottom: 1px solid var(--d2l-theme-border-color-subtle);
-					padding-bottom: 0.9rem;
-					padding-top: 1rem;
-				}
+			@keyframes d2l-dialog-fullscreen-close {
+				0% { opacity: 1; transform: translateY(0); }
+				100% { opacity: 0; transform: translateY(-50px) scale(0.97); }
+			}
 
-				.d2l-dialog-content > div {
-					/* required to properly calculate preferred height when there are bottom
-					margins at the end of the slotted content */
-					border-bottom: 1px solid transparent;
-					box-sizing: border-box;
-					height: calc(100% - 1rem);
-					padding-top: 1rem;
-				}
+			@keyframes d2l-dialog-fullscreen-open {
+				0% { opacity: 0; transform: translateY(-50px) scale(0.97); }
+				100% { opacity: 1; transform: translateY(0); }
+			}
 
-				:host([no-padding]) .d2l-dialog-content > div {
-					height: 100%;
-					padding-top: 0;
-				}
+			dialog.d2l-dialog-outer.d2l-dialog-fullscreen-within,
+			div.d2l-dialog-outer.d2l-dialog-fullscreen-within {
+				/* no margins when there is a fullscreen element within */
+				margin: 0;
+			}
 
-				.d2l-dialog-header > div > d2l-button-icon {
-					flex: none;
-					margin-block: -2px 0;
-					margin-inline: 0 -12px;
-				}
+			:host(:not([in-iframe])) dialog.d2l-dialog-outer,
+			:host(:not([in-iframe])) div.d2l-dialog-outer {
+				height: calc(100% - 3rem);
+			}
 
+			/* for screens wider than 1170px + 60px margins */
+			@media (min-width: 1230px) {
 				dialog.d2l-dialog-outer,
 				div.d2l-dialog-outer {
-					animation: d2l-dialog-fullscreen-close 200ms ease-in;
-					border-radius: 8px;
-					margin: 1.5rem;
-					top: 0;
-					width: auto;
+					/* center the dialog */
+					margin-left: auto;
+					margin-right: auto;
 				}
+			}
 
-				@keyframes d2l-dialog-fullscreen-close {
-					0% { opacity: 1; transform: translateY(0); }
-					100% { opacity: 0; transform: translateY(-50px) scale(0.97); }
-				}
+			:host([_state="showing"]) dialog.d2l-dialog-outer,
+			:host([_state="showing"]) div.d2l-dialog-outer {
+				animation: d2l-dialog-fullscreen-open 400ms ease-out;
+			}
 
-				@keyframes d2l-dialog-fullscreen-open {
-					0% { opacity: 0; transform: translateY(-50px) scale(0.97); }
-					100% { opacity: 1; transform: translateY(0); }
-				}
+			:host([_state="showing"]) dialog::backdrop {
+				transition-duration: 400ms;
+			}
 
-				dialog.d2l-dialog-outer.d2l-dialog-fullscreen-within,
-				div.d2l-dialog-outer.d2l-dialog-fullscreen-within {
-					/* no margins when there is a fullscreen element within */
-					margin: 0;
-				}
+			.d2l-dialog-footer {
+				border-top: 1px solid var(--d2l-theme-border-color-subtle);
+				padding-bottom: 0; /* 0.9rem padding included on button */
+				padding-top: 0.9rem;
+			}
 
-				:host(:not([in-iframe])) dialog.d2l-dialog-outer,
-				:host(:not([in-iframe])) div.d2l-dialog-outer {
-					height: calc(100% - 3rem);
-				}
+			@media (prefers-reduced-motion: reduce) {
 
-				/* for screens wider than 1170px + 60px margins */
-				@media (min-width: 1230px) {
-					dialog.d2l-dialog-outer,
-					div.d2l-dialog-outer {
-						/* center the dialog */
-						margin-left: auto;
-						margin-right: auto;
-					}
-				}
-
+				dialog.d2l-dialog-outer,
+				div.d2l-dialog-outer,
 				:host([_state="showing"]) dialog.d2l-dialog-outer,
 				:host([_state="showing"]) div.d2l-dialog-outer {
-					animation: d2l-dialog-fullscreen-open 400ms ease-out;
+					animation: none;
 				}
 
-				:host([_state="showing"]) dialog::backdrop {
-					transition-duration: 400ms;
-				}
-
-				.d2l-dialog-footer {
-					border-top: 1px solid var(--d2l-theme-border-color-subtle);
-					padding-bottom: 0; /* 0.9rem padding included on button */
-					padding-top: 0.9rem;
-				}
-
-				@media (prefers-reduced-motion: reduce) {
-
-					dialog.d2l-dialog-outer,
-					div.d2l-dialog-outer,
-					:host([_state="showing"]) dialog.d2l-dialog-outer,
-					:host([_state="showing"]) div.d2l-dialog-outer {
-						animation: none;
-					}
-
-					dialog::backdrop {
-						transition: none;
-					}
+				dialog::backdrop {
+					transition: none;
 				}
 			}
+		}
 
-			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+		@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
 
-				.d2l-dialog-header {
-					padding-bottom: 15px;
-				}
-
-				.d2l-dialog-footer.d2l-footer-no-content {
-					padding: 0 0 5px 0;
-				}
-
-				.d2l-dialog-content > div {
-					/* required to properly calculate preferred height when there are bottom
-					margins at the end of the slotted content */
-					border-bottom: 1px solid transparent;
-					/* required to render full height in an i-Frame */
-					height: calc(100% - 1px);
-				}
-
+			.d2l-dialog-header {
+				padding-bottom: 15px;
 			}
-		`];
-	}
+
+			.d2l-dialog-footer.d2l-footer-no-content {
+				padding: 0 0 5px 0;
+			}
+
+			.d2l-dialog-content > div {
+				/* required to properly calculate preferred height when there are bottom
+				margins at the end of the slotted content */
+				border-bottom: 1px solid transparent;
+				/* required to render full height in an i-Frame */
+				height: calc(100% - 1px);
+			}
+
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/dialog/dialog-mixin.js
+++ b/components/dialog/dialog-mixin.js
@@ -30,47 +30,45 @@ const closeDialogWhenDisconnectedFlag = getFlag('GAUD-10113-close-dialog-when-di
 
 export const DialogMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			focusableContentElemPresent: { state: true },
-			/**
-			 * Whether or not the dialog is open
-			 */
-			opened: { type: Boolean, reflect: true },
-			/**
-			 * ADVANCED: Opt out of dialog content scrolling
-			 */
-			noContentScroll: { type: Boolean, attribute: 'no-content-scroll', reflect: true },
-			/**
-			 * @ignore
-			 * Do NOT use this
-			 */
-			preferNative: { type: Boolean, attribute: 'prefer-native' },
-			/**
-			 * The optional title for the dialog
-			 */
-			titleText: { type: String, attribute: 'title-text' },
-			_autoSize: { state: true },
-			_fullscreenWithin: { state: true },
-			_height: { state: true },
-			_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
-			_isFullHeight: { state: true },
-			_left: { state: true },
-			_margin: { state: true },
-			_nestedShowing: { state: true },
-			_overflowBottom: { state: true },
-			_overflowTop: { state: true },
-			_parentDialog: { state: true },
-			_scroll: { state: true },
-			_state: { type: String, reflect: true },
-			_top: { state: true },
-			_width: { state: true },
-			_useNative: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		focusableContentElemPresent: { state: true },
+		/**
+		 * Whether or not the dialog is open
+		 */
+		opened: { type: Boolean, reflect: true },
+		/**
+		 * ADVANCED: Opt out of dialog content scrolling
+		 */
+		noContentScroll: { type: Boolean, attribute: 'no-content-scroll', reflect: true },
+		/**
+		 * @ignore
+		 * Do NOT use this
+		 */
+		preferNative: { type: Boolean, attribute: 'prefer-native' },
+		/**
+		 * The optional title for the dialog
+		 */
+		titleText: { type: String, attribute: 'title-text' },
+		_autoSize: { state: true },
+		_fullscreenWithin: { state: true },
+		_height: { state: true },
+		_inIframe: { type: Boolean, attribute: 'in-iframe', reflect: true },
+		_isFullHeight: { state: true },
+		_left: { state: true },
+		_margin: { state: true },
+		_nestedShowing: { state: true },
+		_overflowBottom: { state: true },
+		_overflowTop: { state: true },
+		_parentDialog: { state: true },
+		_scroll: { state: true },
+		_state: { type: String, reflect: true },
+		_top: { state: true },
+		_width: { state: true },
+		_useNative: { state: true }
+	};
 
 	constructor() {
 		super();

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -22,80 +22,76 @@ const mediaQueryList = window.matchMedia('(max-width: 615px), (max-height: 420px
  */
 class Dialog extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMixin(DialogMixin(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether to render a loading-spinner and wait for state changes via AsyncContainerMixin
-			 */
-			async: { type: Boolean },
+	static properties = {
+		/**
+		 * Whether to render a loading-spinner and wait for state changes via AsyncContainerMixin
+		 */
+		async: { type: Boolean },
 
-			/**
-			 * Whether the dialog should indicate that its message is important to the user
-			 */
-			critical: { type: Boolean },
+		/**
+		 * Whether the dialog should indicate that its message is important to the user
+		 */
+		critical: { type: Boolean },
 
-			/**
-			 * Causes screen readers to announce the content of the dialog on open. Only use if the content is concise and contains only text since screen readers ignore HTML semantics and some have a ~250 character limit.
-			 */
-			describeContent: { type: Boolean, attribute: 'describe-content' },
+		/**
+		 * Causes screen readers to announce the content of the dialog on open. Only use if the content is concise and contains only text since screen readers ignore HTML semantics and some have a ~250 character limit.
+		 */
+		describeContent: { type: Boolean, attribute: 'describe-content' },
 
-			/**
-			 * Whether to render the dialog at the maximum height
-			 */
-			fullHeight: { type: Boolean, attribute: 'full-height' },
+		/**
+		 * Whether to render the dialog at the maximum height
+		 */
+		fullHeight: { type: Boolean, attribute: 'full-height' },
 
-			/**
-			 * REQUIRED: the title for the dialog
-			 */
-			titleText: { type: String, attribute: 'title-text', required: true },
+		/**
+		 * REQUIRED: the title for the dialog
+		 */
+		titleText: { type: String, attribute: 'title-text', required: true },
 
-			/**
-			 * The preferred width (unit-less) for the dialog
-			 */
-			width: { type: Number },
-			_hasFooterContent: { type: Boolean, attribute: false }
-		};
-	}
+		/**
+		 * The preferred width (unit-less) for the dialog
+		 */
+		width: { type: Number },
+		_hasFooterContent: { type: Boolean, attribute: false }
+	};
 
-	static get styles() {
-		return [ _generateResetStyles(':host'), dialogStyles, heading3Styles, css`
+	static styles = [_generateResetStyles(':host'), dialogStyles, heading3Styles, css`
+
+		.d2l-dialog-header,
+		:host([critical]) .d2l-dialog-header {
+			padding-bottom: 15px;
+		}
+
+		.d2l-dialog-header > div > d2l-button-icon {
+			flex: none;
+			margin-block: -4px 0;
+			margin-inline: 15px -15px;
+		}
+
+		.d2l-dialog-content > div {
+			/* required to properly calculate preferred height when there are bottom
+			margins at the end of the slotted content */
+			border-bottom: 1px solid transparent;
+		}
+
+		.d2l-dialog-content-loading {
+			text-align: center;
+		}
+
+		.d2l-dialog-footer.d2l-footer-no-content {
+			padding: 0 0 5px 0;
+		}
+
+		@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
 
 			.d2l-dialog-header,
 			:host([critical]) .d2l-dialog-header {
-				padding-bottom: 15px;
+				padding-bottom: 9px;
 			}
 
-			.d2l-dialog-header > div > d2l-button-icon {
-				flex: none;
-				margin-block: -4px 0;
-				margin-inline: 15px -15px;
-			}
+		}
 
-			.d2l-dialog-content > div {
-				/* required to properly calculate preferred height when there are bottom
-				margins at the end of the slotted content */
-				border-bottom: 1px solid transparent;
-			}
-
-			.d2l-dialog-content-loading {
-				text-align: center;
-			}
-
-			.d2l-dialog-footer.d2l-footer-no-content {
-				padding: 0 0 5px 0;
-			}
-
-			@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
-
-				.d2l-dialog-header,
-				:host([critical]) .d2l-dialog-header {
-					padding-bottom: 9px;
-				}
-
-			}
-
-		`];
-	}
+	`];
 
 	constructor() {
 		super();

--- a/components/dropdown/dropdown-button-subtle.js
+++ b/components/dropdown/dropdown-button-subtle.js
@@ -10,31 +10,27 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  */
 class DropdownButtonSubtle extends DropdownOpenerMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * A description to be added to the opener button for accessibility when text on button does not provide enough context
-			 * @type {string}
-			 */
-			description: { type: String },
+	static properties = {
+		/**
+		 * A description to be added to the opener button for accessibility when text on button does not provide enough context
+		 * @type {string}
+		 */
+		description: { type: String },
 
-			/**
-			* Aligns the leading edge of text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
-			* @type {'text'|'text-end'|''}
-			*/
-			hAlign: { type: String, reflect: true, attribute: 'h-align' },
+		/**
+		* Aligns the leading edge of text if value is set to "text" for left-aligned layouts, the trailing edge of text if value is set to "text-end" for right-aligned layouts
+		* @type {'text'|'text-end'|''}
+		*/
+		hAlign: { type: String, reflect: true, attribute: 'h-align' },
 
-			/**
-			 * REQUIRED: Text for the button
-			 * @type {string}
-			 */
-			text: { type: String }
-		};
-	}
+		/**
+		 * REQUIRED: Text for the button
+		 * @type {string}
+		 */
+		text: { type: String }
+	};
 
-	static get styles() {
-		return dropdownOpenerStyles;
-	}
+	static styles = dropdownOpenerStyles;
 
 	render() {
 		return html`

--- a/components/dropdown/dropdown-button.js
+++ b/components/dropdown/dropdown-button.js
@@ -10,43 +10,39 @@ import { dropdownOpenerStyles } from './dropdown-opener-styles.js';
  */
 class DropdownButton extends DropdownOpenerMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Optionally render button as primary button
-			 * @type {boolean}
-			 */
-			primary: {
-				type: Boolean,
-				reflect: true
-			},
+	static properties = {
+		/**
+		 * Optionally render button as primary button
+		 * @type {boolean}
+		 */
+		primary: {
+			type: Boolean,
+			reflect: true
+		},
 
-			/**
-			 * REQUIRED: Text for the button
-			 * @type {string}
-			 */
-			text: {
-				type: String
-			}
-		};
-	}
+		/**
+		 * REQUIRED: Text for the button
+		 * @type {string}
+		 */
+		text: {
+			type: String
+		}
+	};
 
-	static get styles() {
-		return [dropdownOpenerStyles, css`
-			d2l-icon {
-				height: 0.8rem;
-				margin-inline-start: 0.6rem;
-				pointer-events: none;
-				width: 0.8rem;
-			}
-			:host([primary]) d2l-icon {
-				color: var(--d2l-theme-text-color-static-inverted);
-			}
-			d2l-button {
-				width: 100%;
-			}
-		`];
-	}
+	static styles = [dropdownOpenerStyles, css`
+		d2l-icon {
+			height: 0.8rem;
+			margin-inline-start: 0.6rem;
+			pointer-events: none;
+			width: 0.8rem;
+		}
+		:host([primary]) d2l-icon {
+			color: var(--d2l-theme-text-color-static-inverted);
+		}
+		d2l-button {
+			width: 100%;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/dropdown/dropdown-context-menu.js
+++ b/components/dropdown/dropdown-context-menu.js
@@ -10,39 +10,36 @@ import { dropdownOpenerStyles } from './dropdown-opener-styles.js';
  */
 class DropdownContextMenu extends DropdownOpenerMixin(VisibleOnAncestorMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: Label for the context-menu button
-			 * @type {string}
-			 */
-			text: {
-				type: String
-			},
+	static properties = {
+		/**
+		 * REQUIRED: Label for the context-menu button
+		 * @type {string}
+		 */
+		text: {
+			type: String
+		},
 
-			/**
-			 * Attribute for busy/rich backgrounds
-			 * @type {boolean}
-			 */
-			translucent: {
-				type: Boolean
-			},
-		};
-	}
+		/**
+		 * Attribute for busy/rich backgrounds
+		 * @type {boolean}
+		 */
+		translucent: {
+			type: Boolean
+		},
+	};
 
-	static get styles() {
-		return [dropdownOpenerStyles, visibleOnAncestorStyles, css`
-			:host {
-				--d2l-dropdown-context-menu-min-height: calc(2rem + 2px);
-				--d2l-dropdown-context-menu-min-width: calc(2rem + 2px);
-				display: inline-block;
-			}
-			d2l-button-icon {
-				--d2l-button-icon-min-height: var(--d2l-dropdown-context-menu-min-height);
-				--d2l-button-icon-min-width: var(--d2l-dropdown-context-menu-min-height);
-			}
-		`];
-	}
+	static styles = [dropdownOpenerStyles, visibleOnAncestorStyles, css`
+		:host {
+			--d2l-dropdown-context-menu-min-height: calc(2rem + 2px);
+			--d2l-dropdown-context-menu-min-width: calc(2rem + 2px);
+			display: inline-block;
+		}
+		d2l-button-icon {
+			--d2l-button-icon-min-height: var(--d2l-dropdown-context-menu-min-height);
+			--d2l-button-icon-min-width: var(--d2l-dropdown-context-menu-min-height);
+		}
+	`];
+
 	constructor() {
 		super();
 		this.translucent = false;

--- a/components/dropdown/dropdown-menu.js
+++ b/components/dropdown/dropdown-menu.js
@@ -14,43 +14,39 @@ const dropdownDelay = 300;
  */
 class DropdownMenu extends ThemeMixin(DropdownPopoverMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			_closeRadio: { type: Boolean, reflect: true, attribute: '_close-radio' },
-		};
-	}
+	static properties = {
+		_closeRadio: { type: Boolean, reflect: true, attribute: '_close-radio' },
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				--d2l-dropdown-close-animation-name: d2l-dropdown-close-animation;
-			}
+	static styles = [super.styles, css`
+		:host {
+			--d2l-dropdown-close-animation-name: d2l-dropdown-close-animation;
+		}
 
-			:host([theme="dark"]) {
-				--d2l-dropdown-close-animation-name: d2l-dropdown-close-animation-dark;
-			}
+		:host([theme="dark"]) {
+			--d2l-dropdown-close-animation-name: d2l-dropdown-close-animation-dark;
+		}
 
+		:host([_close-radio]) {
+			animation: var(--d2l-dropdown-close-animation-name) ${dropdownDelay}ms ease-out;
+			animation-delay: 50ms;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
 			:host([_close-radio]) {
-				animation: var(--d2l-dropdown-close-animation-name) ${dropdownDelay}ms ease-out;
-				animation-delay: 50ms;
+				animation: none !important;
 			}
+		}
+		@keyframes d2l-dropdown-close-animation {
+			0% { opacity: 1; transform: translate(0, 0); }
+			100% { opacity: 0; transform: translate(0, -10px); }
+		}
 
-			@media (prefers-reduced-motion: reduce) {
-				:host([_close-radio]) {
-					animation: none !important;
-				}
-			}
-			@keyframes d2l-dropdown-close-animation {
-				0% { opacity: 1; transform: translate(0, 0); }
-				100% { opacity: 0; transform: translate(0, -10px); }
-			}
-
-			@keyframes d2l-dropdown-close-animation-dark {
-				0% { opacity: 0.9; transform: translate(0, 0); }
-				100% { opacity: 0; transform: translate(0, -10px); }
-			}
-		`];
-	}
+		@keyframes d2l-dropdown-close-animation-dark {
+			0% { opacity: 0.9; transform: translate(0, 0); }
+			100% { opacity: 0; transform: translate(0, -10px); }
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/dropdown/dropdown-more.js
+++ b/components/dropdown/dropdown-more.js
@@ -10,33 +10,30 @@ import { dropdownOpenerStyles } from './dropdown-opener-styles.js';
  */
 class DropdownMore extends DropdownOpenerMixin(VisibleOnAncestorMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: Label for the more button
-			 * @type {string}
-			 */
-			text: {
-				type: String
-			},
+	static properties = {
+		/**
+		 * REQUIRED: Label for the more button
+		 * @type {string}
+		 */
+		text: {
+			type: String
+		},
 
-			/**
-			 * Attribute for busy/rich backgrounds
-			 * @type {boolean}
-			 */
-			translucent: {
-				type: Boolean
-			},
-		};
-	}
+		/**
+		 * Attribute for busy/rich backgrounds
+		 * @type {boolean}
+		 */
+		translucent: {
+			type: Boolean
+		},
+	};
 
-	static get styles() {
-		return [dropdownOpenerStyles, visibleOnAncestorStyles, css`
-			:host {
-				display: inline-block;
-			}
-		`];
-	}
+	static styles = [dropdownOpenerStyles, visibleOnAncestorStyles, css`
+		:host {
+			display: inline-block;
+		}
+	`];
+
 	constructor() {
 		super();
 		this.translucent = false;

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -3,52 +3,50 @@ import { isComposedAncestor } from '../../helpers/dom.js';
 
 export const DropdownOpenerMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * Disables the dropdown opener
-			 * @type {boolean}
-			 */
-			disabled: {
-				type: Boolean,
-				reflect: true
-			},
+	static properties = {
+		/**
+		 * Disables the dropdown opener
+		 * @type {boolean}
+		 */
+		disabled: {
+			type: Boolean,
+			reflect: true
+		},
 
-			/**
-			 * @ignore
-			 */
-			dropdownOpened: { state: true },
+		/**
+		 * @ignore
+		 */
+		dropdownOpened: { state: true },
 
-			/**
-			 * @ignore
-			 */
-			dropdownOpener: {
-				type: Boolean
-			},
+		/**
+		 * @ignore
+		 */
+		dropdownOpener: {
+			type: Boolean
+		},
 
-			/**
-			 * Prevents the dropdown from opening automatically on or on key press
-			 * @type {boolean}
-			 */
-			noAutoOpen: {
-				type: Boolean,
-				reflect: true,
-				attribute: 'no-auto-open'
-			},
+		/**
+		 * Prevents the dropdown from opening automatically on or on key press
+		 * @type {boolean}
+		 */
+		noAutoOpen: {
+			type: Boolean,
+			reflect: true,
+			attribute: 'no-auto-open'
+		},
 
-			/**
-			 * Optionally open dropdown on click or hover action
-			 * @type {boolean}
-			 */
-			openOnHover: {
-				type: Boolean,
-				attribute: 'open-on-hover'
-			},
-			_isHovering: { type: Boolean },
-			_isOpenedViaClick: { type: Boolean },
-			_isFading: { type: Boolean }
-		};
-	}
+		/**
+		 * Optionally open dropdown on click or hover action
+		 * @type {boolean}
+		 */
+		openOnHover: {
+			type: Boolean,
+			attribute: 'open-on-hover'
+		},
+		_isHovering: { type: Boolean },
+		_isOpenedViaClick: { type: Boolean },
+		_isFading: { type: Boolean }
+	};
 
 	constructor() {
 		super();

--- a/components/dropdown/dropdown-popover-mixin.js
+++ b/components/dropdown/dropdown-popover-mixin.js
@@ -10,166 +10,162 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 export const DropdownPopoverMixin = superclass => class extends LocalizeCoreElement(PopoverMixin(superclass)) {
 
-	static get properties() {
-		return {
-			/**
-			 * Optionally align dropdown to either start or end. If not set, the dropdown will attempt to be centred.
-			 * @type {'start'|'end'}
-			 */
-			align: { type: String },
-			/**
-			 * Override max-height. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
-			 * @type {number}
-			 */
-			maxHeight: { type: Number, attribute: 'max-height' },
-			/**
-			 * Override default max-width (undefined). Specify a number that would be the px value.
-			 * @type {number}
-			 */
-			maxWidth: { type: Number, attribute: 'max-width' },
-			/**
-			 * Override default height used for required space when `no-auto-fit` is true. Specify a number that would be the px value. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
-			 * @type {number}
-			 */
-			minHeight: { type: Number, attribute: 'min-height' },
-			/**
-			 * Override default min-width (undefined). Specify a number that would be the px value.
-			 * @type {number}
-			 */
-			minWidth: { type: Number, attribute: 'min-width' },
-			/**
-			 * Override the breakpoint at which mobile styling is used. Defaults to 616px.
-			 * @type {number}
-			 */
-			mobileBreakpointOverride: { type: Number, attribute: 'mobile-breakpoint' },
-			/**
-			 * Mobile dropdown style.
-			 * @type {'left'|'right'|'bottom'}
-			 */
-			mobileTray: { type: String, attribute: 'mobile-tray' },
-			/**
-			 * Opt out of automatically closing on focus or click outside of the dropdown content
-			 * @type {boolean}
-			 */
-			noAutoClose: { type: Boolean, attribute: 'no-auto-close' },
-			/**
-			 * Opt out of auto-sizing
-			 * @type {boolean}
-			 */
-			noAutoFit: { type: Boolean, attribute: 'no-auto-fit' },
-			/**
-			 * Opt out of focus being automatically moved to the first focusable element in the dropdown when opened
-			 * @type {boolean}
-			 */
-			noAutoFocus: { type: Boolean, attribute: 'no-auto-focus' },
-			/**
-			 * Opt-out of showing a close button in the footer of tray-style mobile dropdowns.
-			 * @type {boolean}
-			 */
-			noMobileCloseButton: { type: Boolean, attribute: 'no-mobile-close-button' },
-			/**
-			 * Render with no padding
-			 * @type {boolean}
-			 */
-			noPadding: { type: Boolean, attribute: 'no-padding' },
-			/**
-			 * Render the footer with no padding (if it has content)
-			 * @type {boolean}
-			 */
-			noPaddingFooter: { type: Boolean, attribute: 'no-padding-footer' },
-			/**
-			 * Render the header with no padding (if it has content)
-			 * @type {boolean}
-			 */
-			noPaddingHeader: { type: Boolean, attribute: 'no-padding-header' },
-			/**
-			 * Render without a pointer
-			 * @type {boolean}
-			 */
-			noPointer: { type: Boolean, attribute: 'no-pointer' },
-			/**
-			 * Whether the dropdown is open or not
-			 * @type {boolean}
-			 */
-			opened: { type: Boolean, reflect: true },
-			/**
- 			 * Optionally render a d2l-focus-trap around the dropdown content
-			 * @type {boolean}
- 			 */
-			trapFocus: { type: Boolean, attribute: 'trap-focus' },
-			/**
-			 * Provide custom offset, positive or negative
-			 * @type {string}
-			 */
-			verticalOffset: { type: String, attribute: 'vertical-offset' },
-			_blockEndScroll: { state: true },
-			_blockStartScroll: { state: true },
-			_dropdownContent: { type: Boolean, attribute: 'dropdown-content', reflect: true },
-			_hasFooterSlotContent: { state: true },
-			_hasHeaderSlotContent: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Optionally align dropdown to either start or end. If not set, the dropdown will attempt to be centred.
+		 * @type {'start'|'end'}
+		 */
+		align: { type: String },
+		/**
+		 * Override max-height. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
+		 * @type {number}
+		 */
+		maxHeight: { type: Number, attribute: 'max-height' },
+		/**
+		 * Override default max-width (undefined). Specify a number that would be the px value.
+		 * @type {number}
+		 */
+		maxWidth: { type: Number, attribute: 'max-width' },
+		/**
+		 * Override default height used for required space when `no-auto-fit` is true. Specify a number that would be the px value. Note that the default behaviour is to be as tall as necessary within the viewport, so this property is usually not needed.
+		 * @type {number}
+		 */
+		minHeight: { type: Number, attribute: 'min-height' },
+		/**
+		 * Override default min-width (undefined). Specify a number that would be the px value.
+		 * @type {number}
+		 */
+		minWidth: { type: Number, attribute: 'min-width' },
+		/**
+		 * Override the breakpoint at which mobile styling is used. Defaults to 616px.
+		 * @type {number}
+		 */
+		mobileBreakpointOverride: { type: Number, attribute: 'mobile-breakpoint' },
+		/**
+		 * Mobile dropdown style.
+		 * @type {'left'|'right'|'bottom'}
+		 */
+		mobileTray: { type: String, attribute: 'mobile-tray' },
+		/**
+		 * Opt out of automatically closing on focus or click outside of the dropdown content
+		 * @type {boolean}
+		 */
+		noAutoClose: { type: Boolean, attribute: 'no-auto-close' },
+		/**
+		 * Opt out of auto-sizing
+		 * @type {boolean}
+		 */
+		noAutoFit: { type: Boolean, attribute: 'no-auto-fit' },
+		/**
+		 * Opt out of focus being automatically moved to the first focusable element in the dropdown when opened
+		 * @type {boolean}
+		 */
+		noAutoFocus: { type: Boolean, attribute: 'no-auto-focus' },
+		/**
+		 * Opt-out of showing a close button in the footer of tray-style mobile dropdowns.
+		 * @type {boolean}
+		 */
+		noMobileCloseButton: { type: Boolean, attribute: 'no-mobile-close-button' },
+		/**
+		 * Render with no padding
+		 * @type {boolean}
+		 */
+		noPadding: { type: Boolean, attribute: 'no-padding' },
+		/**
+		 * Render the footer with no padding (if it has content)
+		 * @type {boolean}
+		 */
+		noPaddingFooter: { type: Boolean, attribute: 'no-padding-footer' },
+		/**
+		 * Render the header with no padding (if it has content)
+		 * @type {boolean}
+		 */
+		noPaddingHeader: { type: Boolean, attribute: 'no-padding-header' },
+		/**
+		 * Render without a pointer
+		 * @type {boolean}
+		 */
+		noPointer: { type: Boolean, attribute: 'no-pointer' },
+		/**
+		 * Whether the dropdown is open or not
+		 * @type {boolean}
+		 */
+		opened: { type: Boolean, reflect: true },
+		/**
+ 		 * Optionally render a d2l-focus-trap around the dropdown content
+		 * @type {boolean}
+ 		 */
+		trapFocus: { type: Boolean, attribute: 'trap-focus' },
+		/**
+		 * Provide custom offset, positive or negative
+		 * @type {string}
+		 */
+		verticalOffset: { type: String, attribute: 'vertical-offset' },
+		_blockEndScroll: { state: true },
+		_blockStartScroll: { state: true },
+		_dropdownContent: { type: Boolean, attribute: 'dropdown-content', reflect: true },
+		_hasFooterSlotContent: { state: true },
+		_hasHeaderSlotContent: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			.dropdown-content-layout {
-				align-items: stretch;
-				display: flex;
-				flex-direction: column;
-			}
-			.dropdown-content {
-				box-sizing: border-box;
-				flex: auto;
-				max-width: 100%;
-				overflow-y: auto;
-				padding: 1rem;
-			}
-			.dropdown-header,
-			.dropdown-footer {
-				box-sizing: border-box;
-				flex: none;
-				max-width: 100%;
-				min-height: 5px;
-				padding: 1rem;
-				position: relative;
-				width: 100%;
-				z-index: 2;
-			}
-			.dropdown-header {
-				border-block-end: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
-				border-start-end-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
-				border-start-start-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
-			}
-			.dropdown-footer {
-				border-block-start: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
-				border-end-end-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
-				border-end-start-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
-			}
-			.dropdown-no-header {
-				border-block-end: none;
-				padding: 0;
-			}
-			.dropdown-no-footer {
-				border-block-start: none;
-				padding: 0;
-			}
-			.dropdown-no-padding {
-				padding: 0;
-			}
-			.dropdown-header-scroll {
-				box-shadow: 0 3px 3px 0 var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
-			}
-			.dropdown-footer-scroll {
-				box-shadow: 0 -3px 3px 0 var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
-			}
+	static styles = [super.styles, css`
+		.dropdown-content-layout {
+			align-items: stretch;
+			display: flex;
+			flex-direction: column;
+		}
+		.dropdown-content {
+			box-sizing: border-box;
+			flex: auto;
+			max-width: 100%;
+			overflow-y: auto;
+			padding: 1rem;
+		}
+		.dropdown-header,
+		.dropdown-footer {
+			box-sizing: border-box;
+			flex: none;
+			max-width: 100%;
+			min-height: 5px;
+			padding: 1rem;
+			position: relative;
+			width: 100%;
+			z-index: 2;
+		}
+		.dropdown-header {
+			border-block-end: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
+			border-start-end-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
+			border-start-start-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
+		}
+		.dropdown-footer {
+			border-block-start: 1px solid var(--d2l-popover-border-color, var(--d2l-popover-default-border-color));
+			border-end-end-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
+			border-end-start-radius: var(--d2l-popover-border-radius, var(--d2l-popover-default-border-radius));
+		}
+		.dropdown-no-header {
+			border-block-end: none;
+			padding: 0;
+		}
+		.dropdown-no-footer {
+			border-block-start: none;
+			padding: 0;
+		}
+		.dropdown-no-padding {
+			padding: 0;
+		}
+		.dropdown-header-scroll {
+			box-shadow: 0 3px 3px 0 var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
+		}
+		.dropdown-footer-scroll {
+			box-shadow: 0 -3px 3px 0 var(--d2l-popover-shadow-color, var(--d2l-popover-default-shadow-color));
+		}
 
-			:host([_mobile][_mobile-tray-location="inline-start"][opened]) .dropdown-content-layout,
-			:host([_mobile][_mobile-tray-location="inline-end"][opened]) .dropdown-content-layout {
-				height: calc(var(--d2l-vh, 1vh) * 100);
-				height: 100dvh;
-			}
-		`];
-	}
+		:host([_mobile][_mobile-tray-location="inline-start"][opened]) .dropdown-content-layout,
+		:host([_mobile][_mobile-tray-location="inline-end"][opened]) .dropdown-content-layout {
+			height: calc(var(--d2l-vh, 1vh) * 100);
+			height: 100dvh;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/dropdown/dropdown-tabs.js
+++ b/components/dropdown/dropdown-tabs.js
@@ -10,13 +10,11 @@ import { DropdownPopoverMixin } from './dropdown-popover-mixin.js';
  */
 class DropdownTabs extends DropdownPopoverMixin(LitElement) {
 
-	static get styles() {
-		return [super.styles, css`
-			::slotted(d2l-tabs) {
-				margin-bottom: 0;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		::slotted(d2l-tabs) {
+			margin-bottom: 0;
+		}
+	`];
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);

--- a/components/dropdown/dropdown.js
+++ b/components/dropdown/dropdown.js
@@ -8,9 +8,7 @@ import { dropdownOpenerStyles } from './dropdown-opener-styles.js';
  */
 class Dropdown extends DropdownOpenerMixin(LitElement) {
 
-	static get styles() {
-		return dropdownOpenerStyles;
-	}
+	static styles = dropdownOpenerStyles;
 
 	render() {
 		return html`<slot></slot>`;

--- a/components/empty-state/empty-state-action-button.js
+++ b/components/empty-state/empty-state-action-button.js
@@ -12,29 +12,25 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class EmptyStateActionButton extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: The action text to be used in the button
-			 * @type {string}
-			 */
-			text: { type: String, required: true },
-			/**
-			 * This will change the action button to use a primary button instead of the default subtle button. The primary attribute is only valid when `d2l-empty-state-action-button` is placed within `d2l-empty-state-illustrated` components
-			 * @type {boolean}
-			 */
-			primary: { type: Boolean },
-			_illustrated: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: The action text to be used in the button
+		 * @type {string}
+		 */
+		text: { type: String, required: true },
+		/**
+		 * This will change the action button to use a primary button instead of the default subtle button. The primary attribute is only valid when `d2l-empty-state-action-button` is placed within `d2l-empty-state-illustrated` components
+		 * @type {boolean}
+		 */
+		primary: { type: Boolean },
+		_illustrated: { state: true }
+	};
 
-	static get styles() {
-		return css`
-					.d2l-empty-state-action {
-						vertical-align: top;
-					}
-				`;
-	}
+	static styles = css`
+		.d2l-empty-state-action {
+			vertical-align: top;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/empty-state/empty-state-action-link.js
+++ b/components/empty-state/empty-state-action-link.js
@@ -9,24 +9,20 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class EmptyStateActionLink extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: The action text to be used in the subtle button
-			 * @type {string}
-			 */
-			text: { type: String, required: true },
-			/**
-			 * REQUIRED: The action URL or URL fragment of the link
-			 * @type {string}
-			 */
-			href: { type: String, required: true },
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: The action text to be used in the subtle button
+		 * @type {string}
+		 */
+		text: { type: String, required: true },
+		/**
+		 * REQUIRED: The action URL or URL fragment of the link
+		 * @type {string}
+		 */
+		href: { type: String, required: true },
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, linkStyles];
-	}
+	static styles = [bodyCompactStyles, linkStyles];
 
 	static get focusElementSelector() {
 		return '.d2l-link';

--- a/components/empty-state/empty-state-illustrated.js
+++ b/components/empty-state/empty-state-illustrated.js
@@ -18,31 +18,27 @@ const illustrationAspectRatio = 500 / 330;
  */
 class EmptyStateIllustrated extends LoadingCompleteMixin(EmptyStateMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: A description giving details about the empty state
-			 * @type {string}
-			 */
-			description: { type: String, required: true },
-			/**
-			 * The name of the preset image you would like to display in the component
-			 * @type {string}
-			 */
-			illustrationName: { type: String, attribute: 'illustration-name' },
-			/**
-			 * REQUIRED: A title for the empty state
-			 * @type {string}
-			 */
-			titleText: { type: String, attribute: 'title-text', required: true },
-			_contentHeight: { state: true },
-			_titleSmall: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: A description giving details about the empty state
+		 * @type {string}
+		 */
+		description: { type: String, required: true },
+		/**
+		 * The name of the preset image you would like to display in the component
+		 * @type {string}
+		 */
+		illustrationName: { type: String, attribute: 'illustration-name' },
+		/**
+		 * REQUIRED: A title for the empty state
+		 * @type {string}
+		 */
+		titleText: { type: String, attribute: 'title-text', required: true },
+		_contentHeight: { state: true },
+		_titleSmall: { state: true }
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, emptyStateStyles, emptyStateIllustratedStyles];
-	}
+	static styles = [bodyCompactStyles, emptyStateStyles, emptyStateIllustratedStyles];
 
 	constructor() {
 		super();

--- a/components/empty-state/empty-state-simple.js
+++ b/components/empty-state/empty-state-simple.js
@@ -10,19 +10,15 @@ import { EmptyStateMixin } from './empty-state-mixin.js';
  */
 class EmptyStateSimple extends EmptyStateMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: A description giving details about the empty state
-			 * @type {string}
-			 */
-			description: { type: String, required: true },
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: A description giving details about the empty state
+		 * @type {string}
+		 */
+		description: { type: String, required: true },
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, emptyStateStyles, emptyStateSimpleStyles];
-	}
+	static styles = [bodyCompactStyles, emptyStateStyles, emptyStateSimpleStyles];
 
 	render() {
 		return html`

--- a/components/expand-collapse/expand-collapse-content.js
+++ b/components/expand-collapse/expand-collapse-content.js
@@ -20,67 +20,63 @@ export const states = {
  */
 class ExpandCollapseContent extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * Specifies the expanded/collapsed state of the content
-			 * @type {boolean}
-			 */
-			expanded: { type: Boolean, reflect: true },
-			_height: { type: String },
-			_state: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Specifies the expanded/collapsed state of the content
+		 * @type {boolean}
+		 */
+		expanded: { type: Boolean, reflect: true },
+		_height: { type: String },
+		_state: { type: String }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				--d2l-expand-collapse-content-transition-duration: 0.2s;
-				--d2l-expand-collapse-content-transition-function: cubic-bezier(0.4, 0.4, 0.25, 1);
-				display: block;
-			}
+	static styles = css`
+		:host {
+			--d2l-expand-collapse-content-transition-duration: 0.2s;
+			--d2l-expand-collapse-content-transition-function: cubic-bezier(0.4, 0.4, 0.25, 1);
+			display: block;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
+		.d2l-expand-collapse-content-container {
+			display: block;
+			opacity: 0;
+			overflow: hidden;
+			transition:
+				height var(--d2l-expand-collapse-content-transition-duration) var(--d2l-expand-collapse-content-transition-function),
+				opacity var(--d2l-expand-collapse-content-transition-duration) var(--d2l-expand-collapse-content-transition-function);
+		}
+
+		.d2l-expand-collapse-content-container[data-state="collapsed"] {
+			display: none;
+		}
+
+		.d2l-expand-collapse-content-container[data-state="expanded"] {
+			overflow: visible;
+		}
+
+
+		.d2l-expand-collapse-content-container[data-state="expanded"],
+		.d2l-expand-collapse-content-container[data-state="expanding"] {
+			opacity: 1;
+		}
+
+		/* prevent margin colapse on slotted children */
+		.d2l-expand-collapse-content-inner::before,
+		.d2l-expand-collapse-content-inner::after {
+			content: " ";
+			display: table;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
 			.d2l-expand-collapse-content-container {
-				display: block;
-				opacity: 0;
-				overflow: hidden;
-				transition:
-					height var(--d2l-expand-collapse-content-transition-duration) var(--d2l-expand-collapse-content-transition-function),
-					opacity var(--d2l-expand-collapse-content-transition-duration) var(--d2l-expand-collapse-content-transition-function);
+				transition: none;
 			}
-
-			.d2l-expand-collapse-content-container[data-state="collapsed"] {
-				display: none;
-			}
-
-			.d2l-expand-collapse-content-container[data-state="expanded"] {
-				overflow: visible;
-			}
-
-
-			.d2l-expand-collapse-content-container[data-state="expanded"],
-			.d2l-expand-collapse-content-container[data-state="expanding"] {
-				opacity: 1;
-			}
-
-			/* prevent margin colapse on slotted children */
-			.d2l-expand-collapse-content-inner::before,
-			.d2l-expand-collapse-content-inner::after {
-				content: " ";
-				display: table;
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				.d2l-expand-collapse-content-container {
-					transition: none;
-				}
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set-date-text-value.js
+++ b/components/filter/filter-dimension-set-date-text-value.js
@@ -9,42 +9,40 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 class FilterDimensionSetDateTextValue extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether this value in the filter is disabled or not
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * @ignore
-			 */
-			endValue: { type: String },
-			/**
-			 * REQUIRED: Unique key to represent this value in the dimension
-			 * @type {string}
-			 */
-			key: { type: String },
-			/**
-			 * REQUIRED: The preset date/time range that the list item represents
-			 * @type {'today'|'lastHour'|'24hours'|'48hours'|'7days'|'14days'|'30days'|'6months'}
-			 */
-			range: { type: String },
-			/**
-			 * Whether this value in the filter is selected or not
-			 * @type {boolean}
-			 */
-			selected: { type: Boolean, reflect: true },
-			/**
-			 * @ignore
-			 */
-			startValue: { type: String },
-			/**
-			 * @ignore
-			 */
-			text: { type: String, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Whether this value in the filter is disabled or not
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * @ignore
+		 */
+		endValue: { type: String },
+		/**
+		 * REQUIRED: Unique key to represent this value in the dimension
+		 * @type {string}
+		 */
+		key: { type: String },
+		/**
+		 * REQUIRED: The preset date/time range that the list item represents
+		 * @type {'today'|'lastHour'|'24hours'|'48hours'|'7days'|'14days'|'30days'|'6months'}
+		 */
+		range: { type: String },
+		/**
+		 * Whether this value in the filter is selected or not
+		 * @type {boolean}
+		 */
+		selected: { type: Boolean, reflect: true },
+		/**
+		 * @ignore
+		 */
+		startValue: { type: String },
+		/**
+		 * @ignore
+		 */
+		text: { type: String, reflect: true }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set-date-time-range-value.js
+++ b/components/filter/filter-dimension-set-date-time-range-value.js
@@ -13,53 +13,51 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
  */
 class FilterDimensionSetDateTimeRangeValue extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether this value in the filter is disabled or not
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Value of the end date or date-time input. Expected to be in UTC.
-			 * @type {string}
-			 */
-			endValue: { type: String, attribute: 'end-value' },
-			/**
-			 * @ignore
-			 */
-			inactive: { type: Boolean },
-			/**
-			 * REQUIRED: Unique key to represent this value in the dimension
-			 * @type {string}
-			 */
-			key: { type: String },
-			/**
-			 * Whether this value in the filter is selected or not
-			 * @type {boolean}
-			 */
-			selected: { type: Boolean, reflect: true },
-			/**
-			 * Value of the start date or date-time input. Expected to be in UTC.
-			 * @type {string}
-			 */
-			startValue: { type: String, attribute: 'start-value' },
-			/**
-			 * Defaults to "Custom Date Range" (localized). Can be overridden if desired.
-			 * @type {string}
-			 */
-			text: { type: String, reflect: true },
-			/**
-			 * Date/time range input type
-			 * @type {'date'|'date-time'}
-			 */
-			type: { type: String },
-			/**
-			 * @ignore
-			 */
-			valueText: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Whether this value in the filter is disabled or not
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Value of the end date or date-time input. Expected to be in UTC.
+		 * @type {string}
+		 */
+		endValue: { type: String, attribute: 'end-value' },
+		/**
+		 * @ignore
+		 */
+		inactive: { type: Boolean },
+		/**
+		 * REQUIRED: Unique key to represent this value in the dimension
+		 * @type {string}
+		 */
+		key: { type: String },
+		/**
+		 * Whether this value in the filter is selected or not
+		 * @type {boolean}
+		 */
+		selected: { type: Boolean, reflect: true },
+		/**
+		 * Value of the start date or date-time input. Expected to be in UTC.
+		 * @type {string}
+		 */
+		startValue: { type: String, attribute: 'start-value' },
+		/**
+		 * Defaults to "Custom Date Range" (localized). Can be overridden if desired.
+		 * @type {string}
+		 */
+		text: { type: String, reflect: true },
+		/**
+		 * Date/time range input type
+		 * @type {'date'|'date-time'}
+		 */
+		type: { type: String },
+		/**
+		 * @ignore
+		 */
+		valueText: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set-empty-state.js
+++ b/components/filter/filter-dimension-set-empty-state.js
@@ -6,25 +6,23 @@ import { LitElement } from 'lit';
  */
 class FilterDimensionSetEmptyState extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * The href that will be used for the empty state action. When set with action-text, d2l-filter will render a link action.
-			 * @type {string}
-			 */
-			actionHref: { type: String, attribute: 'action-href' },
-			/**
-			 * The text that will be displayed in the empty state action. When set, d2l-filter renders a button action, or a link if action-href is also defined.
-			 * @type {string}
-			 */
-			actionText: { type: String, attribute: 'action-text' },
-			/**
-			 * REQUIRED: The text that is displayed in the empty state description
-			 * @type {string}
-			 */
-			description: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * The href that will be used for the empty state action. When set with action-text, d2l-filter will render a link action.
+		 * @type {string}
+		 */
+		actionHref: { type: String, attribute: 'action-href' },
+		/**
+		 * The text that will be displayed in the empty state action. When set, d2l-filter renders a button action, or a link if action-href is also defined.
+		 * @type {string}
+		 */
+		actionText: { type: String, attribute: 'action-text' },
+		/**
+		 * REQUIRED: The text that is displayed in the empty state description
+		 * @type {string}
+		 */
+		description: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set-value.js
+++ b/components/filter/filter-dimension-set-value.js
@@ -6,35 +6,33 @@ import { LitElement } from 'lit';
  */
 class FilterDimensionSetValue extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * Count for the value in the list. If no count is provided, no count will be displayed
-			 * @type {number}
-			 */
-			count: { type: Number },
-			/**
-			 * Whether this value in the filter is disabled or not
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * REQUIRED: Unique key to represent this value in the dimension
-			 * @type {string}
-			 */
-			key: { type: String },
-			/**
-			 * Whether this value in the filter is selected or not
-			 * @type {boolean}
-			 */
-			selected: { type: Boolean, reflect: true },
-			/**
-			 * REQUIRED: The text that is displayed for the value
-			 * @type {string}
-			 */
-			text: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Count for the value in the list. If no count is provided, no count will be displayed
+		 * @type {number}
+		 */
+		count: { type: Number },
+		/**
+		 * Whether this value in the filter is disabled or not
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * REQUIRED: Unique key to represent this value in the dimension
+		 * @type {string}
+		 */
+		key: { type: String },
+		/**
+		 * Whether this value in the filter is selected or not
+		 * @type {boolean}
+		 */
+		selected: { type: Boolean, reflect: true },
+		/**
+		 * REQUIRED: The text that is displayed for the value
+		 * @type {string}
+		 */
+		text: { type: String }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-dimension-set.js
+++ b/components/filter/filter-dimension-set.js
@@ -9,73 +9,71 @@ import { html, LitElement } from 'lit';
  */
 class FilterDimensionSet extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether the dimension has more values to load. Manual search and selected first should be set if has more is being used
-			 * @type {boolean}
-			 */
-			hasMore: { type: Boolean, attribute: 'has-more' },
-			/**
-			 * A heading displayed above the list items. This is usually unnecessary, but can be used to emphasize or promote something specific about the list of items to help orient users.
-			 * @type {string}
-			 */
-			headerText: { type: String, attribute: 'header-text' },
-			/**
-			 * The introductory text to display at the top of the filter dropdown
-			 * @type {string}
-			 */
-			introductoryText: { type: String, attribute: 'introductory-text' },
-			/**
-			 * REQUIRED: Unique key to represent this dimension in the filter
-			 * @type {string}
-			 */
-			key: { type: String },
-			/**
-			 * Whether the values for this dimension are still loading and a loading spinner should be displayed
-			 * @type {boolean}
-			 */
-			loading: { type: Boolean },
-			/**
-			 * @ignore
-			 */
-			minWidth: { type: Number },
-			/**
-			 * ADVANCED: Whether to ignore the enforce single selection setting for this dimension.
-			 */
-			ignoreEnforceSelectionSingle: { type: Boolean, attribute: 'ignore-enforce-selection-single' },
-			/**
-			 * Whether to hide the search input, perform a simple text search, or fire an event on search
-			 * @type {'none'|'automatic'|'manual'}
-			 */
-			searchType: { type: String, attribute: 'search-type' },
-			/**
-			 * Adds a select all checkbox and summary for this dimension
-			 * @type {boolean}
-			 */
-			selectAll: { type: Boolean, attribute: 'select-all' },
-			/**
-			 * Whether to render the selected items at the top of the filter. Forced on if load more paging is being used
-			 * @type {boolean}
-			 */
-			selectedFirst: { type: Boolean, attribute: 'selected-first' },
-			/**
-			 * Whether only one value can be selected at a time for this dimension
-			 * @type {boolean}
-			 */
-			selectionSingle: { type: Boolean, attribute: 'selection-single' },
-			/**
-			 * REQUIRED: The text that is displayed for the dimension title
-			 * @type {string}
-			 */
-			text: { type: String },
-			/**
-			 * Whether to hide the dimension in the text sent to active filter subscribers
-			 * @type {boolean}
-			 */
-			valueOnlyActiveFilterText: { type: Boolean, attribute: 'value-only-active-filter-text' }
-		};
-	}
+	static properties = {
+		/**
+		 * Whether the dimension has more values to load. Manual search and selected first should be set if has more is being used
+		 * @type {boolean}
+		 */
+		hasMore: { type: Boolean, attribute: 'has-more' },
+		/**
+		 * A heading displayed above the list items. This is usually unnecessary, but can be used to emphasize or promote something specific about the list of items to help orient users.
+		 * @type {string}
+		 */
+		headerText: { type: String, attribute: 'header-text' },
+		/**
+		 * The introductory text to display at the top of the filter dropdown
+		 * @type {string}
+		 */
+		introductoryText: { type: String, attribute: 'introductory-text' },
+		/**
+		 * REQUIRED: Unique key to represent this dimension in the filter
+		 * @type {string}
+		 */
+		key: { type: String },
+		/**
+		 * Whether the values for this dimension are still loading and a loading spinner should be displayed
+		 * @type {boolean}
+		 */
+		loading: { type: Boolean },
+		/**
+		 * @ignore
+		 */
+		minWidth: { type: Number },
+		/**
+		 * ADVANCED: Whether to ignore the enforce single selection setting for this dimension.
+		 */
+		ignoreEnforceSelectionSingle: { type: Boolean, attribute: 'ignore-enforce-selection-single' },
+		/**
+		 * Whether to hide the search input, perform a simple text search, or fire an event on search
+		 * @type {'none'|'automatic'|'manual'}
+		 */
+		searchType: { type: String, attribute: 'search-type' },
+		/**
+		 * Adds a select all checkbox and summary for this dimension
+		 * @type {boolean}
+		 */
+		selectAll: { type: Boolean, attribute: 'select-all' },
+		/**
+		 * Whether to render the selected items at the top of the filter. Forced on if load more paging is being used
+		 * @type {boolean}
+		 */
+		selectedFirst: { type: Boolean, attribute: 'selected-first' },
+		/**
+		 * Whether only one value can be selected at a time for this dimension
+		 * @type {boolean}
+		 */
+		selectionSingle: { type: Boolean, attribute: 'selection-single' },
+		/**
+		 * REQUIRED: The text that is displayed for the dimension title
+		 * @type {string}
+		 */
+		text: { type: String },
+		/**
+		 * Whether to hide the dimension in the text sent to active filter subscribers
+		 * @type {boolean}
+		 */
+		valueOnlyActiveFilterText: { type: Boolean, attribute: 'value-only-active-filter-text' }
+	};
 
 	constructor() {
 		super();

--- a/components/filter/filter-overflow-group.js
+++ b/components/filter/filter-overflow-group.js
@@ -12,25 +12,21 @@ const updateEvents = ['d2l-filter-dimension-load-more', 'd2l-filter-dimension-se
 */
 class FilterOverflowGroup extends OverflowGroupMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Show `d2l-filter-tags` beneath the filters. Tags will be shown for all filters in the group.
-			 * @type {boolean}
-			 */
-			tags: { type: Boolean },
-			_openedDimensions: { state: true },
-			_filterIds: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Show `d2l-filter-tags` beneath the filters. Tags will be shown for all filters in the group.
+		 * @type {boolean}
+		 */
+		tags: { type: Boolean },
+		_openedDimensions: { state: true },
+		_filterIds: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			::slotted(d2l-filter) {
-				margin-inline-end: 0.3rem;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		::slotted(d2l-filter) {
+			margin-inline-end: 0.3rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/filter/filter-tags.js
+++ b/components/filter/filter-tags.js
@@ -11,26 +11,23 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 const CLEAR_TIMEOUT = 310; /** Corresponds to timeout in _dispatchChangeEvent in filter + 10 ms */
 
 class FilterTags extends LocalizeCoreElement(LitElement) {
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: Id(s) (space-delimited) of the filter component(s) to subscribe to
-			 * @type {string}
-			 */
-			filterIds: { type: String, attribute: 'filter-ids' }
-		};
-	}
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static properties = {
+		/**
+		 * REQUIRED: Id(s) (space-delimited) of the filter component(s) to subscribe to
+		 * @type {string}
+		 */
+		filterIds: { type: String, attribute: 'filter-ids' }
+	};
+
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -72,143 +72,139 @@ function addSpaceListener() {
  */
 class Filter extends FocusMixin(LocalizeCoreElement(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * Disables the dropdown opener for the filter
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Indicates if the filter is open
-			 * @type {boolean}
-			 */
-			opened: { type: Boolean, reflect: true },
-			/**
-			 * Optional override for the button text used for a multi-dimensional filter
-			 * @type {string}
-			 */
-			text: { type: String },
-			_activeDimensionKey: { type: String, attribute: false },
-			_dimensions: { type: Array, attribute: false },
-			_displayKeyboardTooltip: { state: true },
-			_ignoreSlotChanges: { type: Boolean },
-			_minWidth: { type: Number, attribute: false },
-			_totalAppliedCount: { type: Number, attribute: false }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the dropdown opener for the filter
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Indicates if the filter is open
+		 * @type {boolean}
+		 */
+		opened: { type: Boolean, reflect: true },
+		/**
+		 * Optional override for the button text used for a multi-dimensional filter
+		 * @type {string}
+		 */
+		text: { type: String },
+		_activeDimensionKey: { type: String, attribute: false },
+		_dimensions: { type: Array, attribute: false },
+		_displayKeyboardTooltip: { state: true },
+		_ignoreSlotChanges: { type: Boolean },
+		_minWidth: { type: Number, attribute: false },
+		_totalAppliedCount: { type: Number, attribute: false }
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, bodySmallStyles, bodyStandardStyles, heading4Styles, offscreenStyles, css`
-			[slot="header"] {
-				padding: 0.9rem 0.3rem;
-			}
+	static styles = [bodyCompactStyles, bodySmallStyles, bodyStandardStyles, heading4Styles, offscreenStyles, css`
+		[slot="header"] {
+			padding: 0.9rem 0.3rem;
+		}
 
-			.d2l-filter-dimension-header {
-				padding-bottom: 0.9rem;
-			}
+		.d2l-filter-dimension-header {
+			padding-bottom: 0.9rem;
+		}
 
-			.d2l-filter-dimension-header.with-intro {
-				padding-bottom: 0.6rem;
-			}
+		.d2l-filter-dimension-header.with-intro {
+			padding-bottom: 0.6rem;
+		}
 
-			.d2l-filter-dimension-header,
-			.d2l-filter-dimension-header-actions {
-				align-items: center;
-				display: flex;
-			}
+		.d2l-filter-dimension-header,
+		.d2l-filter-dimension-header-actions {
+			align-items: center;
+			display: flex;
+		}
 
-			.d2l-filter-dimension-header-actions {
-				flex-flow: row wrap;
-			}
+		.d2l-filter-dimension-header-actions {
+			flex-flow: row wrap;
+		}
 
-			d2l-input-search {
-				flex: 1 0;
-				margin-inline: 0.3rem 0.6rem;
-			}
+		d2l-input-search {
+			flex: 1 0;
+			margin-inline: 0.3rem 0.6rem;
+		}
 
-			.d2l-filter-dimension-select-all {
-				flex-basis: 100%;
-				margin-top: 0.9rem;
-			}
+		.d2l-filter-dimension-select-all {
+			flex-basis: 100%;
+			margin-top: 0.9rem;
+		}
 
-			d2l-selection-select-all {
-				padding: 0 0.6rem;
-			}
+		d2l-selection-select-all {
+			padding: 0 0.6rem;
+		}
 
-			.d2l-filter-dimension-header-text {
-				flex-grow: 1;
-				padding-inline-end: calc(2rem + 2px);
-				text-align: center;
-				${overflowEllipsisDeclarations}
-			}
+		.d2l-filter-dimension-header-text {
+			flex-grow: 1;
+			padding-inline-end: calc(2rem + 2px);
+			text-align: center;
+			${overflowEllipsisDeclarations}
+		}
 
-			.d2l-filter-dimension-set-value {
-				align-items: center;
-				color: var(--d2l-color-ferrite);
-				display: flex;
-				gap: 0.45rem;
-				line-height: unset;
-			}
-			.d2l-filter-dimension-set-value d2l-icon {
-				flex-shrink: 0;
-			}
-			d2l-expand-collapse-content[expanded] {
-				margin-inline-start: -2.1rem;
-				padding-block: 0.8rem 0.4rem;
-			}
-			d2l-list-item.expanding-content {
-				overflow-y: hidden;
-			}
+		.d2l-filter-dimension-set-value {
+			align-items: center;
+			color: var(--d2l-color-ferrite);
+			display: flex;
+			gap: 0.45rem;
+			line-height: unset;
+		}
+		.d2l-filter-dimension-set-value d2l-icon {
+			flex-shrink: 0;
+		}
+		d2l-expand-collapse-content[expanded] {
+			margin-inline-start: -2.1rem;
+			padding-block: 0.8rem 0.4rem;
+		}
+		d2l-list-item.expanding-content {
+			overflow-y: hidden;
+		}
 
-			.d2l-filter-dimension-set-value-text {
-				hyphens: auto;
-				${getOverflowDeclarations({ lines: 2 })}
-			}
+		.d2l-filter-dimension-set-value-text {
+			hyphens: auto;
+			${getOverflowDeclarations({ lines: 2 })}
+		}
 
-			d2l-list-item[selection-disabled] .d2l-filter-dimension-set-value,
-			d2l-list-item[selection-disabled] .d2l-body-small {
-				color: var(--d2l-color-chromite);
-			}
+		d2l-list-item[selection-disabled] .d2l-filter-dimension-set-value,
+		d2l-list-item[selection-disabled] .d2l-body-small {
+			color: var(--d2l-color-chromite);
+		}
 
-			.d2l-filter-dimension-intro-text {
-				margin: 0;
-				padding: 0.6rem 1.5rem 1.5rem;
-				text-align: center;
-			}
+		.d2l-filter-dimension-intro-text {
+			margin: 0;
+			padding: 0.6rem 1.5rem 1.5rem;
+			text-align: center;
+		}
 
-			.d2l-filter-dimension-intro-text.multi-dimension {
-				padding: 0 1.5rem 1.5rem;
-			}
+		.d2l-filter-dimension-intro-text.multi-dimension {
+			padding: 0 1.5rem 1.5rem;
+		}
 
-			.d2l-empty-state-container {
-				padding: 0.9rem 0.9rem calc(0.9rem - 5px);
-			}
+		.d2l-empty-state-container {
+			padding: 0.9rem 0.9rem calc(0.9rem - 5px);
+		}
 
-			.list-header-text {
-				color: var(--d2l-color-ferrite);
-				margin: 0;
-				padding-bottom: 0.05rem;
-				padding-top: 0.65rem;
-			}
+		.list-header-text {
+			color: var(--d2l-color-ferrite);
+			margin: 0;
+			padding-bottom: 0.05rem;
+			padding-top: 0.65rem;
+		}
 
-			.d2l-filter-dimension-info-message {
-				color: var(--d2l-color-ferrite);
-				display: flex;
-				justify-content: center;
-			}
+		.d2l-filter-dimension-info-message {
+			color: var(--d2l-color-ferrite);
+			display: flex;
+			justify-content: center;
+		}
 
-			/* Needed to "undo" the menu-item style for multiple dimensions */
-			d2l-hierarchical-view {
-				cursor: auto;
-			}
+		/* Needed to "undo" the menu-item style for multiple dimensions */
+		d2l-hierarchical-view {
+			cursor: auto;
+		}
 
-			d2l-loading-spinner {
-				padding-top: 0.6rem;
-				width: 100%;
-			}
-		`];
-	}
+		d2l-loading-spinner {
+			padding-top: 0.6rem;
+			width: 100%;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/focus-trap/focus-trap.js
+++ b/components/focus-trap/focus-trap.js
@@ -12,27 +12,23 @@ const traps = [];
  */
 class FocusTrap extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether the component should trap user focus.
-			 * @type {boolean}
-			 */
-			trap: { type: Boolean },
-			_legacyPromptIds: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Whether the component should trap user focus.
+		 * @type {boolean}
+		 */
+		trap: { type: Boolean },
+		_legacyPromptIds: { state: true }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -77,41 +77,39 @@ export class FormElementValidityState {
 
 export const FormElementMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			forceInvalid: { type: Boolean, attribute: false },
-			/**
-			 * @ignore
-			 */
-			invalid: { type: Boolean, reflect: true },
-			/**
-			 * Name of the form control. Submitted with the form as part of a name/value pair.
-			 * @type {string}
-			 */
-			name: { type: String },
-			/**
-			 * @ignore
-			 */
-			noValidate: { type: Boolean, attribute: 'novalidate' },
-			/**
-			 * @ignore
-			 * Perform validation immediately instead of waiting for the user to make changes.
-			 */
-			validateOnInit: { type: Boolean, attribute: 'validate-on-init' },
-			/**
-			 * @ignore
-			 */
-			validationError: { type: String, attribute: false },
-			/**
-			 * @ignore
-			 */
-			childErrors: { type: Object, attribute: false },
-			_errors: { type: Array, attribute: false }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		forceInvalid: { type: Boolean, attribute: false },
+		/**
+		 * @ignore
+		 */
+		invalid: { type: Boolean, reflect: true },
+		/**
+		 * Name of the form control. Submitted with the form as part of a name/value pair.
+		 * @type {string}
+		 */
+		name: { type: String },
+		/**
+		 * @ignore
+		 */
+		noValidate: { type: Boolean, attribute: 'novalidate' },
+		/**
+		 * @ignore
+		 * Perform validation immediately instead of waiting for the user to make changes.
+		 */
+		validateOnInit: { type: Boolean, attribute: 'validate-on-init' },
+		/**
+		 * @ignore
+		 */
+		validationError: { type: String, attribute: false },
+		/**
+		 * @ignore
+		 */
+		childErrors: { type: Object, attribute: false },
+		_errors: { type: Array, attribute: false }
+	};
 
 	constructor() {
 		super();

--- a/components/form/form-error-summary.js
+++ b/components/form/form-error-summary.js
@@ -7,53 +7,48 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 
 class FormErrorSummary extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			errors: { type: Object, attribute: false },
-			_expanded: { type: Boolean, attribute: false },
-			_hasTopMargin: { type: Boolean, attribute: '_has-top-margin', reflect: true },
-			_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
-		};
-	}
+	static properties = {
+		errors: { type: Object, attribute: false },
+		_expanded: { type: Boolean, attribute: false },
+		_hasTopMargin: { type: Boolean, attribute: '_has-top-margin', reflect: true },
+		_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
+	};
 
-	static get styles() {
-		return [linkStyles, css`
+	static styles = [linkStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([_has-top-margin][_has-errors]) {
+			margin-block-start: 1rem;
+		}
 
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([_has-top-margin][_has-errors]) {
-				margin-block-start: 1rem;
-			}
+		.d2l-form-error-summary-header {
+			cursor: pointer;
+			display: flex;
+			justify-content: space-between;
+			padding-block: 0.3rem;
+			padding-inline: 1.2rem 0.3rem;
+		}
 
-			.d2l-form-error-summary-header {
-				cursor: pointer;
-				display: flex;
-				justify-content: space-between;
-				padding-block: 0.3rem;
-				padding-inline: 1.2rem 0.3rem;
-			}
+		.d2l-form-error-summary-text {
+			align-items: center;
+			display: flex;
+		}
 
-			.d2l-form-error-summary-text {
-				align-items: center;
-				display: flex;
-			}
+		.d2l-form-error-summary-error-list {
+			margin-block: 0;
+			margin-inline: 1.2rem 0;
+			padding-bottom: 0.6rem;
+			padding-top: 0.3rem;
+		}
 
-			.d2l-form-error-summary-error-list {
-				margin-block: 0;
-				margin-inline: 1.2rem 0;
-				padding-bottom: 0.6rem;
-				padding-top: 0.3rem;
-			}
-
-			d2l-alert {
-				max-width: none;
-			}
-		`];
-	}
+		d2l-alert {
+			max-width: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -17,43 +17,39 @@ import { localizeFormElement } from './form-element-localize-helper.js';
  */
 class Form extends LocalizeCoreElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Indicates that the form should opt-out of nesting.
-			 * This means that it will not be submitted or validated if an ancestor form is submitted or validated.
-			 * However, directly submitting or validating a form with `no-nesting` will still trigger submission and validation for its descendant forms unless they also opt-out using `no-nesting`.
-			 * @type {boolean}
-			 */
-			noNesting: { type: Boolean, attribute: 'no-nesting', reflect: true },
-			/**
-			 * Indicates that the form should interrupt and warn on navigation if the user has unsaved changes on native elements.
-			 * @type {boolean}
-			 */
-			trackChanges: { type: Boolean, attribute: 'track-changes', reflect: true },
-			/**
-			 * Id for an alternative error summary element
-			 * @type {string}
-			 */
-			summaryId: { type: String, attribute: 'summary-id' },
-			_errors: { type: Object },
-			_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
-		};
-	}
+	static properties = {
+		/**
+		 * Indicates that the form should opt-out of nesting.
+		 * This means that it will not be submitted or validated if an ancestor form is submitted or validated.
+		 * However, directly submitting or validating a form with `no-nesting` will still trigger submission and validation for its descendant forms unless they also opt-out using `no-nesting`.
+		 * @type {boolean}
+		 */
+		noNesting: { type: Boolean, attribute: 'no-nesting', reflect: true },
+		/**
+		 * Indicates that the form should interrupt and warn on navigation if the user has unsaved changes on native elements.
+		 * @type {boolean}
+		 */
+		trackChanges: { type: Boolean, attribute: 'track-changes', reflect: true },
+		/**
+		 * Id for an alternative error summary element
+		 * @type {string}
+		 */
+		summaryId: { type: String, attribute: 'summary-id' },
+		_errors: { type: Object },
+		_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([_has-errors]) ::slotted(d2l-input-group) {
-				margin-block-start: 1rem;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([_has-errors]) ::slotted(d2l-input-group) {
+			margin-block-start: 1rem;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/hierarchical-view/hierarchical-view-mixin.js
+++ b/components/hierarchical-view/hierarchical-view-mixin.js
@@ -8,92 +8,88 @@ const escapeKeyCode = 27;
 
 export const HierarchicalViewMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			hierarchicalView: { type: Boolean },
-			/**
-			 * @ignore
-			 */
-			rootView: { type: Boolean, attribute: 'root-view' },
-			/**
-			 * @ignore
-			 */
-			shown: { type: Boolean, reflect: true },
-			_childView: { type: Boolean, reflect: true, attribute: 'child-view' },
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		hierarchicalView: { type: Boolean },
+		/**
+		 * @ignore
+		 */
+		rootView: { type: Boolean, attribute: 'root-view' },
+		/**
+		 * @ignore
+		 */
+		shown: { type: Boolean, reflect: true },
+		_childView: { type: Boolean, reflect: true, attribute: 'child-view' },
+	};
 
-	static get styles() {
-		return css`
+	static styles = css`
+		:host {
+			--d2l-hierarchical-view-height-transition: height 300ms linear;
+			box-sizing: border-box;
+			display: none;
+			left: 0;
+			overflow: hidden;
+			position: relative;
+			-webkit-transition: var(--d2l-hierarchical-view-height-transition);
+			transition: var(--d2l-hierarchical-view-height-transition);
+			width: 100%;
+		}
+		:host([child-view]) {
+			display: none;
+			left: 100%;
+			position: absolute;
+			top: 0;
+		}
+		:host([shown]) {
+			display: inline-block;
+			vertical-align: top; /* DE37329: required to prevent extra spacing caused by inline-block */
+		}
+		.d2l-hierarchical-view-content {
+			position: relative;
+		}
+		.d2l-hierarchical-view-content.d2l-child-view-show {
+			-webkit-animation: show-child-view-animation forwards 300ms linear;
+			animation: show-child-view-animation 300ms forwards linear;
+		}
+		.d2l-hierarchical-view-content.d2l-child-view-hide {
+			-webkit-animation: hide-child-view-animation forwards 300ms linear;
+			animation: hide-child-view-animation 300ms forwards linear;
+		}
+		@media (prefers-reduced-motion: reduce) {
 			:host {
-				--d2l-hierarchical-view-height-transition: height 300ms linear;
-				box-sizing: border-box;
-				display: none;
-				left: 0;
-				overflow: hidden;
-				position: relative;
-				-webkit-transition: var(--d2l-hierarchical-view-height-transition);
-				transition: var(--d2l-hierarchical-view-height-transition);
-				width: 100%;
-			}
-			:host([child-view]) {
-				display: none;
-				left: 100%;
-				position: absolute;
-				top: 0;
-			}
-			:host([shown]) {
-				display: inline-block;
-				vertical-align: top; /* DE37329: required to prevent extra spacing caused by inline-block */
-			}
-			.d2l-hierarchical-view-content {
-				position: relative;
+				-webkit-transition: none;
+				transition: none;
 			}
 			.d2l-hierarchical-view-content.d2l-child-view-show {
-				-webkit-animation: show-child-view-animation forwards 300ms linear;
-				animation: show-child-view-animation 300ms forwards linear;
+				-webkit-animation: none;
+				animation: none;
+				left: -100%;
 			}
 			.d2l-hierarchical-view-content.d2l-child-view-hide {
-				-webkit-animation: hide-child-view-animation forwards 300ms linear;
-				animation: hide-child-view-animation 300ms forwards linear;
+				-webkit-animation: none;
+				animation: none;
+				left: 0;
 			}
-			@media (prefers-reduced-motion: reduce) {
-				:host {
-					-webkit-transition: none;
-					transition: none;
-				}
-				.d2l-hierarchical-view-content.d2l-child-view-show {
-					-webkit-animation: none;
-					animation: none;
-					left: -100%;
-				}
-				.d2l-hierarchical-view-content.d2l-child-view-hide {
-					-webkit-animation: none;
-					animation: none;
-					left: 0;
-				}
-			}
-			@keyframes show-child-view-animation {
-				0% { left: 0; }
-				100% { left: -100%; }
-			}
-			@-webkit-keyframes show-child-view-animation {
-				0% { left: 0; }
-				100% { left: -100%; }
-			}
-			@keyframes hide-child-view-animation {
-				0% { left: -100%; }
-				100% { left: 0; }
-			}
-			@-webkit-keyframes hide-child-view-animation {
-				0% { left: -100%; }
-				100% { left: 0; }
-			}
-		`;
-	}
+		}
+		@keyframes show-child-view-animation {
+			0% { left: 0; }
+			100% { left: -100%; }
+		}
+		@-webkit-keyframes show-child-view-animation {
+			0% { left: 0; }
+			100% { left: -100%; }
+		}
+		@keyframes hide-child-view-animation {
+			0% { left: -100%; }
+			100% { left: 0; }
+		}
+		@-webkit-keyframes hide-child-view-animation {
+			0% { left: -100%; }
+			100% { left: 0; }
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/hierarchical-view/hierarchical-view.js
+++ b/components/hierarchical-view/hierarchical-view.js
@@ -10,13 +10,11 @@ import { HierarchicalViewMixin } from '../hierarchical-view/hierarchical-view-mi
  */
 class HierarchicalView extends HierarchicalViewMixin(LitElement) {
 
-	static get styles() {
-		return [ super.styles, css`
-			:host {
-				display: inline-block;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+		}
+	`];
 
 	render() {
 		return html`

--- a/components/html-block/html-block.js
+++ b/components/html-block/html-block.js
@@ -188,8 +188,8 @@ const getRenderers = async() => {
 	if (renderers) return renderers;
 	const rendererLoader = requestInstance(document, 'html-block-renderer-loader');
 	const tempRenderers = rendererLoader ? await rendererLoader.getRenderers() : undefined;
-	const defaultRenderers = [ createMathRenderer(), createCodeRenderer() ];
-	renderers = (tempRenderers ? [ ...defaultRenderers, ...tempRenderers ] : defaultRenderers);
+	const defaultRenderers = [createMathRenderer(), createCodeRenderer()];
+	renderers = (tempRenderers ? [...defaultRenderers, ...tempRenderers] : defaultRenderers);
 	return renderers;
 };
 
@@ -198,53 +198,49 @@ const getRenderers = async() => {
  */
 class HtmlBlock extends LoadingCompleteMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether compact styles should be applied
-			 * @type {Boolean}
-			 */
-			compact: { type: Boolean },
-			/**
-			 * The HTML to be rendered. Ignored if slotted content is provided.
-			 * @type {String}
-			 */
-			html: { type: String },
-			/**
-			 * Whether to display the HTML in inline mode
-			 * @type {Boolean}
-			 */
-			inline: { type: Boolean },
-			/**
-			 * Whether to disable deferred rendering of the user-authored HTML. Do *not* set this
-			 * unless your HTML relies on script executions that may break upon stamping.
-			 * @type {Boolean}
-			 */
-			noDeferredRendering: { type: Boolean, attribute: 'no-deferred-rendering' },
-			_context: { type: Object, state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Whether compact styles should be applied
+		 * @type {Boolean}
+		 */
+		compact: { type: Boolean },
+		/**
+		 * The HTML to be rendered. Ignored if slotted content is provided.
+		 * @type {String}
+		 */
+		html: { type: String },
+		/**
+		 * Whether to display the HTML in inline mode
+		 * @type {Boolean}
+		 */
+		inline: { type: Boolean },
+		/**
+		 * Whether to disable deferred rendering of the user-authored HTML. Do *not* set this
+		 * unless your HTML relies on script executions that may break upon stamping.
+		 * @type {Boolean}
+		 */
+		noDeferredRendering: { type: Boolean, attribute: 'no-deferred-rendering' },
+		_context: { type: Object, state: true }
+	};
 
-	static get styles() {
-		return [ htmlBlockContentStyles, css`
-			:host {
-				display: block;
-			}
-			${_generateHtmlBlockRootStyles(':host')}
-			:host([inline]),
-			:host([inline]) .d2l-html-block-rendered {
-				display: inline;
-			}
-			:host([hidden]),
-			:host([no-deferred-rendering]) .d2l-html-block-rendered,
-			slot {
-				display: none;
-			}
-			:host([no-deferred-rendering]) slot {
-				display: contents;
-			}
-		`];
-	}
+	static styles = [htmlBlockContentStyles, css`
+		:host {
+			display: block;
+		}
+		${_generateHtmlBlockRootStyles(':host')}
+		:host([inline]),
+		:host([inline]) .d2l-html-block-rendered {
+			display: inline;
+		}
+		:host([hidden]),
+		:host([no-deferred-rendering]) .d2l-html-block-rendered,
+		slot {
+			display: none;
+		}
+		:host([no-deferred-rendering]) slot {
+			display: contents;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/icons/icon-custom.js
+++ b/components/icons/icon-custom.js
@@ -4,31 +4,27 @@ import { iconStyles } from './icon-styles.js';
 
 class IconCustom extends LitElement {
 
-	static get properties() {
-		return {
-			size: {
-				type: String,
-				reflect: true
-			}
-		};
-	}
+	static properties = {
+		size: {
+			type: String,
+			reflect: true
+		}
+	};
 
-	static get styles() {
-		return [ iconStyles, css`
-			:host([size="tier1"]) {
-				height: var(--d2l-icon-height, 18px);
-				width: var(--d2l-icon-width, 18px);
-			}
-			:host([size="tier2"]) {
-				height: var(--d2l-icon-height, 24px);
-				width: var(--d2l-icon-width, 24px);
-			}
-			:host([size="tier3"]) {
-				height: var(--d2l-icon-height, 30px);
-				width: var(--d2l-icon-width, 30px);
-			}
-		`];
-	}
+	static styles = [iconStyles, css`
+		:host([size="tier1"]) {
+			height: var(--d2l-icon-height, 18px);
+			width: var(--d2l-icon-width, 18px);
+		}
+		:host([size="tier2"]) {
+			height: var(--d2l-icon-height, 24px);
+			width: var(--d2l-icon-width, 24px);
+		}
+		:host([size="tier3"]) {
+			height: var(--d2l-icon-height, 30px);
+			width: var(--d2l-icon-width, 30px);
+		}
+	`];
 
 	render() {
 		return html`<slot @slotchange="${this._handleSlotChange}"></slot>`;

--- a/components/icons/icon.js
+++ b/components/icons/icon.js
@@ -9,31 +9,27 @@ import { until } from 'lit/directives/until.js';
 
 class Icon extends LitElement {
 
-	static get properties() {
-		return {
-			icon: {
-				type: String,
-				reflect: true
-			}
-		};
-	}
+	static properties = {
+		icon: {
+			type: String,
+			reflect: true
+		}
+	};
 
-	static get styles() {
-		return [ iconStyles, css`
-			:host([icon*="tier1:"]) {
-				height: var(--d2l-icon-height, 18px);
-				width: var(--d2l-icon-width, 18px);
-			}
-			:host([icon*="tier2:"]) {
-				height: var(--d2l-icon-height, 24px);
-				width: var(--d2l-icon-width, 24px);
-			}
-			:host([icon*="tier3:"]) {
-				height: var(--d2l-icon-height, 30px);
-				width: var(--d2l-icon-width, 30px);
-			}
-		`];
-	}
+	static styles = [iconStyles, css`
+		:host([icon*="tier1:"]) {
+			height: var(--d2l-icon-height, 18px);
+			width: var(--d2l-icon-width, 18px);
+		}
+		:host([icon*="tier2:"]) {
+			height: var(--d2l-icon-height, 24px);
+			width: var(--d2l-icon-width, 24px);
+		}
+		:host([icon*="tier3:"]) {
+			height: var(--d2l-icon-height, 30px);
+			width: var(--d2l-icon-width, 30px);
+		}
+	`];
 
 	render() {
 		return guard([this.icon], () => until(this._getIcon(), noChange));

--- a/components/icons/slotted-icon-mixin.js
+++ b/components/icons/slotted-icon-mixin.js
@@ -3,26 +3,24 @@ import { css, html, nothing } from 'lit';
 
 export const SlottedIconMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
+	static properties = {
 
-			/**
-			 * Preset icon key (e.g. "tier1:gear")
-			 * @type {string}
-			 */
-			icon: {
-				type: String,
-				reflect: true,
-				required: {
-					validator: (_value, elem, hasValue) => hasValue || elem._hasCustomIcon || !elem._iconRequired
-				}
-			},
-			_hasCustomIcon: { state: true }
-		};
-	}
+		/**
+		 * Preset icon key (e.g. "tier1:gear")
+		 * @type {string}
+		 */
+		icon: {
+			type: String,
+			reflect: true,
+			required: {
+				validator: (_value, elem, hasValue) => hasValue || elem._hasCustomIcon || !elem._iconRequired
+			}
+		},
+		_hasCustomIcon: { state: true }
+	};
 
 	static get styles() {
-		const styles = [ css`
+		const styles = [css`
 			slot[name="icon"]::slotted(*) {
 				display: none;
 			}

--- a/components/inputs/input-checkbox-group.js
+++ b/components/inputs/input-checkbox-group.js
@@ -8,45 +8,41 @@ import { PropertyRequiredMixin } from '../../mixins/property-required/property-r
  */
 class InputCheckboxGroup extends PropertyRequiredMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: Label for the group of checkboxes
-			 * @type {string}
-			 */
-			label: { required: true, type: String },
-			/**
-			 * Hides the label visually
-			 * @type {boolean}
-			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean }
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: Label for the group of checkboxes
+		 * @type {string}
+		 */
+		label: { required: true, type: String },
+		/**
+		 * Hides the label visually
+		 * @type {boolean}
+		 */
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean }
+	};
 
-	static get styles() {
-		return [inputLabelStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.wrapper {
-				display: flex;
-				flex-direction: column;
-				gap: 0.6rem;
-			}
-			::slotted(d2l-input-checkbox) {
-				margin-bottom: 0;
-			}
-			.d2l-input-label {
-				margin-block-end: 0.6rem;
-			}
-			.d2l-input-label[hidden] {
-				display: none;
-			}
-		`];
-	}
+	static styles = [inputLabelStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.wrapper {
+			display: flex;
+			flex-direction: column;
+			gap: 0.6rem;
+		}
+		::slotted(d2l-input-checkbox) {
+			margin-bottom: 0;
+		}
+		.d2l-input-label {
+			margin-block-end: 0.6rem;
+		}
+		.d2l-input-label[hidden] {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-checkbox.js
+++ b/components/inputs/input-checkbox.js
@@ -21,116 +21,112 @@ export const checkboxStyles = _generateInputCheckboxStyles('input[type="checkbox
  */
 class InputCheckbox extends FormElementMixin(InputInlineHelpMixin(FocusMixin(SkeletonMixin(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			ariaLabel: { type: String, attribute: 'aria-label' },
-			/**
-			 * Checked state
-			 * @type {boolean}
-			 */
-			checked: { type: Boolean },
-			/**
-			 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
-			 * @type {string}
-			 */
-			description: { type: String },
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean },
-			/**
-			 * Tooltip text when disabled
-			 * @type {string}
-			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			/**
-			 * Sets checkbox to an indeterminate state
-			 * @type {boolean}
-			 */
-			indeterminate: { type: Boolean },
-			/**
-			 * REQUIRED: Label for the input
-			 * @type {string}
-			 */
-			label: { type: String },
-			/**
-			 * Hides the label visually
-			 * @type {boolean}
-			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
-			/**
-			 * Hides the supporting slot when unchecked
-			 * @type {boolean}
-			 */
-			supportingHiddenWhenUnchecked: { type: Boolean, attribute: 'supporting-hidden-when-unchecked', reflect: true },
-			/**
-			 * Value of the input
-			 * @type {string}
-			 */
-			value: { type: String },
-			_hasSupporting: { state: true },
-			_isHovered: { state: true },
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		ariaLabel: { type: String, attribute: 'aria-label' },
+		/**
+		 * Checked state
+		 * @type {boolean}
+		 */
+		checked: { type: Boolean },
+		/**
+		 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
+		 * @type {string}
+		 */
+		description: { type: String },
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean },
+		/**
+		 * Tooltip text when disabled
+		 * @type {string}
+		 */
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		/**
+		 * Sets checkbox to an indeterminate state
+		 * @type {boolean}
+		 */
+		indeterminate: { type: Boolean },
+		/**
+		 * REQUIRED: Label for the input
+		 * @type {string}
+		 */
+		label: { type: String },
+		/**
+		 * Hides the label visually
+		 * @type {boolean}
+		 */
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
+		/**
+		 * Hides the supporting slot when unchecked
+		 * @type {boolean}
+		 */
+		supportingHiddenWhenUnchecked: { type: Boolean, attribute: 'supporting-hidden-when-unchecked', reflect: true },
+		/**
+		 * Value of the input
+		 * @type {string}
+		 */
+		value: { type: String },
+		_hasSupporting: { state: true },
+		_isHovered: { state: true },
+	};
 
-	static get styles() {
-		return [ super.styles, checkboxStyles, offscreenStyles,
-			css`
-				:host {
-					display: block;
-					margin-block-end: 0.6rem;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([label-hidden]) {
-					display: inline-block;
-					margin-block-end: 0;
-				}
-				label {
-					display: flex;
-					line-height: ${cssSizes.inputBoxSize}rem;
-					overflow-wrap: anywhere;
-				}
-				.d2l-input-checkbox-wrapper {
-					display: inline-block;
-				}
-				.d2l-input-checkbox-text {
-					color: var(--d2l-theme-text-color-static-standard);
-					display: inline-block;
-					font-size: 0.8rem;
-					font-weight: 400;
-					margin-inline-start: ${cssSizes.checkboxMargin}rem;
-					vertical-align: top;
-					white-space: normal;
-				}
-				:host([label-hidden]) .d2l-input-checkbox-text {
-					margin-inline-start: 0;
-				}
-				:host([skeleton]) .d2l-input-checkbox-text.d2l-skeletize::before {
-					bottom: 0.3rem;
-					top: 0.3rem;
-				}
-				.d2l-input-inline-help,
-				.d2l-input-checkbox-supporting {
-					margin-inline-start: ${cssSizes.inputBoxSize + cssSizes.checkboxMargin}rem;
-				}
-				:host(:not([skeleton])) .d2l-input-checkbox-text-disabled {
-					opacity: 0.5;
-				}
-				input[type="checkbox"].d2l-input-checkbox {
-					vertical-align: top;
-				}
-				.d2l-input-checkbox-supporting {
-					margin-block-start: 0.6rem;
-				}
-			`
-		];
-	}
+	static styles = [super.styles, checkboxStyles, offscreenStyles,
+		css`
+			:host {
+				display: block;
+				margin-block-end: 0.6rem;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([label-hidden]) {
+				display: inline-block;
+				margin-block-end: 0;
+			}
+			label {
+				display: flex;
+				line-height: ${cssSizes.inputBoxSize}rem;
+				overflow-wrap: anywhere;
+			}
+			.d2l-input-checkbox-wrapper {
+				display: inline-block;
+			}
+			.d2l-input-checkbox-text {
+				color: var(--d2l-theme-text-color-static-standard);
+				display: inline-block;
+				font-size: 0.8rem;
+				font-weight: 400;
+				margin-inline-start: ${cssSizes.checkboxMargin}rem;
+				vertical-align: top;
+				white-space: normal;
+			}
+			:host([label-hidden]) .d2l-input-checkbox-text {
+				margin-inline-start: 0;
+			}
+			:host([skeleton]) .d2l-input-checkbox-text.d2l-skeletize::before {
+				bottom: 0.3rem;
+				top: 0.3rem;
+			}
+			.d2l-input-inline-help,
+			.d2l-input-checkbox-supporting {
+				margin-inline-start: ${cssSizes.inputBoxSize + cssSizes.checkboxMargin}rem;
+			}
+			:host(:not([skeleton])) .d2l-input-checkbox-text-disabled {
+				opacity: 0.5;
+			}
+			input[type="checkbox"].d2l-input-checkbox {
+				vertical-align: top;
+			}
+			.d2l-input-checkbox-supporting {
+				margin-block-start: 0.6rem;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/components/inputs/input-color.js
+++ b/components/inputs/input-color.js
@@ -88,155 +88,149 @@ const SWATCH_TRANSPARENT = `<svg xmlns="http://www.w3.org/2000/svg" width="24" h
  */
 class InputColor extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: Value of an associated color as a HEX which will be used for color contrast analysis
-			 * @type {string}
-			 */
-			associatedValue: { attribute: 'associated-value', type: String },
-			/**
-			 * Puts the input into a disabled state
-			 * @type {boolean}
-			 */
-			disabled: { reflect: true, type: Boolean },
-			/**
-			 * Disallows the user from selecting "None" as a color value
-			 * @type {boolean}
-			 */
-			disallowNone: { attribute: 'disallow-none', type: Boolean },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Label for the input, comes with a default value for background & foreground types.
-			 * @type {string}
-			 */
-			label: {
-				type: String,
-				required: {
-					dependentProps: ['type'],
-					validator: (_value, elem, hasValue) => elem.type !== 'custom' || hasValue
-				}
-			},
-			/**
-			 * Hides the label visually
-			 * @type {boolean}
-			 */
-			labelHidden: { attribute: 'label-hidden', type: Boolean },
-			/**
-			 * Puts the input into a read-only state
-			 * @type {boolean}
-			 */
-			readonly: { type: Boolean },
-			/**
-			 * Type of color being chosen
-			 * @type {'background'|'foreground'|'custom'}
-			 * @default end
-			 */
-			type: { reflect: true, type: String },
-			/**
-			 * Value of the input as a HEX color
-			 * @type {string}
-			 */
-			value: { type: String },
-			/**
-			 * @ignore
-			 */
-			launchType: { attribute: 'launch-type', type: String },
-			_opened: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * ACCESSIBILITY: Value of an associated color as a HEX which will be used for color contrast analysis
+		 * @type {string}
+		 */
+		associatedValue: { attribute: 'associated-value', type: String },
+		/**
+		 * Puts the input into a disabled state
+		 * @type {boolean}
+		 */
+		disabled: { reflect: true, type: Boolean },
+		/**
+		 * Disallows the user from selecting "None" as a color value
+		 * @type {boolean}
+		 */
+		disallowNone: { attribute: 'disallow-none', type: Boolean },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Label for the input, comes with a default value for background & foreground types.
+		 * @type {string}
+		 */
+		label: {
+			type: String,
+			required: {
+				dependentProps: ['type'],
+				validator: (_value, elem, hasValue) => elem.type !== 'custom' || hasValue
+			}
+		},
+		/**
+		 * Hides the label visually
+		 * @type {boolean}
+		 */
+		labelHidden: { attribute: 'label-hidden', type: Boolean },
+		/**
+		 * Puts the input into a read-only state
+		 * @type {boolean}
+		 */
+		readonly: { type: Boolean },
+		/**
+		 * Type of color being chosen
+		 * @type {'background'|'foreground'|'custom'}
+		 * @default end
+		 */
+		type: { reflect: true, type: String },
+		/**
+		 * Value of the input as a HEX color
+		 * @type {string}
+		 */
+		value: { type: String },
+		/**
+		 * @ignore
+		 */
+		launchType: { attribute: 'launch-type', type: String },
+		_opened: { state: true }
+	};
 
-	static get styles() {
-		return [ super.styles, buttonStyles, inputLabelStyles,
-			css`
-				:host {
-					display: inline-block;
-				}
-				:host([hidden]) {
-					display: none;
-				}
+	static styles = [super.styles, buttonStyles, inputLabelStyles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
 
-				button {
-					align-items: center;
-					background-color: var(--d2l-color-gypsum);
-					display: flex;
-					gap: 0.15rem;
-					min-height: auto;
-					padding: 0.55rem;
-					position: relative;
-				}
-				button:not([aria-disabled]):hover,
-				button:not([aria-disabled]):focus,
-				button.opened {
-					background-color: var(--d2l-color-mica);
-				}
-				:host([disabled]) button {
-					cursor: default;
-					opacity: 0.5;
-				}
-				/* Firefox includes a hidden border which messes up button dimensions */
-				button::-moz-focus-inner {
-					border: 0;
-				}
+		button {
+			align-items: center;
+			background-color: var(--d2l-color-gypsum);
+			display: flex;
+			gap: 0.15rem;
+			min-height: auto;
+			padding: 0.55rem;
+			position: relative;
+		}
+		button:not([aria-disabled]):hover,
+		button:not([aria-disabled]):focus,
+		button.opened {
+			background-color: var(--d2l-color-mica);
+		}
+		:host([disabled]) button {
+			cursor: default;
+			opacity: 0.5;
+		}
+		/* Firefox includes a hidden border which messes up button dimensions */
+		button::-moz-focus-inner {
+			border: 0;
+		}
 
-				.d2l-input-label {
-					margin-bottom: 0;
-					padding-bottom: 7px; /* prevent margin-collapse with readonly swatch margins */
-				}
+		.d2l-input-label {
+			margin-bottom: 0;
+			padding-bottom: 7px; /* prevent margin-collapse with readonly swatch margins */
+		}
 
-				.swatch {
-					border: 1px inset rgba(0, 0, 0, 0.42);
-					border-radius: 0.1rem;
-					box-sizing: border-box;
-					display: inline-block;
-					height: 0.3rem;
-					width: 1.2rem;
-				}
-				:host([type="custom"]) .swatch {
-					border-radius: 0.15rem;
-					height: 1rem;
-				}
-				.swatch-transparent {
-					background-image: ${svgToCSS(SWATCH_TRANSPARENT)};
-					background-position-y: -1.5px;
-					background-size: cover;
-				}
-				:host([type="custom"]) .swatch-transparent {
-					background-position-y: 0;
-				}
+		.swatch {
+			border: 1px inset rgba(0, 0, 0, 0.42);
+			border-radius: 0.1rem;
+			box-sizing: border-box;
+			display: inline-block;
+			height: 0.3rem;
+			width: 1.2rem;
+		}
+		:host([type="custom"]) .swatch {
+			border-radius: 0.15rem;
+			height: 1rem;
+		}
+		.swatch-transparent {
+			background-image: ${svgToCSS(SWATCH_TRANSPARENT)};
+			background-position-y: -1.5px;
+			background-size: cover;
+		}
+		:host([type="custom"]) .swatch-transparent {
+			background-position-y: 0;
+		}
 
-				.icon-wrapper {
-					align-items: center;
-					display: flex;
-					flex-direction: column;
-					gap: 0.1rem;
-				}
-				.icon-wrapper > svg {
-					height: 0.6rem;
-				}
+		.icon-wrapper {
+			align-items: center;
+			display: flex;
+			flex-direction: column;
+			gap: 0.1rem;
+		}
+		.icon-wrapper > svg {
+			height: 0.6rem;
+		}
 
-				button,
-				.readonly-wrapper {
-					color: var(--d2l-color-ferrite);
-				}
+		button,
+		.readonly-wrapper {
+			color: var(--d2l-color-ferrite);
+		}
 
-				.readonly-wrapper {
-					border-radius: 0.1rem;
-					display: block;
-					line-height: 0;
-					margin: 0.55rem 0;
-					outline: none;
-					width: 1.2rem;
-				}
-				${getFocusRingStyles('.readonly-wrapper')}
-				@media (prefers-contrast: more) {
-					.swatch {
-						border: 1px solid FieldText;
-						forced-color-adjust: none;
-					}
-				}
-			`
-		];
-	}
+		.readonly-wrapper {
+			border-radius: 0.1rem;
+			display: block;
+			line-height: 0;
+			margin: 0.55rem 0;
+			outline: none;
+			width: 1.2rem;
+		}
+		${getFocusRingStyles('.readonly-wrapper')}
+		@media (prefers-contrast: more) {
+			.swatch {
+				border: 1px solid FieldText;
+				forced-color-adjust: none;
+			}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -34,101 +34,97 @@ export function getShiftedEndDate(startValue, endValue, prevStartValue, inclusiv
  */
 class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ADVANCED: Automatically shifts end date when start date changes to keep same range
-			 * @type {boolean}
-			 */
-			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
-			/**
-			 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
-			 * @type {boolean}
-			 */
-			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
-			/**
-			 * Disables the inputs
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: Label for the end date input. Defaults to localized "End Date".
-			 * @type {string}
-			 * @default "End Date"
-			 */
-			endLabel: { attribute: 'end-label', reflect: true, type: String },
-			/**
-			 * ADVANCED: Indicates if the end calendar dropdown is open
-			 * @type {boolean}
-			 */
-			endOpened: { attribute: 'end-opened', type: Boolean },
-			/**
-			 * Value of the end date input
-			 * @type {string}
-			 */
-			endValue: { attribute: 'end-value', reflect: true, type: String },
-			/**
-			 * Validates on inclusive range (i.e., it is valid for start and end dates to be equal)
-			 * @type {boolean}
-			 */
-			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date inputs
-			 * @type {string}
-			 */
-			label: { type: String, reflect: true },
-			/**
-			 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
-			/**
-			 * Maximum valid date that could be selected by a user
-			 * @type {string}
-			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
-			 * Minimum valid date that could be selected by a user
-			 * @type {string}
-			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
-			 * Indicates that values are required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: Label for the start date input. Defaults to localized "Start Date".
-			 * @type {string}
-			 * @default "Start Date"
-			 */
-			startLabel: { attribute: 'start-label', reflect: true, type: String },
-			/**
-			 * ADVANCED: Indicates if the start calendar dropdown is open
-			 * @type {boolean}
-			 */
-			startOpened: { attribute: 'start-opened', type: Boolean },
-			/**
-			 * Value of the start date input
-			 * @type {string}
-			 */
-			startValue: { attribute: 'start-value', reflect: true, type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * ADVANCED: Automatically shifts end date when start date changes to keep same range
+		 * @type {boolean}
+		 */
+		autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
+		/**
+		 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
+		 * @type {boolean}
+		 */
+		childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
+		/**
+		 * Disables the inputs
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: Label for the end date input. Defaults to localized "End Date".
+		 * @type {string}
+		 * @default "End Date"
+		 */
+		endLabel: { attribute: 'end-label', reflect: true, type: String },
+		/**
+		 * ADVANCED: Indicates if the end calendar dropdown is open
+		 * @type {boolean}
+		 */
+		endOpened: { attribute: 'end-opened', type: Boolean },
+		/**
+		 * Value of the end date input
+		 * @type {string}
+		 */
+		endValue: { attribute: 'end-value', reflect: true, type: String },
+		/**
+		 * Validates on inclusive range (i.e., it is valid for start and end dates to be equal)
+		 * @type {boolean}
+		 */
+		inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date inputs
+		 * @type {string}
+		 */
+		label: { type: String, reflect: true },
+		/**
+		 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
+		/**
+		 * Maximum valid date that could be selected by a user
+		 * @type {string}
+		 */
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
+		 * Minimum valid date that could be selected by a user
+		 * @type {string}
+		 */
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
+		 * Indicates that values are required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: Label for the start date input. Defaults to localized "Start Date".
+		 * @type {string}
+		 * @default "Start Date"
+		 */
+		startLabel: { attribute: 'start-label', reflect: true, type: String },
+		/**
+		 * ADVANCED: Indicates if the start calendar dropdown is open
+		 * @type {boolean}
+		 */
+		startOpened: { attribute: 'start-opened', type: Boolean },
+		/**
+		 * Value of the start date input
+		 * @type {string}
+		 */
+		startValue: { attribute: 'start-value', reflect: true, type: String }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-input-date {
-				display: block;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-input-date {
+			display: block;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date-time-range-to.js
+++ b/components/inputs/input-date-time-range-to.js
@@ -16,83 +16,79 @@ function debounce(func, delay) {
 
 class InputDateTimeRangeTo extends SkeletonMixin(LocalizeCoreElement(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * Force block (stacked) range display if true
-			 * @type {boolean}
-			 */
-			blockDisplay: { attribute: 'block-display', type: Boolean },
-			/**
-			 * Display localized "to" between the left and right slot contents
-			 * @type {boolean}
-			 */
-			displayTo: { attribute: 'display-to', type: Boolean },
-			/**
-			 * Add margin-top for case where there would be a label above the range
-			 * @type {boolean}
-			 */
-			topMargin: { attribute: 'top-margin', type: Boolean },
-			_blockDisplay: { attribute: false, type: Boolean }
-		};
-	}
+	static properties = {
+		/**
+		 * Force block (stacked) range display if true
+		 * @type {boolean}
+		 */
+		blockDisplay: { attribute: 'block-display', type: Boolean },
+		/**
+		 * Display localized "to" between the left and right slot contents
+		 * @type {boolean}
+		 */
+		displayTo: { attribute: 'display-to', type: Boolean },
+		/**
+		 * Add margin-top for case where there would be a label above the range
+		 * @type {boolean}
+		 */
+		topMargin: { attribute: 'top-margin', type: Boolean },
+		_blockDisplay: { attribute: false, type: Boolean }
+	};
 
-	static get styles() {
-		return [ super.styles, bodySmallStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([top-margin]) {
-				margin-top: calc(0.9rem - 7px);
-			}
-			:host(:not([display-to])) .d2l-input-date-time-range-to-to {
-				display: none;
-			}
+	static styles = [super.styles, bodySmallStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([top-margin]) {
+			margin-top: calc(0.9rem - 7px);
+		}
+		:host(:not([display-to])) .d2l-input-date-time-range-to-to {
+			display: none;
+		}
 
-			/* flex case (not wrapped) */
-			.d2l-input-date-time-range-to-container {
-				column-gap: 1.5rem;
-				display: flex;
-				flex-wrap: wrap;
-			}
-			:host([display-to]) div:not(.d2l-input-date-time-range-to-container-block).d2l-input-date-time-range-to-container,
-			:host([display-to]) div:not(.d2l-input-date-time-range-to-container-block).d2l-input-date-time-range-to-container .d2l-input-date-time-range-end-container {
-				column-gap: 0.9rem;
-			}
-			.d2l-input-date-time-range-end-container {
-				display: flex;
-			}
-			.d2l-input-date-time-range-end-container ::slotted(*) {
-				align-self: flex-end;
-			}
+		/* flex case (not wrapped) */
+		.d2l-input-date-time-range-to-container {
+			column-gap: 1.5rem;
+			display: flex;
+			flex-wrap: wrap;
+		}
+		:host([display-to]) div:not(.d2l-input-date-time-range-to-container-block).d2l-input-date-time-range-to-container,
+		:host([display-to]) div:not(.d2l-input-date-time-range-to-container-block).d2l-input-date-time-range-to-container .d2l-input-date-time-range-end-container {
+			column-gap: 0.9rem;
+		}
+		.d2l-input-date-time-range-end-container {
+			display: flex;
+		}
+		.d2l-input-date-time-range-end-container ::slotted(*) {
+			align-self: flex-end;
+		}
 
-			/* block case (wrapped) */
-			.d2l-input-date-time-range-to-container-block.d2l-input-date-time-range-to-container {
-				display: block;
-				margin-bottom: -1.2rem;
-			}
-			.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-start-container {
-				margin-inline: 0;
-				margin-bottom: 1.2rem;
-			}
-			:host([display-to]) .d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-start-container {
-				margin-bottom: 0.6rem;
-			}
-			.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-end-container {
-				display: block;
-				margin-bottom: 1.2rem;
-			}
-			.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-to-to {
-				display: inline-block;
-				margin-bottom: 0.6rem;
-				margin-top: auto;
-				vertical-align: top;
-			}
-		`];
-	}
+		/* block case (wrapped) */
+		.d2l-input-date-time-range-to-container-block.d2l-input-date-time-range-to-container {
+			display: block;
+			margin-bottom: -1.2rem;
+		}
+		.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-start-container {
+			margin-inline: 0;
+			margin-bottom: 1.2rem;
+		}
+		:host([display-to]) .d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-start-container {
+			margin-bottom: 0.6rem;
+		}
+		.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-end-container {
+			display: block;
+			margin-bottom: 1.2rem;
+		}
+		.d2l-input-date-time-range-to-container-block .d2l-input-date-time-range-to-to {
+			display: inline-block;
+			margin-bottom: 0.6rem;
+			margin-top: auto;
+			vertical-align: top;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -67,121 +67,116 @@ export function getShiftedEndDateTime(startValue, endValue, prevStartValue, incl
  */
 class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ADVANCED: Automatically shifts end date when start date changes to keep same range. If start and end date are equal, automatically shifts end time when start time changes.
-			 * @type {boolean}
-			 */
-			autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
-			/**
-			 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
-			 * @type {boolean}
-			 */
-			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
-			/**
-			 * Disables the inputs
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: Label for the end date-time input. Defaults to localized "End Date".
-			 * @type {string}
-			 * @default "End Date"
-			 */
-			endLabel: { attribute: 'end-label', reflect: true, type: String },
-			/**
-			 * ADVANCED: Indicates if the end date or time dropdown is open
-			 * @type {boolean}
-			 */
-			endOpened: { attribute: 'end-opened', type: Boolean },
-			/**
-			 * Value of the end date-time input
-			 * @type {string}
-			 */
-			endValue: { attribute: 'end-value', reflect: true, type: String },
-			/**
-			 * Validates on inclusive range (i.e., it is valid for start and end date-times to be equal)
-			 * @type {boolean}
-			 */
-			inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date-time inputs
-			 * @type {string}
-			 */
-			label: { type: String, reflect: true },
-			/**
-			 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
-			/**
-			 * Indicates that localization will be handled by the consumer. `*value` will not be converted from/to UTC.
-			 * @type {boolean}
-			 */
-			localized: { reflect: true, type: Boolean },
-			/**
-			 * Maximum valid date/time that could be selected by a user
-			 * @type {string}
-			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
-			 * Minimum valid date/time that could be selected by a user
-			 * @type {string}
-			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
-			 * Indicates that values are required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: Label for the start date-time input. Defaults to localized "Start Date".
-			 * @type {string}
-			 * @default "Start Date"
-			 */
-			startLabel: { attribute: 'start-label', reflect: true, type: String },
-			/**
-			 * ADVANCED: Indicates if the start date or time dropdown is open
-			 * @type {boolean}
-			 */
-			startOpened: { attribute: 'start-opened', type: Boolean },
-			/**
-			 * Value of the start date-time input
-			 * @type {string}
-			 */
-			startValue: { attribute: 'start-value', reflect: true, type: String },
-			/**
-			 * Time zone identifier for the time inputs to use.
-			 * @type {string}
-			 */
-			timeZoneId: { attribute: 'time-zone-id', type: String },
-			/**
-			 * Hides the time zone inside the time selection dropdowns. Should only be used when the time input values are not related to any one time zone
-			 * @type {Boolean}
-			 */
-			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
-			_slotOccupied: { type: Boolean }
-		};
-	}
+	static properties = {
+		/**
+		 * ADVANCED: Automatically shifts end date when start date changes to keep same range. If start and end date are equal, automatically shifts end time when start time changes.
+		 * @type {boolean}
+		 */
+		autoShiftDates: { attribute: 'auto-shift-dates', reflect: true, type: Boolean },
+		/**
+		 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
+		 * @type {boolean}
+		 */
+		childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
+		/**
+		 * Disables the inputs
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: Label for the end date-time input. Defaults to localized "End Date".
+		 * @type {string}
+		 * @default "End Date"
+		 */
+		endLabel: { attribute: 'end-label', reflect: true, type: String },
+		/**
+		 * ADVANCED: Indicates if the end date or time dropdown is open
+		 * @type {boolean}
+		 */
+		endOpened: { attribute: 'end-opened', type: Boolean },
+		/**
+		 * Value of the end date-time input
+		 * @type {string}
+		 */
+		endValue: { attribute: 'end-value', reflect: true, type: String },
+		/**
+		 * Validates on inclusive range (i.e., it is valid for start and end date-times to be equal)
+		 * @type {boolean}
+		 */
+		inclusiveDateRange: { attribute: 'inclusive-date-range', reflect: true, type: Boolean },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date-time inputs
+		 * @type {string}
+		 */
+		label: { type: String, reflect: true },
+		/**
+		 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
+		/**
+		 * Indicates that localization will be handled by the consumer. `*value` will not be converted from/to UTC.
+		 * @type {boolean}
+		 */
+		localized: { reflect: true, type: Boolean },
+		/**
+		 * Maximum valid date/time that could be selected by a user
+		 * @type {string}
+		 */
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
+		 * Minimum valid date/time that could be selected by a user
+		 * @type {string}
+		 */
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
+		 * Indicates that values are required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: Label for the start date-time input. Defaults to localized "Start Date".
+		 * @type {string}
+		 * @default "Start Date"
+		 */
+		startLabel: { attribute: 'start-label', reflect: true, type: String },
+		/**
+		 * ADVANCED: Indicates if the start date or time dropdown is open
+		 * @type {boolean}
+		 */
+		startOpened: { attribute: 'start-opened', type: Boolean },
+		/**
+		 * Value of the start date-time input
+		 * @type {string}
+		 */
+		startValue: { attribute: 'start-value', reflect: true, type: String },
+		/**
+		 * Time zone identifier for the time inputs to use.
+		 * @type {string}
+		 */
+		timeZoneId: { attribute: 'time-zone-id', type: String },
+		/**
+		 * Hides the time zone inside the time selection dropdowns. Should only be used when the time input values are not related to any one time zone
+		 * @type {Boolean}
+		 */
+		timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
+		_slotOccupied: { type: Boolean }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-input-date-time {
-				display: block;
-			}
-			::slotted(*) {
-				margin-top: 0.6rem;
-			}
-
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-input-date-time {
+			display: block;
+		}
+		::slotted(*) {
+			margin-top: 0.6rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date-time.js
+++ b/components/inputs/input-date-time.js
@@ -43,85 +43,81 @@ function _getFormattedDefaultTime(defaultValue) {
  */
 class InputDateTime extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean },
-			/**
-			 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
-			 * @type {boolean}
-			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
-			/**
-			 * Indicates that localization will be handled by the consumer. `*value` will not be converted from/to UTC.
-			 * @type {boolean}
-			 */
-			localized: { reflect: true, type: Boolean },
-			/**
-			 * Maximum valid date/time that could be selected by a user
-			 * @type {string}
-			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
-			 * Minimum valid date/time that could be selected by a user
-			 * @type {string}
-			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
-			 * Indicates if the date or time dropdown is open
-			 * @type {boolean}
-			 */
-			opened: { type: Boolean },
-			/**
-			 * Indicates that a value is required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true },
-			/**
-			 * Default value of time input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
-			 * @type {string}
-			 */
-			timeDefaultValue: { attribute: 'time-default-value', reflect: true, type: String },
-			/**
-			 * Time zone identifier for the time input to use.
-			 * @type {string}
-			 */
-			timeZoneId: { type: String, attribute: 'time-zone-id' },
-			/**
-			 * Hides the time zone inside the time selection dropdown. Should only be used when the time input value is not related to any one time zone
-			 * @type {Boolean}
-			 */
-			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
-			/**
-			 * Value of the input
-			 * @type {string}
-			 */
-			value: { type: String },
-			_maxValueLocalized: { type: String },
-			_minValueLocalized: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean },
+		/**
+		 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
+		 * @type {boolean}
+		 */
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
+		/**
+		 * Indicates that localization will be handled by the consumer. `*value` will not be converted from/to UTC.
+		 * @type {boolean}
+		 */
+		localized: { reflect: true, type: Boolean },
+		/**
+		 * Maximum valid date/time that could be selected by a user
+		 * @type {string}
+		 */
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
+		 * Minimum valid date/time that could be selected by a user
+		 * @type {string}
+		 */
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
+		 * Indicates if the date or time dropdown is open
+		 * @type {boolean}
+		 */
+		opened: { type: Boolean },
+		/**
+		 * Indicates that a value is required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true },
+		/**
+		 * Default value of time input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
+		 * @type {string}
+		 */
+		timeDefaultValue: { attribute: 'time-default-value', reflect: true, type: String },
+		/**
+		 * Time zone identifier for the time input to use.
+		 * @type {string}
+		 */
+		timeZoneId: { type: String, attribute: 'time-zone-id' },
+		/**
+		 * Hides the time zone inside the time selection dropdown. Should only be used when the time input value is not related to any one time zone
+		 * @type {Boolean}
+		 */
+		timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
+		/**
+		 * Value of the input
+		 * @type {string}
+		 */
+		value: { type: String },
+		_maxValueLocalized: { type: String },
+		_minValueLocalized: { type: String }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-input-date-time-container {
-				margin-top: -0.3rem;
-			}
-			d2l-input-date,
-			d2l-input-time {
-				margin-top: 0.3rem;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-input-date-time-container {
+			margin-top: -0.3rem;
+		}
+		d2l-input-date,
+		d2l-input-time {
+			margin-top: 0.3rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-date.js
+++ b/components/inputs/input-date.js
@@ -30,111 +30,107 @@ export function formatISODateInUserCalDescriptor(val) {
  */
 class InputDate extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean },
-			/**
-			 * @ignore
-			 * Optionally add a 'Now' button to be used in date-time pickers only.
-			 */
-			hasNow: { attribute: 'has-now', type: Boolean },
-			/**
-			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
-			 * Maximum valid date that could be selected by a user
-			 * @type {string}
-			 */
-			maxValue: { attribute: 'max-value', reflect: true, type: String },
-			/**
-			 * Minimum valid date that could be selected by a user
-			 * @type {string}
-			 */
-			minValue: { attribute: 'min-value', reflect: true, type: String },
-			/**
-			 * @ignore
-			 * Disables validation of max and min value. The min and max value will still be enforced but the component will not be put into an error state or show an error tooltip.
-			 */
-			noValidateMinMax: { attribute: 'novalidateminmax', type: Boolean },
-			/**
-			 * Indicates if the calendar dropdown is open
-			 * @type {boolean}
-			 */
-			opened: { type: Boolean, reflect: true },
-			/**
-			 * Indicates that a value is required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true },
-			/**
-			 * Value of the input
-			 * @type {string}
-			 */
-			value: { type: String },
-			_hiddenContentWidth: { type: String },
-			_dateTimeDescriptor: { type: Object },
-			_dropdownFirstOpened: { type: Boolean },
-			_formattedValue: { type: String },
-			_inputTextFocusShowTooltip: { type: Boolean },
-			_showInfoTooltip: { type: Boolean },
-			_shownValue: { type: String },
-			_showRevertInstructions: { state: true },
-			_showRevertTooltip: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean },
+		/**
+		 * @ignore
+		 * Optionally add a 'Now' button to be used in date-time pickers only.
+		 */
+		hasNow: { attribute: 'has-now', type: Boolean },
+		/**
+		 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
+		 * Maximum valid date that could be selected by a user
+		 * @type {string}
+		 */
+		maxValue: { attribute: 'max-value', reflect: true, type: String },
+		/**
+		 * Minimum valid date that could be selected by a user
+		 * @type {string}
+		 */
+		minValue: { attribute: 'min-value', reflect: true, type: String },
+		/**
+		 * @ignore
+		 * Disables validation of max and min value. The min and max value will still be enforced but the component will not be put into an error state or show an error tooltip.
+		 */
+		noValidateMinMax: { attribute: 'novalidateminmax', type: Boolean },
+		/**
+		 * Indicates if the calendar dropdown is open
+		 * @type {boolean}
+		 */
+		opened: { type: Boolean, reflect: true },
+		/**
+		 * Indicates that a value is required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true },
+		/**
+		 * Value of the input
+		 * @type {string}
+		 */
+		value: { type: String },
+		_hiddenContentWidth: { type: String },
+		_dateTimeDescriptor: { type: Object },
+		_dropdownFirstOpened: { type: Boolean },
+		_formattedValue: { type: String },
+		_inputTextFocusShowTooltip: { type: Boolean },
+		_showInfoTooltip: { type: Boolean },
+		_shownValue: { type: String },
+		_showRevertInstructions: { state: true },
+		_showRevertTooltip: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-				width: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-dropdown {
-				width: 100%;
-			}
-			d2l-icon {
-				--d2l-icon-height: 0.8rem;
-				--d2l-icon-width: 0.8rem;
-				margin-left: 0.6rem;
-				margin-right: 0.6rem;
-			}
-			:host([disabled]) d2l-icon {
-				opacity: 0.5;
-			}
-			.d2l-input-date-hidden-text {
-				font-family: inherit;
-				font-size: 0.8rem;
-				font-weight: 400;
-				letter-spacing: 0.02rem;
-				line-height: 1.4rem;
-				position: absolute;
-				visibility: hidden;
-				width: auto;
-			}
-			.d2l-input-date-hidden-text > div {
-				padding-left: 2rem; /* simulates space taken up by the icon */
-			}
-			d2l-calendar {
-				padding: 0.25rem 0.6rem;
-			}
-			.d2l-calendar-slot-buttons {
-				border-top: 1px solid var(--d2l-color-gypsum);
-				display: flex;
-				justify-content: center;
-				margin-top: 0.3rem;
-				padding-top: 0.3rem;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-dropdown {
+			width: 100%;
+		}
+		d2l-icon {
+			--d2l-icon-height: 0.8rem;
+			--d2l-icon-width: 0.8rem;
+			margin-left: 0.6rem;
+			margin-right: 0.6rem;
+		}
+		:host([disabled]) d2l-icon {
+			opacity: 0.5;
+		}
+		.d2l-input-date-hidden-text {
+			font-family: inherit;
+			font-size: 0.8rem;
+			font-weight: 400;
+			letter-spacing: 0.02rem;
+			line-height: 1.4rem;
+			position: absolute;
+			visibility: hidden;
+			width: auto;
+		}
+		.d2l-input-date-hidden-text > div {
+			padding-left: 2rem; /* simulates space taken up by the icon */
+		}
+		d2l-calendar {
+			padding: 0.25rem 0.6rem;
+		}
+		.d2l-calendar-slot-buttons {
+			border-top: 1px solid var(--d2l-color-gypsum);
+			display: flex;
+			justify-content: center;
+			margin-top: 0.3rem;
+			padding-top: 0.3rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-fieldset.js
+++ b/components/inputs/input-fieldset.js
@@ -16,50 +16,44 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  */
 class InputFieldset extends PropertyRequiredMixin(InputInlineHelpMixin(SkeletonMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: Label for the fieldset
-			 * @type {string}
-			 */
-			label: { type: String, required: true },
-			/**
-			 * Hides the label visually
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
-			/**
-			 * Style of the fieldset label
-			 * @type {'default'|'heading'}
-			 */
-			labelStyle: { type: String, attribute: 'label-style', reflect: true },
-			/**
-			 * Indicates that a value is required for inputs in the fieldset
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: Label for the fieldset
+		 * @type {string}
+		 */
+		label: { type: String, required: true },
+		/**
+		 * Hides the label visually
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden', reflect: true },
+		/**
+		 * Style of the fieldset label
+		 * @type {'default'|'heading'}
+		 */
+		labelStyle: { type: String, attribute: 'label-style', reflect: true },
+		/**
+		 * Indicates that a value is required for inputs in the fieldset
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return [ super.styles, heading4Styles, inputLabelStyles, offscreenStyles,
-			css`
-				:host {
-					display: block;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([label-style="heading"]:not([label-hidden])) {
-					margin-block-start: 0.3rem;
-				}
-				legend.d2l-heading-4 {
-					margin-block: 0 0.6rem;
-					padding: 0;
-				}
-			`
-		];
-	}
+	static styles = [super.styles, heading4Styles, inputLabelStyles, offscreenStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([label-style="heading"]:not([label-hidden])) {
+			margin-block-start: 0.3rem;
+		}
+		legend.d2l-heading-4 {
+			margin-block: 0 0.6rem;
+			padding: 0;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-group.js
+++ b/components/inputs/input-group.js
@@ -6,18 +6,16 @@ import { css, html, LitElement } from 'lit';
  */
 class InputGroup extends LitElement {
 
-	static get styles() {
-		return css`
-			:host {
-				display: flex;
-				flex-direction: column;
-				gap: 0.9rem;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: flex;
+			flex-direction: column;
+			gap: 0.9rem;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	render() {
 		return html`<slot></slot>`;

--- a/components/inputs/input-inline-help.js
+++ b/components/inputs/input-inline-help.js
@@ -14,14 +14,12 @@ export const inlineHelpStyles = [
 
 export const InputInlineHelpMixin = superclass => class extends SkeletonMixin(superclass) {
 
-	static get properties() {
-		return {
-			_hasInlineHelp: { type: Boolean, reflect: true, attribute: '_has-inline-help' }
-		};
-	}
+	static properties = {
+		_hasInlineHelp: { type: Boolean, reflect: true, attribute: '_has-inline-help' }
+	};
 
 	static get styles() {
-		const styles = [ inlineHelpStyles, css`
+		const styles = [inlineHelpStyles, css`
 			:host([_has-inline-help]) .d2l-input-inline-help {
 				display: block;
 			}

--- a/components/inputs/input-number.js
+++ b/components/inputs/input-number.js
@@ -80,124 +80,118 @@ function roundPrecisely(val, maxFractionDigits) {
  */
 class InputNumber extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * Specifies which types of values [can be autofilled](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) by the browser.
-			 * @type {string}
-			 */
-			autocomplete: { type: String },
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean },
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean },
-			/**
-			 * ADVANCED: Hide the alert icon when input is invalid
-			 * @type {boolean}
-			 */
-			hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
-			/**
-			 * Restricts the maximum width of the input box without restricting the width of the label
-			 * @type {string}
-			 */
-			inputWidth: { attribute: 'input-width', type: String },
-			/**
-			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
-			 * Maximum value allowed
-			 * @type {number}
-			 */
-			max: { type: Number },
-			/**
-			 * Indicates whether the max value is exclusive
-			 * @type {boolean}
-			 */
-			maxExclusive: { type: Boolean, attribute: 'max-exclusive' },
-			/**
-			 * Maximum number of digits allowed after the decimal place. Must be between 0 and 20 and greater than or equal to `minFractionDigits`. Default is Greater of `minFractionDigits` or `3`.
-			 * @type {number}
-			 */
-			maxFractionDigits: { type: Number, attribute: 'max-fraction-digits' },
-			/**
-			 * Minimum value allowed
-			 * @type {number}
-			 */
-			min: { type: Number },
-			/**
-			 * Indicates whether the min value is exclusive
-			 * @type {boolean}
-			 */
-			minExclusive: { type: Boolean, attribute: 'min-exclusive' },
-			/**
-			 * Minimum number of digits allowed after the decimal place. Must be between 0 and 20 and less than or equal to `maxFractionDigits`. Default is `0`.
-			 * @type {number}
-			 */
-			minFractionDigits: { type: Number, attribute: 'min-fraction-digits' },
-			/**
-			 * Indicates that a value is required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean },
-			/**
-			 * @ignore
-			 */
-			trailingZeroes: { type: Boolean, attribute: 'trailing-zeroes' },
-			/**
-			 * Unit associated with the input value, displayed next to input and announced as part of the label
-			 * @type {string}
-			 */
-			unit: { type: String },
-			/**
-			 * ACCESSIBILITY: Label for the unit, which is only picked up by screenreaders. Required if `unit` is used.
-			 * @type {string}
-			 */
-			unitLabel: { attribute: 'unit-label', type: String },
-			/**
-			 * Value of the input
-			 * @type {number}
-			 */
-			value: { type: Number, converter: numberConverter },
-			/**
-			 * Alignment of the value text within the input
-			 * @type {'start'|'end'}
-			 */
-			valueAlign: { attribute: 'value-align', type: String },
-			/**
-			 * @ignore
-			 */
-			valueTrailingZeroes: { type: String, attribute: 'value-trailing-zeroes' },
-			_afterSlotWidth: { state: true },
-			_hintType: { state: true },
-			_formattedValue: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Specifies which types of values [can be autofilled](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) by the browser.
+		 * @type {string}
+		 */
+		autocomplete: { type: String },
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean },
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean },
+		/**
+		 * ADVANCED: Hide the alert icon when input is invalid
+		 * @type {boolean}
+		 */
+		hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
+		/**
+		 * Restricts the maximum width of the input box without restricting the width of the label
+		 * @type {string}
+		 */
+		inputWidth: { attribute: 'input-width', type: String },
+		/**
+		 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
+		 * Maximum value allowed
+		 * @type {number}
+		 */
+		max: { type: Number },
+		/**
+		 * Indicates whether the max value is exclusive
+		 * @type {boolean}
+		 */
+		maxExclusive: { type: Boolean, attribute: 'max-exclusive' },
+		/**
+		 * Maximum number of digits allowed after the decimal place. Must be between 0 and 20 and greater than or equal to `minFractionDigits`. Default is Greater of `minFractionDigits` or `3`.
+		 * @type {number}
+		 */
+		maxFractionDigits: { type: Number, attribute: 'max-fraction-digits' },
+		/**
+		 * Minimum value allowed
+		 * @type {number}
+		 */
+		min: { type: Number },
+		/**
+		 * Indicates whether the min value is exclusive
+		 * @type {boolean}
+		 */
+		minExclusive: { type: Boolean, attribute: 'min-exclusive' },
+		/**
+		 * Minimum number of digits allowed after the decimal place. Must be between 0 and 20 and less than or equal to `maxFractionDigits`. Default is `0`.
+		 * @type {number}
+		 */
+		minFractionDigits: { type: Number, attribute: 'min-fraction-digits' },
+		/**
+		 * Indicates that a value is required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean },
+		/**
+		 * @ignore
+		 */
+		trailingZeroes: { type: Boolean, attribute: 'trailing-zeroes' },
+		/**
+		 * Unit associated with the input value, displayed next to input and announced as part of the label
+		 * @type {string}
+		 */
+		unit: { type: String },
+		/**
+		 * ACCESSIBILITY: Label for the unit, which is only picked up by screenreaders. Required if `unit` is used.
+		 * @type {string}
+		 */
+		unitLabel: { attribute: 'unit-label', type: String },
+		/**
+		 * Value of the input
+		 * @type {number}
+		 */
+		value: { type: Number, converter: numberConverter },
+		/**
+		 * Alignment of the value text within the input
+		 * @type {'start'|'end'}
+		 */
+		valueAlign: { attribute: 'value-align', type: String },
+		/**
+		 * @ignore
+		 */
+		valueTrailingZeroes: { type: String, attribute: 'value-trailing-zeroes' },
+		_afterSlotWidth: { state: true },
+		_hintType: { state: true },
+		_formattedValue: { state: true }
+	};
 
-	static get styles() {
-		return [ super.styles,
-			css`
-				:host {
-					display: inline-block;
-					position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				d2l-input-text:not([skeleton]) {
-					width: auto;
-				}
-			`
-		];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+			position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-input-text:not([skeleton]) {
+			width: auto;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-percent.js
+++ b/components/inputs/input-percent.js
@@ -15,65 +15,59 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  */
 class InputPercent extends FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean },
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean },
-			/**
-			 * Restricts the maximum width of the input box without restricting the width of the label.
-			 * @type {string}
-			 */
-			inputWidth: { attribute: 'input-width', type: String },
-			/**
-			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
-			 * Maximum number of decimal values to show (rounds value up or down).
-			 * @type {number}
-			 */
-			maxFractionDigits: { type: Number, attribute: 'max-fraction-digits' },
-			/**
-			 * Minimum number of decimal values to show.
-			 * @type {number}
-			 */
-			minFractionDigits: { type: Number, attribute: 'min-fraction-digits' },
-			/**
-			 * Indicates that a value is required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean },
-			/**
-			 * Value of the input
-			 * @type {number}
-			 */
-			value: { type: Number }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean },
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean },
+		/**
+		 * Restricts the maximum width of the input box without restricting the width of the label.
+		 * @type {string}
+		 */
+		inputWidth: { attribute: 'input-width', type: String },
+		/**
+		 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
+		 * Maximum number of decimal values to show (rounds value up or down).
+		 * @type {number}
+		 */
+		maxFractionDigits: { type: Number, attribute: 'max-fraction-digits' },
+		/**
+		 * Minimum number of decimal values to show.
+		 * @type {number}
+		 */
+		minFractionDigits: { type: Number, attribute: 'min-fraction-digits' },
+		/**
+		 * Indicates that a value is required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean },
+		/**
+		 * Value of the input
+		 * @type {number}
+		 */
+		value: { type: Number }
+	};
 
-	static get styles() {
-		return [ super.styles,
-			css`
-				:host {
-					display: inline-block;
-					position: relative;
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-			`
-		];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+			position: relative;
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-radio-group.js
+++ b/components/inputs/input-radio-group.js
@@ -13,57 +13,53 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
  */
 class InputRadioGroup extends PropertyRequiredMixin(SkeletonMixin(FormElementMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			/**
-			 * Display the radio buttons horizontally
-			 * @type {boolean}
-			 */
-			horizontal: { type: Boolean, reflect: true },
-			/**
-			 * REQUIRED: Label for the group of radio inputs
-			 * @type {string}
-			 */
-			label: { required: true, type: String },
-			/**
-			 * Hides the label visually
-			 * @type {boolean}
-			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
-			/**
-			 * Indicates that a value is required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Display the radio buttons horizontally
+		 * @type {boolean}
+		 */
+		horizontal: { type: Boolean, reflect: true },
+		/**
+		 * REQUIRED: Label for the group of radio inputs
+		 * @type {string}
+		 */
+		label: { required: true, type: String },
+		/**
+		 * Hides the label visually
+		 * @type {boolean}
+		 */
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
+		/**
+		 * Indicates that a value is required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true }
+	};
 
-	static get styles() {
-		return [super.styles, inputLabelStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			div[role="radiogroup"] {
-				display: flex;
-				flex-direction: column;
-				gap: 0.6rem;
-			}
-			:host([horizontal]) div[role="radiogroup"] {
-				flex-direction: row;
-				flex-wrap: wrap;
-			}
+	static styles = [super.styles, inputLabelStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		div[role="radiogroup"] {
+			display: flex;
+			flex-direction: column;
+			gap: 0.6rem;
+		}
+		:host([horizontal]) div[role="radiogroup"] {
+			flex-direction: row;
+			flex-wrap: wrap;
+		}
 
-			.d2l-input-label[hidden] {
-				display: none;
-			}
-			::slotted(:not(d2l-input-radio)) {
-				display: none;
-			}
-		`];
-	}
+		.d2l-input-label[hidden] {
+			display: none;
+		}
+		::slotted(:not(d2l-input-radio)) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-radio-spacer.js
+++ b/components/inputs/input-radio-spacer.js
@@ -6,19 +6,17 @@ import { css, html, LitElement } from 'lit';
  */
 class InputRadioSpacer extends LitElement {
 
-	static get styles() {
-		return css`
-				:host {
-					box-sizing: border-box;
-					display: block;
-					margin-bottom: 0.9rem;
-					padding-inline-start: 1.7rem;
-				}
-				:host(.d2l-input-inline-help) {
-					margin-bottom: 0.9rem !important;
-				}
-			`;
-	}
+	static styles = css`
+		:host {
+			box-sizing: border-box;
+			display: block;
+			margin-bottom: 0.9rem;
+			padding-inline-start: 1.7rem;
+		}
+		:host(.d2l-input-inline-help) {
+			margin-bottom: 0.9rem !important;
+		}
+	`;
 
 	render() {
 		return html`<slot></slot>`;

--- a/components/inputs/input-radio.js
+++ b/components/inputs/input-radio.js
@@ -18,73 +18,69 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class InputRadio extends InputInlineHelpMixin(SkeletonMixin(FocusMixin(PropertyRequiredMixin(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
-			 * Checked state
-			 * @type {boolean}
-			 */
-			checked: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
-			 * @type {string}
-			 */
-			description: { type: String },
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Tooltip text displayed when the input is disabled
-			 * @type {string}
-			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			/**
-			 * REQUIRED: Label for the input
-			 * @type {string}
-			 */
-			label: { required: true, type: String },
-			/**
-			 * Hides the supporting slot when unchecked
-			 * @type {boolean}
-			 */
-			supportingHiddenWhenUnchecked: { type: Boolean, attribute: 'supporting-hidden-when-unchecked', reflect: true },
-			/**
-			 * Value of the input
-			 * @type {string}
-			 */
-			value: { type: String },
-			_checked: { state: true },
-			_focusable: { state: true },
-			_hasSupporting: { state: true },
-			_horizontal: { state: true },
-			_isHovered: { state: true },
-			_invalid: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Checked state
+		 * @type {boolean}
+		 */
+		checked: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
+		 * @type {string}
+		 */
+		description: { type: String },
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Tooltip text displayed when the input is disabled
+		 * @type {string}
+		 */
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		/**
+		 * REQUIRED: Label for the input
+		 * @type {string}
+		 */
+		label: { required: true, type: String },
+		/**
+		 * Hides the supporting slot when unchecked
+		 * @type {boolean}
+		 */
+		supportingHiddenWhenUnchecked: { type: Boolean, attribute: 'supporting-hidden-when-unchecked', reflect: true },
+		/**
+		 * Value of the input
+		 * @type {string}
+		 */
+		value: { type: String },
+		_checked: { state: true },
+		_focusable: { state: true },
+		_hasSupporting: { state: true },
+		_horizontal: { state: true },
+		_isHovered: { state: true },
+		_invalid: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, radioStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-input-radio-label {
-				cursor: default;
-				margin-block-end: 0;
-			}
-			.d2l-input-inline-help,
-			.d2l-input-radio-supporting {
-				margin-inline-start: 1.7rem;
-			}
-			.d2l-input-radio-supporting {
-				margin-block-start: 0.6rem;
-			}
-		`];
-	}
+	static styles = [super.styles, radioStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-input-radio-label {
+			cursor: default;
+			margin-block-end: 0;
+		}
+		.d2l-input-inline-help,
+		.d2l-input-radio-supporting {
+			margin-inline-start: 1.7rem;
+		}
+		.d2l-input-radio-supporting {
+			margin-block-start: 0.6rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-search.js
+++ b/components/inputs/input-search.js
@@ -17,74 +17,69 @@ export const SUPPRESS_ENTER_TIMEOUT_MS = 1000;
  */
 class InputSearch extends FocusMixin(LocalizeCoreElement(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
-			 * @type {string}
-			 */
-			description: { type: String, reflect: true },
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Acts as the primary label for the input. Not visible.
-			 * @type {string}
-			 */
-			label: { type: String },
-			/**
-			 * @ignore
-			 */
-			lastSearchValue: { type: String, attribute: false },
-			/**
-			 * Imposes an upper character limit
-			 * @type {number}
-			 */
-			maxlength: { type: Number },
-			/**
-			 * Prevents the "clear" button from appearing
-			 * @type {boolean}
-			 */
-			noClear: { type: Boolean, attribute: 'no-clear' },
-			/**
-			 * Placeholder text (default: "Search...")
-			 * @type {string}
-			 */
-			placeholder: { type: String },
-			/**
-			 * Dispatch search events after each input event
-			 * @type {boolean}
-			 */
-			searchOnInput: { type: Boolean, attribute: 'search-on-input' },
-			/**
-			 * Value of the input
-			 * @type {string}
-			 */
-			value: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * ACCESSIBILITY: Additional information communicated to screenreader users when focusing on the input
+		 * @type {string}
+		 */
+		description: { type: String, reflect: true },
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Acts as the primary label for the input. Not visible.
+		 * @type {string}
+		 */
+		label: { type: String },
+		/**
+		 * @ignore
+		 */
+		lastSearchValue: { type: String, attribute: false },
+		/**
+		 * Imposes an upper character limit
+		 * @type {number}
+		 */
+		maxlength: { type: Number },
+		/**
+		 * Prevents the "clear" button from appearing
+		 * @type {boolean}
+		 */
+		noClear: { type: Boolean, attribute: 'no-clear' },
+		/**
+		 * Placeholder text (default: "Search...")
+		 * @type {string}
+		 */
+		placeholder: { type: String },
+		/**
+		 * Dispatch search events after each input event
+		 * @type {boolean}
+		 */
+		searchOnInput: { type: Boolean, attribute: 'search-on-input' },
+		/**
+		 * Value of the input
+		 * @type {string}
+		 */
+		value: { type: String }
+	};
 
-	static get styles() {
-		return [inputStyles, css`
-				:host {
-					display: inline-block;
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				d2l-button-icon {
-					--d2l-button-icon-min-height: 1.5rem;
-					--d2l-button-icon-min-width: 1.5rem;
-					--d2l-button-icon-border-radius: 4px;
-					--d2l-focus-ring-offset: 1px;
-					margin-inline: 0.3rem;
-				}
-			`
-		];
-	}
+	static styles = [inputStyles, css`
+		:host {
+			display: inline-block;
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-button-icon {
+			--d2l-button-icon-min-height: 1.5rem;
+			--d2l-button-icon-min-width: 1.5rem;
+			--d2l-button-icon-border-radius: 4px;
+			--d2l-focus-ring-offset: 1px;
+			margin-inline: 0.3rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -29,258 +29,252 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class InputText extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(RtlMixin(LitElement))))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ADVANCED: Indicates that the input has a popup menu
-			 * @type {string}
-			 */
-			ariaHaspopup: { type: String, attribute: 'aria-haspopup' },
-			/**
-			 * ADVANCED: Indicates that the input value is invalid
-			 * @type {string}
-			 */
-			ariaInvalid: { type: String, attribute: 'aria-invalid' },
-			/**
-			 * ADVANCED: Specifies which types of values can be autofilled by the browser
-			 * @type {string}
-			 */
-			autocomplete: { type: String },
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			autofocus: { type: Boolean },
-			/**
-			 * Additional information communicated in the aria-describedby on the input
-			 * @type {string}
-			 */
-			description: { type: String, reflect: true },
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * ADVANCED: Hide the alert icon when input is invalid
-			 * @type {boolean}
-			 */
-			hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
-			/**
-			 * ADVANCED: Hide the tooltip when input is invalid
-			 * @type {boolean}
-			 */
-			hideInvalidTooltip: { attribute: 'hide-invalid-tooltip', type: Boolean, reflect: true },
-			/**
-			 * Restricts the maximum width of the input box without restricting the width of the label.
-			 * @type {string}
-			 */
-			inputWidth: { attribute: 'input-width', type: String },
-			/**
-			 * ADVANCED: Additional information relating to how to use the component
-			 * @type {string}
-			 */
-			instructions: { type: String, attribute: 'instructions' },
-			/**
-			 * Hides the label visually (moves it to the input's "aria-label" attribute)
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
-			 * For number inputs, maximum value
-			 * @type {string}
-			 */
-			max: { type: String },
-			/**
-			 * Imposes an upper character limit
-			 * @type {number}
-			 */
-			maxlength: { type: Number },
-			/**
-			 * For number inputs, minimum value
-			 * @type {string}
-			 */
-			min: { type: String },
-			/**
-			 * Imposes a lower character limit
-			 * @type {number}
-			 */
-			minlength: { type: Number },
-			/**
-			 * ADVANCED: Regular expression pattern to validate the value
-			 * @type {string}
-			 */
-			pattern: { type: String },
-			/**
-			 * ADVANCED: Text to display when input fails validation against the pattern.  If a list of characters is included in the message, use `LocalizeMixin`'s `localizeCharacter`.
-			 */
-			patternFailureText: { type: String, attribute: 'pattern-failure-text' },
-			/**
-			 * @ignore
-			 */
-			placeholder: { type: String },
-			/**
-			 * Prevents pressing ENTER from submitting forms
-			 * @type {boolean}
-			 */
-			preventSubmit: { type: Boolean, attribute: 'prevent-submit' },
-			/**
-			 * ADVANCED: Makes the input read-only
-			 * @type {boolean}
-			 */
-			readonly: { type: Boolean },
-			/**
-			 * Indicates that a value is required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true },
-			/**
-			 * Size of the input
-			 * @type {number}
-			 */
-			size: { type: Number },
-			/**
-			 * ADVANCED: For number inputs, sets the step size
-			 * @type {number}
-			 */
-			step: { type: Number },
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			title: { type: String },
-			/**
-			 * The type of the text input
-			 * @type {'text'|'email'|'number'|'password'|'search'|'tel'|'url'}
-			 */
-			type: { type: String },
-			/**
-			 * Unit associated with the input value, displayed next to input and announced as part of the label
-			 * @type {string}
-			 */
-			unit: { type: String },
-			/**
-			 * Accessible label for the unit which will not be visually rendered
-			 * @type {string}
-			 */
-			unitLabel: {
-				attribute: 'unit-label',
-				required: {
-					dependentProps: ['unit'],
-					message: (_value, elem) => `<d2l-input-text>: missing required attribute "unit-label" for unit "${elem.unit}"`,
-					validator: (_value, elem, hasValue) => {
-						const hasUnit = (typeof elem.unit === 'string') && elem.unit.length > 0;
-						return !(hasUnit && elem.unit !== '%' && !hasValue);
-					}
-				},
-				type: String
+	static properties = {
+		/**
+		 * ADVANCED: Indicates that the input has a popup menu
+		 * @type {string}
+		 */
+		ariaHaspopup: { type: String, attribute: 'aria-haspopup' },
+		/**
+		 * ADVANCED: Indicates that the input value is invalid
+		 * @type {string}
+		 */
+		ariaInvalid: { type: String, attribute: 'aria-invalid' },
+		/**
+		 * ADVANCED: Specifies which types of values can be autofilled by the browser
+		 * @type {string}
+		 */
+		autocomplete: { type: String },
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		autofocus: { type: Boolean },
+		/**
+		 * Additional information communicated in the aria-describedby on the input
+		 * @type {string}
+		 */
+		description: { type: String, reflect: true },
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * ADVANCED: Hide the alert icon when input is invalid
+		 * @type {boolean}
+		 */
+		hideInvalidIcon: { attribute: 'hide-invalid-icon', type: Boolean, reflect: true },
+		/**
+		 * ADVANCED: Hide the tooltip when input is invalid
+		 * @type {boolean}
+		 */
+		hideInvalidTooltip: { attribute: 'hide-invalid-tooltip', type: Boolean, reflect: true },
+		/**
+		 * Restricts the maximum width of the input box without restricting the width of the label.
+		 * @type {string}
+		 */
+		inputWidth: { attribute: 'input-width', type: String },
+		/**
+		 * ADVANCED: Additional information relating to how to use the component
+		 * @type {string}
+		 */
+		instructions: { type: String, attribute: 'instructions' },
+		/**
+		 * Hides the label visually (moves it to the input's "aria-label" attribute)
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
+		 * For number inputs, maximum value
+		 * @type {string}
+		 */
+		max: { type: String },
+		/**
+		 * Imposes an upper character limit
+		 * @type {number}
+		 */
+		maxlength: { type: Number },
+		/**
+		 * For number inputs, minimum value
+		 * @type {string}
+		 */
+		min: { type: String },
+		/**
+		 * Imposes a lower character limit
+		 * @type {number}
+		 */
+		minlength: { type: Number },
+		/**
+		 * ADVANCED: Regular expression pattern to validate the value
+		 * @type {string}
+		 */
+		pattern: { type: String },
+		/**
+		 * ADVANCED: Text to display when input fails validation against the pattern.  If a list of characters is included in the message, use `LocalizeMixin`'s `localizeCharacter`.
+		 */
+		patternFailureText: { type: String, attribute: 'pattern-failure-text' },
+		/**
+		 * @ignore
+		 */
+		placeholder: { type: String },
+		/**
+		 * Prevents pressing ENTER from submitting forms
+		 * @type {boolean}
+		 */
+		preventSubmit: { type: Boolean, attribute: 'prevent-submit' },
+		/**
+		 * ADVANCED: Makes the input read-only
+		 * @type {boolean}
+		 */
+		readonly: { type: Boolean },
+		/**
+		 * Indicates that a value is required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true },
+		/**
+		 * Size of the input
+		 * @type {number}
+		 */
+		size: { type: Number },
+		/**
+		 * ADVANCED: For number inputs, sets the step size
+		 * @type {number}
+		 */
+		step: { type: Number },
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		title: { type: String },
+		/**
+		 * The type of the text input
+		 * @type {'text'|'email'|'number'|'password'|'search'|'tel'|'url'}
+		 */
+		type: { type: String },
+		/**
+		 * Unit associated with the input value, displayed next to input and announced as part of the label
+		 * @type {string}
+		 */
+		unit: { type: String },
+		/**
+		 * Accessible label for the unit which will not be visually rendered
+		 * @type {string}
+		 */
+		unitLabel: {
+			attribute: 'unit-label',
+			required: {
+				dependentProps: ['unit'],
+				message: (_value, elem) => `<d2l-input-text>: missing required attribute "unit-label" for unit "${elem.unit}"`,
+				validator: (_value, elem, hasValue) => {
+					const hasUnit = (typeof elem.unit === 'string') && elem.unit.length > 0;
+					return !(hasUnit && elem.unit !== '%' && !hasValue);
+				}
 			},
-			/**
-			 * Value of the input
-			 * @type {string}
-			 */
-			value: { type: String },
-			/**
-			 * ADVANCED: Alignment of the value text within the input
-			 * @type {'start'|'end'}
-			 */
-			valueAlign: { attribute: 'value-align', type: String },
-			_firstSlotWidth: { type: Number },
-			_hasAfterContent: { type: Boolean, attribute: false },
-			_focused: { type: Boolean },
-			_hovered: { type: Boolean },
-			_lastSlotWidth: { type: Number }
-		};
-	}
+			type: String
+		},
+		/**
+		 * Value of the input
+		 * @type {string}
+		 */
+		value: { type: String },
+		/**
+		 * ADVANCED: Alignment of the value text within the input
+		 * @type {'start'|'end'}
+		 */
+		valueAlign: { attribute: 'value-align', type: String },
+		_firstSlotWidth: { type: Number },
+		_hasAfterContent: { type: Boolean, attribute: false },
+		_focused: { type: Boolean },
+		_hovered: { type: Boolean },
+		_lastSlotWidth: { type: Number }
+	};
 
-	static get styles() {
-		return [ super.styles, inputStyles, inputLabelStyles, offscreenStyles,
-			css`
-				:host {
-					display: inline-block;
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([value-align="end"]) {
-					--d2l-input-text-align: end;
-				}
-				.d2l-input-label {
-					display: inline-block;
-					vertical-align: bottom;
-				}
-				:host(:not([skeleton])) .d2l-input-label {
-					margin: 0;
-					padding-block: 0 0.4rem;
-					padding-inline: 0;
-				}
-				:host(:not([skeleton]):not([input-width])) .d2l-input-label {
-					width: 100%;
-				}
-				.d2l-input-container {
-					display: flex;
-				}
-				.d2l-input-text-container {
-					flex: 1 1 auto;
-					position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
-				}
-				.d2l-input {
-					-webkit-appearance: textfield;
-					appearance: textfield;
-					overflow: hidden;
-					text-overflow: ellipsis;
-					white-space: nowrap;
-				}
-				#after-slot {
-					display: inline-block;
-					flex: 0 0 auto;
-				}
-				.d2l-input-inside-before, .d2l-input-inside-after {
-					align-items: center;
-					display: flex;
-					position: absolute;
-					top: 50%;
-					transform: translateY(-50%);
-				}
-				.d2l-input-inside-before {
-					left: 0;
-				}
-				.d2l-input-inside-after {
-					right: 0;
-				}
-				.d2l-input-unit {
-					color: var(--d2l-theme-text-color-static-faint);
-					font-size: 0.7rem;
-					margin-top: 0.05rem;
-				}
-				.d2l-input-inside-before .d2l-input-unit {
-					margin-left: 12px;
-					margin-right: 6px;
-				}
-				.d2l-input-inside-after .d2l-input-unit {
-					display: inline-block;
-					margin-left: 6px;
-					margin-right: 12px;
-				}
-				:host([disabled]) .d2l-input-unit {
-					opacity: var(--d2l-theme-opacity-disabled-control);
-				}
-				.d2l-input-text-invalid-icon {
-					background-image: var(--d2l-input-invalid-image);
-					background-position: center center;
-					background-repeat: no-repeat;
-					background-size: 0.8rem 0.8rem;
-					display: flex;
-					height: 22px;
-					position: absolute;
-					top: 50%;
-					transform: translateY(-50%);
-					width: 22px;
-				}
-			`
-		];
-	}
+	static styles = [super.styles, inputStyles, inputLabelStyles, offscreenStyles, css`
+		:host {
+			display: inline-block;
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([value-align="end"]) {
+			--d2l-input-text-align: end;
+		}
+		.d2l-input-label {
+			display: inline-block;
+			vertical-align: bottom;
+		}
+		:host(:not([skeleton])) .d2l-input-label {
+			margin: 0;
+			padding-block: 0 0.4rem;
+			padding-inline: 0;
+		}
+		:host(:not([skeleton]):not([input-width])) .d2l-input-label {
+			width: 100%;
+		}
+		.d2l-input-container {
+			display: flex;
+		}
+		.d2l-input-text-container {
+			flex: 1 1 auto;
+			position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */
+		}
+		.d2l-input {
+			-webkit-appearance: textfield;
+			appearance: textfield;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+		#after-slot {
+			display: inline-block;
+			flex: 0 0 auto;
+		}
+		.d2l-input-inside-before, .d2l-input-inside-after {
+			align-items: center;
+			display: flex;
+			position: absolute;
+			top: 50%;
+			transform: translateY(-50%);
+		}
+		.d2l-input-inside-before {
+			left: 0;
+		}
+		.d2l-input-inside-after {
+			right: 0;
+		}
+		.d2l-input-unit {
+			color: var(--d2l-theme-text-color-static-faint);
+			font-size: 0.7rem;
+			margin-top: 0.05rem;
+		}
+		.d2l-input-inside-before .d2l-input-unit {
+			margin-left: 12px;
+			margin-right: 6px;
+		}
+		.d2l-input-inside-after .d2l-input-unit {
+			display: inline-block;
+			margin-left: 6px;
+			margin-right: 12px;
+		}
+		:host([disabled]) .d2l-input-unit {
+			opacity: var(--d2l-theme-opacity-disabled-control);
+		}
+		.d2l-input-text-invalid-icon {
+			background-image: var(--d2l-input-invalid-image);
+			background-position: center center;
+			background-repeat: no-repeat;
+			background-size: 0.8rem 0.8rem;
+			display: flex;
+			height: 22px;
+			position: absolute;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 22px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-textarea.js
+++ b/components/inputs/input-textarea.js
@@ -22,139 +22,135 @@ import { styleMap } from 'lit/directives/style-map.js';
  */
 class InputTextArea extends InputInlineHelpMixin(FocusMixin(LabelledMixin(FormElementMixin(SkeletonMixin(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ADVANCED: Indicates that the input value is invalid
-			 * @type {string}
-			 */
-			ariaInvalid: { type: String, attribute: 'aria-invalid' },
-			/**
-			 * Additional information communicated in the aria-describedby on the input
-			 * @type {string}
-			 */
-			description: { type: String, reflect: true },
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Restricts the maximum width of the input box without restricting the width of the label.
-			 * @type {string}
-			 */
-			inputWidth: { attribute: 'input-width', type: String },
-			/**
-			 * Hides the label visually (moves it to the input's "aria-label" attribute)
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
-			 * Imposes an upper character limit
-			 * @type {number}
-			 */
-			maxlength: { type: Number },
-			/**
-			 * Maximum number of rows before scrolling
-			 * @type {number}
-			 */
-			maxRows: { type: Number, attribute: 'max-rows' },
-			/**
-			 * Imposes a lower character limit
-			 * @type {number}
-			 */
-			minlength: { type: Number },
-			/**
-			 * Hides the border
-			 * @type {boolean}
-			 */
-			noBorder: { type: Boolean, attribute: 'no-border' },
-			/**
-			 * Removes default left/right padding
-			 * @type {boolean}
-			 */
-			noPadding: { type: Boolean, attribute: 'no-padding' },
-			/**
-			 * @ignore
-			 */
-			placeholder: { type: String },
-			/**
-			 * Indicates that a value is required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true },
-			/**
-			 * Minimum number of rows
-			 * @type {number}
-			 */
-			rows: { type: Number },
-			/**
-			 * Value of the input
-			 * @type {string}
-			 */
-			value: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * ADVANCED: Indicates that the input value is invalid
+		 * @type {string}
+		 */
+		ariaInvalid: { type: String, attribute: 'aria-invalid' },
+		/**
+		 * Additional information communicated in the aria-describedby on the input
+		 * @type {string}
+		 */
+		description: { type: String, reflect: true },
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Restricts the maximum width of the input box without restricting the width of the label.
+		 * @type {string}
+		 */
+		inputWidth: { attribute: 'input-width', type: String },
+		/**
+		 * Hides the label visually (moves it to the input's "aria-label" attribute)
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
+		 * Imposes an upper character limit
+		 * @type {number}
+		 */
+		maxlength: { type: Number },
+		/**
+		 * Maximum number of rows before scrolling
+		 * @type {number}
+		 */
+		maxRows: { type: Number, attribute: 'max-rows' },
+		/**
+		 * Imposes a lower character limit
+		 * @type {number}
+		 */
+		minlength: { type: Number },
+		/**
+		 * Hides the border
+		 * @type {boolean}
+		 */
+		noBorder: { type: Boolean, attribute: 'no-border' },
+		/**
+		 * Removes default left/right padding
+		 * @type {boolean}
+		 */
+		noPadding: { type: Boolean, attribute: 'no-padding' },
+		/**
+		 * @ignore
+		 */
+		placeholder: { type: String },
+		/**
+		 * Indicates that a value is required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true },
+		/**
+		 * Minimum number of rows
+		 * @type {number}
+		 */
+		rows: { type: Number },
+		/**
+		 * Value of the input
+		 * @type {string}
+		 */
+		value: { type: String }
+	};
 
-	static get styles() {
-		return [ super.styles, inputStyles, inputLabelStyles, offscreenStyles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-input-label {
-				display: inline-block;
-				vertical-align: bottom;
-			}
-			:host(:not([skeleton])) .d2l-input-label {
-				margin: 0;
-				padding-block: 0 0.4rem;
-				padding-inline: 0;
-			}
-			:host(:not([skeleton]):not([input-width])) .d2l-input-label {
-				width: 100%;
-			}
-			.d2l-input-textarea-container {
-				height: 100%;
-				max-width: 100%;
-				position: relative;
-			}
-			textarea.d2l-input {
-				height: 100%;
-				left: 0;
-				line-height: 1rem;
-				position: absolute;
-				resize: none;
-				top: 0;
-			}
-			:host([no-border]) textarea.d2l-input {
-				border-color: transparent;
-				box-shadow: none;
-			}
-			/* mirror dimensions must match textarea - match border + padding */
-			.d2l-input-textarea-mirror {
-				line-height: 1rem;
-				overflow: hidden;
-				overflow-wrap: anywhere; /* prevent width from growing */
-				padding-bottom: 0.5rem;
-				padding-top: 0.5rem;
-				visibility: hidden;
-			}
-			:host([no-padding]) .d2l-input {
-				padding-inline: 0;
-			}
-			:host([no-border][no-padding]) textarea.d2l-input:hover,
-			:host([no-border][no-padding]) textarea.d2l-input:focus {
-				border-left-width: 1px;
-				border-right-width: 1px;
-			}
-			.d2l-input-textarea-mirror[aria-invalid="true"] {
-				padding-inline-end: calc(18px + 0.8rem);
-			}
-		`];
-	}
+	static styles = [super.styles, inputStyles, inputLabelStyles, offscreenStyles, css`
+		:host {
+			display: block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-input-label {
+			display: inline-block;
+			vertical-align: bottom;
+		}
+		:host(:not([skeleton])) .d2l-input-label {
+			margin: 0;
+			padding-block: 0 0.4rem;
+			padding-inline: 0;
+		}
+		:host(:not([skeleton]):not([input-width])) .d2l-input-label {
+			width: 100%;
+		}
+		.d2l-input-textarea-container {
+			height: 100%;
+			max-width: 100%;
+			position: relative;
+		}
+		textarea.d2l-input {
+			height: 100%;
+			left: 0;
+			line-height: 1rem;
+			position: absolute;
+			resize: none;
+			top: 0;
+		}
+		:host([no-border]) textarea.d2l-input {
+			border-color: transparent;
+			box-shadow: none;
+		}
+		/* mirror dimensions must match textarea - match border + padding */
+		.d2l-input-textarea-mirror {
+			line-height: 1rem;
+			overflow: hidden;
+			overflow-wrap: anywhere; /* prevent width from growing */
+			padding-bottom: 0.5rem;
+			padding-top: 0.5rem;
+			visibility: hidden;
+		}
+		:host([no-padding]) .d2l-input {
+			padding-inline: 0;
+		}
+		:host([no-border][no-padding]) textarea.d2l-input:hover,
+		:host([no-border][no-padding]) textarea.d2l-input:focus {
+			border-left-width: 1px;
+			border-right-width: 1px;
+		}
+		.d2l-input-textarea-mirror[aria-invalid="true"] {
+			padding-inline-end: calc(18px + 0.8rem);
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-time-range.js
+++ b/components/inputs/input-time-range.js
@@ -41,111 +41,107 @@ function getValidISOTimeAtInterval(val, timeInterval) {
 
 class InputTimeRange extends FocusMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement)))) {
 
-	static get properties() {
-		return {
-			/**
-			 * ADVANCED: Automatically shifts end time when start time changes to keep same range
-			 * @type {boolean}
-			 */
-			autoShiftTimes: { attribute: 'auto-shift-times', reflect: true, type: Boolean },
-			/**
-			 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
-			 * @type {boolean}
-			 */
-			childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
-			/**
-			 * Disables the inputs
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: Label for the end time input. Defaults to localized "End Time".
-			 * @type {string}
-			 * @default "End Time"
-			 */
-			endLabel: { attribute: 'end-label', reflect: true, type: String },
-			/**
-			 * ADVANCED: Indicates if the end dropdown is open
-			 * @type {boolean}
-			 */
-			endOpened: { attribute: 'end-opened', type: Boolean },
-			/**
-			 * Value of the end time input
-			 * @type {string}
-			 */
-			endValue: { attribute: 'end-value', reflect: true, type: String },
-			/**
-			 * Rounds typed input up to nearest valid interval time (specified with "time-interval")
-			 * @type {boolean}
-			 */
-			enforceTimeIntervals: { attribute: 'enforce-time-intervals', reflect: true, type: Boolean },
-			/**
-			 * Validates on inclusive range (i.e., it is valid for start and end times to be equal)
-			 * @type {boolean}
-			 */
-			inclusiveTimeRange: { attribute: 'inclusive-time-range', reflect: true, type: Boolean },
-			/**
-			 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the time inputs
-			 * @type {string}
-			 */
-			label: { type: String, reflect: true },
-			/**
-			 * Hides the fieldset label visually.  Hidden labels are still read by screen readers so make sure to set an appropriate label.
-			 * @type {boolean}
-			 */
-			labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
-			/**
-			 * Indicates that values are required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true },
-			/**
-			 * ACCESSIBILITY: Label for the start time input. Defaults to localized "Start Time".
-			 * @type {string}
-			 * @default "Start Time"
-			 */
-			startLabel: { attribute: 'start-label', reflect: true, type: String },
-			/**
-			 * ADVANCED: Indicates if the start dropdown is open
-			 * @type {boolean}
-			 */
-			startOpened: { attribute: 'start-opened', type: Boolean },
-			/**
-			 * Value of the start time input
-			 * @type {string}
-			 */
-			startValue: { attribute: 'start-value', reflect: true, type: String },
-			/**
-			 * Number of minutes between times shown in dropdown menu
-			 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
-			 */
-			timeInterval: { attribute: 'time-interval', reflect: true, type: String },
-			/**
-			 * Time zone identifier for the inputs to use.
-			 * @type {string}
-			 */
-			timeZoneId: { type: String },
-			/**
-			 * Hides the time zone inside the selection dropdowns. Should only be used when the input values are not related to any one time zone
-			 * @type {Boolean}
-			 */
-			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
-		};
-	}
+	static properties = {
+		/**
+		 * ADVANCED: Automatically shifts end time when start time changes to keep same range
+		 * @type {boolean}
+		 */
+		autoShiftTimes: { attribute: 'auto-shift-times', reflect: true, type: Boolean },
+		/**
+		 * Hides the start and end labels visually. Hidden labels are still read by screen readers so make sure to set appropriate start and end labels.
+		 * @type {boolean}
+		 */
+		childLabelsHidden: { attribute: 'child-labels-hidden', reflect: true, type: Boolean },
+		/**
+		 * Disables the inputs
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: Label for the end time input. Defaults to localized "End Time".
+		 * @type {string}
+		 * @default "End Time"
+		 */
+		endLabel: { attribute: 'end-label', reflect: true, type: String },
+		/**
+		 * ADVANCED: Indicates if the end dropdown is open
+		 * @type {boolean}
+		 */
+		endOpened: { attribute: 'end-opened', type: Boolean },
+		/**
+		 * Value of the end time input
+		 * @type {string}
+		 */
+		endValue: { attribute: 'end-value', reflect: true, type: String },
+		/**
+		 * Rounds typed input up to nearest valid interval time (specified with "time-interval")
+		 * @type {boolean}
+		 */
+		enforceTimeIntervals: { attribute: 'enforce-time-intervals', reflect: true, type: Boolean },
+		/**
+		 * Validates on inclusive range (i.e., it is valid for start and end times to be equal)
+		 * @type {boolean}
+		 */
+		inclusiveTimeRange: { attribute: 'inclusive-time-range', reflect: true, type: Boolean },
+		/**
+		 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the time inputs
+		 * @type {string}
+		 */
+		label: { type: String, reflect: true },
+		/**
+		 * Hides the fieldset label visually.  Hidden labels are still read by screen readers so make sure to set an appropriate label.
+		 * @type {boolean}
+		 */
+		labelHidden: { attribute: 'label-hidden', reflect: true, type: Boolean },
+		/**
+		 * Indicates that values are required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true },
+		/**
+		 * ACCESSIBILITY: Label for the start time input. Defaults to localized "Start Time".
+		 * @type {string}
+		 * @default "Start Time"
+		 */
+		startLabel: { attribute: 'start-label', reflect: true, type: String },
+		/**
+		 * ADVANCED: Indicates if the start dropdown is open
+		 * @type {boolean}
+		 */
+		startOpened: { attribute: 'start-opened', type: Boolean },
+		/**
+		 * Value of the start time input
+		 * @type {string}
+		 */
+		startValue: { attribute: 'start-value', reflect: true, type: String },
+		/**
+		 * Number of minutes between times shown in dropdown menu
+		 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
+		 */
+		timeInterval: { attribute: 'time-interval', reflect: true, type: String },
+		/**
+		 * Time zone identifier for the inputs to use.
+		 * @type {string}
+		 */
+		timeZoneId: { type: String },
+		/**
+		 * Hides the time zone inside the selection dropdowns. Should only be used when the input values are not related to any one time zone
+		 * @type {Boolean}
+		 */
+		timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			d2l-input-time {
-				display: block;
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-input-time {
+			display: block;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/inputs/input-time.js
+++ b/components/inputs/input-time.js
@@ -126,120 +126,114 @@ function initIntervals(size, enforceTimeIntervals) {
  */
 class InputTime extends InputInlineHelpMixin(FocusMixin(LabelledMixin(SkeletonMixin(FormElementMixin(LitElement))))) {
 
-	static get properties() {
-		return {
-			/**
-			 * Default value of input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
-			 * @type {string}
-			 */
-			defaultValue: { type: String, attribute: 'default-value' },
-			/**
-			 * Disables the input
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean },
-			/**
-			 * Rounds typed input up to nearest valid interval time (specified with "time-interval")
-			 * @type {boolean}
-			 */
-			enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
-			/**
-			 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
-			 * @type {boolean}
-			 */
-			labelHidden: { type: Boolean, attribute: 'label-hidden' },
-			/**
-			 * Overrides max-height of the time dropdown menu
-			 * @type {number}
-			 */
-			maxHeight: { type: Number, attribute: 'max-height' },
-			/**
-			 * Indicates if the dropdown is open
-			 * @type {boolean}
-			 */
-			opened: { type: Boolean },
-			/**
-			 * Indicates that a value is required
-			 * @type {boolean}
-			 */
-			required: { type: Boolean, reflect: true },
-			/**
-			 * Number of minutes between times shown in dropdown menu
-			 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
-			 */
-			timeInterval: { type: String, attribute: 'time-interval' },
-			/**
-			 * Time zone identifier for the input to use. e.g. America/Toronto. Defaults to the user's account or device time zone setting.
-			 * @type {string}
-			 */
-			timeZoneId: { type: String, attribute: 'time-zone-id' },
-			/**
-			 * Hides the time zone inside the selection dropdown. Should only be used when the input value is not related to any one time zone
-			 * @type {Boolean}
-			 */
-			timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
-			/**
-			 * Value of the input
-			 * @type {string}
-			 */
-			value: { type: String },
-			_dropdownFirstOpened: { type: Boolean },
-			_formattedValue: { type: String },
-			_hiddenContentWidth: { type: String },
-			_timeZone: { state: true },
-		};
-	}
+	static properties = {
+		/**
+		 * Default value of input. Accepts times formatted as "hh:mm:ss", and the keywords "startOfDay" and "endOfDay".
+		 * @type {string}
+		 */
+		defaultValue: { type: String, attribute: 'default-value' },
+		/**
+		 * Disables the input
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean },
+		/**
+		 * Rounds typed input up to nearest valid interval time (specified with "time-interval")
+		 * @type {boolean}
+		 */
+		enforceTimeIntervals: { type: Boolean, attribute: 'enforce-time-intervals' },
+		/**
+		 * Hides the label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
+		 * @type {boolean}
+		 */
+		labelHidden: { type: Boolean, attribute: 'label-hidden' },
+		/**
+		 * Overrides max-height of the time dropdown menu
+		 * @type {number}
+		 */
+		maxHeight: { type: Number, attribute: 'max-height' },
+		/**
+		 * Indicates if the dropdown is open
+		 * @type {boolean}
+		 */
+		opened: { type: Boolean },
+		/**
+		 * Indicates that a value is required
+		 * @type {boolean}
+		 */
+		required: { type: Boolean, reflect: true },
+		/**
+		 * Number of minutes between times shown in dropdown menu
+		 * @type {'five'|'ten'|'fifteen'|'twenty'|'thirty'|'sixty'}
+		 */
+		timeInterval: { type: String, attribute: 'time-interval' },
+		/**
+		 * Time zone identifier for the input to use. e.g. America/Toronto. Defaults to the user's account or device time zone setting.
+		 * @type {string}
+		 */
+		timeZoneId: { type: String, attribute: 'time-zone-id' },
+		/**
+		 * Hides the time zone inside the selection dropdown. Should only be used when the input value is not related to any one time zone
+		 * @type {Boolean}
+		 */
+		timeZoneHidden: { type: Boolean, attribute: 'time-zone-hidden' },
+		/**
+		 * Value of the input
+		 * @type {string}
+		 */
+		value: { type: String },
+		_dropdownFirstOpened: { type: Boolean },
+		_formattedValue: { type: String },
+		_hiddenContentWidth: { type: String },
+		_timeZone: { state: true },
+	};
 
-	static get styles() {
-		return [
-			super.styles,
-			bodySmallStyles,
-			inputLabelStyles,
-			inputStyles,
-			offscreenStyles,
-			css`
-				:host {
-					display: inline-block;
-					max-width: 6rem;
-					width: 100%;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				d2l-dropdown-menu[data-mobile][mobile-tray] .d2l-input-time-menu {
-					text-align: center;
-				}
-				.d2l-input-label {
-					display: inline-block;
-					vertical-align: top;
-				}
-				.d2l-input-time-time-zone {
-					line-height: 1.8rem;
-					text-align: center;
-					vertical-align: middle;
-					width: auto;
-				}
-				.d2l-input-time-time-zone.d2l-input-time-time-zone-custom {
-					align-items: center;
-					column-gap: 0.3rem;
-					display: flex;
-					font-weight: 700;
-					justify-content: center;
-				}
+	static styles = [
+		super.styles,
+		bodySmallStyles,
+		inputLabelStyles,
+		inputStyles,
+		offscreenStyles, css`
+		:host {
+			display: inline-block;
+			max-width: 6rem;
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		d2l-dropdown-menu[data-mobile][mobile-tray] .d2l-input-time-menu {
+			text-align: center;
+		}
+		.d2l-input-label {
+			display: inline-block;
+			vertical-align: top;
+		}
+		.d2l-input-time-time-zone {
+			line-height: 1.8rem;
+			text-align: center;
+			vertical-align: middle;
+			width: auto;
+		}
+		.d2l-input-time-time-zone.d2l-input-time-time-zone-custom {
+			align-items: center;
+			column-gap: 0.3rem;
+			display: flex;
+			font-weight: 700;
+			justify-content: center;
+		}
 
-				.d2l-input-time-hidden-content {
-					font-family: inherit;
-					font-size: 0.8rem;
-					font-weight: 400;
-					letter-spacing: 0.02rem;
-					line-height: 1.4rem;
-					position: absolute;
-					visibility: hidden;
-					width: auto;
-				}
-			`
-		];
-	}
+		.d2l-input-time-hidden-content {
+			font-family: inherit;
+			font-size: 0.8rem;
+			font-weight: 400;
+			letter-spacing: 0.02rem;
+			line-height: 1.4rem;
+			position: absolute;
+			visibility: hidden;
+			width: auto;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/link/link-mixin.js
+++ b/components/link/link-mixin.js
@@ -7,50 +7,46 @@ import { offscreenStyles } from '../offscreen/offscreen.js';
 
 export const LinkMixin = superclass => class extends LocalizeCoreElement(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Prompts the user to save the linked URL instead of navigating to it.
-			 * Must be to a resource on the same origin.
-			 * Can be used with or without a value, when set the value becomes the filename.
-			 * @type {string}
-			 */
-			download: { type: String },
-			/**
-			 * REQUIRED: URL or URL fragment of the link
-			 * @type {string}
-			 */
-			href: { type: String },
-			/**
-			 * Where to display the linked URL
-			 * @type {string}
-			 */
-			target: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Prompts the user to save the linked URL instead of navigating to it.
+		 * Must be to a resource on the same origin.
+		 * Can be used with or without a value, when set the value becomes the filename.
+		 * @type {string}
+		 */
+		download: { type: String },
+		/**
+		 * REQUIRED: URL or URL fragment of the link
+		 * @type {string}
+		 */
+		href: { type: String },
+		/**
+		 * Where to display the linked URL
+		 * @type {string}
+		 */
+		target: { type: String }
+	};
 
-	static get styles() {
-		return [offscreenStyles, css`
-			#new-window {
-				line-height: 0;
-				white-space: nowrap;
-			}
+	static styles = [offscreenStyles, css`
+		#new-window {
+			line-height: 0;
+			white-space: nowrap;
+		}
+		d2l-icon {
+			color: inherit;
+			height: calc(1em - 1px);
+			margin-inline-start: 0.315em;
+			transform: translateY(0.1em);
+			vertical-align: inherit;
+			width: calc(1em - 1px);
+		}
+
+		@media print {
 			d2l-icon {
-				color: inherit;
-				height: calc(1em - 1px);
-				margin-inline-start: 0.315em;
-				transform: translateY(0.1em);
-				vertical-align: inherit;
-				width: calc(1em - 1px);
+				display: none;
 			}
-
-			@media print {
-				d2l-icon {
-					display: none;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	getNewWindowDescription(label) {
 		return label && this.target === '_blank' ? this.localize('components.link.open-in-new-window') : undefined;

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -20,129 +20,123 @@ export const linkStyles = _generateLinkStyles('.d2l-link', true);
  */
 class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * ACCESSIBILITY: Label to provide more context for screen reader users when the link text is not enough
-			 * @type {string}
-			 */
-			ariaLabel: { type: String, attribute: 'aria-label' },
-			/**
-			 * Disables the link
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Tooltip text when disabled
-			 * @type {string}
-			 */
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip', reflect: true },
-			/**
-			 * Download a URL instead of navigating to it
-			 * @type {boolean}
-			 */
-			download: { type: Boolean },
-			/**
-			 * REQUIRED: URL or URL fragment of the link
-			 * @type {string}
-			 */
-			href: { type: String },
-			/**
-			 * Whether to apply the "main" link style
-			 * @type {boolean}
-			 */
-			main: { type: Boolean, reflect: true },
-			/**
-			 * The number of lines to display before truncating text with an ellipsis. The text will not be truncated unless a value is specified.
-			 * @type {number}
-			 */
-			lines: { type: Number },
-			/**
-			 * Whether to apply the "small" link style
-			 * @type {boolean}
-			 */
-			small: { type: Boolean, reflect: true },
-			/**
-			 * Where to display the linked URL
-			 * @type {string}
-			 */
-			target: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * ACCESSIBILITY: Label to provide more context for screen reader users when the link text is not enough
+		 * @type {string}
+		 */
+		ariaLabel: { type: String, attribute: 'aria-label' },
+		/**
+		 * Disables the link
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Tooltip text when disabled
+		 * @type {string}
+		 */
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip', reflect: true },
+		/**
+		 * Download a URL instead of navigating to it
+		 * @type {boolean}
+		 */
+		download: { type: Boolean },
+		/**
+		 * REQUIRED: URL or URL fragment of the link
+		 * @type {string}
+		 */
+		href: { type: String },
+		/**
+		 * Whether to apply the "main" link style
+		 * @type {boolean}
+		 */
+		main: { type: Boolean, reflect: true },
+		/**
+		 * The number of lines to display before truncating text with an ellipsis. The text will not be truncated unless a value is specified.
+		 * @type {number}
+		 */
+		lines: { type: Number },
+		/**
+		 * Whether to apply the "small" link style
+		 * @type {boolean}
+		 */
+		small: { type: Boolean, reflect: true },
+		/**
+		 * Where to display the linked URL
+		 * @type {string}
+		 */
+		target: { type: String }
+	};
 
-	static get styles() {
-		return [ linkStyles, offscreenStyles,
-			css`
-				:host {
-					display: inline;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				:host([small]) {
-					/* needed to keep host element same height as link */
-					font-size: 0.7rem;
-					line-height: 1.05rem;
-				}
-				:host([lines]) {
-					min-width: 0;
-				}
-				a {
-					display: inherit;
-				}
-				:host([lines]) a {
-					align-items: baseline;
-					display: flex;
-				}
-				a span.truncate {
-					${getOverflowDeclarations({ lines: 1 })}
-				}
-				a span.truncate-one {
-					${overflowEllipsisDeclarations}
-				}
-				#new-window {
-					line-height: 0;
-					white-space: nowrap;
-				}
-				d2l-icon {
-					color: var(--d2l-theme-text-color-interactive-default);
-					height: calc(1em - 1px);
-					margin-inline-start: 0.315em;
-					transform: translateY(0.1em);
-					vertical-align: inherit;
-					width: calc(1em - 1px);
-				}
+	static styles = [linkStyles, offscreenStyles, css`
+		:host {
+			display: inline;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([small]) {
+			/* needed to keep host element same height as link */
+			font-size: 0.7rem;
+			line-height: 1.05rem;
+		}
+		:host([lines]) {
+			min-width: 0;
+		}
+		a {
+			display: inherit;
+		}
+		:host([lines]) a {
+			align-items: baseline;
+			display: flex;
+		}
+		a span.truncate {
+			${getOverflowDeclarations({ lines: 1 })}
+		}
+		a span.truncate-one {
+			${overflowEllipsisDeclarations}
+		}
+		#new-window {
+			line-height: 0;
+			white-space: nowrap;
+		}
+		d2l-icon {
+			color: var(--d2l-theme-text-color-interactive-default);
+			height: calc(1em - 1px);
+			margin-inline-start: 0.315em;
+			transform: translateY(0.1em);
+			vertical-align: inherit;
+			width: calc(1em - 1px);
+		}
 
-				a:hover d2l-icon {
-					--d2l-icon-fill-color: var(--d2l-theme-text-color-interactive-hover);
-				}
+		a:hover d2l-icon {
+			--d2l-icon-fill-color: var(--d2l-theme-text-color-interactive-hover);
+		}
 
-				:host([disabled]:not([disabled-tooltip])) a:hover {
-					color: var(--d2l-theme-text-color-interactive-default);
-					text-decoration: none;
-				}
-				:host([disabled]:not([disabled-tooltip])) a:hover d2l-icon {
-					--d2l-icon-fill-color: var(--d2l-theme-text-color-interactive-default);
-				}
-				a[aria-disabled="true"],
-				a[aria-disabled="true"]:active {
-					cursor: default;
-				}
-				a[aria-disabled="true"] .d2l-link-content {
-					opacity: var(--d2l-theme-opacity-disabled-link);
-				}
-				a[aria-disabled="true"] d2l-icon {
-					opacity: var(--d2l-theme-opacity-disabled-linkicon);
-				}
+		:host([disabled]:not([disabled-tooltip])) a:hover {
+			color: var(--d2l-theme-text-color-interactive-default);
+			text-decoration: none;
+		}
+		:host([disabled]:not([disabled-tooltip])) a:hover d2l-icon {
+			--d2l-icon-fill-color: var(--d2l-theme-text-color-interactive-default);
+		}
+		a[aria-disabled="true"],
+		a[aria-disabled="true"]:active {
+			cursor: default;
+		}
+		a[aria-disabled="true"] .d2l-link-content {
+			opacity: var(--d2l-theme-opacity-disabled-link);
+		}
+		a[aria-disabled="true"] d2l-icon {
+			opacity: var(--d2l-theme-opacity-disabled-linkicon);
+		}
 
-				@media print {
-					d2l-icon {
-						display: none;
-					}
-				}
-			`
-		];
-	}
+		@media print {
+			d2l-icon {
+				display: none;
+			}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/list/list-controls.js
+++ b/components/list/list-controls.js
@@ -7,36 +7,32 @@ import { SelectionControls } from '../selection/selection-controls.js';
  * Controls for list components containing select-all, etc.
  */
 export class ListControls extends SelectionControls {
-	static get properties() {
-		return {
-			_extendSeparator: { state: true },
-			_siblingHasColor: { state: true }
-		};
-	}
+	static properties = {
+		_extendSeparator: { state: true },
+		_siblingHasColor: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, css`
-			:host {
-				--d2l-selection-controls-background-color: var(--d2l-list-controls-background-color);
-				--d2l-selection-controls-offset: -12px;
-				--d2l-selection-controls-padding: var(--d2l-list-controls-padding, 18px);
-				z-index: 6; /* must be greater than d2l-list-item-active-border */
-			}
-			:host([no-sticky]) {
-				z-index: auto;
-			}
-			.d2l-list-controls-color {
-				padding-inline-start: 1.8rem;
-			}
-			.d2l-list-controls-extend-separator {
-				--d2l-selection-controls-offset: 0;
-				padding: 0 0.9rem;
-			}
-			.d2l-list-controls-color.d2l-list-controls-extend-separator {
-				padding-inline-start: calc(0.6rem + 9px);
-			}
-		`];
-	}
+	static styles = [super.styles, css`
+		:host {
+			--d2l-selection-controls-background-color: var(--d2l-list-controls-background-color);
+			--d2l-selection-controls-offset: -12px;
+			--d2l-selection-controls-padding: var(--d2l-list-controls-padding, 18px);
+			z-index: 6; /* must be greater than d2l-list-item-active-border */
+		}
+		:host([no-sticky]) {
+			z-index: auto;
+		}
+		.d2l-list-controls-color {
+			padding-inline-start: 1.8rem;
+		}
+		.d2l-list-controls-extend-separator {
+			--d2l-selection-controls-offset: 0;
+			padding: 0 0.9rem;
+		}
+		.d2l-list-controls-color.d2l-list-controls-extend-separator {
+			padding-inline-start: calc(0.6rem + 9px);
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/list/list-item-button-mixin.js
+++ b/components/list/list-item-button-mixin.js
@@ -5,20 +5,18 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 export const ListItemButtonMixin = superclass => class extends ListItemMixin(superclass) {
-	static get properties() {
-		return {
-			/**
-			 * Disables the primary action button
-			 * @type {boolean}
-			 */
-			buttonDisabled : { type: Boolean, attribute: 'button-disabled', reflect: true },
-			_ariaCurrent: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the primary action button
+		 * @type {boolean}
+		 */
+		buttonDisabled : { type: Boolean, attribute: 'button-disabled', reflect: true },
+		_ariaCurrent: { type: String }
+	};
 
 	static get styles() {
 
-		const styles = [ css`
+		const styles = [css`
 			:host(:not([button-disabled])) {
 				--d2l-list-item-content-text-color: var(--d2l-color-celestine);
 			}
@@ -49,7 +47,7 @@ export const ListItemButtonMixin = superclass => class extends ListItemMixin(sup
 			:host(:not([button-disabled])) [slot="outside-control-action"] {
 				grid-column-end: control-end;
 			}
-		` ];
+		`];
 
 		super.styles && styles.unshift(super.styles);
 		return styles;

--- a/components/list/list-item-checkbox-mixin.js
+++ b/components/list/list-item-checkbox-mixin.js
@@ -8,44 +8,42 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * **Selection:** Disables selection
-			 * @type {boolean}
-			 */
-			selectionDisabled: { type: Boolean, attribute: 'selection-disabled', reflect: true },
-			/**
-			 * **Selection:** Tooltip text when selection is disabled
-			 * @type {string}
-			 */
-			selectionDisabledTooltip: { type: String, attribute: 'selection-disabled-tooltip' },
-			/**
-			 * **Selection:** Value to identify item if selectable
-			 * @type {string}
-			 */
-			key: { type: String, reflect: true },
-			/**
-			 * **Selection:** Indicates an input should be rendered for selecting the item
-			 * @type {boolean}
-			 */
-			selectable: { type: Boolean },
-			/**
-			 * **Selection:** Whether the item is selected
-			 * @type {boolean}
-			 */
-			selected: { type: Boolean, reflect: true },
-			/**
-			 * Private. The selection info (set by the selection component).
-			 * @ignore
-			 */
-			selectionInfo: { type: Object, attribute: false },
-			_hoveringSelection: { type: Boolean, attribute: '_hovering-selection', reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * **Selection:** Disables selection
+		 * @type {boolean}
+		 */
+		selectionDisabled: { type: Boolean, attribute: 'selection-disabled', reflect: true },
+		/**
+		 * **Selection:** Tooltip text when selection is disabled
+		 * @type {string}
+		 */
+		selectionDisabledTooltip: { type: String, attribute: 'selection-disabled-tooltip' },
+		/**
+		 * **Selection:** Value to identify item if selectable
+		 * @type {string}
+		 */
+		key: { type: String, reflect: true },
+		/**
+		 * **Selection:** Indicates an input should be rendered for selecting the item
+		 * @type {boolean}
+		 */
+		selectable: { type: Boolean },
+		/**
+		 * **Selection:** Whether the item is selected
+		 * @type {boolean}
+		 */
+		selected: { type: Boolean, reflect: true },
+		/**
+		 * Private. The selection info (set by the selection component).
+		 * @ignore
+		 */
+		selectionInfo: { type: Object, attribute: false },
+		_hoveringSelection: { type: Boolean, attribute: '_hovering-selection', reflect: true }
+	};
 
 	static get styles() {
-		const styles = [ css`
+		const styles = [css`
 			.d2l-checkbox-action {
 				cursor: pointer;
 				display: block;
@@ -61,7 +59,7 @@ export const ListItemCheckboxMixin = superclass => class extends SkeletonMixin(s
 			:host([layout="tile"]) .bump-inline {
 				margin-inline-start: 2rem !important;
 			}
-		` ];
+		`];
 
 		super.styles && styles.unshift(super.styles);
 		return styles;

--- a/components/list/list-item-content.js
+++ b/components/list/list-item-content.js
@@ -10,41 +10,39 @@ import { css, html, LitElement } from 'lit';
  */
 class ListItemContent extends LitElement {
 
-	static get styles() {
-		return [ bodySmallStyles, bodyCompactStyles, css`
-			:host {
-				min-width: 0;
-			}
+	static styles = [bodySmallStyles, bodyCompactStyles, css`
+		:host {
+			min-width: 0;
+		}
 
-			.d2l-list-item-content-text {
-				margin: 0;
-			}
+		.d2l-list-item-content-text {
+			margin: 0;
+		}
 
-			.d2l-list-item-content-text > div {
-				border-radius: var(--d2l-list-item-content-text-border-radius);
-				color: var(--d2l-list-item-content-text-color);
-				display: block; /* multi-line clamping won't work inside of inline-block in Safari - the compromise is the outline is full width */
-				max-width: 100%;
-				outline: var(--d2l-list-item-content-text-outline, none);
-				outline-offset: var(--d2l-list-item-content-text-outline-offset);
-				overflow-wrap: anywhere;
-				text-decoration: var(--d2l-list-item-content-text-decoration, none);
-			}
+		.d2l-list-item-content-text > div {
+			border-radius: var(--d2l-list-item-content-text-border-radius);
+			color: var(--d2l-list-item-content-text-color);
+			display: block; /* multi-line clamping won't work inside of inline-block in Safari - the compromise is the outline is full width */
+			max-width: 100%;
+			outline: var(--d2l-list-item-content-text-outline, none);
+			outline-offset: var(--d2l-list-item-content-text-outline-offset);
+			overflow-wrap: anywhere;
+			text-decoration: var(--d2l-list-item-content-text-decoration, none);
+		}
 
-			.d2l-list-item-content-text-secondary {
-				color: var(--d2l-list-item-content-text-secondary-color, var(--d2l-color-tungsten));
-			}
+		.d2l-list-item-content-text-secondary {
+			color: var(--d2l-list-item-content-text-secondary-color, var(--d2l-color-tungsten));
+		}
 
-			.d2l-list-item-content-text-supporting-info {
-				color: var(--d2l-color-ferrite);
-			}
+		.d2l-list-item-content-text-supporting-info {
+			color: var(--d2l-color-ferrite);
+		}
 
-			.d2l-list-item-content-text-secondary ::slotted(*),
-			.d2l-list-item-content-text-supporting-info ::slotted(*) {
-				margin-top: 0.15rem;
-			}
-		`];
-	}
+		.d2l-list-item-content-text-secondary ::slotted(*),
+		.d2l-list-item-content-text-supporting-info ::slotted(*) {
+			margin-top: 0.15rem;
+		}
+	`];
 
 	render() {
 		return html`

--- a/components/list/list-item-drag-drop-mixin.js
+++ b/components/list/list-item-drag-drop-mixin.js
@@ -248,55 +248,53 @@ export class NewPositionEventDetails {
 
 export const ListItemDragDropMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * **Drag & drop:** Disables keyboard dragging interaction. If draggable, a keyboard alternative should be provided for the dragging functionality.
-			 * @type {boolean}
-			 */
-			keyboardDragDisabled: { type: Boolean, attribute: 'keyboard-drag-disabled' },
-			/**
-			 * **Drag & drop:** Whether the item is draggable
-			 * @type {boolean}
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			draggable: { type: Boolean, reflect: true },
-			/**
-			 * @ignore
-			 */
-			dragging: { type: Boolean, reflect: true },
-			/**
-			 * **Drag & drop:** The drag-handle label for assistive technology. If implementing drag & drop, you should change this to dynamically announce what the drag-handle is moving for assistive technology in keyboard mode.
-			 * @type {string}
-			*/
-			dragHandleText: { type: String, attribute: 'drag-handle-text' },
-			/**
-			 * **Drag & drop:** Whether nested items can be dropped on this item
-			 * @type {boolean}
-			*/
-			dropNested: { type: Boolean, attribute: 'drop-nested' },
-			/**
-			 * **Drag & drop:** Text to drag and drop
-			 * @type {string}
-			*/
-			dropText: { type: String, attribute: 'drop-text' },
-			/**
-			 * Value to identify item if selectable
-			 * @type {string}
-			*/
-			key: { type: String, reflect: true },
-			_dragHandleShowAlways: { type: Boolean, attribute: '_drag-handle-show-always', reflect: true },
-			_draggingOver: { type: Boolean },
-			_dropLocation: { type: Number, reflect: true, attribute: '_drop-location' },
-			_focusingDragHandle: { type: Boolean },
-			_hovering: { type: Boolean },
-			_keyboardActive: { type: Boolean },
-			_keyboardTextInfo: { type: Object }
-		};
-	}
+	static properties = {
+		/**
+		 * **Drag & drop:** Disables keyboard dragging interaction. If draggable, a keyboard alternative should be provided for the dragging functionality.
+		 * @type {boolean}
+		 */
+		keyboardDragDisabled: { type: Boolean, attribute: 'keyboard-drag-disabled' },
+		/**
+		 * **Drag & drop:** Whether the item is draggable
+		 * @type {boolean}
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		draggable: { type: Boolean, reflect: true },
+		/**
+		 * @ignore
+		 */
+		dragging: { type: Boolean, reflect: true },
+		/**
+		 * **Drag & drop:** The drag-handle label for assistive technology. If implementing drag & drop, you should change this to dynamically announce what the drag-handle is moving for assistive technology in keyboard mode.
+		 * @type {string}
+		*/
+		dragHandleText: { type: String, attribute: 'drag-handle-text' },
+		/**
+		 * **Drag & drop:** Whether nested items can be dropped on this item
+		 * @type {boolean}
+		*/
+		dropNested: { type: Boolean, attribute: 'drop-nested' },
+		/**
+		 * **Drag & drop:** Text to drag and drop
+		 * @type {string}
+		*/
+		dropText: { type: String, attribute: 'drop-text' },
+		/**
+		 * Value to identify item if selectable
+		 * @type {string}
+		*/
+		key: { type: String, reflect: true },
+		_dragHandleShowAlways: { type: Boolean, attribute: '_drag-handle-show-always', reflect: true },
+		_draggingOver: { type: Boolean },
+		_dropLocation: { type: Number, reflect: true, attribute: '_drop-location' },
+		_focusingDragHandle: { type: Boolean },
+		_hovering: { type: Boolean },
+		_keyboardActive: { type: Boolean },
+		_keyboardTextInfo: { type: Object }
+	};
 
 	static get styles() {
-		const styles = [ css`
+		const styles = [css`
 			:host {
 				display: block;
 				position: relative;

--- a/components/list/list-item-drag-handle.js
+++ b/components/list/list-item-drag-handle.js
@@ -47,91 +47,87 @@ export const resetDisplayedTooltip = () => {
  */
 class ListItemDragHandle extends LocalizeCoreElement(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * Disables the handle
-			 * @type {boolean}
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Additional context information for accessibility
-			 * @type {object}
-			 */
-			keyboardTextInfo: { type: Object, attribute: 'keyboard-text-info' },
-			/**
-			 * The drag-handle label for assistive technology
-			 * @type {string}
-			 */
-			text: { type: String },
-			/**
-			 * When layout = tile, the drag handle become horizontal
-			 */
-			layout: { type: String },
-			_displayKeyboardTooltip: { type: Boolean },
-			_keyboardActive: { type: Boolean }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the handle
+		 * @type {boolean}
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Additional context information for accessibility
+		 * @type {object}
+		 */
+		keyboardTextInfo: { type: Object, attribute: 'keyboard-text-info' },
+		/**
+		 * The drag-handle label for assistive technology
+		 * @type {string}
+		 */
+		text: { type: String },
+		/**
+		 * When layout = tile, the drag handle become horizontal
+		 */
+		layout: { type: String },
+		_displayKeyboardTooltip: { type: Boolean },
+		_keyboardActive: { type: Boolean }
+	};
 
-	static get styles() {
-		return [ buttonStyles, css`
-			:host {
-				display: flex;
-				margin: 0.25rem;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-list-item-drag-handle-dragger-button {
-				background-color: unset;
-				display: block;
-				margin: 0;
-				min-height: 1.8rem;
-				padding: 0;
-				width: 0.9rem;
-			}
-			/* Firefox includes a hidden border which messes up button dimensions */
-			button::-moz-focus-inner {
-				border: 0;
-			}
-			.d2l-button-dragger-icon {
-				height: 0.9rem;
-				width: 0.9rem;
-			}
-			button,
-			button[disabled]:hover,
-			button[disabled]:focus {
-				background-color: var(--d2l-color-gypsum);
-				color: var(--d2l-color-ferrite);
-			}
-			.d2l-list-item-drag-handle-dragger-button:hover,
-			.d2l-list-item-drag-handle-dragger-button:focus {
-				background-color: var(--d2l-color-mica);
-			}
-			button[disabled] {
-				cursor: default;
-				opacity: 0.5;
-			}
-			d2l-tooltip > div {
-				font-weight: 700;
-			}
-			d2l-tooltip > ul {
-				padding-inline-start: 1rem;
-			}
-			.d2l-list-item-drag-handle-tooltip-key {
-				font-weight: 700;
-			}
-			d2l-button-move {
-				pointer-events: auto; /* required since ancestors may set point-events: none; (see generic layout) */
-			}
+	static styles = [buttonStyles, css`
+		:host {
+			display: flex;
+			margin: 0.25rem;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-list-item-drag-handle-dragger-button {
+			background-color: unset;
+			display: block;
+			margin: 0;
+			min-height: 1.8rem;
+			padding: 0;
+			width: 0.9rem;
+		}
+		/* Firefox includes a hidden border which messes up button dimensions */
+		button::-moz-focus-inner {
+			border: 0;
+		}
+		.d2l-button-dragger-icon {
+			height: 0.9rem;
+			width: 0.9rem;
+		}
+		button,
+		button[disabled]:hover,
+		button[disabled]:focus {
+			background-color: var(--d2l-color-gypsum);
+			color: var(--d2l-color-ferrite);
+		}
+		.d2l-list-item-drag-handle-dragger-button:hover,
+		.d2l-list-item-drag-handle-dragger-button:focus {
+			background-color: var(--d2l-color-mica);
+		}
+		button[disabled] {
+			cursor: default;
+			opacity: 0.5;
+		}
+		d2l-tooltip > div {
+			font-weight: 700;
+		}
+		d2l-tooltip > ul {
+			padding-inline-start: 1rem;
+		}
+		.d2l-list-item-drag-handle-tooltip-key {
+			font-weight: 700;
+		}
+		d2l-button-move {
+			pointer-events: auto; /* required since ancestors may set point-events: none; (see generic layout) */
+		}
 
-			:host([layout="tile"]) {
-				align-items: center;
-				display: flex;
-				height: 39px;
-			}
-		`];
-	}
+		:host([layout="tile"]) {
+			align-items: center;
+			display: flex;
+			height: 39px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/list/list-item-drag-image.js
+++ b/components/list/list-item-drag-image.js
@@ -8,88 +8,84 @@ import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 class ListItemDragImage extends LocalizeCoreElement(SkeletonMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			count: { type: Number },
-			includePlusSign: { type: Boolean, attribute: 'include-plus-sign' }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		count: { type: Number },
+		includePlusSign: { type: Boolean, attribute: 'include-plus-sign' }
+	};
 
-	static get styles() {
-		return [ super.styles, bodySmallStyles, css`
-			:host {
-				display: block;
-				height: 70px;
-				inset-inline-start: -10000px;
-				position: absolute;
-				width: 340px;
-				z-index: 0;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.first, .second, .third {
-				background-color: white;
-				border: 1px solid var(--d2l-color-mica);
-				border-radius: 4px;
-				box-sizing: border-box;
-				height: 100%;
-				position: absolute;
-				width: 100%;
-			}
-			.first {
-				align-items: start;
-				display: flex;
-				padding: 16px 8px;
-			}
-			.second {
-				margin-inline-start: 6px;
-				margin-top: 6px;
-				z-index: -1;
-			}
-			.third {
-				margin-inline-start: 12px;
-				margin-top: 12px;
-				z-index: -2;
-			}
-			.text {
-				width: 100%;
-			}
-			.line-1 {
-				height: 24px;
-				margin-bottom: 4px;
-				width: 100%;
-			}
-			.line-2 {
-				height: 16px;
-				width: 25%;
-			}
-			d2l-input-checkbox {
-				line-height: 0;
-				margin: 0;
-				margin-inline-start: 16px;
-			}
-			.count {
-				background-color: var(--d2l-color-celestine);
-				border-radius: 0.7rem;
-				box-sizing: border-box;
-				color: white;
-				left: 26px;
-				min-width: 1.4rem;
-				padding: 0.25rem 0.4rem;
-				position: absolute;
-				text-align: center;
-				top: 30px;
-				z-index: 998; /* must be higher than the skeleton z-index */
-			}
-			.count:dir(rtl) {
-				left: 14px;
-			}
-		`];
-	}
+	static styles = [super.styles, bodySmallStyles, css`
+		:host {
+			display: block;
+			height: 70px;
+			inset-inline-start: -10000px;
+			position: absolute;
+			width: 340px;
+			z-index: 0;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.first, .second, .third {
+			background-color: white;
+			border: 1px solid var(--d2l-color-mica);
+			border-radius: 4px;
+			box-sizing: border-box;
+			height: 100%;
+			position: absolute;
+			width: 100%;
+		}
+		.first {
+			align-items: start;
+			display: flex;
+			padding: 16px 8px;
+		}
+		.second {
+			margin-inline-start: 6px;
+			margin-top: 6px;
+			z-index: -1;
+		}
+		.third {
+			margin-inline-start: 12px;
+			margin-top: 12px;
+			z-index: -2;
+		}
+		.text {
+			width: 100%;
+		}
+		.line-1 {
+			height: 24px;
+			margin-bottom: 4px;
+			width: 100%;
+		}
+		.line-2 {
+			height: 16px;
+			width: 25%;
+		}
+		d2l-input-checkbox {
+			line-height: 0;
+			margin: 0;
+			margin-inline-start: 16px;
+		}
+		.count {
+			background-color: var(--d2l-color-celestine);
+			border-radius: 0.7rem;
+			box-sizing: border-box;
+			color: white;
+			left: 26px;
+			min-width: 1.4rem;
+			padding: 0.25rem 0.4rem;
+			position: absolute;
+			text-align: center;
+			top: 30px;
+			z-index: 998; /* must be higher than the skeleton z-index */
+		}
+		.count:dir(rtl) {
+			left: 14px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/components/list/list-item-expand-collapse-mixin.js
+++ b/components/list/list-item-expand-collapse-mixin.js
@@ -10,26 +10,24 @@ const dragHoverDropTime = 1000;
 
 export const ListItemExpandCollapseMixin = superclass => class extends SkeletonMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether to show the expand collapse toggle
-			 * @type {boolean}
-			 */
-			expandable: { type: Boolean },
-			/**
-			 * Default state for expand collapse toggle - if not set, collapsed will be the default state
-			 * @type {boolean}
-			 */
-			expanded: { type: Boolean, reflect: true },
-			_siblingHasNestedItems: { state: true },
-			_renderExpandCollapseSlot: { type: Boolean, reflect: true, attribute: '_render-expand-collapse-slot' },
-			_showNestedLoadingSpinner: { state: true }
-		};
-	}
+	static properties = {
+		/**
+		 * Whether to show the expand collapse toggle
+		 * @type {boolean}
+		 */
+		expandable: { type: Boolean },
+		/**
+		 * Default state for expand collapse toggle - if not set, collapsed will be the default state
+		 * @type {boolean}
+		 */
+		expanded: { type: Boolean, reflect: true },
+		_siblingHasNestedItems: { state: true },
+		_renderExpandCollapseSlot: { type: Boolean, reflect: true, attribute: '_render-expand-collapse-slot' },
+		_showNestedLoadingSpinner: { state: true }
+	};
 
 	static get styles() {
-		const styles = [ css`
+		const styles = [css`
 			:host {
 				--d2l-expand-collapse-slot-transition-duration: 0.3s;
 			}
@@ -66,7 +64,7 @@ export const ListItemExpandCollapseMixin = superclass => class extends SkeletonM
 					transition: width var(--d2l-expand-collapse-slot-transition-duration) cubic-bezier(0, 0.7, 0.5, 1);
 				}
 			}
-		` ];
+		`];
 
 		super.styles && styles.unshift(super.styles);
 		return styles;

--- a/components/list/list-item-generic-layout.js
+++ b/components/list/list-item-generic-layout.js
@@ -35,264 +35,260 @@ function isRtl() {
  */
 class ListItemGenericLayout extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * How to align content in the nested slot
-			 * @type {'content'|'control'}
-			 */
-			alignNested: { type: String, reflect: true, attribute: 'align-nested' },
-			/**
-			 * Whether to constrain actions so they do not fill the item. Required if slotted content is interactive.
-			 * @type {boolean}
-			 */
-			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action', reflect: true },
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
-			/**
-			 * Specifies whether the grid is active or not
-			 * @type {boolean}
-			 */
-			gridActive: { type: Boolean, attribute: 'grid-active' },
-			/**
-			 * Inline start padding (in px) to apply to list item(s) in the nested slot. When used, nested list items will not use the grid start calcuations and will only use this number to determine indentation.
-			 * @type {number}
-			 */
-			indentation: { type: Number, reflect: true },
-			/**
-			 * @ignore
-			 */
-			layout: { type: String, reflect: true },
-		};
-	}
+	static properties = {
+		/**
+		 * How to align content in the nested slot
+		 * @type {'content'|'control'}
+		 */
+		alignNested: { type: String, reflect: true, attribute: 'align-nested' },
+		/**
+		 * Whether to constrain actions so they do not fill the item. Required if slotted content is interactive.
+		 * @type {boolean}
+		 */
+		noPrimaryAction: { type: Boolean, attribute: 'no-primary-action', reflect: true },
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		role: { type: String, reflect: true },
+		/**
+		 * Specifies whether the grid is active or not
+		 * @type {boolean}
+		 */
+		gridActive: { type: Boolean, attribute: 'grid-active' },
+		/**
+		 * Inline start padding (in px) to apply to list item(s) in the nested slot. When used, nested list items will not use the grid start calcuations and will only use this number to determine indentation.
+		 * @type {number}
+		 */
+		indentation: { type: Number, reflect: true },
+		/**
+		 * @ignore
+		 */
+		layout: { type: String, reflect: true },
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: grid;
-				grid-template-columns:
-					[start outside-control-start] minmax(0, min-content)
-					[color-start outside-control-end] minmax(0, min-content)
-					[expand-collapse-start color-end] minmax(0, min-content)
-					[control-start expand-collapse-end] minmax(0, min-content)
-					[control-end content-start] minmax(0, auto)
-					[content-end actions-start] minmax(0, min-content)
-					[end actions-end];
-				grid-template-rows:
-					[start add-top-start] minmax(0, min-content)
-					[add-top-end main-start] minmax(0, min-content)
-					[main-end nested-start] minmax(0, min-content)
-					[nested-end add-start] minmax(0, min-content)
-					[add-end end];
-			}
+	static styles = css`
+		:host {
+			display: grid;
+			grid-template-columns:
+				[start outside-control-start] minmax(0, min-content)
+				[color-start outside-control-end] minmax(0, min-content)
+				[expand-collapse-start color-end] minmax(0, min-content)
+				[control-start expand-collapse-end] minmax(0, min-content)
+				[control-end content-start] minmax(0, auto)
+				[content-end actions-start] minmax(0, min-content)
+				[end actions-end];
+			grid-template-rows:
+				[start add-top-start] minmax(0, min-content)
+				[add-top-end main-start] minmax(0, min-content)
+				[main-end nested-start] minmax(0, min-content)
+				[nested-end add-start] minmax(0, min-content)
+				[add-end end];
+		}
 
-			:host([align-nested="control"]) ::slotted([slot="nested"]) {
-				grid-column: control-start / end;
-			}
+		:host([align-nested="control"]) ::slotted([slot="nested"]) {
+			grid-column: control-start / end;
+		}
 
-			::slotted([slot="drop-target"]) {
-				grid-column: start / end;
-			}
+		::slotted([slot="drop-target"]) {
+			grid-column: start / end;
+		}
 
-			::slotted([slot="outside-control"]),
-			::slotted([slot="color-indicator"]),
-			::slotted([slot="expand-collapse"]),
-			::slotted([slot="control"]),
-			::slotted([slot="content"]),
-			::slotted([slot="actions"]),
-			::slotted([slot="outside-control-action"]),
-			::slotted([slot="before-content"]),
-			::slotted([slot="control-action"]),
-			::slotted([slot="content-action"]),
-			::slotted([slot="outside-control-container"]),
-			::slotted([slot="control-container"]),
-			::slotted([slot="drop-target"]) {
-				grid-row: 2 / 3;
-			}
+		::slotted([slot="outside-control"]),
+		::slotted([slot="color-indicator"]),
+		::slotted([slot="expand-collapse"]),
+		::slotted([slot="control"]),
+		::slotted([slot="content"]),
+		::slotted([slot="actions"]),
+		::slotted([slot="outside-control-action"]),
+		::slotted([slot="before-content"]),
+		::slotted([slot="control-action"]),
+		::slotted([slot="content-action"]),
+		::slotted([slot="outside-control-container"]),
+		::slotted([slot="control-container"]),
+		::slotted([slot="drop-target"]) {
+			grid-row: 2 / 3;
+		}
 
-			::slotted([slot="outside-control"]) {
-				grid-column: outside-control-start / outside-control-end;
-			}
+		::slotted([slot="outside-control"]) {
+			grid-column: outside-control-start / outside-control-end;
+		}
 
-			::slotted([slot="outside-control"]:not(.handle-only)) {
-				pointer-events: none;
-			}
+		::slotted([slot="outside-control"]:not(.handle-only)) {
+			pointer-events: none;
+		}
 
-			::slotted([slot="expand-collapse"]) {
-				cursor: pointer;
-				grid-column: expand-collapse-start / expand-collapse-end;
-			}
+		::slotted([slot="expand-collapse"]) {
+			cursor: pointer;
+			grid-column: expand-collapse-start / expand-collapse-end;
+		}
 
-			::slotted([slot="control"]) {
-				grid-column: control-start / control-end;
-				pointer-events: none;
-				width: 2.1rem;
-			}
+		::slotted([slot="control"]) {
+			grid-column: control-start / control-end;
+			pointer-events: none;
+			width: 2.1rem;
+		}
 
-			::slotted([slot="content"]) {
-				grid-column: content-start / content-end;
-			}
+		::slotted([slot="content"]) {
+			grid-column: content-start / content-end;
+		}
 
-			::slotted([slot="color-indicator"]) {
-				grid-column: color-start / color-end;
-			}
+		::slotted([slot="color-indicator"]) {
+			grid-column: color-start / color-end;
+		}
 
-			::slotted([slot="before-content"]) {
-				grid-column: color-start / content-start;
-			}
+		::slotted([slot="before-content"]) {
+			grid-column: color-start / content-start;
+		}
 
-			::slotted([slot="control-action"]) ~ ::slotted([slot="content"]),
-			::slotted([slot="outside-control-action"]) ~ ::slotted([slot="content"]) {
-				pointer-events: unset;
-			}
+		::slotted([slot="control-action"]) ~ ::slotted([slot="content"]),
+		::slotted([slot="outside-control-action"]) ~ ::slotted([slot="content"]) {
+			pointer-events: unset;
+		}
 
-			slot[name="actions"] {
-				white-space: nowrap;
-			}
+		slot[name="actions"] {
+			white-space: nowrap;
+		}
 
-			::slotted([slot="actions"]) {
-				grid-column: actions-start / actions-end;
-				justify-self: end;
-			}
+		::slotted([slot="actions"]) {
+			grid-column: actions-start / actions-end;
+			justify-self: end;
+		}
 
-			::slotted([slot="outside-control-action"]) {
-				grid-column: start / end;
-			}
-			:host([no-primary-action]) ::slotted([slot="outside-control-action"]) {
-				grid-column: start / outside-control-end;
-			}
+		::slotted([slot="outside-control-action"]) {
+			grid-column: start / end;
+		}
+		:host([no-primary-action]) ::slotted([slot="outside-control-action"]) {
+			grid-column: start / outside-control-end;
+		}
 
-			::slotted([slot="content-action"]) {
-				grid-column: content-start / content-end;
-			}
+		::slotted([slot="content-action"]) {
+			grid-column: content-start / content-end;
+		}
 
-			:host([no-primary-action]) ::slotted([slot="content-action"]) {
-				display: none;
-			}
+		:host([no-primary-action]) ::slotted([slot="content-action"]) {
+			display: none;
+		}
 
-			::slotted([slot="control-action"]) {
-				grid-column-start: control-start;
-			}
+		::slotted([slot="control-action"]) {
+			grid-column-start: control-start;
+		}
 
-			:host(:not([no-primary-action])) ::slotted([slot="outside-control-action"]) {
-				grid-column-end: end;
-			}
+		:host(:not([no-primary-action])) ::slotted([slot="outside-control-action"]) {
+			grid-column-end: end;
+		}
 
-			:host(:not([no-primary-action])) ::slotted([slot="control-action"]) {
-				grid-column-end: actions-start;
-			}
+		:host(:not([no-primary-action])) ::slotted([slot="control-action"]) {
+			grid-column-end: actions-start;
+		}
 
-			::slotted([slot="outside-control-container"]) {
-				grid-column: start / end;
-			}
-			::slotted([slot="control-container"]) {
-				grid-column: color-start / end;
-			}
+		::slotted([slot="outside-control-container"]) {
+			grid-column: start / end;
+		}
+		::slotted([slot="control-container"]) {
+			grid-column: color-start / end;
+		}
 
-			::slotted([slot="nested"]) {
-				grid-column: content-start / end;
-				grid-row: nested;
-			}
+		::slotted([slot="nested"]) {
+			grid-column: content-start / end;
+			grid-row: nested;
+		}
 
-			:host([indentation]) ::slotted([slot="nested"]) {
-				grid-column-start: start;
-				padding-inline-start: var(--d2l-list-item-generic-layout-nested-indentation);
-			}
+		:host([indentation]) ::slotted([slot="nested"]) {
+			grid-column-start: start;
+			padding-inline-start: var(--d2l-list-item-generic-layout-nested-indentation);
+		}
 
-			::slotted([slot="add"]) {
-				grid-row: add;
-			}
-			::slotted([slot="add-top"]) {
-				grid-row: add-top;
-			}
-			::slotted([slot="add-top"]),
-			::slotted([slot="add"]) {
-				grid-column: color-start / end;
-			}
+		::slotted([slot="add"]) {
+			grid-row: add;
+		}
+		::slotted([slot="add-top"]) {
+			grid-row: add-top;
+		}
+		::slotted([slot="add-top"]),
+		::slotted([slot="add"]) {
+			grid-column: color-start / end;
+		}
 
-			:host([layout="tile"]) {
-				grid-template-columns:
-					[start outside-control-start] minmax(0, 26px)
-					[outside-control-end control-start] minmax(0, min-content)
-					[control-end actions-start] minmax(0, auto)
-					[actions-end end];
-				grid-template-rows:
-					[start header-start] minmax(0, min-content)
-					[header-end content-start] auto
-					[content-end end];
-				height: 100%;
-			}
+		:host([layout="tile"]) {
+			grid-template-columns:
+				[start outside-control-start] minmax(0, 26px)
+				[outside-control-end control-start] minmax(0, min-content)
+				[control-end actions-start] minmax(0, auto)
+				[actions-end end];
+			grid-template-rows:
+				[start header-start] minmax(0, min-content)
+				[header-end content-start] auto
+				[content-end end];
+			height: 100%;
+		}
 
-			:host([layout="tile"]:not([is-draggable])) {
-				grid-template-columns:
-					[start outside-control-start] 0
-					[outside-control-end control-start] minmax(0, min-content)
-					[control-end actions-start] minmax(0, auto)
-					[actions-end end];
-				grid-template-rows:
-					[start header-start] minmax(0, min-content)
-					[header-end content-start] auto
-					[content-end end];
-				height: 100%;
-			}
+		:host([layout="tile"]:not([is-draggable])) {
+			grid-template-columns:
+				[start outside-control-start] 0
+				[outside-control-end control-start] minmax(0, min-content)
+				[control-end actions-start] minmax(0, auto)
+				[actions-end end];
+			grid-template-rows:
+				[start header-start] minmax(0, min-content)
+				[header-end content-start] auto
+				[content-end end];
+			height: 100%;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="header"]) {
-				grid-column: start / end;
-				grid-row: header-start / header-end;
-			}
+		:host([layout="tile"]) ::slotted([slot="header"]) {
+			grid-column: start / end;
+			grid-row: header-start / header-end;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="content"]),
-			:host([layout="tile"]) ::slotted([slot="content-action"]),
-			:host([layout="tile"]) ::slotted([slot="control-action"]) {
-				grid-column: start / end;
-				grid-row: content-start / end;
-			}
-			:host([layout="tile"]) ::slotted([slot="outside-control-container"]) {
-				grid-column: start / end;
-				grid-row: start / end;
-			}
-			:host([layout="tile"]) ::slotted([slot="control"]) {
-				grid-column: control-start / control-end;
-				grid-row: start / start;
-				pointer-events: all;
-				width: unset;
-			}
+		:host([layout="tile"]) ::slotted([slot="content"]),
+		:host([layout="tile"]) ::slotted([slot="content-action"]),
+		:host([layout="tile"]) ::slotted([slot="control-action"]) {
+			grid-column: start / end;
+			grid-row: content-start / end;
+		}
+		:host([layout="tile"]) ::slotted([slot="outside-control-container"]) {
+			grid-column: start / end;
+			grid-row: start / end;
+		}
+		:host([layout="tile"]) ::slotted([slot="control"]) {
+			grid-column: control-start / control-end;
+			grid-row: start / start;
+			pointer-events: all;
+			width: unset;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="actions"]) {
-				grid-column: actions-start / actions-end;
-				grid-row: start / start;
-			}
+		:host([layout="tile"]) ::slotted([slot="actions"]) {
+			grid-column: actions-start / actions-end;
+			grid-row: start / start;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="color-indicator"]) {
-				grid-column: start;
-				grid-row: content-start / content-end;
-			}
+		:host([layout="tile"]) ::slotted([slot="color-indicator"]) {
+			grid-column: start;
+			grid-row: content-start / content-end;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="outside-control"]) {
-				grid-column: outside-control-start / outside-control-end;
-				grid-row: start / start;
-				width: min-content;
-			}
+		:host([layout="tile"]) ::slotted([slot="outside-control"]) {
+			grid-column: outside-control-start / outside-control-end;
+			grid-row: start / start;
+			width: min-content;
+		}
 
-			:host([layout="tile"]) ::slotted([slot="outside-control-action"]) {
-				grid-column: start / end;
-				grid-row: start / start;
-			}
+		:host([layout="tile"]) ::slotted([slot="outside-control-action"]) {
+			grid-column: start / end;
+			grid-row: start / start;
+		}
 
-			:host(:not([layout="tile"])) slot[name="header"],
-			:host([layout="tile"]) slot[name="add-top"],
-			:host([layout="tile"]) slot[name="control-container"],
-			:host([layout="tile"]) slot[name="before-content"],
-			:host([layout="tile"]) slot[name="expand-collapse"],
-			:host([layout="tile"]) slot[name="nested"],
-			:host([layout="tile"]) slot[name="add"] {
-				display: none;
-			}
-		`;
-	}
+		:host(:not([layout="tile"])) slot[name="header"],
+		:host([layout="tile"]) slot[name="add-top"],
+		:host([layout="tile"]) slot[name="control-container"],
+		:host([layout="tile"]) slot[name="before-content"],
+		:host([layout="tile"]) slot[name="expand-collapse"],
+		:host([layout="tile"]) slot[name="nested"],
+		:host([layout="tile"]) slot[name="add"] {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/list/list-item-link-mixin.js
+++ b/components/list/list-item-link-mixin.js
@@ -6,20 +6,18 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 export const ListItemLinkMixin = superclass => class extends ListItemMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Address of item link if navigable
-			 * @type {string}
-			 */
-			actionHref: { type: String, attribute: 'action-href', reflect: true },
-			_ariaCurrent: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Address of item link if navigable
+		 * @type {string}
+		 */
+		actionHref: { type: String, attribute: 'action-href', reflect: true },
+		_ariaCurrent: { type: String }
+	};
 
 	static get styles() {
 
-		const styles = [ css`
+		const styles = [css`
 			:host([action-href]:not([action-href=""])) {
 				--d2l-list-item-content-text-color: var(--d2l-color-celestine);
 			}
@@ -39,7 +37,7 @@ export const ListItemLinkMixin = superclass => class extends ListItemMixin(super
 			:host([action-href]:not([action-href=""])[layout="tile"]) [slot="outside-control-action"] {
 				grid-column-end: end;
 			}
-		` ];
+		`];
 
 		super.styles && styles.unshift(super.styles);
 		return styles;

--- a/components/list/list-item-mixin.js
+++ b/components/list/list-item-mixin.js
@@ -63,79 +63,77 @@ export const ListItemMixin = superclass => class extends composeMixins(
 	ListItemRoleMixin,
 	SkeletonMixin) {
 
-	static get properties() {
-		return {
-			/**
-			 * A color indicator to appear at the beginning of a list item. Expected value is a valid 3, 4, 6, or 8 character CSS color hex code (e.g., #006fbf).
-			 * @type {string}
-			 */
-			color: { type: String },
-			/**
-			 * @ignore
-			 */
-			first: { type: Boolean, reflect: true },
-			/**
-			 * Whether to allow the drag target to be the handle only rather than the entire cell
-			 * @type {boolean}
-			 */
-			dragTargetHandleOnly: { type: Boolean, attribute: 'drag-target-handle-only' },
-			/**
-			 * Inline start padding (in px) to apply to list item(s) in the nested slot. When used, nested list items will not use the grid start calcuations and will only use this number to determine indentation.
-			 * @type {number}
-			 */
-			indentation: { type: Number, reflect: true },
-			/**
-			 * @ignore
-			 */
-			last: { type: Boolean, reflect: true },
-			/**
-			 * @ignore
-			 */
-			layout: { type: String, reflect: true },
-			/**
-			 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
-			 * @type {boolean}
-			 */
-			noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
-			/**
-			 * How much padding to render in standard/normal list items
-			 * @type {'normal'|'none'}
-			 */
-			paddingType: { type: String, attribute: 'padding-type' },
-			/**
-			 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
-			 * @type {boolean}
-			 */
-			tileHeader: { type: Boolean, reflect: true, attribute: 'tile-header' },
-			/**
-			 * How much padding to render in tile list items
-			 * @type {'normal'|'none'}
-			 * @default "normal"
-			 */
-			tilePaddingType: { type: String, attribute: 'tile-padding-type' },
-			_addButtonText: { state: true },
-			_displayKeyboardTooltip: { type: Boolean },
-			_hasColorSlot: { type: Boolean, reflect: true, attribute: '_has-color-slot' },
-			_hasListItemContent: { state: true },
-			_hasNestedList: { type: Boolean, reflect: true, attribute: '_has-nested-list' },
-			_hasNestedListAddButton: { type: Boolean, reflect: true, attribute: '_has-nested-list-add-button' },
-			_hovering: { type: Boolean, reflect: true },
-			_hoveringControl: { type: Boolean, attribute: '_hovering-control', reflect: true },
-			_hoveringPrimaryAction: { type: Boolean, attribute: '_hovering-primary-action', reflect: true },
-			_focusing: { type: Boolean, reflect: true },
-			_focusingPrimaryAction: { type: Boolean, attribute: '_focusing-primary-action', reflect: true },
-			_forceShowSelection: { type: Boolean, attribute: '_force-show-selection', reflect: true },
-			_highlight: { type: Boolean, reflect: true },
-			_highlighting: { type: Boolean, reflect: true },
-			_showAddButton: { type: Boolean, attribute: '_show-add-button', reflect: true },
-			_selectionWhenInteracted: { type: Boolean, attribute: '_selection-when-interacted', reflect: true },
-			_siblingHasColor: { state: true },
-		};
-	}
+	static properties = {
+		/**
+		 * A color indicator to appear at the beginning of a list item. Expected value is a valid 3, 4, 6, or 8 character CSS color hex code (e.g., #006fbf).
+		 * @type {string}
+		 */
+		color: { type: String },
+		/**
+		 * @ignore
+		 */
+		first: { type: Boolean, reflect: true },
+		/**
+		 * Whether to allow the drag target to be the handle only rather than the entire cell
+		 * @type {boolean}
+		 */
+		dragTargetHandleOnly: { type: Boolean, attribute: 'drag-target-handle-only' },
+		/**
+		 * Inline start padding (in px) to apply to list item(s) in the nested slot. When used, nested list items will not use the grid start calcuations and will only use this number to determine indentation.
+		 * @type {number}
+		 */
+		indentation: { type: Number, reflect: true },
+		/**
+		 * @ignore
+		 */
+		last: { type: Boolean, reflect: true },
+		/**
+		 * @ignore
+		 */
+		layout: { type: String, reflect: true },
+		/**
+		 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
+		 * @type {boolean}
+		 */
+		noPrimaryAction: { type: Boolean, attribute: 'no-primary-action' },
+		/**
+		 * How much padding to render in standard/normal list items
+		 * @type {'normal'|'none'}
+		 */
+		paddingType: { type: String, attribute: 'padding-type' },
+		/**
+		 * Whether to disable rendering the entire item as the primary action. Required if slotted content is interactive.
+		 * @type {boolean}
+		 */
+		tileHeader: { type: Boolean, reflect: true, attribute: 'tile-header' },
+		/**
+		 * How much padding to render in tile list items
+		 * @type {'normal'|'none'}
+		 * @default "normal"
+		 */
+		tilePaddingType: { type: String, attribute: 'tile-padding-type' },
+		_addButtonText: { state: true },
+		_displayKeyboardTooltip: { type: Boolean },
+		_hasColorSlot: { type: Boolean, reflect: true, attribute: '_has-color-slot' },
+		_hasListItemContent: { state: true },
+		_hasNestedList: { type: Boolean, reflect: true, attribute: '_has-nested-list' },
+		_hasNestedListAddButton: { type: Boolean, reflect: true, attribute: '_has-nested-list-add-button' },
+		_hovering: { type: Boolean, reflect: true },
+		_hoveringControl: { type: Boolean, attribute: '_hovering-control', reflect: true },
+		_hoveringPrimaryAction: { type: Boolean, attribute: '_hovering-primary-action', reflect: true },
+		_focusing: { type: Boolean, reflect: true },
+		_focusingPrimaryAction: { type: Boolean, attribute: '_focusing-primary-action', reflect: true },
+		_forceShowSelection: { type: Boolean, attribute: '_force-show-selection', reflect: true },
+		_highlight: { type: Boolean, reflect: true },
+		_highlighting: { type: Boolean, reflect: true },
+		_showAddButton: { type: Boolean, attribute: '_show-add-button', reflect: true },
+		_selectionWhenInteracted: { type: Boolean, attribute: '_selection-when-interacted', reflect: true },
+		_siblingHasColor: { state: true },
+	};
 
 	static get styles() {
 
-		const styles = [ css`
+		const styles = [css`
 			:host {
 				display: block;
 				position: relative;

--- a/components/list/list-item-nav-mixin.js
+++ b/components/list/list-item-nav-mixin.js
@@ -4,27 +4,25 @@ import { ListItemLinkMixin } from './list-item-link-mixin.js';
 
 export const ListItemNavMixin = superclass => class extends ListItemLinkMixin(superclass) {
 
-	static get properties() {
-		return {
-			/**
-			 * Whether the list item is the current page in a navigation context. At most one list item should have the `current` attribute at any time; this will be managed by the `list` after initial render.
-			 * @type {boolean}
-			 */
-			current: { type: Boolean, reflect: true },
-			/**
-			 * Whether to prevent the default navigation behavior of the link
-			 * @type {boolean}
-			 */
-			preventNavigation: { type: Boolean, attribute: 'prevent-navigation' },
-			_childCurrent: { type: Boolean, reflect: true, attribute: '_child-current' },
-			_hasCurrentParent: { type: Boolean, reflect: true, attribute: '_has-current-parent' },
-			_nextSiblingCurrent: { type: Boolean, reflect: true, attribute: '_next-sibling-current' },
-		};
-	}
+	static properties = {
+		/**
+		 * Whether the list item is the current page in a navigation context. At most one list item should have the `current` attribute at any time; this will be managed by the `list` after initial render.
+		 * @type {boolean}
+		 */
+		current: { type: Boolean, reflect: true },
+		/**
+		 * Whether to prevent the default navigation behavior of the link
+		 * @type {boolean}
+		 */
+		preventNavigation: { type: Boolean, attribute: 'prevent-navigation' },
+		_childCurrent: { type: Boolean, reflect: true, attribute: '_child-current' },
+		_hasCurrentParent: { type: Boolean, reflect: true, attribute: '_has-current-parent' },
+		_nextSiblingCurrent: { type: Boolean, reflect: true, attribute: '_next-sibling-current' },
+	};
 
 	static get styles() {
 
-		const styles = [ css`
+		const styles = [css`
 			:host([action-href]:not([action-href=""])) {
 				--d2l-list-item-content-text-color: var(--d2l-color-ferrite);
 			}
@@ -65,7 +63,7 @@ export const ListItemNavMixin = superclass => class extends ListItemLinkMixin(su
 			:host([current]) .d2l-list-item-color-outer {
 				padding-block: 3px;
 			}
-		` ];
+		`];
 
 		super.styles && styles.unshift(super.styles);
 		return styles;

--- a/components/list/list-item-placement-marker.js
+++ b/components/list/list-item-placement-marker.js
@@ -7,73 +7,71 @@ class ListItemPlacementMarker extends LitElement {
 		vertical: { type: Boolean, reflect: true }
 	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-			}
+	static styles = css`
+		:host {
+			display: block;
+		}
 
-			:host([vertical]) {
-				height: 100%;
-			}
+		:host([vertical]) {
+			height: 100%;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
-			:host([vertical]) .d2l-list-drag-marker-line {
-				height: 100%;
-				margin: -1px 0;
-				width: 12px;
-			}
+		:host([vertical]) .d2l-list-drag-marker-line {
+			height: 100%;
+			margin: -1px 0;
+			width: 12px;
+		}
 
-			.d2l-list-drag-marker-line {
-				height: 12px;
-				margin-inline: -1px;
-				stroke: var(--d2l-color-celestine);
-				stroke-width: 3px;
-				width: 100%;
-			}
+		.d2l-list-drag-marker-line {
+			height: 12px;
+			margin-inline: -1px;
+			stroke: var(--d2l-color-celestine);
+			stroke-width: 3px;
+			width: 100%;
+		}
 
-			:host([vertical]) .d2l-list-drag-marker-linecap {
-				height: 4px;
-				margin-inline: 0 -2px;
-				width: 12px;
-			}
+		:host([vertical]) .d2l-list-drag-marker-linecap {
+			height: 4px;
+			margin-inline: 0 -2px;
+			width: 12px;
+		}
 
-			.d2l-list-drag-marker-linecap {
-				fill: var(--d2l-color-celestine);
-				height: 12px;
-				margin-inline: -1px 0;
-				stroke: none;
-				width: 4px;
-			}
+		.d2l-list-drag-marker-linecap {
+			fill: var(--d2l-color-celestine);
+			height: 12px;
+			margin-inline: -1px 0;
+			stroke: none;
+			width: 4px;
+		}
 
-			:host([vertical]) .d2l-list-drag-marker-circle {
-				margin-inline: 0 0;
-			}
+		:host([vertical]) .d2l-list-drag-marker-circle {
+			margin-inline: 0 0;
+		}
 
 
-			.d2l-list-drag-marker-circle {
-				fill: none;
-				height: 12px;
-				margin-inline: 0 -1px;
-				stroke: var(--d2l-color-celestine);
-				stroke-width: 3px;
-				width: 12px;
-			}
+		.d2l-list-drag-marker-circle {
+			fill: none;
+			height: 12px;
+			margin-inline: 0 -1px;
+			stroke: var(--d2l-color-celestine);
+			stroke-width: 3px;
+			width: 12px;
+		}
 
-			.d2l-list-drag-marker {
-				display: flex;
-				flex-wrap: nowrap;
-			}
+		.d2l-list-drag-marker {
+			display: flex;
+			flex-wrap: nowrap;
+		}
 
-			:host([vertical]) .d2l-list-drag-marker {
-				flex-direction: column;
-				height: 100%;
-			}
-		`;
-	}
+		:host([vertical]) .d2l-list-drag-marker {
+			flex-direction: column;
+			height: 100%;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/list/list-item-role-mixin.js
+++ b/components/list/list-item-role-mixin.js
@@ -2,17 +2,15 @@ import { findComposedAncestor } from '../../helpers/dom.js';
 
 export const ListItemRoleMixin = superclass => class extends superclass {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 */
-			// eslint-disable-next-line lit/no-native-attributes
-			role: { type: String, reflect: true },
-			_nested: { type: Boolean, reflect: true },
-			_separators: { type: String, reflect: true }
-		};
-	}
+	static properties = {
+		/**
+		 * @ignore
+		 */
+		// eslint-disable-next-line lit/no-native-attributes
+		role: { type: String, reflect: true },
+		_nested: { type: Boolean, reflect: true },
+		_separators: { type: String, reflect: true }
+	};
 
 	constructor() {
 		super();

--- a/components/list/list-item.js
+++ b/components/list/list-item.js
@@ -10,15 +10,13 @@ import { LitElement } from 'lit';
  */
 class ListItem extends ListItemLinkMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Address of item link if navigable
-			 * @type {string}
-			 */
-			href: { type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Address of item link if navigable
+		 * @type {string}
+		 */
+		href: { type: String }
+	};
 
 	get href() {
 		return this.actionHref;

--- a/components/list/list.js
+++ b/components/list/list.js
@@ -35,134 +35,130 @@ const ro = new ResizeObserver(entries => {
  */
 class List extends PageableMixin(SelectionMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			/**
-			 * When true, show the inline add button after each list item.
-			 * @type {boolean}
-			 */
-			addButton: { type: Boolean, reflect: true, attribute: 'add-button' },
-			/**
-			 * Text to show in label tooltip on inline add button. Defaults to "Add Item".
-			 * @type {string}
-			 */
-			addButtonText: { type: String, reflect: true, attribute: 'add-button-text' },
-			/**
-			 * Breakpoints for responsiveness in pixels. There are four different breakpoints and only the four largest breakpoints will be used.
-			 * @type {array}
-			 */
-			breakpoints: { type: Array },
-			/**
-			 * Always show drag handle
-			 * @type {boolean}
-			 */
-			dragHandleShowAlways: { type: Boolean, attribute: 'drag-handle-show-always' },
-			/**
-			 * Whether the user can drag multiple items
-			 * @type {boolean}
+	static properties = {
+		/**
+		 * When true, show the inline add button after each list item.
+		 * @type {boolean}
+		 */
+		addButton: { type: Boolean, reflect: true, attribute: 'add-button' },
+		/**
+		 * Text to show in label tooltip on inline add button. Defaults to "Add Item".
+		 * @type {string}
+		 */
+		addButtonText: { type: String, reflect: true, attribute: 'add-button-text' },
+		/**
+		 * Breakpoints for responsiveness in pixels. There are four different breakpoints and only the four largest breakpoints will be used.
+		 * @type {array}
+		 */
+		breakpoints: { type: Array },
+		/**
+		 * Always show drag handle
+		 * @type {boolean}
+		 */
+		dragHandleShowAlways: { type: Boolean, attribute: 'drag-handle-show-always' },
+		/**
+		 * Whether the user can drag multiple items
+		 * @type {boolean}
  			 */
-			dragMultiple: { type: Boolean, reflect: true, attribute: 'drag-multiple' },
-			/**
-			 * Disable ability to drop items above or below this item
-			 * @type {boolean}
-			 */
-			dropNestedOnly: { type: Boolean, attribute: 'drop-nested-only' },
-			/**
-			 * Whether to extend the separators beyond the content's edge
-			 * @type {boolean}
-			 */
-			extendSeparators: { type: Boolean, reflect: true, attribute: 'extend-separators' },
-			/**
-			 * Use grid to manage focus with arrow keys. See [Accessibility](#accessibility).
-			 * @type {boolean}
-			 */
-			grid: { type: Boolean },
-			/**
-			 * Sets an accessible label. For use when the list context is unclear. This property is only valid on top-level lists and will have no effect on nested lists.
-			 * @type {string}
+		dragMultiple: { type: Boolean, reflect: true, attribute: 'drag-multiple' },
+		/**
+		 * Disable ability to drop items above or below this item
+		 * @type {boolean}
+		 */
+		dropNestedOnly: { type: Boolean, attribute: 'drop-nested-only' },
+		/**
+		 * Whether to extend the separators beyond the content's edge
+		 * @type {boolean}
+		 */
+		extendSeparators: { type: Boolean, reflect: true, attribute: 'extend-separators' },
+		/**
+		 * Use grid to manage focus with arrow keys. See [Accessibility](#accessibility).
+		 * @type {boolean}
+		 */
+		grid: { type: Boolean },
+		/**
+		 * Sets an accessible label. For use when the list context is unclear. This property is only valid on top-level lists and will have no effect on nested lists.
+		 * @type {string}
  			 */
-			label: { type: String },
-			/**
-			 * The type of layout for the list items. Valid values are "list" (default) and "tiles". The tile layout is only valid for single level (non-nested) lists.
-			 * @type {'list'|'tiles'}
-			 * @default "list"
-			 */
-			layout: { type: String, reflect: true },
-			/**
-			 * Display separators. Valid values are "all" (default), "between", "none"
-			 * @type {'all'|'between'|'none'}
-			 * @default "all"
-			 */
-			separators: { type: String, reflect: true },
-			/**
-			 * Show selection only on hover, focus or if at least one item is selected. Exclusive for the tile layout
-			 * @type {boolean}
-			 */
-			selectionWhenInteracted: { type: Boolean, attribute: 'selection-when-interacted', reflect: true },
-			_breakpoint: { type: Number, reflect: true },
-			_slimColor: { type: Boolean, reflect: true, attribute: '_slim-color' }
-		};
-	}
+		label: { type: String },
+		/**
+		 * The type of layout for the list items. Valid values are "list" (default) and "tiles". The tile layout is only valid for single level (non-nested) lists.
+		 * @type {'list'|'tiles'}
+		 * @default "list"
+		 */
+		layout: { type: String, reflect: true },
+		/**
+		 * Display separators. Valid values are "all" (default), "between", "none"
+		 * @type {'all'|'between'|'none'}
+		 * @default "all"
+		 */
+		separators: { type: String, reflect: true },
+		/**
+		 * Show selection only on hover, focus or if at least one item is selected. Exclusive for the tile layout
+		 * @type {boolean}
+		 */
+		selectionWhenInteracted: { type: Boolean, attribute: 'selection-when-interacted', reflect: true },
+		_breakpoint: { type: Number, reflect: true },
+		_slimColor: { type: Boolean, reflect: true, attribute: '_slim-color' }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				--d2l-list-item-color-border-radius: 6px;
-				--d2l-list-item-color-width: 6px;
-				--d2l-list-item-illustration-margin-inline-end: 0.9rem;
-				--d2l-list-item-illustration-max-height: 2.6rem;
-				--d2l-list-item-illustration-max-width: 4.5rem;
-				display: block;
-			}
-			:host([layout="tiles"]) > .d2l-list-content {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 0.9rem;
-				justify-content: normal;
-			}
-			:host(:not([slot="nested"])) > .d2l-list-content {
-				padding-bottom: 1px;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			slot[name="pager"]::slotted(*) {
-				margin-top: 10px;
-			}
-			:host([extend-separators]) slot[name="pager"]::slotted(*) {
-				margin-left: 0.9rem;
-				margin-right: 0.9rem;
-			}
-			:host([_breakpoint="1"]) {
-				--d2l-list-item-illustration-max-height: 3.55rem;
-				--d2l-list-item-illustration-max-width: 6rem;
-			}
-			:host([_breakpoint="2"]) {
-				--d2l-list-item-illustration-max-height: 5.1rem;
-				--d2l-list-item-illustration-max-width: 9rem;
-			}
-			:host([_breakpoint="3"]) {
-				--d2l-list-item-illustration-max-height: 6rem;
-				--d2l-list-item-illustration-max-width: 10.8rem;
-			}
-			:host([_slim-color]) {
-				--d2l-list-item-color-border-radius: 3px;
-				--d2l-list-item-color-width: 3px;
-			}
-			:host([add-button]) ::slotted([slot="controls"]) {
-				margin-bottom: calc(6px + 0.4rem); /* controls section margin-bottom + spacing for add-button */
-			}
+	static styles = css`
+		:host {
+			--d2l-list-item-color-border-radius: 6px;
+			--d2l-list-item-color-width: 6px;
+			--d2l-list-item-illustration-margin-inline-end: 0.9rem;
+			--d2l-list-item-illustration-max-height: 2.6rem;
+			--d2l-list-item-illustration-max-width: 4.5rem;
+			display: block;
+		}
+		:host([layout="tiles"]) > .d2l-list-content {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.9rem;
+			justify-content: normal;
+		}
+		:host(:not([slot="nested"])) > .d2l-list-content {
+			padding-bottom: 1px;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		slot[name="pager"]::slotted(*) {
+			margin-top: 10px;
+		}
+		:host([extend-separators]) slot[name="pager"]::slotted(*) {
+			margin-left: 0.9rem;
+			margin-right: 0.9rem;
+		}
+		:host([_breakpoint="1"]) {
+			--d2l-list-item-illustration-max-height: 3.55rem;
+			--d2l-list-item-illustration-max-width: 6rem;
+		}
+		:host([_breakpoint="2"]) {
+			--d2l-list-item-illustration-max-height: 5.1rem;
+			--d2l-list-item-illustration-max-width: 9rem;
+		}
+		:host([_breakpoint="3"]) {
+			--d2l-list-item-illustration-max-height: 6rem;
+			--d2l-list-item-illustration-max-width: 10.8rem;
+		}
+		:host([_slim-color]) {
+			--d2l-list-item-color-border-radius: 3px;
+			--d2l-list-item-color-width: 3px;
+		}
+		:host([add-button]) ::slotted([slot="controls"]) {
+			margin-bottom: calc(6px + 0.4rem); /* controls section margin-bottom + spacing for add-button */
+		}
 
-			::slotted(.d2l-list-tile-break) {
-				display: none;
-			}
-			:host([layout="tiles"]) ::slotted(.d2l-list-tile-break) {
-				display: block;
-				flex-basis: 100%;
-				height: 0;
-			}
-		`;
-	}
+		::slotted(.d2l-list-tile-break) {
+			display: none;
+		}
+		:host([layout="tiles"]) ::slotted(.d2l-list-tile-break) {
+			display: block;
+			flex-basis: 100%;
+			height: 0;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/components/loading-spinner/loading-spinner.js
+++ b/components/loading-spinner/loading-spinner.js
@@ -7,109 +7,105 @@ import { classMap } from 'lit/directives/class-map.js';
  */
 class LoadingSpinner extends LitElement {
 
-	static get properties() {
-		return {
-			/**
-			 * @ignore
-			 * Color of the animated bar
-			 * @type {string}
-			 * @default var(--d2l-color-celestine)
-			 */
-			color: { type: String },
-			/**
-			 * Height and width (px) of the spinner
-			 * @type {number}
-			 * @default 50
-			 */
-			size: { type: Number }
-		};
-	}
-	static get styles() {
-		return css`
+	static properties = {
+		/**
+		 * @ignore
+		 * Color of the animated bar
+		 * @type {string}
+		 * @default var(--d2l-color-celestine)
+		 */
+		color: { type: String },
+		/**
+		 * Height and width (px) of the spinner
+		 * @type {number}
+		 * @default 50
+		 */
+		size: { type: Number }
+	};
 
-			:host {
-				color: var(--d2l-loading-spinner-color, var(--d2l-color-celestine));
-				display: inline-block;
-				text-align: initial;
-			}
+	static styles = css`
+		:host {
+			color: var(--d2l-loading-spinner-color, var(--d2l-color-celestine));
+			display: inline-block;
+			text-align: initial;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
-			.d2l-loading-spinner-wrapper {
-				height: var(--d2l-loading-spinner-size, 48px);
-				margin: auto;
-				overflow: hidden;
-				position: relative;
-				width: var(--d2l-loading-spinner-size, 48px);
-			}
-			svg {
-				background: radial-gradient(rgba(0, 0, 0, 0.42), transparent 70%); /* 70% ≈ 100%/sqrt(2) = radius of circle since corners lie on 100% of radial gradient */
-				height: 100%;
-				position: absolute;
-				top: 0;
-				width: 100%;
-			}
-			.outer-circle {
-				fill: white;
-				stroke: none;
-			}
-			.inner-circle {
-				fill: none;
-				stroke: var(--d2l-loading-spinner-color, var(--d2l-color-celestine));
-				stroke-width: 3;
-			}
+		.d2l-loading-spinner-wrapper {
+			height: var(--d2l-loading-spinner-size, 48px);
+			margin: auto;
+			overflow: hidden;
+			position: relative;
+			width: var(--d2l-loading-spinner-size, 48px);
+		}
+		svg {
+			background: radial-gradient(rgba(0, 0, 0, 0.42), transparent 70%); /* 70% ≈ 100%/sqrt(2) = radius of circle since corners lie on 100% of radial gradient */
+			height: 100%;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
+		.outer-circle {
+			fill: white;
+			stroke: none;
+		}
+		.inner-circle {
+			fill: none;
+			stroke: var(--d2l-loading-spinner-color, var(--d2l-color-celestine));
+			stroke-width: 3;
+		}
 
-			.slice {
-				animation-duration: 1.5s;
-				animation-iteration-count: infinite;
-				animation-timing-function: cubic-bezier(0.5, 0, 0.5, 1);
-				transform-origin: center;
-			}
-			.slice-1 {
-				animation-name: slicespin1;
-				transform: rotate(54deg);
-			}
-			.slice-2 {
-				animation-name: slicespin2;
-				transform: rotate(124deg);
-			}
-			.slice-3 {
-				animation-name: slicespin3;
-				transform: rotate(198deg);
-			}
-			.slice-4 {
-				animation-name: slicespin4;
-				transform: rotate(270deg);
-			}
-			.slice-5 {
-				animation-name: slicespin5;
-				transform: rotate(344deg);
-			}
+		.slice {
+			animation-duration: 1.5s;
+			animation-iteration-count: infinite;
+			animation-timing-function: cubic-bezier(0.5, 0, 0.5, 1);
+			transform-origin: center;
+		}
+		.slice-1 {
+			animation-name: slicespin1;
+			transform: rotate(54deg);
+		}
+		.slice-2 {
+			animation-name: slicespin2;
+			transform: rotate(124deg);
+		}
+		.slice-3 {
+			animation-name: slicespin3;
+			transform: rotate(198deg);
+		}
+		.slice-4 {
+			animation-name: slicespin4;
+			transform: rotate(270deg);
+		}
+		.slice-5 {
+			animation-name: slicespin5;
+			transform: rotate(344deg);
+		}
 
-			@keyframes slicespin1 {
-				0% { transform: rotate(54deg); }
-				80%, 100% { transform: rotate(430deg); }
-			}
-			@keyframes slicespin2 {
-				0%, 10% { transform: rotate(124deg); }
-				80%, 100% { transform: rotate(500deg); }
-			}
-			@keyframes slicespin3 {
-				0%, 20% { transform: rotate(198deg); }
-				80%, 100% { transform: rotate(574deg); }
-			}
-			@keyframes slicespin4 {
-				0%, 35% { transform: rotate(270deg); }
-				80%, 100% { transform: rotate(644deg); }
-			}
-			@keyframes slicespin5 {
-				80%, 100% { transform: rotate(720deg); }
-			}
+		@keyframes slicespin1 {
+			0% { transform: rotate(54deg); }
+			80%, 100% { transform: rotate(430deg); }
+		}
+		@keyframes slicespin2 {
+			0%, 10% { transform: rotate(124deg); }
+			80%, 100% { transform: rotate(500deg); }
+		}
+		@keyframes slicespin3 {
+			0%, 20% { transform: rotate(198deg); }
+			80%, 100% { transform: rotate(574deg); }
+		}
+		@keyframes slicespin4 {
+			0%, 35% { transform: rotate(270deg); }
+			80%, 100% { transform: rotate(644deg); }
+		}
+		@keyframes slicespin5 {
+			80%, 100% { transform: rotate(720deg); }
+		}
 
-		`;
-	}
+	`;
 
 	render() {
 		return html`


### PR DESCRIPTION
> Disclaimer: this is mostly AI-generated. I've reviewed it myself and do not expect you to fully review it line by line -- although I will need an approval! 😆 

This is part 1 of a conversion from static getters:

```javascript
static get properties() {
  return {
    ...
  };
}
```

To static class level properties:
```javascript
static properties = {
  ...
};
```

And the same for `styles`, although there were a few [complex cases like this](https://github.com/BrightspaceUI/core/blob/8d5ab19367915c1b98d14cfa6780294d77dc0dae/components/inputs/input-inline-help.js#L24) that were left alone.

I also couldn't convert `ButtonMixin`, since the `web-component-analyzer` apparently can't handle them and complains about missing descriptions. I think [it's this issue](https://github.com/runem/web-component-analyzer/issues/135).

Much easier reviewed with whitespace OFF.