### PR TITLE
GAUD-10287: suppress warning in tests

### DIFF
--- a/helpers/flags.js
+++ b/helpers/flags.js
@@ -1,6 +1,10 @@
 const knownFlags = new Map();
 const flagOverrides = new Map();
 
+export function getWarnMessage(key) {
+	return `mockFlag called after getFlag for '${key}'. This is likely to result in unexpected behaviour.`;
+}
+
 export function getFlag(key, defaultValue) {
 	let value;
 	if (flagOverrides.has(key)) {
@@ -21,7 +25,9 @@ export function getKnownFlags() {
 }
 
 export function mockFlag(key, value) {
-	if (knownFlags.has(key)) console.warn(`mockFlag called after getFlag for '${key}'. This is likely to result in unexpected behaviour.`);
+	if (!window.isD2LTestPage && knownFlags.has(key)) {
+		console.warn(getWarnMessage(key));
+	}
 	flagOverrides.set(key, value);
 }
 

--- a/helpers/flags.js
+++ b/helpers/flags.js
@@ -25,7 +25,7 @@ export function getKnownFlags() {
 }
 
 export function mockFlag(key, value) {
-	if (!window.isD2LTestPage && knownFlags.has(key)) {
+	if (!globalThis.isD2LTestPage && knownFlags.has(key)) {
 		console.warn(getWarnMessage(key));
 	}
 	flagOverrides.set(key, value);

--- a/helpers/test/flags.test.js
+++ b/helpers/test/flags.test.js
@@ -1,10 +1,21 @@
+import { fake, replace, restore, stub } from 'sinon';
+import { getFlag, getWarnMessage, mockFlag, resetFlag } from '../flags.js';
 import { expect } from '@brightspace-ui/testing';
-import { getFlag } from '../flags.js';
+
+function setupFlagValue(name) {
+	window.D2L = { LP: { Web: { UI: { Flags: { Flag: key => (key === name) } } } } };
+}
 
 describe('flags', () => {
 
+	const oldD2L = window.D2L;
 	beforeEach(() => {
 		window.D2L = undefined;
+	});
+
+	afterEach(() => {
+		window.D2L = oldD2L;
+		restore();
 	});
 
 	it('should return default value when D2L API is not defined', async() => {
@@ -12,8 +23,44 @@ describe('flags', () => {
 	});
 
 	it('should return the flag value when D2L API is defined', async() => {
-		window.D2L = { LP: { Web: { UI: { Flags: { Flag: key => (key === 'some-flag') } } } } };
+		setupFlagValue('some-flag');
 		expect(getFlag('some-flag', false)).to.be.true;
+	});
+
+	it('should mock the flag', () => {
+		setupFlagValue('mocked-flag');
+		expect(getFlag('mocked-flag', true)).to.be.true;
+		mockFlag('mocked-flag', false);
+		expect(getFlag('mocked-flag', true)).to.be.false;
+	});
+
+	it('should reset the mock', () => {
+		setupFlagValue('mocked-flag');
+		mockFlag('mocked-flag', false);
+		resetFlag('mocked-flag');
+		expect(getFlag('mocked-flag', true)).to.be.true;
+	});
+
+	it('should warn when mocking a flag after it has been retrieved in a non-test environment', () => {
+		stub(window, 'isD2LTestPage').value(false);
+		const fakeWarn = replace(console, 'warn', fake());
+		setupFlagValue('mocked-flag');
+
+		getFlag('mocked-flag', true);
+		mockFlag('mocked-flag', false);
+
+		expect(fakeWarn).to.have.been.calledOnce;
+		expect(fakeWarn).to.have.been.calledWith(getWarnMessage('mocked-flag'));
+	});
+
+	it('should not warn when mocking a flag after it has been retrieved in a test environment', () => {
+		const fakeWarn = replace(console, 'warn', fake());
+		setupFlagValue('mocked-flag');
+
+		getFlag('mocked-flag', true);
+		mockFlag('mocked-flag', false);
+
+		expect(fakeWarn).to.not.have.been.called;
 	});
 
 });


### PR DESCRIPTION
This warning is showing up in our tests as well as other team's tests, even when `mockFlag`/`resetFlag` are being properly used between tests.

It was originally meant to warn you if the order of the imports was such that the mock happened too late, like in demo pages.