### PR TITLE
GAUD-10205 - Fix divider percent value

### DIFF
--- a/components/page/page-divider-internal.js
+++ b/components/page/page-divider-internal.js
@@ -1,6 +1,7 @@
 import '../colors/colors.js';
 import { css, html, LitElement } from 'lit';
 import { formatPercent } from '@brightspace-ui/intl';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 
 export const DIVIDER_WIDTH = 4;
@@ -88,8 +89,10 @@ class PageDivider extends PropertyRequiredMixin(LitElement) {
 	}
 
 	render() {
-		let currentSizePercent = this.currentSize / this.maxSize;
-		if (!Number.isFinite(currentSizePercent)) currentSizePercent = 0; // Avoid NaN or Infinity
+		let ariaValues = {};
+		if (this.maxSize > 0) {
+			ariaValues = { max: this.maxSize, min: 0, now: this.currentSize, text: formatPercent(this.currentSize / this.maxSize, { maximumFractionDigits: 0 }) };
+		}
 
 		return html`
 			<div
@@ -98,10 +101,10 @@ class PageDivider extends PropertyRequiredMixin(LitElement) {
 				tabindex="0"
 				aria-label="${this.label}"
 				aria-orientation="${this.panelType === 'panel' ? 'horizontal' : 'vertical'}"
-				aria-valuemax="${this.maxSize}"
-				aria-valuemin="0"
-				aria-valuenow="${this.currentSize}"
-				aria-valuetext="${formatPercent(currentSizePercent, { maximumFractionDigits: 0 })}"
+				aria-valuemax="${ifDefined(ariaValues.max)}"
+				aria-valuemin="${ifDefined(ariaValues.min)}"
+				aria-valuenow="${ifDefined(ariaValues.now)}"
+				aria-valuetext="${ifDefined(ariaValues.text)}"
 				@keydown="${this.#handleKeyDown}">
 			</div>
 		`;

--- a/components/page/page-divider-internal.js
+++ b/components/page/page-divider-internal.js
@@ -88,7 +88,8 @@ class PageDivider extends PropertyRequiredMixin(LitElement) {
 	}
 
 	render() {
-		const currentSizePercent = formatPercent(Math.round(this.currentSize / this.maxSize) || 0);
+		let currentSizePercent = this.currentSize / this.maxSize;
+		if (!Number.isFinite(currentSizePercent)) currentSizePercent = 0; // Avoid NaN or Infinity
 
 		return html`
 			<div
@@ -100,7 +101,7 @@ class PageDivider extends PropertyRequiredMixin(LitElement) {
 				aria-valuemax="${this.maxSize}"
 				aria-valuemin="0"
 				aria-valuenow="${this.currentSize}"
-				aria-valuetext="${currentSizePercent}"
+				aria-valuetext="${formatPercent(currentSizePercent, { maximumFractionDigits: 0 })}"
 				@keydown="${this.#handleKeyDown}">
 			</div>
 		`;


### PR DESCRIPTION
Turns out I didn't know how `Math.round` works 😓. Rather than adding `* 100` just to then divide by 100 to get back to the decimal `formatPercent` expects, we can let `formatPercent` do the rounding.