### PR TITLE
GAUD-10272: add eslint plugin for array spaces

### DIFF
--- a/components/alert/test/alert.vdiff.js
+++ b/components/alert/test/alert.vdiff.js
@@ -13,7 +13,7 @@ function createAlertWithCloseButton(opts) {
 
 describe('alert', () => {
 
-	[ 'default', 'success', 'critical', 'warning', 'error', 'call-to-action'].forEach(type => {
+	['default', 'success', 'critical', 'warning', 'error', 'call-to-action'].forEach(type => {
 
 		const template = html`<d2l-alert type="${type}">${`A${type === 'error' ? 'n' : ''} ${type === 'call-to-action' ? 'call to action.' : `${type} message.`}`}</d2l-alert>`;
 

--- a/components/backdrop/backdrop.js
+++ b/components/backdrop/backdrop.js
@@ -41,7 +41,7 @@ class Backdrop extends LitElement {
 		_state: { type: String, reflect: true }
 	};
 
-	static styles = [ css`
+	static styles = [css`
 		:host {
 			background-color: var(--d2l-theme-backdrop-background-color);
 			height: 0;

--- a/components/button/button-move.js
+++ b/components/button/button-move.js
@@ -87,7 +87,7 @@ class ButtonMove extends ThemeMixin(FocusMixin(LitElement)) {
 		sideToSide: { type: Boolean, attribute: 'side-to-side', reflect: true }
 	};
 
-	static styles = [ buttonStyles,
+	static styles = [buttonStyles,
 		css`
 			:host {
 				--d2l-button-move-background-color-focus: #ffffff;

--- a/components/button/button-split-item.js
+++ b/components/button/button-split-item.js
@@ -16,7 +16,7 @@ class ButtonSplitItem extends PropertyRequiredMixin(MenuItemMixin(LitElement)) {
 		key: { type: String, required: true }
 	};
 
-	static styles = [ menuItemStyles,
+	static styles = [menuItemStyles,
 		css`
 			:host {
 				align-items: center;

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -27,7 +27,7 @@ class Button extends ButtonMixin(LitElement) {
 		primary: { type: Boolean, reflect: true }
 	};
 
-	static styles = [ labelStyles, buttonStyles,
+	static styles = [labelStyles, buttonStyles,
 		css`
 			:host {
 				display: inline-block;

--- a/components/description-list/test/description-list.vdiff.js
+++ b/components/description-list/test/description-list.vdiff.js
@@ -11,7 +11,7 @@ describe('description-list-wrapper', () => {
 		{ name: 'bulk-course-import', template: html`<d2l-test-dl type="bulk-course-import"></d2l-test-dl>` },
 		{ name: 'slotted', template: html`<d2l-test-dl type="slotted"></d2l-test-dl>` }
 	].forEach(({ name, template }) => {
-		[ 799, 599, 299, 239 ].forEach((width) => {
+		[799, 599, 299, 239].forEach((width) => {
 			it(`${name} ${width}`, async() => {
 				const elem = await fixture(template, { viewport: { width: width + 76 } }); // body has 30px padding + 8px margin
 				await expect(elem).to.be.golden();

--- a/components/dialog/test/dialog-fullscreen.vdiff.js
+++ b/components/dialog/test/dialog-fullscreen.vdiff.js
@@ -22,7 +22,7 @@ function dispatchFullscreenWithinEvent(elem, state) {
 
 describe('dialog-fullscreen', () => {
 
-	[/*'native',*/ 'custom'].forEach((type) => {
+	[/*'native', */'custom'].forEach((type) => {
 
 		describe(type, () => {
 			before(() => window.D2L.DialogMixin.preferNative = type === 'native');

--- a/components/dialog/test/dialog-ifrau.vdiff.js
+++ b/components/dialog/test/dialog-ifrau.vdiff.js
@@ -3,7 +3,7 @@ import { Host } from 'ifrau/host.js';
 
 describe('dialog-ifrau', () => {
 
-	[/*'native',*/ 'custom'].forEach((type) => {
+	[/*'native', */'custom'].forEach((type) => {
 
 		describe(type, () => {
 			let iframeSrc;

--- a/components/dialog/test/dialog-mixin.vdiff.js
+++ b/components/dialog/test/dialog-mixin.vdiff.js
@@ -27,7 +27,7 @@ const delayedTag = defineCE(
 
 describe('dialog-mixin', () => {
 
-	[/*'native',*/ 'custom'].forEach((type) => {
+	[/*'native', */'custom'].forEach((type) => {
 
 		describe(type, () => {
 			before(() => window.D2L.DialogMixin.preferNative = type === 'native');

--- a/components/dialog/test/dialog-with-mobile-dropdown.vdiff.js
+++ b/components/dialog/test/dialog-with-mobile-dropdown.vdiff.js
@@ -44,7 +44,7 @@ async function openFilter(filter) {
 
 describe('dialog-with-mobile-dropdown', () => {
 
-	[/*'native',*/ 'custom'].forEach((type) => {
+	[/*'native', */'custom'].forEach((type) => {
 
 		describe(type, () => {
 			before(() => window.D2L.DialogMixin.preferNative = type === 'native');

--- a/components/dialog/test/dialog.vdiff.js
+++ b/components/dialog/test/dialog.vdiff.js
@@ -21,7 +21,7 @@ function dispatchFullscreenWithinEvent(elem, state) {
 
 describe('dialog', () => {
 
-	[/*'native',*/ 'custom'].forEach((type) => {
+	[/*'native', */'custom'].forEach((type) => {
 
 		describe(type, () => {
 			before(() => window.D2L.DialogMixin.preferNative = type === 'native');

--- a/components/filter/test/filter.test.js
+++ b/components/filter/test/filter.test.js
@@ -1321,7 +1321,7 @@ describe('d2l-filter', () => {
 		it('slot chnages are ignored if _ignoreSlotChanges is true', async() => {
 			/* eslint-disable lit/no-private-properties */
 			const elem = await fixture(html`<d2l-filter _ignoreSlotChanges ._dimensions=${[
-				{ key: 'dim', type: 'd2l-filter-dimension-set', values: [ { key: 'value', text: 'Value', selected: true } ] }
+				{ key: 'dim', type: 'd2l-filter-dimension-set', values: [{ key: 'value', text: 'Value', selected: true }] }
 			]}></d2l-filter>`);
 			/* eslint-enable lit/no-private-properties */
 

--- a/components/html-block/demo/html-block.html
+++ b/components/html-block/demo/html-block.html
@@ -42,7 +42,7 @@
 			// demo replacement renderer for html-block
 			provideInstance(document, 'html-block-renderer-loader', {
 				async getRenderers() {
-					return [ new DemoReplacementRenderer() ];
+					return [new DemoReplacementRenderer()];
 				}
 			});
 

--- a/components/list/demo/list-item-custom.js
+++ b/components/list/demo/list-item-custom.js
@@ -7,7 +7,7 @@ const demoData = {
 	'L1-1': {
 		primaryText: 'Earth Sciences (L1)',
 		supportingText: 'Earth science or geoscience includes all fields of natural science related to planet Earth. This is a branch of science dealing with the physical and chemical constitution of Earth and its atmosphere. Earth science can be considered to be a branch of planetary science, but with a much older history.',
-		nested: [ 'L2-1', 'L2-2', 'L2-3' ]
+		nested: ['L2-1', 'L2-2', 'L2-3']
 	},
 	'L1-2': {
 		primaryText: 'Biology (L1)',
@@ -20,7 +20,7 @@ const demoData = {
 	'L2-1': {
 		primaryText: 'Introductory Earth Sciences (L2)',
 		supportingText: 'This course explores the geological processes of the Earth\'s interior and surface. These include volcanism, earthquakes, mountain building, glaciation and weathering. Students will gain an appreciation of how these processes have controlled the evolution of our planet and the role of geology in meeting society\'s current and future demand for sustainable energy and mineral resources.',
-		nested: [ 'L3-1', 'L3-2', 'L3-3' ]
+		nested: ['L3-1', 'L3-2', 'L3-3']
 	},
 	'L2-2': {
 		primaryText: 'Flow and Transport Through Fractured Rocks (L2)',
@@ -33,7 +33,7 @@ const demoData = {
 	'L3-1': {
 		primaryText: 'Glaciation (L3)',
 		supportingText: 'Supporting Info',
-		nested: [ 'L4-1', 'L4-2' ]
+		nested: ['L4-1', 'L4-2']
 	},
 	'L3-2': {
 		primaryText: 'Weathering (L3)',
@@ -46,7 +46,7 @@ const demoData = {
 	'L4-1': {
 		primaryText: 'Ice Sheets',
 		supportingText: 'Supporting Info',
-		nested: [ /*'L5-1', 'L5-2', 'L5-3', 'L5-4', 'L5-5'*/ ]
+		nested: []
 	},
 	'L4-2': {
 		primaryText: 'Alpine Glaciers',
@@ -55,72 +55,72 @@ const demoData = {
 	'L5-1': {
 		primaryText: 'Topic L5-1',
 		supportingText: 'Supporting Info',
-		nested: [ 'L6-1' /*, 'L6-2', 'L6-3', 'L6-4', 'L6-5', 'L6-6', 'L6-7', 'L6-8'*/ ]
+		nested: ['L6-1']
 	},
 	'L5-2': {
 		primaryText: 'Topic L5-2',
 		supportingText: 'Supporting Info',
-		nested: [ 'L6-1', 'L6-2', 'L6-3', 'L6-4', 'L6-5', 'L6-6', 'L6-7', 'L6-8' ]
+		nested: ['L6-1', 'L6-2', 'L6-3', 'L6-4', 'L6-5', 'L6-6', 'L6-7', 'L6-8']
 	},
 	'L5-3': {
 		primaryText: 'Topic L5-3',
 		supportingText: 'Supporting Info',
-		nested: [ 'L6-1', 'L6-2', 'L6-3', 'L6-4', 'L6-5', 'L6-6', 'L6-7', 'L6-8' ]
+		nested: ['L6-1', 'L6-2', 'L6-3', 'L6-4', 'L6-5', 'L6-6', 'L6-7', 'L6-8']
 	},
 	'L5-4': {
 		primaryText: 'Topic L5-4',
 		supportingText: 'Supporting Info',
-		nested: [ 'L6-1', 'L6-2', 'L6-3', 'L6-4', 'L6-5', 'L6-6', 'L6-7', 'L6-8' ]
+		nested: ['L6-1', 'L6-2', 'L6-3', 'L6-4', 'L6-5', 'L6-6', 'L6-7', 'L6-8']
 	},
 	'L5-5': {
 		primaryText: 'Topic L5-5',
 		supportingText: 'Supporting Info',
-		nested: [ 'L6-1', 'L6-2', 'L6-3', 'L6-4', 'L6-5', 'L6-6', 'L6-7', 'L6-8' ]
+		nested: ['L6-1', 'L6-2', 'L6-3', 'L6-4', 'L6-5', 'L6-6', 'L6-7', 'L6-8']
 	},
 	'L6-1': {
 		primaryText: 'Topic L6-1',
 		supportingText: 'Supporting Info',
-		nested: [ 'L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10' ]
+		nested: ['L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10']
 	},
 	'L6-2': {
 		primaryText: 'Topic L6-2',
 		supportingText: 'Supporting Info',
-		nested: [ 'L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10' ]
+		nested: ['L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10']
 	},
 	'L6-3': {
 		primaryText: 'Topic L6-3',
 		supportingText: 'Supporting Info',
-		nested: [ 'L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10' ]
+		nested: ['L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10']
 	},
 	'L6-4': {
 		primaryText: 'Topic L6-4',
 		supportingText: 'Supporting Info',
-		nested: [ 'L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10' ]
+		nested: ['L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10']
 	},
 	'L6-5': {
 		primaryText: 'Topic L6-5',
 		supportingText: 'Supporting Info',
-		nested: [ 'L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10' ]
+		nested: ['L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10']
 	},
 	'L6-6': {
 		primaryText: 'Topic L6-6',
 		supportingText: 'Supporting Info',
-		nested: [ 'L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10' ]
+		nested: ['L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10']
 	},
 	'L6-7': {
 		primaryText: 'Topic L6-7',
 		supportingText: 'Supporting Info',
-		nested: [ 'L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10' ]
+		nested: ['L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10']
 	},
 	'L6-8': {
 		primaryText: 'Topic L6-8',
 		supportingText: 'Supporting Info',
-		nested: [ 'L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10' ]
+		nested: ['L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10']
 	},
 	'L6-9': {
 		primaryText: 'Topic L6-9',
 		supportingText: 'Supporting Info',
-		nested: [ 'L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10' ]
+		nested: ['L7-1', 'L7-2', 'L7-3', 'L7-4', 'L7-5', 'L7-6', 'L7-7', 'L7-8', 'L7-9', 'L7-10']
 	},
 	'L7-1': {
 		primaryText: 'Topic L7-1',

--- a/components/list/test/list.vdiff.js
+++ b/components/list/test/list.vdiff.js
@@ -415,7 +415,7 @@ describe('list', () => {
 
 	describe('separators', () => {
 
-		[ true, false ].forEach((addButton) => {
+		[true, false].forEach((addButton) => {
 			[
 				{ name: `default${addButton ? ' add-button' : ''}`, template: createSimpleList({ color1: '#0000ff', addButton }) },
 				{ name: `none${addButton ? ' add-button' : ''}`, template: createSimpleList({ color1: '#00ff00', color2: '#00ff00', separatorType: 'none', addButton }) },

--- a/components/menu/menu-item-selectable-styles.js
+++ b/components/menu/menu-item-selectable-styles.js
@@ -1,7 +1,7 @@
 import { css } from 'lit';
 import { menuItemStyles } from './menu-item-styles.js';
 
-export const menuItemSelectableStyles = [ menuItemStyles,
+export const menuItemSelectableStyles = [menuItemStyles,
 	css`
 		:host {
 			align-items: center;

--- a/components/object-property-list/object-property-list.js
+++ b/components/object-property-list/object-property-list.js
@@ -65,7 +65,7 @@ class ObjectPropertyList extends LocalizeCoreElement(SkeletonMixin(LitElement)) 
 
 	_setItemSeparatorVisibility(slot) {
 		const slottedElements = slot.assignedElements();
-		const elements = slottedElements.length ? slottedElements : [ ...slot.children ];
+		const elements = slottedElements.length ? slottedElements : [...slot.children];
 		const filtered = elements.filter(item => item.tagName?.toLowerCase().includes('d2l-object-property-list-') && !item.hidden);
 
 		const lastIndex = filtered.length - 1;

--- a/components/paging/pageable-subscriber-mixin.js
+++ b/components/paging/pageable-subscriber-mixin.js
@@ -25,7 +25,7 @@ export const PageableSubscriberMixin = superclass => class extends superclass {
 	}
 
 	_getPageableRegistries() {
-		return this.pageableFor ? this._pageableIdSubscriber.registries : [ this._pageableEventSubscriber.registry ];
+		return this.pageableFor ? this._pageableIdSubscriber.registries : [this._pageableEventSubscriber.registry];
 	}
 
 };

--- a/components/scroll-wrapper/scroll-wrapper.js
+++ b/components/scroll-wrapper/scroll-wrapper.js
@@ -293,8 +293,8 @@ class ScrollWrapper extends LocalizeCoreElement(LitElement) {
 		this._baseContainer = this.shadowRoot.querySelector('.d2l-scroll-wrapper-container');
 		this._container = this.customScrollers?.primary || this._baseContainer;
 		this._secondaryScrollers = this.customScrollers?.secondary || [];
-		if (this._secondaryScrollers.length === undefined) this._secondaryScrollers = [ this._secondaryScrollers ];
-		this._allScrollers = [ this._container, ...this._secondaryScrollers ];
+		if (this._secondaryScrollers.length === undefined) this._secondaryScrollers = [this._secondaryScrollers];
+		this._allScrollers = [this._container, ...this._secondaryScrollers];
 
 		if (this._container) {
 			this._container.classList.add('d2l-scroll-wrapper-focus');

--- a/components/selection/test/selection.test.js
+++ b/components/selection/test/selection.test.js
@@ -47,14 +47,14 @@ describe('d2l-selection-action', () => {
 
 	it('dispatches d2l-selection-action-click event if less than max-selection-count is selected', async() => {
 		const el = await fixture(html`<d2l-selection-action max-selection-count="2"></d2l-selection-action>`);
-		el.selectionInfo = { state: 'some', keys: [ 'first' ] };
+		el.selectionInfo = { state: 'some', keys: ['first'] };
 		clickElem(el);
 		await oneEvent(el, 'd2l-selection-action-click');
 	});
 
 	it('dispatches d2l-selection-action-click event if max-selection-count is selected', async() => {
 		const el = await fixture(html`<d2l-selection-action max-selection-count="2"></d2l-selection-action>`);
-		el.selectionInfo = { state: 'some', keys: [ 'first', 'second' ] };
+		el.selectionInfo = { state: 'some', keys: ['first', 'second'] };
 		clickElem(el);
 		await oneEvent(el, 'd2l-selection-action-click');
 	});
@@ -63,7 +63,7 @@ describe('d2l-selection-action', () => {
 		const el = await fixture(html`<d2l-selection-action max-selection-count="2"></d2l-selection-action>`);
 		let dispatched = false;
 		el.addEventListener('d2l-selection-action-click', () => dispatched = true);
-		el.selectionInfo = { state: 'some', keys: [ 'first', 'second', 'third' ] };
+		el.selectionInfo = { state: 'some', keys: ['first', 'second', 'third'] };
 		clickElem(el);
 		expect(dispatched).to.be.false;
 	});
@@ -72,7 +72,7 @@ describe('d2l-selection-action', () => {
 		const el = await fixture(html`<d2l-selection-action disabled></d2l-selection-action>`);
 		let dispatched = false;
 		el.addEventListener('d2l-selection-action-click', () => dispatched = true);
-		el.selectionInfo = { state: 'some', keys: [ 'first', 'second', 'third' ] };
+		el.selectionInfo = { state: 'some', keys: ['first', 'second', 'third'] };
 		clickElem(el);
 		expect(dispatched).to.be.false;
 	});
@@ -120,7 +120,7 @@ describe('d2l-selection-action-menu-item', () => {
 	it('dispatches d2l-selection-action-click event if less than max-selection-count is selected', async() => {
 		const el = await fixture(html`<d2l-menu label="Actions"><d2l-selection-action-menu-item text="Action" max-selection-count="2"></d2l-selection-action-menu-item></d2l-menu>`);
 		const item = el.querySelector('d2l-selection-action-menu-item');
-		item.selectionInfo = { state: 'some', keys: [ 'first' ] };
+		item.selectionInfo = { state: 'some', keys: ['first'] };
 		clickElem(item);
 		await oneEvent(el, 'd2l-selection-action-click');
 	});
@@ -128,7 +128,7 @@ describe('d2l-selection-action-menu-item', () => {
 	it('dispatches d2l-selection-action-click event if max-selection-count is selected', async() => {
 		const el = await fixture(html`<d2l-menu label="Actions"><d2l-selection-action-menu-item text="Action" max-selection-count="2"></d2l-selection-action-menu-item></d2l-menu>`);
 		const item = el.querySelector('d2l-selection-action-menu-item');
-		item.selectionInfo = { state: 'some', keys: [ 'first', 'second' ] };
+		item.selectionInfo = { state: 'some', keys: ['first', 'second'] };
 		clickElem(item);
 		await oneEvent(el, 'd2l-selection-action-click');
 	});
@@ -138,7 +138,7 @@ describe('d2l-selection-action-menu-item', () => {
 		const item = el.querySelector('d2l-selection-action-menu-item');
 		let dispatched = false;
 		item.addEventListener('d2l-selection-action-click', () => dispatched = true);
-		item.selectionInfo = { state: 'some', keys: [ 'first', 'second', 'third' ] };
+		item.selectionInfo = { state: 'some', keys: ['first', 'second', 'third'] };
 		clickElem(item);
 		expect(dispatched).to.be.false;
 	});
@@ -148,7 +148,7 @@ describe('d2l-selection-action-menu-item', () => {
 		const item = el.querySelector('d2l-selection-action-menu-item');
 		let dispatched = false;
 		item.addEventListener('d2l-selection-action-click', () => dispatched = true);
-		item.selectionInfo = { state: 'some', keys: [ 'first', 'second', 'third' ] };
+		item.selectionInfo = { state: 'some', keys: ['first', 'second', 'third'] };
 		clickElem(item);
 		expect(dispatched).to.be.false;
 	});

--- a/components/selection/test/selection.vdiff.js
+++ b/components/selection/test/selection.vdiff.js
@@ -36,18 +36,18 @@ describe('selection-components', () => {
 		tests: [
 			{ name: 'text', template: html`<d2l-selection-action text="action"></d2l-selection-action>` },
 			{ name: 'text-icon', template: html`<d2l-selection-action text="action" icon="tier1:gear"></d2l-selection-action>` },
-			{ name: 'disabled', template: html`<d2l-selection-action text="action" disabled disabled-tooltip="Disabled message"></d2l-selection-action>`, waitFor: elem => oneEvent(elem, 'd2l-tooltip-show'), selectionInfo: { state: 'some', keys: [ 'first' ] } },
+			{ name: 'disabled', template: html`<d2l-selection-action text="action" disabled disabled-tooltip="Disabled message"></d2l-selection-action>`, waitFor: elem => oneEvent(elem, 'd2l-tooltip-show'), selectionInfo: { state: 'some', keys: ['first'] } },
 			{ name: 'requires-selection', template: html`<d2l-selection-action text="action" requires-selection></d2l-selection-action>`, waitFor: elem => oneEvent(elem, 'd2l-tooltip-show'), selectionInfo: { state: 'none', keys: [] } },
-			{ name: 'max-selection-count', template: html`<d2l-selection-action text="action" max-selection-count="2"></d2l-selection-action>`, waitFor: elem => oneEvent(elem, 'd2l-tooltip-show'), selectionInfo: { state: 'some', keys: [ 'first', 'second', 'third' ] } }
+			{ name: 'max-selection-count', template: html`<d2l-selection-action text="action" max-selection-count="2"></d2l-selection-action>`, waitFor: elem => oneEvent(elem, 'd2l-tooltip-show'), selectionInfo: { state: 'some', keys: ['first', 'second', 'third'] } }
 		]
 	},
 	{
 		category: 'dropdown',
 		tests: [
 			{ name: 'text', template: html`<d2l-selection-action-dropdown text="action"></d2l-selection-action-dropdown>` },
-			{ name: 'disabled', template: html`<d2l-selection-action-dropdown text="action" disabled></d2l-selection-action-dropdown>`, selectionInfo: { state: 'some', keys: [ 'first' ] } },
+			{ name: 'disabled', template: html`<d2l-selection-action-dropdown text="action" disabled></d2l-selection-action-dropdown>`, selectionInfo: { state: 'some', keys: ['first'] } },
 			{ name: 'requires-selection', template: html`<d2l-selection-action-dropdown text="action" requires-selection></d2l-selection-action-dropdown>`, waitFor: elem => oneEvent(elem, 'd2l-tooltip-show'), selectionInfo: { state: 'none', keys: [] } },
-			{ name: 'max-selection-count', template: html`<d2l-selection-action-dropdown text="action" max-selection-count="2"></d2l-selection-action-dropdown>`, waitFor: elem => oneEvent(elem, 'd2l-tooltip-show'), selectionInfo: { state: 'some', keys: [ 'first', 'second', 'third' ] } }
+			{ name: 'max-selection-count', template: html`<d2l-selection-action-dropdown text="action" max-selection-count="2"></d2l-selection-action-dropdown>`, waitFor: elem => oneEvent(elem, 'd2l-tooltip-show'), selectionInfo: { state: 'some', keys: ['first', 'second', 'third'] } }
 		]
 	}].forEach(({ category, tests }) => {
 

--- a/components/skeleton/skeleton-mixin.js
+++ b/components/skeleton/skeleton-mixin.js
@@ -175,7 +175,7 @@ export const SkeletonMixin = dedupeMixin(superclass => class extends superclass 
 	};
 
 	static get styles() {
-		const styles = [ skeletonStyles ];
+		const styles = [skeletonStyles];
 		super.styles && styles.unshift(super.styles);
 		return styles;
 	}

--- a/components/tabs/demo/tab-custom.js
+++ b/components/tabs/demo/tab-custom.js
@@ -5,7 +5,7 @@ import { TabMixin } from '../tab-mixin.js';
 class TabCustom extends TabMixin(LitElement) {
 
 	static get styles() {
-		const styles = [ css`
+		const styles = [css`
 			.d2l-tab-custom-content {
 				--d2l-focus-ring-offset: 0;
 				margin: 0.5rem;

--- a/components/tabs/tab-mixin.js
+++ b/components/tabs/tab-mixin.js
@@ -34,7 +34,7 @@ export const TabMixin = superclass => class extends SkeletonMixin(superclass) {
 	};
 
 	static get styles() {
-		const styles = [ css`
+		const styles = [css`
 			:host {
 				box-sizing: border-box;
 				display: inline-block;

--- a/components/tabs/tab.js
+++ b/components/tabs/tab.js
@@ -27,7 +27,7 @@ class Tab extends TabMixin(LitElement) {
 	};
 
 	static get styles() {
-		const styles = [ css`
+		const styles = [css`
 			.d2l-tab-text-inner-content {
 				--d2l-focus-ring-offset: 0;
 				display: flex;

--- a/components/typography/test/typography.vdiff.js
+++ b/components/typography/test/typography.vdiff.js
@@ -20,7 +20,7 @@ describe('typography', () => {
 
 		describe(category, () => {
 
-			[ '1', '2', '3', '4'].forEach(level => {
+			['1', '2', '3', '4'].forEach(level => {
 
 				it(`heading-${level}`, async() => {
 					const elem = await fixture(createTypographyWrapper(html`<h1 class="d2l-heading-${level}">${`Heading ${level}`}</h1>`), { viewport });

--- a/controllers/subscriber/test/subscriberControllers.test.js
+++ b/controllers/subscriber/test/subscriberControllers.test.js
@@ -127,7 +127,7 @@ describe('SubscriberRegistryController', () => {
 			expect(registry._eventSubscribers.subscribers.has(elem.querySelector('#event'))).to.be.true;
 			expect(registry._idSubscribers.subscribers.size).to.equal(1);
 			expect(registry._idSubscribers.subscribers.has(elem.querySelector('#id'))).to.be.true;
-			expect(registry._onSubscribeTargets).to.eql([ elem.querySelector('#id'), elem.querySelector('#event') ]);
+			expect(registry._onSubscribeTargets).to.eql([elem.querySelector('#id'), elem.querySelector('#event')]);
 		});
 
 		it('Additional subscribers can be subscribed manually', () => {
@@ -152,25 +152,25 @@ describe('SubscriberRegistryController', () => {
 			eventElem.remove();
 			await registry.updateComplete;
 			expect(registry._eventSubscribers.subscribers.size).to.equal(0);
-			expect(registry._onUnsubscribeTargets).to.eql([ eventElem ]);
+			expect(registry._onUnsubscribeTargets).to.eql([eventElem]);
 
 			const idElem = elem.querySelector('#id');
 			idElem.remove();
 			await registry.updateComplete;
 			expect(registry._idSubscribers.subscribers.size).to.equal(0);
-			expect(registry._onUnsubscribeTargets).to.eql([ eventElem, idElem ]);
+			expect(registry._onUnsubscribeTargets).to.eql([eventElem, idElem]);
 		});
 
 		it('Subscribers can be unsubscribed manually', () => {
 			const eventElem = elem.querySelector('#event');
 			registry._eventSubscribers.unsubscribe(eventElem);
 			expect(registry._eventSubscribers.subscribers.size).to.equal(0);
-			expect(registry._onUnsubscribeTargets).to.eql([ eventElem ]);
+			expect(registry._onUnsubscribeTargets).to.eql([eventElem]);
 
 			const idElem = elem.querySelector('#id');
 			registry._idSubscribers.unsubscribe(idElem);
 			expect(registry._idSubscribers.subscribers.size).to.equal(0);
-			expect(registry._onUnsubscribeTargets).to.eql([ eventElem, idElem ]);
+			expect(registry._onUnsubscribeTargets).to.eql([eventElem, idElem]);
 		});
 
 		it('Calls to updateSubscribers are debounced', async() => {
@@ -184,7 +184,7 @@ describe('SubscriberRegistryController', () => {
 			registry._eventSubscribers.updateSubscribers();
 			await nextFrame();
 			await nextFrame();
-			expect(registry._updateSubscribersCalledWith).to.eql([ registry._idSubscribers.subscribers, registry._eventSubscribers.subscribers ]);
+			expect(registry._updateSubscribersCalledWith).to.eql([registry._idSubscribers.subscribers, registry._eventSubscribers.subscribers]);
 		});
 	});
 
@@ -205,7 +205,7 @@ describe('SubscriberRegistryController', () => {
 			expect(registry._combinedSubscribers.subscribers.size).to.equal(2);
 			expect(registry._combinedSubscribers.subscribers.has(elem.querySelector('#event'))).to.be.true;
 			expect(registry._combinedSubscribers.subscribers.has(elem.querySelector('#id'))).to.be.true;
-			expect(registry._onSubscribeTargets).to.eql([ elem.querySelector('#id'), elem.querySelector('#event') ]);
+			expect(registry._onSubscribeTargets).to.eql([elem.querySelector('#id'), elem.querySelector('#event')]);
 		});
 
 		it('Additional subscribers can be subscribed manually', () => {
@@ -224,27 +224,27 @@ describe('SubscriberRegistryController', () => {
 			eventElem.remove();
 			await registry.updateComplete;
 			expect(registry._combinedSubscribers.subscribers.size).to.equal(1);
-			expect(registry._onUnsubscribeTargets).to.eql([ eventElem ]);
+			expect(registry._onUnsubscribeTargets).to.eql([eventElem]);
 			expect(registry._combinedSubscribers.subscribers.has(elem.querySelector('#id'))).to.be.true;
 
 			const idElem = elem.querySelector('#id');
 			idElem.remove();
 			await registry.updateComplete;
 			expect(registry._combinedSubscribers.subscribers.size).to.equal(0);
-			expect(registry._onUnsubscribeTargets).to.eql([ eventElem, idElem ]);
+			expect(registry._onUnsubscribeTargets).to.eql([eventElem, idElem]);
 		});
 
 		it('Subscribers can be unsubscribed manually', () => {
 			const eventElem = elem.querySelector('#event');
 			registry._combinedSubscribers.unsubscribe(eventElem);
 			expect(registry._combinedSubscribers.subscribers.size).to.equal(1);
-			expect(registry._onUnsubscribeTargets).to.eql([ eventElem ]);
+			expect(registry._onUnsubscribeTargets).to.eql([eventElem]);
 			expect(registry._combinedSubscribers.subscribers.has(elem.querySelector('#id'))).to.be.true;
 
 			const idElem = elem.querySelector('#id');
 			registry._combinedSubscribers.unsubscribe(idElem);
 			expect(registry._combinedSubscribers.subscribers.size).to.equal(0);
-			expect(registry._onUnsubscribeTargets).to.eql([ eventElem, idElem ]);
+			expect(registry._onUnsubscribeTargets).to.eql([eventElem, idElem]);
 		});
 
 		it('Calls to updateSubscribers are debounced', async() => {
@@ -255,7 +255,7 @@ describe('SubscriberRegistryController', () => {
 			registry._combinedSubscribers.updateSubscribers();
 			await nextFrame();
 			await nextFrame();
-			expect(registry._updateSubscribersCalledWith).to.eql([ registry._combinedSubscribers.subscribers ]);
+			expect(registry._updateSubscribersCalledWith).to.eql([registry._combinedSubscribers.subscribers]);
 		});
 	});
 });
@@ -285,7 +285,7 @@ describe('EventSubscriberController', () => {
 
 	it('Call onSubscribe after subscribing and getting the registry component', () => {
 		const subscriber = elem.querySelector('#success');
-		expect(subscriber._onSubscribeRegistries).to.eql([ elem.querySelector('#registry') ]);
+		expect(subscriber._onSubscribeRegistries).to.eql([elem.querySelector('#registry')]);
 		expect(subscriber._onErrorRegistryIds).to.eql([]);
 	});
 
@@ -294,12 +294,12 @@ describe('EventSubscriberController', () => {
 
 		clock.tick(400);
 		expect(subscriber._onSubscribeRegistries).to.eql([]);
-		expect(subscriber._onErrorRegistryIds).to.eql([ undefined ]);
+		expect(subscriber._onErrorRegistryIds).to.eql([undefined]);
 	});
 
 	it('Subscribe to slotted registries properly', () => {
 		const subscriber = elem.querySelector('#slotted');
-		expect(subscriber._onSubscribeRegistries).to.eql([ elem.querySelector('#registry-wrapper').shadowRoot.querySelector('#registry-shadow') ]);
+		expect(subscriber._onSubscribeRegistries).to.eql([elem.querySelector('#registry-wrapper').shadowRoot.querySelector('#registry-shadow')]);
 		expect(subscriber._onErrorRegistryIds).to.eql([]);
 	});
 
@@ -313,7 +313,7 @@ describe('EventSubscriberController', () => {
 		expect(subscriber._onSubscribeRegistries).to.eql([]);
 
 		clock.tick(40);
-		expect(subscriber._onSubscribeRegistries).to.eql([ elem.querySelector('#registry-wrapper-delayed').shadowRoot.querySelector('#registry-shadow') ]);
+		expect(subscriber._onSubscribeRegistries).to.eql([elem.querySelector('#registry-wrapper-delayed').shadowRoot.querySelector('#registry-shadow')]);
 		expect(subscriber._onErrorRegistryIds).to.eql([]);
 	});
 });
@@ -345,13 +345,13 @@ describe('IdSubscriberController', () => {
 
 		it('Call onSubscribe after subscribing and getting the registry component', () => {
 			const nestedSubscriber = elem.querySelector('#nested');
-			expect(nestedSubscriber._onSubscribeRegistries).to.eql([ elem.querySelector('#registry-1') ]);
+			expect(nestedSubscriber._onSubscribeRegistries).to.eql([elem.querySelector('#registry-1')]);
 
 			const singleSubscriber = elem.querySelector('#single');
-			expect(singleSubscriber._onSubscribeRegistries).to.eql([ elem.querySelector('#registry-1') ]);
+			expect(singleSubscriber._onSubscribeRegistries).to.eql([elem.querySelector('#registry-1')]);
 
 			const multipleSubscriber = elem.querySelector('#multiple');
-			expect(multipleSubscriber._onSubscribeRegistries).to.eql([ elem.querySelector('#registry-1'), elem.querySelector('#registry-2') ]);
+			expect(multipleSubscriber._onSubscribeRegistries).to.eql([elem.querySelector('#registry-1'), elem.querySelector('#registry-2')]);
 		});
 
 		it('If a registry component is removed, registry maps are updated', async() => {
@@ -366,10 +366,10 @@ describe('IdSubscriberController', () => {
 			await singleSubscriber.updateComplete;
 			await multipleSubscriber.updateComplete;
 
-			expect(singleSubscriber._onUnsubscribeRegistryIds).to.eql([ 'registry-1' ]);
+			expect(singleSubscriber._onUnsubscribeRegistryIds).to.eql(['registry-1']);
 			expect(singleSubscriber._subscriberController.registries).to.eql([]);
-			expect(multipleSubscriber._onUnsubscribeRegistryIds).to.eql([ 'registry-1' ]);
-			expect(multipleSubscriber._subscriberController.registries).to.eql([ registry2 ]);
+			expect(multipleSubscriber._onUnsubscribeRegistryIds).to.eql(['registry-1']);
+			expect(multipleSubscriber._subscriberController.registries).to.eql([registry2]);
 		});
 
 		it('If a registry component is added, the registry and subscriber maps are updated', async() => {
@@ -385,8 +385,8 @@ describe('IdSubscriberController', () => {
 			elem.appendChild(newNode);
 			await newNode.updateComplete;
 
-			expect(errorSubscriber._onSubscribeRegistries).to.eql([ newNode ]);
-			expect(errorSubscriber._subscriberController.registries).to.eql([ newNode ]);
+			expect(errorSubscriber._onSubscribeRegistries).to.eql([newNode]);
+			expect(errorSubscriber._subscriberController.registries).to.eql([newNode]);
 			expect(multipleSubscriber._onSubscribeRegistries.length).to.equal(3);
 			expect(multipleSubscriber._onSubscribeRegistries[2]).to.equal(newNode);
 			expect(multipleSubscriber._subscriberController.registries.length).to.equal(3);
@@ -400,18 +400,18 @@ describe('IdSubscriberController', () => {
 			const registry1 = elem.querySelector('#registry-1');
 			const registry2 = elem.querySelector('#registry-2');
 			const singleSubscriber = elem.querySelector('#single');
-			expect(singleSubscriber._onSubscribeRegistries).to.eql([ registry1 ]);
+			expect(singleSubscriber._onSubscribeRegistries).to.eql([registry1]);
 			expect(singleSubscriber._onUnsubscribeRegistryIds).to.eql([]);
-			expect(singleSubscriber._subscriberController.registries).to.eql([ registry1 ]);
+			expect(singleSubscriber._subscriberController.registries).to.eql([registry1]);
 			expect(registry1._idSubscribers.subscribers.has(singleSubscriber)).to.be.true;
 			expect(registry2._idSubscribers.subscribers.has(singleSubscriber)).to.be.false;
 
 			singleSubscriber.for = 'registry-2';
 			await singleSubscriber.updateComplete;
 
-			expect(singleSubscriber._onSubscribeRegistries).to.eql([ registry1, registry2 ]);
-			expect(singleSubscriber._onUnsubscribeRegistryIds).to.eql([ 'registry-1' ]);
-			expect(singleSubscriber._subscriberController.registries).to.eql([ registry2 ]);
+			expect(singleSubscriber._onSubscribeRegistries).to.eql([registry1, registry2]);
+			expect(singleSubscriber._onUnsubscribeRegistryIds).to.eql(['registry-1']);
+			expect(singleSubscriber._subscriberController.registries).to.eql([registry2]);
 			expect(registry1._idSubscribers.subscribers.has(singleSubscriber)).to.be.false;
 			expect(registry2._idSubscribers.subscribers.has(singleSubscriber)).to.be.true;
 		});
@@ -424,7 +424,7 @@ describe('IdSubscriberController', () => {
 			expect(subscriber._onSubscribeRegistries).to.eql([]);
 
 			clock.tick(100);
-			expect(subscriber._onSubscribeRegistries).to.eql([ registry3 ]);
+			expect(subscriber._onSubscribeRegistries).to.eql([registry3]);
 			expect(subscriber._onErrorRegistryIds).to.eql([]);
 		});
 	});
@@ -453,9 +453,9 @@ describe('IdSubscriberController', () => {
 			clock.tick(1);
 
 			expect(errorSubscriber._onSubscribeRegistries).to.be.empty;
-			expect(errorSubscriber._onErrorRegistryIds).to.eql([ 'non-existant' ]);
-			expect(multipleSubscriber._onSubscribeRegistries).to.eql([ elem.querySelector('#registry-1'), elem.querySelector('#registry-2') ]);
-			expect(multipleSubscriber._onErrorRegistryIds).to.eql([ 'non-existant' ]);
+			expect(errorSubscriber._onErrorRegistryIds).to.eql(['non-existant']);
+			expect(multipleSubscriber._onSubscribeRegistries).to.eql([elem.querySelector('#registry-1'), elem.querySelector('#registry-2')]);
+			expect(multipleSubscriber._onErrorRegistryIds).to.eql(['non-existant']);
 		});
 	});
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import { addExtensions, litConfig, nodeConfig, setDirectoryConfigs, testingConfig } from 'eslint-config-brightspace';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
+import stylistic from '@stylistic/eslint-plugin';
 
 export default [
 	{
@@ -37,5 +38,13 @@ export default [
 			'no-restricted-globals': ['error', 'document'],
 			'unicorn/prefer-global-this': 'error',
 		},
+	},
+	{
+		plugins: {
+			'@stylistic': stylistic
+		},
+		rules: {
+			'@stylistic/array-bracket-spacing': ['error', 'never']
+		}
 	}
 ];

--- a/helpers/prism.js
+++ b/helpers/prism.js
@@ -343,9 +343,9 @@ const getLanguageInfo = elem => {
 };
 
 const languageDependencies = {
-	arduino: [ 'cpp' ],
-	cpp: [ 'c' ],
-	racket: [ 'scheme' ]
+	arduino: ['cpp'],
+	cpp: ['c'],
+	racket: ['scheme']
 };
 
 const languagesLoaded = {

--- a/helpers/template-tags.js
+++ b/helpers/template-tags.js
@@ -5,7 +5,7 @@ export function set(strings, ...expressions) {
 	let w = Number.MAX_SAFE_INTEGER;
 	const emptyStart = strings[0].match(emptyStartRe);
 	if (emptyStart) {
-		strings = [ strings[0].replace(emptyStartRe, ''), ...strings.slice(1) ];
+		strings = [strings[0].replace(emptyStartRe, ''), ...strings.slice(1)];
 		strings[strings.length - 1] = strings.at(-1).replace(emptyEndRe, '');
 	}
 	strings

--- a/helpers/test/interactive.test.js
+++ b/helpers/test/interactive.test.js
@@ -79,27 +79,27 @@ describe('interactive', () => {
 	describe('isInteractiveInComposedPath', () => {
 		it('should return true if an interactive element is found', () => {
 			const ele = document.createElement('button');
-			const path = [ ele ];
+			const path = [ele];
 			expect(isInteractiveInComposedPath(path)).to.be.true;
 		});
 
 		it('should return false if no interactive elements are found', () => {
 			const ele = document.createElement('div');
-			const path = [ ele ];
+			const path = [ele];
 			expect(isInteractiveInComposedPath(path)).to.be.false;
 		});
 
 		it('should return true if interactive element is found in the path', () => {
 			const ele1 = document.createElement('div');
 			const ele2 = document.createElement('button');
-			const path = [ ele1, ele2 ];
+			const path = [ele1, ele2];
 			expect(isInteractiveInComposedPath(path)).to.be.true;
 		});
 
 		it('should return true if options elements are passed and an interactive element is found', () => {
 			const ele1 = document.createElement('div');
 			const ele2 = document.createElement('d2l-button');
-			const path = [ ele1, ele2 ];
+			const path = [ele1, ele2];
 			const options = { elements: { 'd2l-button': true } };
 			expect(isInteractiveInComposedPath(path, null, options)).to.be.true;
 		});
@@ -108,7 +108,7 @@ describe('interactive', () => {
 			const ele1 = document.createElement('div');
 			const ele2 = document.createElement('div');
 			ele2.setAttribute('role', 'h2');
-			const path = [ ele1, ele2 ];
+			const path = [ele1, ele2];
 			const options = { roles: { 'h2': true } };
 			expect(isInteractiveInComposedPath(path, null, options)).to.be.true;
 		});
@@ -118,7 +118,7 @@ describe('interactive', () => {
 			const ele2 = document.createElement('div');
 			ele2.setAttribute('id', 'test-id');
 			const ele3 = document.createElement('button');
-			const path = [ ele1, ele2, ele3 ];
+			const path = [ele1, ele2, ele3];
 			const isPrimaryAction = (elem) => elem.id === 'test-id';
 			expect(isInteractiveInComposedPath(path, isPrimaryAction)).to.be.false;
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@rollup/plugin-dynamic-import-vars": "^2",
         "@rollup/plugin-node-resolve": "^16",
         "@rollup/plugin-replace": "^6",
+        "@stylistic/eslint-plugin": "^5",
         "@web/dev-server": "^0.4",
         "chalk": "^5",
         "eslint": "^9",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@rollup/plugin-dynamic-import-vars": "^2",
     "@rollup/plugin-node-resolve": "^16",
     "@rollup/plugin-replace": "^6",
+    "@stylistic/eslint-plugin": "^5",
     "@web/dev-server": "^0.4",
     "chalk": "^5",
     "eslint": "^9",


### PR DESCRIPTION
As discussed, this adds the `array-bracket-spacing` which enforces that there be no spaces at the start & end of arrays.

If we like this in core, we can think about adding it to the shared config next time we want to do a major bump.

Much easier to review with whitespace off!