### PR TITLE
fix: Re-add min-height

### DIFF
--- a/components/inputs/input-styles.js
+++ b/components/inputs/input-styles.js
@@ -81,6 +81,7 @@ export function _generateInputStyles(selector, focusSelector) {
 			letter-spacing: 0.02rem;
 			line-height: 1.2rem;
 			margin: 0;
+			min-height: calc(2rem + 2px);
 			min-width: calc(2rem + 1em);
 			padding: var(--d2l-input-padding, 0.4rem 0.75rem);
 			position: var(--d2l-input-position, relative); /* overridden by sticky headers in grades */


### PR DESCRIPTION
[GAUD-8852](https://desire2learn.atlassian.net/browse/GAUD-8852)

The comment [here](https://github.com/BrightspaceUI/core/blob/728f56c5509f6e165fb94c96dbeea63aa7732002/components/inputs/input-styles.js#L166) made it seem like min-height was no longer needed and only for IE11 support. However there are now places in the wild that use non-input elements as a `d2l-input`(e.g. a div), which may initially contain no text, meaning line-height alone is doing nothing.

[GAUD-8852]: https://desire2learn.atlassian.net/browse/GAUD-8852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ