### PR TITLE
GAUD-8854: Make offscreen styles node safe

### DIFF
--- a/components/offscreen/offscreen-styles.js
+++ b/components/offscreen/offscreen-styles.js
@@ -1,0 +1,29 @@
+import { css, html, LitElement, unsafeCSS } from 'lit';
+import { getFlag } from '../../helpers/flags.js';
+
+const OffSCREEN_SIZELESS = getFlag('d2l-offscreen-sizeless', true);
+const HAS_DOCUMENT = globalThis.document !== undefined;
+
+const offscreenSize = HAS_DOCUMENT && OffSCREEN_SIZELESS ? css`0` : css`1px`;
+const documentDirection = !HAS_DOCUMENT ? css`var(--d2l-document-direction)`
+							: css`var(--d2l-document-direction, ${document.dir === 'rtl' ? css`rtl` : css`ltr`})`;
+
+/**
+ * A private helper declarations that should not be used by general consumers
+ */
+export const _offscreenStyleDeclarations = css`
+	direction: ${documentDirection}; /* stylelint-disable-line @stylistic/string-quotes */
+	height: ${offscreenSize};
+	inset-inline-start: -10000px;
+	overflow: hidden;
+	position: absolute !important;
+	white-space: nowrap;
+	width: ${offscreenSize};
+	inset-inline-start: -10000px;
+`;
+
+export const offscreenStyles = css`
+	.d2l-offscreen {
+		${_offscreenStyleDeclarations}
+	}
+`;

--- a/components/offscreen/offscreen-styles.js
+++ b/components/offscreen/offscreen-styles.js
@@ -1,25 +1,20 @@
-import { css, html, LitElement, unsafeCSS } from 'lit';
+import { css } from 'lit';
 import { getFlag } from '../../helpers/flags.js';
 
 const OffSCREEN_SIZELESS = getFlag('d2l-offscreen-sizeless', true);
 const HAS_DOCUMENT = globalThis.document !== undefined;
 
-const offscreenSize = HAS_DOCUMENT && OffSCREEN_SIZELESS ? css`0` : css`1px`;
-const documentDirection = !HAS_DOCUMENT ? css`var(--d2l-document-direction)`
-							: css`var(--d2l-document-direction, ${document.dir === 'rtl' ? css`rtl` : css`ltr`})`;
-
 /**
  * A private helper declarations that should not be used by general consumers
  */
 export const _offscreenStyleDeclarations = css`
-	direction: ${documentDirection}; /* stylelint-disable-line @stylistic/string-quotes */
-	height: ${offscreenSize};
+	direction: var(--d2l-document-direction, ${ !HAS_DOCUMENT ? css`unset` : (document.dir === 'rtl' ? css`rtl` : css`ltr`)}); /* stylelint-disable-line @stylistic/string-quotes */
+	height: ${HAS_DOCUMENT && OffSCREEN_SIZELESS ? 0 : 1}px;
 	inset-inline-start: -10000px;
 	overflow: hidden;
 	position: absolute !important;
 	white-space: nowrap;
-	width: ${offscreenSize};
-	inset-inline-start: -10000px;
+	width: ${HAS_DOCUMENT && OffSCREEN_SIZELESS ? 0 : 1}px;
 `;
 
 export const offscreenStyles = css`

--- a/components/offscreen/offscreen.js
+++ b/components/offscreen/offscreen.js
@@ -1,27 +1,8 @@
 import { css, html, LitElement } from 'lit';
 import { getFlag } from '../../helpers/flags.js';
+import { _offscreenStyleDeclarations, offscreenStyles } from './offscreen-styles.js';
 
-const OffSCREEN_SIZELESS = getFlag('d2l-offscreen-sizeless', true);
-
-/**
- * A private helper declarations that should not be used by general consumers
- */
-export const _offscreenStyleDeclarations = css`
-	direction: var(--d2l-document-direction, ${document.dir === 'rtl' ? css`rtl` : css`ltr`}); /* stylelint-disable-line @stylistic/string-quotes */
-	height: ${OffSCREEN_SIZELESS ? 0 : 1}px;
-	inset-inline-start: -10000px;
-	overflow: hidden;
-	position: absolute !important;
-	white-space: nowrap;
-	width: ${OffSCREEN_SIZELESS ? 0 : 1}px;
-	${document.dir === 'rtl' ? css`right` : css`left`}: -10000px;
-`;
-
-export const offscreenStyles = css`
-	.d2l-offscreen {
-		${_offscreenStyleDeclarations}
-	}
-`;
+export { _offscreenStyleDeclarations, offscreenStyles };
 
 /**
  * A component for positioning content offscreen to only be visible to screen readers.

--- a/components/offscreen/offscreen.js
+++ b/components/offscreen/offscreen.js
@@ -1,6 +1,5 @@
-import { css, html, LitElement } from 'lit';
-import { getFlag } from '../../helpers/flags.js';
 import { _offscreenStyleDeclarations, offscreenStyles } from './offscreen-styles.js';
+import { css, html, LitElement } from 'lit';
 
 export { _offscreenStyleDeclarations, offscreenStyles };
 

--- a/test/node-imports-test.js
+++ b/test/node-imports-test.js
@@ -24,4 +24,10 @@ describe('node imports', () => {
 		assert.ok(t._generateSelectStyles);
 	});
 
+	it('should import offscreen styles in a node environment', async() => {
+		const t = await import('../components/offscreen/offscreen-styles.js');
+		assert.ok(t._offscreenStyleDeclarations);
+		assert.ok(t.offscreenStyles);
+	});
+
 });


### PR DESCRIPTION
[GAUD-8854](https://desire2learn.atlassian.net/browse/GAUD-8854)

BSI needs to import these styles, `document` and `customElements` won't allow it.

[GAUD-8854]: https://desire2learn.atlassian.net/browse/GAUD-8854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ