### PR TITLE
GAUD-10267: use reactive state properties

### DIFF
--- a/components/button/floating-buttons.js
+++ b/components/button/floating-buttons.js
@@ -22,10 +22,10 @@ class FloatingButtons extends LoadingCompleteMixin(LitElement) {
 		 * @type {boolean}
 		 */
 		alwaysFloat: { type: Boolean, attribute: 'always-float', reflect: true },
-		_containerMarginLeft: { attribute: false, type: String },
-		_containerMarginRight: { attribute: false, type: String },
+		_containerMarginLeft: { state: true },
+		_containerMarginRight: { state: true },
 		_floating: { type: Boolean, reflect: true },
-		_innerContainerLeft: { attribute: false, type: String }
+		_innerContainerLeft: { state: true }
 	};
 
 	static styles = css`

--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -22,7 +22,7 @@ class DemoSnippet extends LitElement {
 		overflowHidden: { type: Boolean, reflect: true, attribute: 'overflow-hidden' },
 		_code: { type: String },
 		_fullscreen: { state: true },
-		_hasSkeleton: { type: Boolean, attribute: false },
+		_hasSkeleton: { state: true },
 		_settingsPeek: { state: true },
 		_skeletonOn: { type: Boolean, reflect: false }
 	};

--- a/components/dialog/dialog.js
+++ b/components/dialog/dialog.js
@@ -52,7 +52,7 @@ class Dialog extends PropertyRequiredMixin(LocalizeCoreElement(AsyncContainerMix
 		 * The preferred width (unit-less) for the dialog
 		 */
 		width: { type: Number },
-		_hasFooterContent: { type: Boolean, attribute: false }
+		_hasFooterContent: { state: true }
 	};
 
 	static styles = [_generateResetStyles(':host'), dialogStyles, heading3Styles, css`

--- a/components/filter/filter.js
+++ b/components/filter/filter.js
@@ -88,12 +88,12 @@ class Filter extends FocusMixin(LocalizeCoreElement(LitElement)) {
 		 * @type {string}
 		 */
 		text: { type: String },
-		_activeDimensionKey: { type: String, attribute: false },
-		_dimensions: { type: Array, attribute: false },
+		_activeDimensionKey: { state: true },
+		_dimensions: { state: true },
 		_displayKeyboardTooltip: { state: true },
 		_ignoreSlotChanges: { type: Boolean },
-		_minWidth: { type: Number, attribute: false },
-		_totalAppliedCount: { type: Number, attribute: false }
+		_minWidth: { state: true },
+		_totalAppliedCount: { state: true }
 	};
 
 	static styles = [bodyCompactStyles, bodySmallStyles, bodyStandardStyles, heading4Styles, offscreenStyles, css`

--- a/components/form/demo/form-panel-demo.js
+++ b/components/form/demo/form-panel-demo.js
@@ -12,7 +12,7 @@ import { inputStyles } from '../../inputs/input-styles.js';
 class FormPanelDemo extends LitElement {
 
 	static properties = {
-		_expanded: { type: Boolean, attribute: false }
+		_expanded: { state: true }
 	};
 
 	static styles = [heading3Styles, inputStyles, css`

--- a/components/form/form-element-mixin.js
+++ b/components/form/form-element-mixin.js
@@ -108,7 +108,7 @@ export const FormElementMixin = superclass => class extends LocalizeCoreElement(
 		 * @ignore
 		 */
 		childErrors: { type: Object, attribute: false },
-		_errors: { type: Array, attribute: false }
+		_errors: { state: true }
 	};
 
 	constructor() {

--- a/components/form/form-error-summary.js
+++ b/components/form/form-error-summary.js
@@ -9,7 +9,7 @@ class FormErrorSummary extends LocalizeCoreElement(LitElement) {
 
 	static properties = {
 		errors: { type: Object, attribute: false },
-		_expanded: { type: Boolean, attribute: false },
+		_expanded: { state: true },
 		_hasTopMargin: { type: Boolean, attribute: '_has-top-margin', reflect: true },
 		_hasErrors: { type: Boolean, attribute: '_has-errors', reflect: true },
 	};

--- a/components/inputs/input-date-time-range-to.js
+++ b/components/inputs/input-date-time-range-to.js
@@ -32,7 +32,7 @@ class InputDateTimeRangeTo extends SkeletonMixin(LocalizeCoreElement(LitElement)
 		 * @type {boolean}
 		 */
 		topMargin: { attribute: 'top-margin', type: Boolean },
-		_blockDisplay: { attribute: false, type: Boolean }
+		_blockDisplay: { state: true }
 	};
 
 	static styles = [super.styles, bodySmallStyles, css`

--- a/components/inputs/input-text.js
+++ b/components/inputs/input-text.js
@@ -185,7 +185,7 @@ class InputText extends InputInlineHelpMixin(PropertyRequiredMixin(FocusMixin(La
 		 */
 		valueAlign: { attribute: 'value-align', type: String },
 		_firstSlotWidth: { type: Number },
-		_hasAfterContent: { type: Boolean, attribute: false },
+		_hasAfterContent: { state: true },
 		_focused: { type: Boolean },
 		_hovered: { type: Boolean },
 		_lastSlotWidth: { type: Number }

--- a/components/selection/selection-observer-mixin.js
+++ b/components/selection/selection-observer-mixin.js
@@ -15,7 +15,7 @@ export const SelectionObserverMixin = superclass => class extends superclass {
 		 * @type {object}
 		 */
 		selectionInfo: { type: Object },
-		_provider: { type: Object, attribute: false }
+		_provider: { state: true }
 	};
 
 	constructor() {

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -146,7 +146,7 @@ For the example below:
   class MySortableTableElem extends LitElement {
 
     static properties = {
-      _sortDesc: { attribute: false, type: Boolean }
+      _sortDesc: { state: true }
     };
 
     static styles = tableStyles;

--- a/templates/primary-secondary/primary-secondary.js
+++ b/templates/primary-secondary/primary-secondary.js
@@ -596,11 +596,11 @@ class TemplatePrimarySecondary extends LocalizeCoreElement(LitElement) {
 		 */
 		hasForm: { type: Boolean, attribute: 'has-form' },
 		_formErrorSummary: { type: Array },
-		_hasFooter: { type: Boolean, attribute: false },
-		_isCollapsed: { type: Boolean, attribute: false },
-		_isExpanded: { type: Boolean, attribute: false },
-		_isMobile: { type: Boolean, attribute: false },
-		_size: { type: Number, attribute: false },
+		_hasFooter: { state: true },
+		_isCollapsed: { state: true },
+		_isExpanded: { state: true },
+		_isMobile: { state: true },
+		_size: { state: true },
 		_sizeAsPercent: { state: true }
 	};
 


### PR DESCRIPTION
Converts core from the old way to do "internal" state to use reactive state properties.

The only potential issue with this conversion would be if someone was doing a property binding (e.g. `<d2l-floating-buttons ._containerMarginLeft="5px">`), which... hopefully isn't being done because that's gross.