### PR TITLE
fix: adjust overflow clip margin to line height

### DIFF
--- a/components/typography/styles.js
+++ b/components/typography/styles.js
@@ -149,6 +149,7 @@ export const _generateBodySmallStyles = (selector, includeSkeleton = true) => {
 		}` : unsafeCSS('');
 	return css`
 		${selector} {
+			--d2l-overflow-clip-margin: 0.1em;
 			color: var(--d2l-theme-text-color-static-subtle);
 			font-size: 0.7rem;
 			font-weight: 400;
@@ -186,6 +187,7 @@ export const _generateHeading1Styles = (selector, includeFocus = false) => {
 		${focusStyles}
 		@media (max-width: 615px) {
 			${selector} {
+				--d2l-overflow-clip-margin: 0.15em;
 				font-size: 1.5rem;
 				line-height: 1.8rem;
 			}
@@ -224,6 +226,7 @@ export const _generateHeading2Styles = (selector, includeFocus = false) => {
 	selector = unsafeCSS(selector);
 	return css`
 		${selector} {
+			--d2l-overflow-clip-margin: 0.15em;
 			font-size: 1.5rem;
 			font-weight: 400;
 			line-height: 1.8rem;
@@ -352,6 +355,7 @@ export const _generateLabelStyles = (selector, includeSkeleton = true) => {
 	` : unsafeCSS('');
 	return css`
 		${selector} {
+			--d2l-overflow-clip-margin: 0.1em;
 			font-size: 0.7rem;
 			font-weight: 700;
 			letter-spacing: 0.2px;

--- a/helpers/overflow.js
+++ b/helpers/overflow.js
@@ -13,7 +13,7 @@ export function getOverflowDeclarations({ textOverflow = '', lines = 0, lit = tr
 		${lines
 			? set`
 			display: -webkit-box;
-			overflow-clip-margin: 0.2em;
+			overflow-clip-margin: var(--d2l-overflow-clip-margin, 0.2em);
 			overflow-wrap: anywhere;
 			overflow-y: clip;
 			text-overflow: ${textOverflow || 'ellipsis'};

--- a/helpers/test/overflow.test.js
+++ b/helpers/test/overflow.test.js
@@ -27,7 +27,7 @@ describe('overflow', () => {
 				min-width: 0; /* clamps width of flex items */
 				overflow-x: clip;
 				display: -webkit-box;
-				overflow-clip-margin: 0.2em;
+				overflow-clip-margin: var(--d2l-overflow-clip-margin, 0.2em);
 				overflow-wrap: anywhere;
 				overflow-y: clip;
 				text-overflow: ellipsis;


### PR DESCRIPTION
[PHNX-4815](https://desire2learn.atlassian.net/browse/PHNX-4815)

From the commit history it seems that the clip margin was added to support Thai, the problem is that it's set to a fixed value. 

The set value starts having issues as with smaller line-heights(relative to it's font-size) it shows part of the next line this sets a css variable so that margin adapts to the line-height.  

Not 100% on this but from testing, it seems that (`line-height` - `font-size`) / 2 is the ideal value

[PHNX-4815]: https://desire2learn.atlassian.net/browse/PHNX-4815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ