### PR TITLE
GAUD-10311 - Smoother Collapse Reversed/Sliced

### DIFF
--- a/components/page/page.js
+++ b/components/page/page.js
@@ -187,10 +187,10 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 			overflow: clip auto;
 		}
 		.side-nav-panel-content {
-			float: inline-end;
+			float: inline-start;
 		}
 		.supporting-panel-content {
-			float: inline-start;
+			float: inline-end;
 		}
 
 		.divider {


### PR DESCRIPTION
Reverses the float, so instead of sliding away, the panel is smoothly sliced off. I don't _think_ this is what we want, but it's an option so I want to check.