### PR TITLE
Use the browser Node enum for node types to improve readability.

### DIFF
--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -84,7 +84,7 @@ export function getComposedChildren(node, predicate = () => true) {
 	if (!node) {
 		return null;
 	}
-	if (node.nodeType !== 1 && node.nodeType !== 9 && node.nodeType !== 11) {
+	if (node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.DOCUMENT_NODE && node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE) {
 		return null;
 	}
 
@@ -94,6 +94,7 @@ export function getComposedChildren(node, predicate = () => true) {
 	if (node.tagName === 'CONTENT') {
 		nodes = node.getDistributedNodes();
 	} else if (node.tagName === 'SLOT') {
+		// note: this is not handling default slot content
 		nodes = node.assignedNodes({ flatten: true });
 	} else {
 		if (node.shadowRoot) {
@@ -103,7 +104,7 @@ export function getComposedChildren(node, predicate = () => true) {
 	}
 
 	for (let i = 0; i < nodes.length; i++) {
-		if (nodes[i].nodeType === 1) {
+		if (nodes[i].nodeType === Node.ELEMENT_NODE) {
 			if (predicate(nodes[i])) {
 				children.push(nodes[i]);
 			}
@@ -243,7 +244,7 @@ export function getFirstVisibleAncestor(node) {
 
 export function querySelectorComposed(node, selector) {
 
-	if (!node || (node.nodeType !== 1 && node.nodeType !== 9 && node.nodeType !== 11)) {
+	if (!node || (node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.DOCUMENT_NODE && node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE)) {
 		throw new TypeError('Invalid node. Must be nodeType document, element or document fragment');
 	}
 	if (typeof selector !== 'string') {

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -210,7 +210,7 @@ export function getPreviousFocusableAncestor(node, includeHidden, includeTabbabl
 
 export function isFocusable(node, includeHidden, includeTabbablesOnly, includeDisabled) {
 
-	if (!node || node.nodeType !== 1 || (!includeDisabled && node.disabled)) return false;
+	if (!node || node.nodeType !== Node.ELEMENT_NODE || (!includeDisabled && node.disabled)) return false;
 
 	if (includeTabbablesOnly === undefined) includeTabbablesOnly = true;
 


### PR DESCRIPTION
[GAUD-10507](https://desire2learn.atlassian.net/browse/GAUD-10507)

This PR simply updates to use the browser `Node` enum for these `nodeType` constants to improve readability.

[GAUD-10507]: https://desire2learn.atlassian.net/browse/GAUD-10507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ