### PR TITLE
GAUD-10322 - Store and restore panel sizes

### DIFF
--- a/components/page/demo/page-component.js
+++ b/components/page/demo/page-component.js
@@ -27,7 +27,6 @@ import '../../selection/selection-action.js';
 import '../../switch/switch-visibility.js';
 import '../../switch/switch.js';
 import '../../table/table-controls.js';
-import '../page.js';
 import '../page-footer.js';
 import '../page-main.js';
 import '../page-side-nav.js';
@@ -37,8 +36,11 @@ import { css, html, LitElement, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { inputLabelStyles } from '../../inputs/input-label-styles.js';
 import { pageHeaderImmersiveActionsDemo } from '../test/page-header-immersive-fixtures.js';
+import { panelStateStorageKey } from '../page.js';
 import { selectStyles } from '../../inputs/input-select-styles.js';
 import { tableStyles } from '../../table/table-wrapper.js';
+
+const DEMO_STATE_STORAGE_KEY = 'core-demo';
 
 class PageDemo extends LitElement {
 
@@ -99,7 +101,7 @@ class PageDemo extends LitElement {
 
 	render() {
 		return html`
-			<d2l-page width-type="${this.widthType}">
+			<d2l-page state-storage-key="${DEMO_STATE_STORAGE_KEY}" width-type="${this.widthType}">
 				${this.#renderHeader()}
 				${this.#renderSideNavPanel()}
 				${this.#renderMainPanel()}
@@ -107,6 +109,10 @@ class PageDemo extends LitElement {
 				${this.#renderFooter()}
 			</d2l-page>
 		`;
+	}
+
+	#handleClearStateStorage() {
+		localStorage.removeItem(panelStateStorageKey(DEMO_STATE_STORAGE_KEY));
 	}
 
 	#handleHeaderChange(e) {
@@ -250,6 +256,9 @@ class PageDemo extends LitElement {
 								<d2l-switch id="switch-main-header" text="Main" data-key="hasMainHeader" @change="${this.#handleVisibilityChange}" ?on="${this.hasMainHeader}"></d2l-switch>
 								${this.layout === 'side-nav' ? html`<d2l-switch text="Side Nav" data-key="hasSideNavHeader" @change="${this.#handleVisibilityChange}" ?on="${this.hasSideNavHeader}"></d2l-switch>` : nothing}
 								${this.layout === 'supporting' ? html`<d2l-switch text="Supporting" data-key="hasSupportingHeader" @change="${this.#handleVisibilityChange}" ?on="${this.hasSupportingHeader}"></d2l-switch>` : nothing}
+							</d2l-input-fieldset>
+							<d2l-input-fieldset label="State Storage">
+								<d2l-button-subtle text="Clear" @click="${this.#handleClearStateStorage}"></d2l-button-subtle>
 							</d2l-input-fieldset>
 						</div>
 					</d2l-input-fieldset>

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -58,7 +58,7 @@ class PanelStateController {
 		}
 	}
 
-	resize(key, requestedSize, animate = false, storeState = false) {
+	resize(key, requestedSize, { animate = false, storeState = false } = {}) {
 		const panel = this.#panels[key];
 		// Clamp requested size to min and max bounds
 		panel.size = Math.max(panel.minSize, Math.min(requestedSize, panel.maxSize));
@@ -412,7 +412,7 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 
 	#handleDividerResize(e) {
 		const panelKey = e.target.dataset.panelKey;
-		this._panelState.resize(panelKey, e.detail.requestedSize, true, true);
+		this._panelState.resize(panelKey, e.detail.requestedSize, { animate: true, storeState: true });
 	};
 
 	#handleDividerToggle(e) {

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -7,6 +7,8 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { ProviderMixin } from '../../mixins/provider/provider-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
+export const panelStateStorageKey = key => `d2l-page-panel-state-${key}`;
+
 const DRAWER_MIN_HEIGHT = 200; // TO DO: Confirm
 const MAIN_MIN_WIDTH = 600; // TO DO: Confirm
 const PANEL_MIN_WIDTH = 320;
@@ -92,12 +94,12 @@ class PanelStateController {
 	#host;
 	#panels;
 
-	#getFullStorageKey() {
-		return this.#host.stateStorageKey ? `d2l-page-panel-state-${this.#host.stateStorageKey}` : null;
+	#getPanelStateStorageKey() {
+		return this.#host.stateStorageKey ? panelStateStorageKey(this.#host.stateStorageKey) : null;
 	}
 
 	#getStoredState() {
-		const fullKey = this.#getFullStorageKey();
+		const fullKey = this.#getPanelStateStorageKey();
 		if (!fullKey) return;
 
 		try {
@@ -109,7 +111,7 @@ class PanelStateController {
 	}
 
 	#storePanelState(panelKey) {
-		const fullKey = this.#getFullStorageKey();
+		const fullKey = this.#getPanelStateStorageKey();
 		if (!fullKey) return;
 		const state = this.#getStoredState() || {};
 

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -93,7 +93,7 @@ class PanelStateController {
 	#panels;
 
 	#getFullStorageKey() {
-		return this.#host.storageKey ? `d2l-page-panel-state-${this.#host.storageKey}` : null;
+		return this.#host.stateStorageKey ? `d2l-page-panel-state-${this.#host.stateStorageKey}` : null;
 	}
 
 	#getStoredState() {
@@ -138,10 +138,11 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 
 	static properties = {
 		/**
-		 * Key used to optionally store panel sizes across reloads (using localStorage). Different pages should use different keys.
+		 * Key used to optionally store page state across reloads (using localStorage). Different pages should use different keys.
+		 * Currently, this includes panel state info.
 		 * @type {string}
 		 */
-		storageKey: { type: String, attribute: 'storage-key' },
+		stateStorageKey: { type: String, attribute: 'state-storage-key' },
 		/**
 		 * Width type of the page and its underlying pieces
 		 * @type {'normal'|'wide'|'fullscreen'}

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -121,6 +121,7 @@ class PanelStateController {
 			localStorage.setItem(fullKey, JSON.stringify(state));
 		} catch {
 			// Do nothing if storage quota exceeded or using private browsing mode of an old Safari version
+			// TO DO: If QuotaExceededError, log this to our logging framework
 		}
 	}
 }

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -49,7 +49,7 @@ class PanelStateController {
 			if (stored) {
 				const storedSize = parseInt(stored.size);
 				this.resize(key, isFinite(storedSize) ? storedSize : defaults[key]);
-				if (stored.collapsed === 'true') panel.collapsed = true;
+				if (stored.collapsed) panel.collapsed = true;
 			} else {
 				this.resize(key, defaults[key]);
 			}
@@ -115,8 +115,8 @@ class PanelStateController {
 
 		try {
 			state[panelKey] = {
-				size: String(this.#panels[panelKey].size),
-				collapsed: String(this.#panels[panelKey].collapsed)
+				size: this.#panels[panelKey].size,
+				collapsed: this.#panels[panelKey].collapsed
 			};
 			localStorage.setItem(fullKey, JSON.stringify(state));
 		} catch {

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -41,12 +41,28 @@ class PanelStateController {
 		return panel.size;
 	}
 
-	resize(key, requestedSize, animate = false) {
+	initialize(defaults) {
+		const storedState = this.#getStoredState();
+
+		for (const [key, panel] of Object.entries(this.#panels)) {
+			const stored = storedState?.[key];
+			if (stored) {
+				const storedSize = parseInt(stored.size);
+				this.resize(key, isFinite(storedSize) ? storedSize : defaults[key]);
+				if (stored.collapsed === 'true') panel.collapsed = true;
+			} else {
+				this.resize(key, defaults[key]);
+			}
+		}
+	}
+
+	resize(key, requestedSize, animate = false, storeState = false) {
 		const panel = this.#panels[key];
 		// Clamp requested size to min and max bounds
 		panel.size = Math.max(panel.minSize, Math.min(requestedSize, panel.maxSize));
 		panel.animate = animate;
 		this.#host.requestUpdate();
+		if (storeState) this.#storePanelState(key);
 	}
 
 	setCollapsed(key, collapsed) {
@@ -54,6 +70,7 @@ class PanelStateController {
 		panel.collapsed = collapsed;
 		panel.animate = true;
 		this.#host.requestUpdate();
+		this.#storePanelState(key);
 	}
 
 	setDragSize(key) {
@@ -74,6 +91,38 @@ class PanelStateController {
 
 	#host;
 	#panels;
+
+	#getFullStorageKey() {
+		return this.#host.storageKey ? `d2l-page-panel-state-${this.#host.storageKey}` : null;
+	}
+
+	#getStoredState() {
+		const fullKey = this.#getFullStorageKey();
+		if (!fullKey) return;
+
+		try {
+			return JSON.parse(localStorage.getItem(fullKey));
+		} catch {
+			// Return nothing if local storage isn't available or has bad data
+			return;
+		}
+	}
+
+	#storePanelState(panelKey) {
+		const fullKey = this.#getFullStorageKey();
+		if (!fullKey) return;
+		const state = this.#getStoredState() || {};
+
+		try {
+			state[panelKey] = {
+				size: String(this.#panels[panelKey].size),
+				collapsed: String(this.#panels[panelKey].collapsed)
+			};
+			localStorage.setItem(fullKey, JSON.stringify(state));
+		} catch {
+			// Do nothing if storage quota exceeded or using private browsing mode of an old Safari version
+		}
+	}
 }
 
 /**
@@ -87,6 +136,11 @@ class PanelStateController {
 class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 
 	static properties = {
+		/**
+		 * Key used to optionally store panel sizes across reloads (using localStorage). Different pages should use different keys.
+		 * @type {string}
+		 */
+		storageKey: { type: String, attribute: 'storage-key' },
 		/**
 		 * Width type of the page and its underlying pieces
 		 * @type {'normal'|'wide'|'fullscreen'}
@@ -354,7 +408,7 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 
 	#handleDividerResize(e) {
 		const panelKey = e.target.dataset.panelKey;
-		this._panelState.resize(panelKey, e.detail.requestedSize, true);
+		this._panelState.resize(panelKey, e.detail.requestedSize, true, true);
 	};
 
 	#handleDividerToggle(e) {
@@ -373,9 +427,11 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		const defaultWidth = Math.floor(this._contentWidth / 3);
 		const defaultHeight = Math.floor(window.innerHeight / 2);
 
-		this._panelState.resize('side-nav', defaultWidth);
-		this._panelState.resize('supporting', defaultWidth);
-		this._panelState.resize('supporting-mobile', defaultHeight);
+		this._panelState.initialize({
+			'side-nav': defaultWidth,
+			'supporting': defaultWidth,
+			'supporting-mobile': defaultHeight
+		});
 	}
 
 	#renderDivider(panelKey, label, panelPosition) {

--- a/components/page/test/page-fixtures.js
+++ b/components/page/test/page-fixtures.js
@@ -74,7 +74,7 @@ export function createPage({
 	overrides = {}
 } = {}) {
 	return html`
-		<d2l-page width-type="${widthType}" storage-key="${ifDefined(setStorageKey ? TEST_STORAGE_KEY : undefined)}">
+		<d2l-page width-type="${widthType}" state-storage-key="${ifDefined(setStorageKey ? TEST_STORAGE_KEY : undefined)}">
 			${header === 'full' ? fullHeader : immersiveHeader}
 			${layout === 'side-nav' ? html`
 				<d2l-page-side-nav slot="side-nav">

--- a/components/page/test/page-fixtures.js
+++ b/components/page/test/page-fixtures.js
@@ -26,6 +26,9 @@ export function getStoredPanelState() {
 export function setStoredPanelState(state) {
 	localStorage.setItem(fullStorageKey, JSON.stringify(state));
 }
+export function clearStoredPanelState() {
+	localStorage.removeItem(fullStorageKey);
+}
 
 const footer = html`
 	<d2l-page-footer slot="footer">

--- a/components/page/test/page-fixtures.js
+++ b/components/page/test/page-fixtures.js
@@ -1,4 +1,3 @@
-import '../page.js';
 import '../page-footer.js';
 import '../page-header-custom.js';
 import '../page-header-immersive.js';
@@ -7,6 +6,7 @@ import '../page-side-nav.js';
 import '../page-supporting.js';
 import { html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { panelStateStorageKey } from '../page.js';
 
 export function scrollBody() {
 	window.scrollTo(0, document.body.scrollHeight);
@@ -17,17 +17,17 @@ export function scrollPanel(elem, panel) {
 	panelElem.scrollTop = panelElem.scrollHeight;
 }
 
-const TEST_STORAGE_KEY = 'test-page';
-const fullStorageKey = `d2l-page-panel-state-${TEST_STORAGE_KEY}`;
+const TEST_STATE_STORAGE_KEY = 'test-page';
+const panelStorageKey = panelStateStorageKey(TEST_STATE_STORAGE_KEY);
 export function getStoredPanelState() {
-	const stored = localStorage.getItem(fullStorageKey);
+	const stored = localStorage.getItem(panelStorageKey);
 	return JSON.parse(stored);
 }
 export function setStoredPanelState(state) {
-	localStorage.setItem(fullStorageKey, JSON.stringify(state));
+	localStorage.setItem(panelStorageKey, JSON.stringify(state));
 }
 export function clearStoredPanelState() {
-	localStorage.removeItem(fullStorageKey);
+	localStorage.removeItem(panelStorageKey);
 }
 
 const footer = html`
@@ -70,11 +70,11 @@ export function createPage({
 	sideNavHeight = '250px',
 	supportingHeight = '250px',
 	widthType = 'normal',
-	setStorageKey = false,
+	setStateStorageKey = false,
 	overrides = {}
 } = {}) {
 	return html`
-		<d2l-page width-type="${widthType}" state-storage-key="${ifDefined(setStorageKey ? TEST_STORAGE_KEY : undefined)}">
+		<d2l-page width-type="${widthType}" state-storage-key="${ifDefined(setStateStorageKey ? TEST_STATE_STORAGE_KEY : undefined)}">
 			${header === 'full' ? fullHeader : immersiveHeader}
 			${layout === 'side-nav' ? html`
 				<d2l-page-side-nav slot="side-nav">
@@ -176,8 +176,8 @@ export const pageFixtures = {
 	supportingBothHeadersFooterFullscreen: createPage({ layout: 'supporting', widthType: 'fullscreen', mainHeight: '600px', hasMainHeader: true, hasSupportingHeader: true, hasFooter: true }),
 	supportingImmersiveBothHeadersFooterWide: createPage({ header: 'immersive', layout: 'supporting', widthType: 'wide', hasMainHeader: true, hasSupportingHeader: true, hasFooter: true }),
 	supportingImmersiveBothHeadersFooterFullscreen: createPage({ header: 'immersive', layout: 'supporting', widthType: 'fullscreen', hasMainHeader: true, hasSupportingHeader: true, hasFooter: true }),
-	// With storage-key set
-	mainStorageKey: createPage({ setStorageKey: true }),
-	sideNavHeaderStorageKey: createPage({ setStorageKey: true, layout: 'side-nav', hasSideNavHeader: true }),
-	supportingFooterStorageKey: createPage({ setStorageKey: true, layout: 'supporting', mainHeight: '600px', hasFooter: true }),
+	// With state-storage-key set
+	mainStorageKey: createPage({ setStateStorageKey: true }),
+	sideNavHeaderStorageKey: createPage({ setStateStorageKey: true, layout: 'side-nav', hasSideNavHeader: true }),
+	supportingFooterStorageKey: createPage({ setStateStorageKey: true, layout: 'supporting', mainHeight: '600px', hasFooter: true }),
 };

--- a/components/page/test/page-fixtures.js
+++ b/components/page/test/page-fixtures.js
@@ -6,6 +6,7 @@ import '../page-main.js';
 import '../page-side-nav.js';
 import '../page-supporting.js';
 import { html, nothing } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 export function scrollBody() {
 	window.scrollTo(0, document.body.scrollHeight);
@@ -14,6 +15,16 @@ export function scrollBody() {
 export function scrollPanel(elem, panel) {
 	const panelElem = elem.shadowRoot.querySelector(`.${panel}-panel-content`);
 	panelElem.scrollTop = panelElem.scrollHeight;
+}
+
+const TEST_STORAGE_KEY = 'test-page';
+const fullStorageKey = `d2l-page-panel-state-${TEST_STORAGE_KEY}`;
+export function getStoredPanelState() {
+	const stored = localStorage.getItem(fullStorageKey);
+	return JSON.parse(stored);
+}
+export function setStoredPanelState(state) {
+	localStorage.setItem(fullStorageKey, JSON.stringify(state));
 }
 
 const footer = html`
@@ -56,10 +67,11 @@ export function createPage({
 	sideNavHeight = '250px',
 	supportingHeight = '250px',
 	widthType = 'normal',
+	setStorageKey = false,
 	overrides = {}
 } = {}) {
 	return html`
-		<d2l-page width-type="${widthType}">
+		<d2l-page width-type="${widthType}" storage-key="${ifDefined(setStorageKey ? TEST_STORAGE_KEY : undefined)}">
 			${header === 'full' ? fullHeader : immersiveHeader}
 			${layout === 'side-nav' ? html`
 				<d2l-page-side-nav slot="side-nav">
@@ -160,5 +172,9 @@ export const pageFixtures = {
 	supportingBothHeadersFooterWide: createPage({ layout: 'supporting', widthType: 'wide', mainHeight: '600px', hasMainHeader: true, hasSupportingHeader: true, hasFooter: true }),
 	supportingBothHeadersFooterFullscreen: createPage({ layout: 'supporting', widthType: 'fullscreen', mainHeight: '600px', hasMainHeader: true, hasSupportingHeader: true, hasFooter: true }),
 	supportingImmersiveBothHeadersFooterWide: createPage({ header: 'immersive', layout: 'supporting', widthType: 'wide', hasMainHeader: true, hasSupportingHeader: true, hasFooter: true }),
-	supportingImmersiveBothHeadersFooterFullscreen: createPage({ header: 'immersive', layout: 'supporting', widthType: 'fullscreen', hasMainHeader: true, hasSupportingHeader: true, hasFooter: true })
+	supportingImmersiveBothHeadersFooterFullscreen: createPage({ header: 'immersive', layout: 'supporting', widthType: 'fullscreen', hasMainHeader: true, hasSupportingHeader: true, hasFooter: true }),
+	// With storage-key set
+	mainStorageKey: createPage({ setStorageKey: true }),
+	sideNavHeaderStorageKey: createPage({ setStorageKey: true, layout: 'side-nav', hasSideNavHeader: true }),
+	supportingFooterStorageKey: createPage({ setStorageKey: true, layout: 'supporting', mainHeight: '600px', hasFooter: true }),
 };

--- a/components/page/test/page.test.js
+++ b/components/page/test/page.test.js
@@ -1,6 +1,6 @@
 import '../page.js';
+import { clearStoredPanelState, getStoredPanelState, pageFixtures, setStoredPanelState } from './page-fixtures.js';
 import { expect, fixture, runConstructor, setViewport, waitUntil } from '@brightspace-ui/testing';
-import { getStoredPanelState, pageFixtures, setStoredPanelState } from './page-fixtures.js';
 import { getDivider } from './page-divider-internal-fixtures.js';
 
 const defaultFixtureOptions = { pagePadding: false, viewport: { width: 1300, height: 800 } };
@@ -13,23 +13,29 @@ describe('page', () => {
 
 	describe('storing panel state', () => {
 		afterEach(() => {
-			localStorage.clear();
+			clearStoredPanelState();
 		});
 
 		describe('restoring', () => {
 			it('applies the stored size over the default', async() => {
-				setStoredPanelState({ 'side-nav': { size: '450', collapsed: 'false' } });
+				setStoredPanelState({ 'side-nav': { size: 450, collapsed: false } });
 				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getTrueSize('side-nav')).to.equal(450);
 				expect(elem._panelState.getCollapsed('side-nav')).to.be.false;
 			});
 
 			it('applies the stored collapsed state', async() => {
-				setStoredPanelState({ 'side-nav': { size: '450', collapsed: 'true' } });
+				setStoredPanelState({ 'side-nav': { size: 450, collapsed: true } });
 				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getCollapsed('side-nav')).to.be.true;
 				expect(elem._panelState.getSize('side-nav')).to.equal(0);
 				expect(elem._panelState.getTrueSize('side-nav')).to.equal(450);
+			});
+
+			it('falls back to the default when no storage key set', async() => {
+				const elem = await fixture(pageFixtures.sideNavHeader, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('side-nav')).to.equal(Math.floor(elem._contentWidth / 3));
+				expect(elem._panelState.getCollapsed('side-nav')).to.be.false;
 			});
 
 			it('falls back to the default when there is no stored entry', async() => {
@@ -39,21 +45,21 @@ describe('page', () => {
 			});
 
 			it('clamps a stored size larger than the max', async() => {
-				setStoredPanelState({ 'side-nav': { size: '9999', collapsed: 'false' } });
+				setStoredPanelState({ 'side-nav': { size: 9999, collapsed: false } });
 				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getTrueSize('side-nav')).to.equal(elem._panelState.getMaxSize('side-nav'));
 			});
 
 			it('clamps a stored size smaller than the min', async() => {
-				setStoredPanelState({ 'side-nav': { size: '10', collapsed: 'false' } });
+				setStoredPanelState({ 'side-nav': { size: 10, collapsed: false } });
 				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getTrueSize('side-nav')).to.equal(elem._panelState.getMinSize('side-nav'));
 			});
 
 			it('restores each panel independently', async() => {
 				setStoredPanelState({
-					'side-nav': { size: '400', collapsed: 'false' },
-					'supporting': { size: '500', collapsed: 'true' }
+					'side-nav': { size: 400, collapsed: false },
+					'supporting': { size: 500, collapsed: true }
 				});
 				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getTrueSize('side-nav')).to.equal(400);
@@ -62,11 +68,32 @@ describe('page', () => {
 				expect(elem._panelState.getCollapsed('supporting')).to.be.true;
 			});
 
-			it('ignores invalid stored data', async() => {
+			it('ignores empty stored state', async() => {
+				setStoredPanelState({});
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('supporting-mobile')).to.equal(Math.floor(window.innerHeight / 2));
+				expect(elem._panelState.getCollapsed('supporting-mobile')).to.be.false;
+			});
+
+			it('ignores empty stored panel state', async() => {
+				setStoredPanelState({ 'supporting-mobile': {} });
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('supporting-mobile')).to.equal(Math.floor(window.innerHeight / 2));
+				expect(elem._panelState.getCollapsed('supporting-mobile')).to.be.false;
+			});
+
+			it('ignores invalid stored state', async() => {
 				setStoredPanelState('not-json');
 				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getTrueSize('supporting-mobile')).to.equal(Math.floor(window.innerHeight / 2));
 				expect(elem._panelState.getCollapsed('supporting-mobile')).to.be.false;
+			});
+
+			it('ignores invalid stored panel state', async() => {
+				setStoredPanelState({ 'supporting-mobile': { size: 'not-a-number', collapsed: true } });
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('supporting-mobile')).to.equal(Math.floor(window.innerHeight / 2));
+				expect(elem._panelState.getCollapsed('supporting-mobile')).to.be.true;
 			});
 		});
 
@@ -75,26 +102,26 @@ describe('page', () => {
 				const elem = await fixture(pageFixtures.sideNavHeaderStorageKey, defaultFixtureOptions);
 				getDivider(elem, 'side-nav').dispatchEvent(new CustomEvent('d2l-page-divider-resize', { detail: { requestedSize: 450 } }));
 				const stored = getStoredPanelState();
-				expect(stored['side-nav'].size).to.equal('450');
+				expect(stored['side-nav'].size).to.equal(450);
 			});
 
 			it('persists the collapsed state when a panel is toggled', async() => {
 				const elem = await fixture(pageFixtures.sideNavHeaderStorageKey, defaultFixtureOptions);
 				getDivider(elem, 'side-nav').dispatchEvent(new CustomEvent('d2l-page-divider-toggle'));
 				const stored = getStoredPanelState();
-				expect(stored['side-nav'].collapsed).to.equal('true');
-				expect(stored['side-nav'].size).to.equal((elem._contentWidth / 3).toString());
+				expect(stored['side-nav'].collapsed).to.be.true;
+				expect(stored['side-nav'].size).to.equal(Math.floor(elem._contentWidth / 3));
 			});
 
 			it('persists each panel under its own key', async() => {
-				setStoredPanelState({ 'side-nav': { size: '450', collapsed: 'true' } });
+				setStoredPanelState({ 'side-nav': { size: 450, collapsed: true } });
 				const elem = await fixture(pageFixtures.supportingFooterStorageKey, defaultFixtureOptions);
 				getDivider(elem, 'supporting').dispatchEvent(new CustomEvent('d2l-page-divider-resize', { detail: { requestedSize: 500 } }));
 				const stored = getStoredPanelState();
-				expect(stored['side-nav'].size).to.equal('450');
-				expect(stored['side-nav'].collapsed).to.equal('true');
-				expect(stored['supporting'].size).to.equal('500');
-				expect(stored['supporting'].collapsed).to.equal('false');
+				expect(stored['side-nav'].size).to.equal(450);
+				expect(stored['side-nav'].collapsed).to.be.true;
+				expect(stored['supporting'].size).to.equal(500);
+				expect(stored['supporting'].collapsed).to.be.false;
 			});
 
 			it('does not persist when no storage key is set', async() => {
@@ -104,15 +131,15 @@ describe('page', () => {
 			});
 
 			it('does not update when size adjusted by initial clamping', async() => {
-				setStoredPanelState({ 'supporting': { size: '9999', collapsed: 'false' } });
+				setStoredPanelState({ 'supporting': { size: 9999, collapsed: false } });
 				const elem = await fixture(pageFixtures.supportingFooterStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getTrueSize('supporting')).to.equal(elem._panelState.getMaxSize('supporting'));
 				const stored = getStoredPanelState();
-				expect(stored['supporting'].size).to.equal('9999');
+				expect(stored['supporting'].size).to.equal(9999);
 			});
 
 			it('does not update when size adjusted by window resize', async() => {
-				setStoredPanelState({ 'supporting': { size: '500', collapsed: 'false' } });
+				setStoredPanelState({ 'supporting': { size: 500, collapsed: false } });
 				const elem = await fixture(pageFixtures.supportingFooterStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getTrueSize('supporting')).to.equal(500);
 
@@ -120,7 +147,7 @@ describe('page', () => {
 				await waitUntil(() => elem._panelState.getTrueSize('supporting') !== 500);
 
 				const stored = getStoredPanelState();
-				expect(stored['supporting'].size).to.equal('500');
+				expect(stored['supporting'].size).to.equal(500);
 			});
 		});
 	});

--- a/components/page/test/page.test.js
+++ b/components/page/test/page.test.js
@@ -2,6 +2,7 @@ import '../page.js';
 import { clearStoredPanelState, getStoredPanelState, pageFixtures, setStoredPanelState } from './page-fixtures.js';
 import { expect, fixture, runConstructor, setViewport, waitUntil } from '@brightspace-ui/testing';
 import { getDivider } from './page-divider-internal-fixtures.js';
+import { restore, spy } from 'sinon';
 
 const defaultFixtureOptions = { pagePadding: false, viewport: { width: 1300, height: 800 } };
 
@@ -98,6 +99,10 @@ describe('page', () => {
 		});
 
 		describe('storing', () => {
+			afterEach(() => {
+				restore();
+			});
+
 			it('persists the size when a panel is resized', async() => {
 				const elem = await fixture(pageFixtures.sideNavHeaderStorageKey, defaultFixtureOptions);
 				getDivider(elem, 'side-nav').dispatchEvent(new CustomEvent('d2l-page-divider-resize', { detail: { requestedSize: 450 } }));
@@ -125,9 +130,10 @@ describe('page', () => {
 			});
 
 			it('does not persist when no storage key is set', async() => {
+				const setItemSpy = spy(localStorage, 'setItem');
 				const elem = await fixture(pageFixtures.sideNavHeader, defaultFixtureOptions);
 				getDivider(elem, 'side-nav').dispatchEvent(new CustomEvent('d2l-page-divider-resize', { detail: { requestedSize: 450 } }));
-				expect(getStoredPanelState()).to.be.null;
+				expect(setItemSpy.called).to.be.false;
 			});
 
 			it('does not update when size adjusted by initial clamping', async() => {

--- a/components/page/test/page.test.js
+++ b/components/page/test/page.test.js
@@ -1,8 +1,8 @@
 import '../page.js';
 import { clearStoredPanelState, getStoredPanelState, pageFixtures, setStoredPanelState } from './page-fixtures.js';
 import { expect, fixture, runConstructor, setViewport, waitUntil } from '@brightspace-ui/testing';
-import { getDivider } from './page-divider-internal-fixtures.js';
 import { restore, spy } from 'sinon';
+import { getDivider } from './page-divider-internal-fixtures.js';
 
 const defaultFixtureOptions = { pagePadding: false, viewport: { width: 1300, height: 800 } };
 

--- a/components/page/test/page.test.js
+++ b/components/page/test/page.test.js
@@ -1,5 +1,9 @@
 import '../page.js';
-import { runConstructor } from '@brightspace-ui/testing';
+import { expect, fixture, runConstructor, setViewport, waitUntil } from '@brightspace-ui/testing';
+import { getStoredPanelState, pageFixtures, setStoredPanelState } from './page-fixtures.js';
+import { getDivider } from './page-divider-internal-fixtures.js';
+
+const defaultFixtureOptions = { pagePadding: false, viewport: { width: 1300, height: 800 } };
 
 describe('page', () => {
 
@@ -7,4 +11,117 @@ describe('page', () => {
 		runConstructor('d2l-page');
 	});
 
+	describe('storing panel state', () => {
+		afterEach(() => {
+			localStorage.clear();
+		});
+
+		describe('restoring', () => {
+			it('applies the stored size over the default', async() => {
+				setStoredPanelState({ 'side-nav': { size: '450', collapsed: 'false' } });
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('side-nav')).to.equal(450);
+				expect(elem._panelState.getCollapsed('side-nav')).to.be.false;
+			});
+
+			it('applies the stored collapsed state', async() => {
+				setStoredPanelState({ 'side-nav': { size: '450', collapsed: 'true' } });
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getCollapsed('side-nav')).to.be.true;
+				expect(elem._panelState.getSize('side-nav')).to.equal(0);
+				expect(elem._panelState.getTrueSize('side-nav')).to.equal(450);
+			});
+
+			it('falls back to the default when there is no stored entry', async() => {
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('side-nav')).to.equal(Math.floor(elem._contentWidth / 3));
+				expect(elem._panelState.getCollapsed('side-nav')).to.be.false;
+			});
+
+			it('clamps a stored size larger than the max', async() => {
+				setStoredPanelState({ 'side-nav': { size: '9999', collapsed: 'false' } });
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('side-nav')).to.equal(elem._panelState.getMaxSize('side-nav'));
+			});
+
+			it('clamps a stored size smaller than the min', async() => {
+				setStoredPanelState({ 'side-nav': { size: '10', collapsed: 'false' } });
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('side-nav')).to.equal(elem._panelState.getMinSize('side-nav'));
+			});
+
+			it('restores each panel independently', async() => {
+				setStoredPanelState({
+					'side-nav': { size: '400', collapsed: 'false' },
+					'supporting': { size: '500', collapsed: 'true' }
+				});
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('side-nav')).to.equal(400);
+				expect(elem._panelState.getCollapsed('side-nav')).to.be.false;
+				expect(elem._panelState.getTrueSize('supporting')).to.equal(500);
+				expect(elem._panelState.getCollapsed('supporting')).to.be.true;
+			});
+
+			it('ignores invalid stored data', async() => {
+				setStoredPanelState('not-json');
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('supporting-mobile')).to.equal(Math.floor(window.innerHeight / 2));
+				expect(elem._panelState.getCollapsed('supporting-mobile')).to.be.false;
+			});
+		});
+
+		describe('storing', () => {
+			it('persists the size when a panel is resized', async() => {
+				const elem = await fixture(pageFixtures.sideNavHeaderStorageKey, defaultFixtureOptions);
+				getDivider(elem, 'side-nav').dispatchEvent(new CustomEvent('d2l-page-divider-resize', { detail: { requestedSize: 450 } }));
+				const stored = getStoredPanelState();
+				expect(stored['side-nav'].size).to.equal('450');
+			});
+
+			it('persists the collapsed state when a panel is toggled', async() => {
+				const elem = await fixture(pageFixtures.sideNavHeaderStorageKey, defaultFixtureOptions);
+				getDivider(elem, 'side-nav').dispatchEvent(new CustomEvent('d2l-page-divider-toggle'));
+				const stored = getStoredPanelState();
+				expect(stored['side-nav'].collapsed).to.equal('true');
+				expect(stored['side-nav'].size).to.equal((elem._contentWidth / 3).toString());
+			});
+
+			it('persists each panel under its own key', async() => {
+				setStoredPanelState({ 'side-nav': { size: '450', collapsed: 'true' } });
+				const elem = await fixture(pageFixtures.supportingFooterStorageKey, defaultFixtureOptions);
+				getDivider(elem, 'supporting').dispatchEvent(new CustomEvent('d2l-page-divider-resize', { detail: { requestedSize: 500 } }));
+				const stored = getStoredPanelState();
+				expect(stored['side-nav'].size).to.equal('450');
+				expect(stored['side-nav'].collapsed).to.equal('true');
+				expect(stored['supporting'].size).to.equal('500');
+				expect(stored['supporting'].collapsed).to.equal('false');
+			});
+
+			it('does not persist when no storage key is set', async() => {
+				const elem = await fixture(pageFixtures.sideNavHeader, defaultFixtureOptions);
+				getDivider(elem, 'side-nav').dispatchEvent(new CustomEvent('d2l-page-divider-resize', { detail: { requestedSize: 450 } }));
+				expect(getStoredPanelState()).to.be.null;
+			});
+
+			it('does not update when size adjusted by initial clamping', async() => {
+				setStoredPanelState({ 'supporting': { size: '9999', collapsed: 'false' } });
+				const elem = await fixture(pageFixtures.supportingFooterStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('supporting')).to.equal(elem._panelState.getMaxSize('supporting'));
+				const stored = getStoredPanelState();
+				expect(stored['supporting'].size).to.equal('9999');
+			});
+
+			it('does not update when size adjusted by window resize', async() => {
+				setStoredPanelState({ 'supporting': { size: '500', collapsed: 'false' } });
+				const elem = await fixture(pageFixtures.supportingFooterStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('supporting')).to.equal(500);
+
+				await setViewport({ height: 800, width: 1000 });
+				await waitUntil(() => elem._panelState.getTrueSize('supporting') !== 500);
+
+				const stored = getStoredPanelState();
+				expect(stored['supporting'].size).to.equal('500');
+			});
+		});
+	});
 });


### PR DESCRIPTION
This PR adds the ability to store the last size and collapsed state of the panels, and restore to that state the next time the user returns to that page/tool/whatever. It uses a key, so the consumer decides which of its tool's pages should use the same key or not.

It'll only store/update the value on user interaction - not if the panel is forced to resize due to screen size.

The next PR will have a few vdiffs for the panel storing, plus the vdiff tests I delayed until this functionality was in.