### PR TITLE
GAUD-10514: align our usage of beforeunload with best practices

### DIFF
--- a/components/form/form.js
+++ b/components/form/form.js
@@ -80,7 +80,6 @@ class Form extends LocalizeCoreElement(LitElement) {
 
 	connectedCallback() {
 		super.connectedCallback();
-		
 		/** @ignore */
 		this._isSubForm = !this.dispatchEvent(new CustomEvent('d2l-form-connect', { bubbles: true, composed: true, cancelable: true }));
 	}
@@ -289,7 +288,7 @@ class Form extends LocalizeCoreElement(LitElement) {
 			if (!this._dirty) {
 				window.addEventListener('beforeunload', this.#onUnload);
 				this._dirty = true;
-			}			
+			}
 			/** Dispatched whenever any form element fires an `input` or `change` event. Can be used to track whether the form is dirty or not. */
 			this.dispatchEvent(new CustomEvent('d2l-form-dirty'));
 		}

--- a/components/form/form.js
+++ b/components/form/form.js
@@ -80,7 +80,7 @@ class Form extends LocalizeCoreElement(LitElement) {
 
 	connectedCallback() {
 		super.connectedCallback();
-		window.addEventListener('beforeunload', this.#onUnload);
+		
 		/** @ignore */
 		this._isSubForm = !this.dispatchEvent(new CustomEvent('d2l-form-connect', { bubbles: true, composed: true, cancelable: true }));
 	}
@@ -286,7 +286,10 @@ class Form extends LocalizeCoreElement(LitElement) {
 		const ele = e.target;
 
 		if ((isNativeFormElement(ele) || isCustomFormElement(ele)) && e.type !== 'focusout') {
-			this._dirty = true;
+			if (!this._dirty) {
+				window.addEventListener('beforeunload', this.#onUnload);
+				this._dirty = true;
+			}			
 			/** Dispatched whenever any form element fires an `input` or `change` event. Can be used to track whether the form is dirty or not. */
 			this.dispatchEvent(new CustomEvent('d2l-form-dirty'));
 		}
@@ -312,6 +315,7 @@ class Form extends LocalizeCoreElement(LitElement) {
 	}
 
 	async _submitData(submitter) {
+		window.removeEventListener('beforeunload', this.#onUnload);
 		this._dirty = false;
 
 		let formData = {};

--- a/components/form/test/form.test.js
+++ b/components/form/test/form.test.js
@@ -3,7 +3,8 @@ import '../../dialog/dialog.js';
 import '../form.js';
 import './form-element.js';
 import './nested-form.js';
-import { defineCE, expect, fixture, oneEvent } from '@brightspace-ui/testing';
+import { defineCE, expect, fixture, oneEvent, sendKeysElem } from '@brightspace-ui/testing';
+import { fake, replace, restore } from 'sinon';
 import { html, LitElement } from 'lit';
 import { FormElementMixin } from '../form-element-mixin.js';
 
@@ -40,6 +41,10 @@ describe('d2l-form', () => {
 
 	before(() => {
 		customElements.define('d2l-test-two-forms', TestTwoForms);
+	});
+
+	afterEach(() => {
+		restore();
 	});
 
 	describe('single form', () => {
@@ -552,6 +557,79 @@ describe('d2l-form', () => {
 			expect(form._errors.size).to.equal(0);
 		});
 
+	});
+
+	describe('track-changes', () => {
+
+		const createFixture = async(trackChanges) => {
+			const elem = await fixture(html`
+				<d2l-form ?track-changes="${trackChanges}">
+					<input name="cb" type="text">
+				</d2l-form>
+			`);
+			return elem;
+		};
+
+		let beforeUnloadListeners;
+		const triggerBeforeUnload = function() {
+			const event = new Event('beforeunload', { cancelable: true });
+			beforeUnloadListeners.forEach(listener => listener(event));
+			return event;
+		};
+
+		beforeEach(() => {
+			beforeUnloadListeners = [];
+			replace(window, 'addEventListener', fake((eventName, listener) => {
+				if (eventName === 'beforeunload') beforeUnloadListeners.push(listener);
+			}));
+			replace(window, 'removeEventListener', fake((eventName, listener) => {
+				if (eventName === 'beforeunload') {
+					const index = beforeUnloadListeners.indexOf(listener);
+					if (index > -1) beforeUnloadListeners.splice(index, 1);
+				}
+			}));
+		});
+
+		it('should not prompt on unload if track-changes is false', async() => {
+			const elem = await createFixture(false);
+			await sendKeysElem(elem.querySelector('input'), 'type', 'hello');
+			const event = triggerBeforeUnload();
+			expect(event.defaultPrevented).to.be.false;
+			expect(event.returnValue).to.be.true;
+		});
+
+		it('should not prompt on unload if track-changes is true and form is pristine', async() => {
+			await createFixture(true);
+			const event = triggerBeforeUnload();
+			expect(event.defaultPrevented).to.be.false;
+			expect(event.returnValue).to.be.true;
+		});
+
+		it('should prompt on unload if track-changes is true and form is dirty', async() => {
+			const elem = await createFixture(true);
+			await sendKeysElem(elem.querySelector('input'), 'type', 'hello');
+			const event = triggerBeforeUnload();
+			expect(event.defaultPrevented).to.be.true;
+			expect(event.returnValue).to.be.false;
+		});
+
+		it('should not prompt on unload after dirty form is submitted', async() => {
+			const elem = await createFixture(true);
+			await sendKeysElem(elem.querySelector('input'), 'type', 'hello');
+			await elem.requestSubmit();
+			const event = triggerBeforeUnload();
+			expect(event.defaultPrevented).to.be.false;
+			expect(event.returnValue).to.be.true;
+		});
+
+		it('should not prompt on unload if track-changes is disabled later and form is dirty', async() => {
+			const elem = await createFixture(true);
+			await sendKeysElem(elem.querySelector('input'), 'type', 'hello');
+			elem.trackChanges = false;
+			const event = triggerBeforeUnload();
+			expect(event.defaultPrevented).to.be.false;
+			expect(event.returnValue).to.be.true;
+		});
 	});
 
 	it('should validate custom form elements when they have nested forms', async() => {


### PR DESCRIPTION
This was contributed by @omsmith based [on this conversation](https://d2l.slack.com/archives/C0PHG3QB0/p1785352822331889). I've added unit tests as there was nothing covering this code.

When you want to prompt for unsaved changes before a user leaves the page, the `beforeunload` event is what's used. Our `<d2l-form>` uses it when `track-changes` is set. We weren't [following the best practice](https://developer.chrome.com/docs/web-platform/page-lifecycle-api#the_beforeunload_event) though of only conditionally adding the listener when the form becomes dirty and then removing it when it's pristine. Owen's change resolves that.