### PR TITLE
Use overflowEllipsisDeclarations when lines=1

### DIFF
--- a/components/collapsible-panel/collapsible-panel-summary-item.js
+++ b/components/collapsible-panel/collapsible-panel-summary-item.js
@@ -1,10 +1,8 @@
 import '../colors/colors.js';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { bodySmallStyles } from '../typography/styles.js';
-import { classMap } from 'lit/directives/class-map.js';
 import { getOverflowDeclarations } from '../../helpers/overflow.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
-import { styleMap } from 'lit/directives/style-map.js';
 
 /**
  * A component for a "summary item" child component that describes the content in a collapsible panel.
@@ -35,9 +33,6 @@ class CollapsiblePanelSummaryItem extends SkeletonMixin(LitElement) {
 		.d2l-body-small {
 			line-height: 1.2rem;
 		}
-		p.truncate {
-			${getOverflowDeclarations({ lines: 1 })}
-		}
 	`];
 
 	constructor() {
@@ -47,13 +42,8 @@ class CollapsiblePanelSummaryItem extends SkeletonMixin(LitElement) {
 	}
 
 	render() {
-		const classes = {
-			'd2l-body-small': true,
-			'd2l-skeletize': true,
-			'truncate': this.lines > 0
-		};
-		const styles = (this.lines > 0) ? { '-webkit-line-clamp': this.lines } : {};
-		return html`<p class="${classMap(classes)}" style="${styleMap(styles)}">${this.text}</p>`;
+		const styles = this.lines ? getOverflowDeclarations({ lines: this.lines }) : null;
+		return html`<p class="d2l-body-small d2l-skeletize" style="${styles ?? nothing}">${this.text}</p>`;
 	}
 }
 

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -180,8 +180,11 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 
 	#linkId = getUniqueId();
 
-	#handleClick() {
-		if (this.disabled) return false;
+	#handleClick(e) {
+		if (this.disabled) {
+			e.stopPropagation();
+			e.preventDefault();
+		}
 	}
 
 }

--- a/components/link/link.js
+++ b/components/link/link.js
@@ -2,15 +2,14 @@ import '../colors/colors.js';
 import '../icons/icon.js';
 import '../tooltip/tooltip.js';
 import { css, html, LitElement, nothing } from 'lit';
-import { getOverflowDeclarations, overflowEllipsisDeclarations } from '../../helpers/overflow.js';
 import { _generateLinkStyles } from './link-styles.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { FocusMixin } from '../../mixins/focus/focus-mixin.js';
+import { getOverflowDeclarations } from '../../helpers/overflow.js';
 import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { offscreenStyles } from '../offscreen/offscreen.js';
-import { styleMap } from 'lit/directives/style-map.js';
 
 export const linkStyles = _generateLinkStyles('.d2l-link', true);
 
@@ -90,12 +89,6 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 			align-items: baseline;
 			display: flex;
 		}
-		a span.truncate {
-			${getOverflowDeclarations({ lines: 1 })}
-		}
-		a span.truncate-one {
-			${overflowEllipsisDeclarations}
-		}
 		#new-window {
 			line-height: 0;
 			white-space: nowrap;
@@ -157,12 +150,7 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 			'd2l-link-main': this.main,
 			'd2l-link-small': this.small
 		};
-		const spanClasses = {
-			'd2l-link-content': true,
-			'truncate': this.lines > 1,
-			'truncate-one': this.lines === 1
-		};
-		const styles = { webkitLineClamp: this.lines || null };
+		const styles = this.lines ? getOverflowDeclarations({ lines: this.lines }) : null;
 		const newWindowElements = (this.target === '_blank')
 			? html`<span id="new-window"><span style="font-size: 0;">&nbsp;</span><d2l-icon icon="tier1:new-window"></d2l-icon></span><span class="d2l-offscreen">${this.localize('components.link.open-in-new-window')}</span>`
 			: nothing;
@@ -186,17 +174,14 @@ class Link extends LocalizeCoreElement(FocusMixin(LitElement)) {
 				tabindex="${ifDefined(this.disabled && this.disabledTooltip ? 0 : undefined)}"
 				target="${ifDefined(this.target)}"
 				><span
-					class="${classMap(spanClasses)}"
-					style="${styleMap(styles)}"><slot></slot></span>${newWindowElements}</a>${disabledTooltip}`;
+					class="d2l-link-content"
+					style="${styles ?? nothing}"><slot></slot></span>${newWindowElements}</a>${disabledTooltip}`;
 	}
 
 	#linkId = getUniqueId();
 
-	#handleClick(e) {
-		if (this.disabled) {
-			e.stopPropagation();
-			e.preventDefault();
-		}
+	#handleClick() {
+		if (this.disabled) return false;
 	}
 
 }

--- a/helpers/overflow.js
+++ b/helpers/overflow.js
@@ -1,22 +1,22 @@
 import { set } from './template-tags.js';
 import { unsafeCSS } from 'lit';
 
-export const overflowHiddenDeclarations = getOverflowDeclarations({});
-export const overflowEllipsisDeclarations = getOverflowDeclarations({ textOverflow: 'ellipsis' });
+export const overflowHiddenDeclarations = getOverflowDeclarations({ lines: 0 });
+export const overflowEllipsisDeclarations = getOverflowDeclarations({ textOverflow: 'ellipsis', lines: 0 });
 
-export function getOverflowDeclarations({ textOverflow = '', lines = 0, lit = true } = {}) {
+export function getOverflowDeclarations({ textOverflow = '', lines = 1, lit = true } = {}) {
 	if (!arguments.length) return overflowHiddenDeclarations;
+	if (arguments[0].lines === 1) return overflowEllipsisDeclarations;
 
 	const declarations = set`
 		min-width: 0; /* clamps width of flex items */
 		overflow-x: clip;
-		${lines
+		${lines > 1 || lines.constructor === String
 			? set`
 			display: -webkit-box;
 			overflow-clip-margin: 0.2em;
 			overflow-wrap: anywhere;
 			overflow-y: clip;
-			text-overflow: ${textOverflow || 'ellipsis'};
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: ${lines};`
 			: set`

--- a/helpers/test/overflow.test.js
+++ b/helpers/test/overflow.test.js
@@ -21,7 +21,7 @@ describe('overflow', () => {
 			expect(declarations).to.equal(overflowHiddenDeclarations.cssText);
 		});
 
-		it('should return line clamping declarations when lines > 0', () => {
+		it('should return line clamping declarations when lines > 1', () => {
 			const declarations = getOverflowDeclarations({ lines: 3 });
 			expect(declarations.cssText).to.equal(set`
 				min-width: 0; /* clamps width of flex items */
@@ -30,7 +30,6 @@ describe('overflow', () => {
 				overflow-clip-margin: 0.2em;
 				overflow-wrap: anywhere;
 				overflow-y: clip;
-				text-overflow: ellipsis;
 				-webkit-box-orient: vertical;
 				-webkit-line-clamp: 3;
 			`);
@@ -45,6 +44,18 @@ describe('overflow', () => {
 				overflow-clip-margin: 1em;
 				overflow-y: visible;
 				text-overflow: ${textOverflow};
+				white-space: nowrap;
+			`);
+		});
+
+		it('should produce overflow ellipsis declarations when lines is 1', () => {
+			const declarations = getOverflowDeclarations({ lines: 1 });
+			expect(declarations.cssText).to.equal(set`
+				min-width: 0; /* clamps width of flex items */
+				overflow-x: clip;
+				overflow-clip-margin: 1em;
+				overflow-y: visible;
+				text-overflow: ellipsis;
 				white-space: nowrap;
 			`);
 		});


### PR DESCRIPTION
[PHNX-4815](https://desire2learn.atlassian.net/browse/PHNX-4815)

In #7233 we adjusted the overflow clip margin to roughly follow the line-height to fix an issue with subsequent lines of text partially showing at the bottom of the clipped area. However, this only happens in Windows at mobile device widths (when we shrink the font-size and line-height) and when using `line-clamp` styles. This is unlikely to occur in real-world usage already, but this PR changes `line=1` usages of `getOverflowDeclarations` to always use `overflowEllipsisDeclarations` instead of `line-clamp` which prevents this issue even further in the majority of uses.

If it later becomes a problem in production we can try some other changes like adjusting the font-face styles in Windows etc.

[PHNX-4815]: https://desire2learn.atlassian.net/browse/PHNX-4815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ