### PR TITLE
Add new getComposedNextElementSibling dom helper.

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -86,18 +86,25 @@ elemIdListRemoves(node, attrName, value);
 findComposedAncestor(node, predicate);
 
 // gets the composed children (including shadow children & distributed children)
-// includes a predicate which will add children nodes when predicate(node) is true
+// includes optional predicate for filtering child elements
 getComposedChildren(element, predicate = () => true);
+
+// gets the composed next element sibling considing how children are distributed into slots
+// includes optional predicate for filtering elements
+getComposedNextElementSibling(node, { predicate } = {}) {
 
 // gets the composed parent (including shadow host & insertion points)
 getComposedParent(node);
 
+// returns the first visible ancestor of the given node
+getFirstVisibleAncestor(node)
+
 // returns the next composed sibling at least one dom level up
-// includes a predicate which will return the node when predicate(node) is true
+// includes optional predicate for filtering elements
 getNextAncestorSibling(node, predicate = () => true);
 
 // returns the previous composed sibling at least one dom level up
-// includes a predicate which will return the node when predicate(node) is true
+// includes optional predicate for filtering elements
 getPreviousAncestorSibling(node, predicate = () => true);
 
 // browser consistent implementation of HTMLElement.offsetParent
@@ -108,9 +115,6 @@ isComposedAncestor(ancestorNode, node);
 
 // returns true/false whether the element is visible regardless of positioning
 isVisible(node, { checkAncestors: true });
-
-// returns the first visible ancestor of the given node
-getFirstVisibleAncestor(node)
 
 // similar to document.querySelector or element.querySelector,
 // except it queries not just the light DOM but also shadow DOM

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -79,7 +79,7 @@ export function getBoundingAncestor(node) {
 	});
 }
 
-function getComposedChildNodes(node, { elementsOnly, predicate } = {}) {
+function getComposedChildNodes(node, { elementsOnly = false, predicate } = {}) {
 
 	if (!node) return null;
 

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -79,40 +79,65 @@ export function getBoundingAncestor(node) {
 	});
 }
 
-export function getComposedChildren(node, predicate = () => true) {
+function getComposedChildNodes(node, { elementsOnly, predicate } = {}) {
 
-	if (!node) {
-		return null;
-	}
-	if (node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.DOCUMENT_NODE && node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE) {
+	if (!node) return null;
+
+	if (node.nodeType !== Node.ELEMENT_NODE
+		&& node.nodeType !== Node.DOCUMENT_NODE
+		&& node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE) {
 		return null;
 	}
 
 	let nodes;
-	const children = [];
+	const filteredNodes = [];
 
 	if (node.tagName === 'CONTENT') {
 		nodes = node.getDistributedNodes();
 	} else if (node.tagName === 'SLOT') {
 		// note: this is not handling default slot content
-		nodes = node.assignedNodes({ flatten: true });
+		nodes = elementsOnly ? node.assignedElements({ flatten: true }) : node.assignedNodes({ flatten: true });
 	} else {
-		if (node.shadowRoot) {
-			node = node.shadowRoot;
-		}
-		nodes = node.children || node.childNodes;
+		if (node.shadowRoot) node = node.shadowRoot;
+		nodes = elementsOnly ? node.children : node.childNodes;
 	}
 
 	for (let i = 0; i < nodes.length; i++) {
-		if (nodes[i].nodeType === Node.ELEMENT_NODE) {
-			if (predicate(nodes[i])) {
-				children.push(nodes[i]);
-			}
+		// need to check nodeType since old Polymer getDistributedNodes could return non-elements
+		if (!elementsOnly || nodes[i].nodeType === Node.ELEMENT_NODE) {
+			if (!predicate || predicate(nodes[i])) filteredNodes.push(nodes[i]);
 		}
 	}
 
-	return children;
+	return filteredNodes;
+}
 
+export function getComposedChildren(node, predicate) {
+	return getComposedChildNodes(node, { elementsOnly: true, predicate });
+}
+
+export function getComposedNextElementSibling(node, { predicate } = {}) {
+
+	if (!node || node.nodeType === undefined) return null;
+
+	const parentNode = getComposedParent(node);
+	if (!parentNode) return null;
+
+	// for regular parents this is child elements; for SLOT this is distributed elements
+	const composedChildNodes = getComposedChildNodes(parentNode, { elementsOnly: (node.nodeType === Node.ELEMENT_NODE) });
+
+	if (!composedChildNodes || composedChildNodes.length === 0) return null;
+
+	const index = composedChildNodes.indexOf(node);
+	if (index === -1) return null;
+
+	for (let i = index + 1; i < composedChildNodes.length; i++) {
+		if (composedChildNodes[i].nodeType === Node.ELEMENT_NODE && (!predicate || predicate(composedChildNodes[i]))) {
+			return composedChildNodes[i];
+		}
+	}
+
+	return null;
 }
 
 export function getComposedParent(node) {

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -7,6 +7,7 @@ import {
 	findComposedAncestor,
 	getBoundingAncestor,
 	getComposedChildren,
+	getComposedNextElementSibling,
 	getComposedParent,
 	getFirstVisibleAncestor,
 	getNextAncestorSibling,
@@ -26,10 +27,28 @@ const testElemTag = defineCE(
 			return html`<div id="container"><slot id="slot1"></slot></div>`;
 		}
 		getContainer() {
-			return this.shadowRoot && this.shadowRoot.querySelector('#container');
+			return this.shadowRoot?.querySelector('#container');
 		}
 	},
 );
+
+const testMultiSlotElemTag = defineCE(
+	class extends LitElement {
+		render() {
+			return html`<div id="container">
+				<slot id="slot1" name="slot1"></slot>
+				text node before divider
+				<div id="divider"></div>
+				text node after divider
+				<slot id="slot2" name="slot1"></slot>
+			</div>`;
+		}
+		getContainer() {
+			return this.shadowRoot?.querySelector('#container');
+		}
+	},
+);
+
 const offsetParentWrapperTag = defineCE(
 	class extends LitElement {
 		static properties = {
@@ -59,11 +78,25 @@ const simpleFixture = html`
 		some text
 	</div>`
 ;
+const simpleMultiElementFixture = html`
+	<div id="light1">
+		<div id="light2"></div>
+		some text
+		<div id="light3"></div>
+	</div>`
+;
 const wcFixture = `
 	<${testElemTag}>
 		<div id="light1"></div>
 		<div id="light2"></div>
 	</${testElemTag}>
+`;
+const wcMultiSlotFixture = `
+	<${testMultiSlotElemTag}>
+		<div id="light1" slot="slot1"></div>
+		<div id="light2" slot="slot2"></div>
+		<div id="light3" slot="slot1"></div>
+	</${testMultiSlotElemTag}>
 `;
 const mixedFixture = `
 	<div id="light1">
@@ -405,6 +438,16 @@ describe('dom', () => {
 			expect(children[0]).to.equal(expected[0]);
 		});
 
+		it('returns filtered child elememts', async() => {
+			const elem = await fixture(wcFixture);
+			const container = elem.getContainer();
+			let children = getComposedChildren(container);
+			expect(children[0].tagName).to.be.oneOf(['SLOT', 'CONTENT']);
+			children = getComposedChildren(children[0], elem => elem.id === 'light2');
+			expect(children.length).to.equal(1);
+			expect(children[0]).to.equal(elem.querySelector('#light2'));
+		});
+
 		it('returns child elememts for document', async() => {
 			const children = getComposedChildren(document);
 			const expected = document.children;
@@ -428,6 +471,79 @@ describe('dom', () => {
 			expect(children.length).to.equal(2);
 			expect(children[0]).to.equal(elem.querySelector('#light1'));
 			expect(children[1]).to.equal(elem.querySelector('#light2'));
+		});
+
+	});
+
+	describe('getComposedNextElementSibling', () => {
+
+		it('returns next element sibling in vanilla', async() => {
+			const elem = await fixture(simpleMultiElementFixture);
+			const target = elem.querySelector('#light2');
+			const elementSibling = getComposedNextElementSibling(target);
+			const expected = elem.querySelector('#light3');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns null when there is no next element sibling in vanilla', async() => {
+			const elem = await fixture(simpleFixture);
+			const target = elem.querySelector('#light2');
+			const elementSibling = getComposedNextElementSibling(target);
+			expect(elementSibling).to.be.null;
+		});
+
+		it('returns next element sibling when text node is passed in vanilla', async() => {
+			const elem = await fixture(simpleMultiElementFixture);
+			const target = elem.querySelector('#light2').nextSibling;
+			const elementSibling = getComposedNextElementSibling(target);
+			const expected = elem.querySelector('#light3');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns next element sibling in default slot of custom element', async() => {
+			const elem = await fixture(wcFixture);
+			const target = elem.querySelector('#light1');
+			const elementSibling = getComposedNextElementSibling(target);
+			const expected = elem.querySelector('#light2');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns null when there is no next element sibling in the same slot of custom element', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const target = elem.querySelector('#light2');
+			const elementSibling = getComposedNextElementSibling(target);
+			expect(elementSibling).to.be.null;
+		});
+
+		it('returns next element sibling in the same slot of custom element', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const target = elem.querySelector('#light1');
+			const elementSibling = getComposedNextElementSibling(target);
+			const expected = elem.querySelector('#light3');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns next element sibling in shadowDOM of custom element', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const target = elem.getContainer().querySelector('#slot1');
+			const elementSibling = getComposedNextElementSibling(target);
+			const expected = elem.getContainer().querySelector('#divider');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns next element sibling slot in shadowDOM of custom element', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const target = elem.getContainer().querySelector('#divider');
+			const elementSibling = getComposedNextElementSibling(target);
+			const expected = elem.getContainer().querySelector('#slot2');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns null when the target is the shadowRoot', async() => {
+			const elem = await fixture(wcFixture);
+			const target = elem.shadowRoot;
+			const elementSibling = getComposedNextElementSibling(target);
+			expect(elementSibling).to.be.null;
 		});
 
 	});


### PR DESCRIPTION
[GAUD-10517](https://desire2learn.atlassian.net/browse/GAUD-10517)

This PR adds a new `getComposedNextElementSibling` DOM helper. To support this, the logic from the original `getComposedChildren` has been refactored into the more generic `getComposedChildNodes`.

This change is needed for the followup PR that will fix the `getNextFocusable` helper which needs to walk the composed tree. (a change that I intend to flag)

[GAUD-10517]: https://desire2learn.atlassian.net/browse/GAUD-10517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ