### PR TITLE
Add new getComposedPreviousElementSibling dom helper.

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -91,10 +91,14 @@ getComposedChildren(element, predicate = () => true);
 
 // gets the composed next element sibling considing how children are distributed into slots
 // includes optional predicate for filtering elements
-getComposedNextElementSibling(node, { predicate } = {}) {
+getComposedNextElementSibling(node, { predicate });
 
 // gets the composed parent (including shadow host & insertion points)
 getComposedParent(node);
+
+// gets the composed previous element sibling considing how children are distributed into slots
+// includes optional predicate for filtering elements
+getComposedPreviousElementSibling(node, { predicate });
 
 // returns the first visible ancestor of the given node
 getFirstVisibleAncestor(node)

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -116,7 +116,7 @@ export function getComposedChildren(node, predicate) {
 	return getComposedChildNodes(node, { elementsOnly: true, predicate });
 }
 
-export function getComposedNextElementSibling(node, { predicate } = {}) {
+function getComposedElementSibling(node, { direction = 'next', predicate } = {}) {
 
 	if (!node || node.nodeType === undefined) return null;
 
@@ -131,13 +131,25 @@ export function getComposedNextElementSibling(node, { predicate } = {}) {
 	const index = composedChildNodes.indexOf(node);
 	if (index === -1) return null;
 
-	for (let i = index + 1; i < composedChildNodes.length; i++) {
-		if (composedChildNodes[i].nodeType === Node.ELEMENT_NODE && (!predicate || predicate(composedChildNodes[i]))) {
-			return composedChildNodes[i];
+	if (direction === 'previous') {
+		for (let i = index - 1; i >= 0; i--) {
+			if (composedChildNodes[i].nodeType === Node.ELEMENT_NODE && (!predicate || predicate(composedChildNodes[i]))) {
+				return composedChildNodes[i];
+			}
+		}
+	} else {
+		for (let i = index + 1; i < composedChildNodes.length; i++) {
+			if (composedChildNodes[i].nodeType === Node.ELEMENT_NODE && (!predicate || predicate(composedChildNodes[i]))) {
+				return composedChildNodes[i];
+			}
 		}
 	}
 
 	return null;
+}
+
+export function getComposedNextElementSibling(node, { predicate } = {}) {
+	return getComposedElementSibling(node, { direction: 'next', predicate });
 }
 
 export function getComposedParent(node) {
@@ -161,6 +173,10 @@ export function getComposedParent(node) {
 
 	return null;
 
+}
+
+export function getComposedPreviousElementSibling(node, { predicate } = {}) {
+	return getComposedElementSibling(node, { direction: 'previous', predicate });
 }
 
 export function getNextAncestorSibling(node, predicate = () => true) {

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -83,6 +83,7 @@ const simpleMultiElementFixture = html`
 		<div id="light2"></div>
 		some text
 		<div id="light3"></div>
+		<div id="light4"></div>
 	</div>`
 ;
 const wcFixture = `
@@ -498,6 +499,21 @@ describe('dom', () => {
 			const elementSibling = getComposedNextElementSibling(target);
 			const expected = elem.querySelector('#light3');
 			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns next element sibling that fulfills predicate in vanilla', async() => {
+			const elem = await fixture(simpleMultiElementFixture);
+			const target = elem.querySelector('#light2');
+			const elementSibling = getComposedNextElementSibling(target, { predicate: elem => elem.id === 'light4' });
+			const expected = elem.querySelector('#light4');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns null when no next element siblings fulfill predicate in vanilla', async() => {
+			const elem = await fixture(simpleMultiElementFixture);
+			const target = elem.querySelector('#light2');
+			const elementSibling = getComposedNextElementSibling(target, { predicate: elem => elem.id === 'light5' });
+			expect(elementSibling).to.be.null;
 		});
 
 		it('returns next element sibling in default slot of custom element', async() => {

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -9,6 +9,7 @@ import {
 	getComposedChildren,
 	getComposedNextElementSibling,
 	getComposedParent,
+	getComposedPreviousElementSibling,
 	getFirstVisibleAncestor,
 	getNextAncestorSibling,
 	getOffsetParent,
@@ -592,6 +593,94 @@ describe('dom', () => {
 		it('returns null as parent of document', async() => {
 			expect(getComposedParent(document))
 				.to.equal(null);
+		});
+
+	});
+
+	describe('getComposedPreviousElementSibling', () => {
+
+		it('returns previous element sibling in vanilla', async() => {
+			const elem = await fixture(simpleMultiElementFixture);
+			const target = elem.querySelector('#light4');
+			const elementSibling = getComposedPreviousElementSibling(target);
+			const expected = elem.querySelector('#light3');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns null when there is no previous element sibling in vanilla', async() => {
+			const elem = await fixture(simpleFixture);
+			const target = elem.querySelector('#light2');
+			const elementSibling = getComposedPreviousElementSibling(target);
+			expect(elementSibling).to.be.null;
+		});
+
+		it('returns previous element sibling when text node is passed in vanilla', async() => {
+			const elem = await fixture(simpleMultiElementFixture);
+			const target = elem.querySelector('#light3').previousSibling;
+			const elementSibling = getComposedPreviousElementSibling(target);
+			const expected = elem.querySelector('#light2');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns previous element sibling that fulfills predicate in vanilla', async() => {
+			const elem = await fixture(simpleMultiElementFixture);
+			const target = elem.querySelector('#light4');
+			const elementSibling = getComposedPreviousElementSibling(target, { predicate: elem => elem.id === 'light2' });
+			const expected = elem.querySelector('#light2');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns null when no previous element siblings fulfill predicate in vanilla', async() => {
+			const elem = await fixture(simpleMultiElementFixture);
+			const target = elem.querySelector('#light4');
+			const elementSibling = getComposedPreviousElementSibling(target, { predicate: elem => elem.id === 'light0' });
+			expect(elementSibling).to.be.null;
+		});
+
+		it('returns previous element sibling in default slot of custom element', async() => {
+			const elem = await fixture(wcFixture);
+			const target = elem.querySelector('#light2');
+			const elementSibling = getComposedPreviousElementSibling(target);
+			const expected = elem.querySelector('#light1');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns null when there is no previous element sibling in the same slot of custom element', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const target = elem.querySelector('#light2');
+			const elementSibling = getComposedPreviousElementSibling(target);
+			expect(elementSibling).to.be.null;
+		});
+
+		it('returns previous element sibling in the same slot of custom element', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const target = elem.querySelector('#light3');
+			const elementSibling = getComposedPreviousElementSibling(target);
+			const expected = elem.querySelector('#light1');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns previous element sibling in shadowDOM of custom element', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const target = elem.getContainer().querySelector('#slot2');
+			const elementSibling = getComposedPreviousElementSibling(target);
+			const expected = elem.getContainer().querySelector('#divider');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns previous element sibling slot in shadowDOM of custom element', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const target = elem.getContainer().querySelector('#divider');
+			const elementSibling = getComposedPreviousElementSibling(target);
+			const expected = elem.getContainer().querySelector('#slot1');
+			expect(elementSibling).to.equal(expected);
+		});
+
+		it('returns null when the target is the shadowRoot', async() => {
+			const elem = await fixture(wcFixture);
+			const target = elem.shadowRoot;
+			const elementSibling = getComposedPreviousElementSibling(target);
+			expect(elementSibling).to.be.null;
 		});
 
 	});


### PR DESCRIPTION
[GAUD-10523](https://desire2learn.atlassian.net/browse/GAUD-10523)

This PR adds the new `getComposedPreviousElementSibling` helper method that will be needed to improve the `getNext`/`getPreviousFocusable` helpers. The logic for these is identical except for the iteration order, so the logic was factored into the `getComposedElementSibling` private helper.

[GAUD-10523]: https://desire2learn.atlassian.net/browse/GAUD-10523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ