### PR TITLE
GAUD-10322 - Add storage key validation

### DIFF
--- a/components/page/page.js
+++ b/components/page/page.js
@@ -7,6 +7,7 @@ import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
 import { ProviderMixin } from '../../mixins/provider/provider-mixin.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
+const VALID_STATE_STORAGE_KEY = /^[a-z0-9_-]+$/i;
 export const panelStateStorageKey = key => `d2l-page-panel-state-${key}`;
 
 const DRAWER_MIN_HEIGHT = 200; // TO DO: Confirm
@@ -348,6 +349,16 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		});
 	}
 
+	get stateStorageKey() { return this.#stateStorageKey; }
+	set stateStorageKey(value) {
+		if (value && !VALID_STATE_STORAGE_KEY.test(value)) {
+			this.#stateStorageKey = undefined;
+			throw new Error(`d2l-page: invalid state-storage-key "${value}". Keys may only contain alphanumeric characters, dashes, and underscores.`);
+		}
+
+		this.#stateStorageKey = value;
+	}
+
 	connectedCallback() {
 		super.connectedCallback();
 		window.addEventListener('resize', this.#handleWindowResize);
@@ -399,6 +410,7 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 	}
 
 	#resizeObserver;
+	#stateStorageKey;
 
 	#handleWindowResize = () => {
 		this._panelState.updateMaxSize('supporting-mobile', this.#getMaxDrawerHeight());

--- a/components/page/test/page.test.js
+++ b/components/page/test/page.test.js
@@ -18,6 +18,28 @@ describe('page', () => {
 			clearStoredPanelState();
 		});
 
+		describe('key validation', () => {
+			it('accepts valid keys', async() => {
+				const elem = await fixture(pageFixtures.sideNavHeader, defaultFixtureOptions);
+				elem.stateStorageKey = 'test-PAGE_123';
+				expect(elem.stateStorageKey).to.equal('test-PAGE_123');
+			});
+
+			it('rejects invalid keys', async() => {
+				const elem = await fixture(pageFixtures.sideNavHeader, defaultFixtureOptions);
+				expect(() => { elem.stateStorageKey = 'test page'; }).to.throw();
+				expect(elem.stateStorageKey).to.be.undefined;
+			});
+
+			it('clears key once invalid key is set', async() => {
+				const elem = await fixture(pageFixtures.sideNavHeaderStorageKey, defaultFixtureOptions);
+				expect(elem.stateStorageKey).to.equal('test-page');
+
+				expect(() => { elem.stateStorageKey = 'test page'; }).to.throw();
+				expect(elem.stateStorageKey).to.be.undefined;
+			});
+		});
+
 		describe('restoring', () => {
 			it('applies the stored size over the default', async() => {
 				setStoredPanelState({ 'side-nav': { size: 450, collapsed: false } });


### PR DESCRIPTION
As discussed, this PR adds some simple validation to check the key only contains letters, numbers, dashes or underscores. If it doesn't, the property is set to `undefined` and a console error is thrown.