### PR TITLE
Fix getNextFocusable and getPreviousFocusable

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -89,6 +89,10 @@ findComposedAncestor(node, predicate);
 // includes optional predicate for filtering child elements
 getComposedChildren(element, predicate = () => true);
 
+//gets the composed next ancestor sibling by walking the composed ancestors
+// includes optional predicate for filtering elements
+getComposedNextAncestorElementSibling(node, { predicate });
+
 // gets the composed next element sibling considing how children are distributed into slots
 // includes optional predicate for filtering elements
 getComposedNextElementSibling(node, { predicate });
@@ -96,20 +100,16 @@ getComposedNextElementSibling(node, { predicate });
 // gets the composed parent (including shadow host & insertion points)
 getComposedParent(node);
 
+//gets the composed previous ancestor sibling by walking the composed ancestors
+// includes optional predicate for filtering elements
+getComposedPreviousAncestorElementSibling(node, { predicate });
+
 // gets the composed previous element sibling considing how children are distributed into slots
 // includes optional predicate for filtering elements
 getComposedPreviousElementSibling(node, { predicate });
 
 // returns the first visible ancestor of the given node
 getFirstVisibleAncestor(node)
-
-// returns the next composed sibling at least one dom level up
-// includes optional predicate for filtering elements
-getNextAncestorSibling(node, predicate = () => true);
-
-// returns the previous composed sibling at least one dom level up
-// includes optional predicate for filtering elements
-getPreviousAncestorSibling(node, predicate = () => true);
 
 // browser consistent implementation of HTMLElement.offsetParent
 getOffsetParent(node);

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -148,6 +148,18 @@ function getComposedElementSibling(node, { direction = 'next', predicate } = {})
 	return null;
 }
 
+export function getComposedNextAncestorSibling(node, { predicate } = {}) {
+	let parentNode = getComposedParent(node);
+
+	while (parentNode) {
+		const nextParentSibling = getComposedNextElementSibling(parentNode, { predicate });
+		if (nextParentSibling) return nextParentSibling;
+		parentNode = getComposedParent(parentNode);
+	}
+
+	return null;
+}
+
 export function getComposedNextElementSibling(node, { predicate } = {}) {
 	return getComposedElementSibling(node, { direction: 'next', predicate });
 }
@@ -173,6 +185,18 @@ export function getComposedParent(node) {
 
 	return null;
 
+}
+
+export function getComposedPreviousAncestorSibling(node, { predicate } = {}) {
+	let parentNode = getComposedParent(node);
+
+	while (parentNode) {
+		const previousParentSibling = getComposedPreviousElementSibling(parentNode, { predicate });
+		if (previousParentSibling) return previousParentSibling;
+		parentNode = getComposedParent(parentNode);
+	}
+
+	return null;
 }
 
 export function getComposedPreviousElementSibling(node, { predicate } = {}) {

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -1,3 +1,5 @@
+import { getFlag } from './flags.js';
+
 // needed for legacy-Edge, after it's removed use CSS.escape directly
 export function cssEscape(val) {
 	if (window.CSS && window.CSS.escape) {
@@ -149,10 +151,14 @@ function getComposedElementSibling(node, { direction = 'next', predicate } = {})
 }
 
 export function getComposedNextAncestorElementSibling(node, { predicate } = {}) {
+
+	const focusableFixFlag = getFlag('GAUD-10260-get-focusable-fix', true);
+
 	let parentNode = getComposedParent(node);
 
 	while (parentNode) {
-		const nextParentSibling = getComposedNextElementSibling(parentNode, { predicate });
+		// Clean-up this next line when cleaning up GAUD-10260-get-focusable-fix
+		const nextParentSibling = focusableFixFlag ? getComposedNextElementSibling(parentNode, { predicate }) : parentNode.nextElementSibling;
 		if (nextParentSibling) return nextParentSibling;
 		parentNode = getComposedParent(parentNode);
 	}
@@ -188,10 +194,14 @@ export function getComposedParent(node) {
 }
 
 export function getComposedPreviousAncestorElementSibling(node, { predicate } = {}) {
+
+	const focusableFixFlag = getFlag('GAUD-10260-get-focusable-fix', true);
+
 	let parentNode = getComposedParent(node);
 
 	while (parentNode) {
-		const previousParentSibling = getComposedPreviousElementSibling(parentNode, { predicate });
+		// Clean-up this next line when cleaning up GAUD-10260-get-focusable-fix
+		const previousParentSibling = focusableFixFlag ? getComposedPreviousElementSibling(parentNode, { predicate }) : parentNode.previousElementSibling;
 		if (previousParentSibling) return previousParentSibling;
 		parentNode = getComposedParent(parentNode);
 	}
@@ -201,32 +211,6 @@ export function getComposedPreviousAncestorElementSibling(node, { predicate } = 
 
 export function getComposedPreviousElementSibling(node, { predicate } = {}) {
 	return getComposedElementSibling(node, { direction: 'previous', predicate });
-}
-
-// This method can be removed when cleaning up GAUD-10260-get-focusable-fix (double-check usage)
-export function getNextAncestorSibling(node, predicate = () => true) {
-	let parentNode = getComposedParent(node);
-
-	while (parentNode) {
-		const nextParentSibling = parentNode.nextElementSibling;
-		if (nextParentSibling && predicate(nextParentSibling)) return nextParentSibling;
-		parentNode = getComposedParent(parentNode);
-	}
-
-	return null;
-}
-
-// This method can be removed when cleaning up GAUD-10260-get-focusable-fix (double-check usage)
-export function getPreviousAncestorSibling(node, predicate = () => true) {
-	let parentNode = getComposedParent(node);
-
-	while (parentNode) {
-		const previousParentSibling = parentNode.previousElementSibling;
-		if (previousParentSibling && predicate(previousParentSibling)) return previousParentSibling;
-		parentNode = getComposedParent(parentNode);
-	}
-
-	return null;
 }
 
 export function getOffsetParent(node) {

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -203,6 +203,7 @@ export function getComposedPreviousElementSibling(node, { predicate } = {}) {
 	return getComposedElementSibling(node, { direction: 'previous', predicate });
 }
 
+// This method can be removed when cleaning up GAUD-10260-get-focusable-fix (double-check usage)
 export function getNextAncestorSibling(node, predicate = () => true) {
 	let parentNode = getComposedParent(node);
 
@@ -215,6 +216,7 @@ export function getNextAncestorSibling(node, predicate = () => true) {
 	return null;
 }
 
+// This method can be removed when cleaning up GAUD-10260-get-focusable-fix (double-check usage)
 export function getPreviousAncestorSibling(node, predicate = () => true) {
 	let parentNode = getComposedParent(node);
 

--- a/helpers/dom.js
+++ b/helpers/dom.js
@@ -148,7 +148,7 @@ function getComposedElementSibling(node, { direction = 'next', predicate } = {})
 	return null;
 }
 
-export function getComposedNextAncestorSibling(node, { predicate } = {}) {
+export function getComposedNextAncestorElementSibling(node, { predicate } = {}) {
 	let parentNode = getComposedParent(node);
 
 	while (parentNode) {
@@ -187,7 +187,7 @@ export function getComposedParent(node) {
 
 }
 
-export function getComposedPreviousAncestorSibling(node, { predicate } = {}) {
+export function getComposedPreviousAncestorElementSibling(node, { predicate } = {}) {
 	let parentNode = getComposedParent(node);
 
 	while (parentNode) {

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -1,5 +1,15 @@
 import { css, unsafeCSS } from 'lit';
-import { getComposedChildren, getComposedParent, getFirstVisibleAncestor, getNextAncestorSibling, getPreviousAncestorSibling, isVisible } from './dom.js';
+import {
+	getComposedChildren,
+	getComposedNextAncestorElementSibling,
+	getComposedParent,
+	getComposedPreviousAncestorElementSibling,
+	getFirstVisibleAncestor,
+	getNextAncestorSibling,
+	getPreviousAncestorSibling,
+	isVisible
+} from './dom.js';
+import { getFlag } from './flags.js';
 
 const focusableElements = {
 	a: true,
@@ -123,6 +133,9 @@ export function getLastFocusableDescendant(node, includeHidden) {
 }
 
 export function getPreviousFocusable(node, includeHidden) {
+
+	const focusableFixFlag = getFlag('GAUD-10260-get-focusable-fix', true);
+
 	if (!node) return null;
 
 	if (includeHidden === undefined) includeHidden = false;
@@ -142,7 +155,7 @@ export function getPreviousFocusable(node, includeHidden) {
 			return null;
 		}
 
-		const previousAncestorSibling = getPreviousAncestorSibling(node);
+		const previousAncestorSibling = focusableFixFlag ? getComposedPreviousAncestorElementSibling(node) : getPreviousAncestorSibling(node);
 		if (previousAncestorSibling) {
 			const parentSibingFocusable = _getPreviousFocusable(previousAncestorSibling, false, false);
 			if (parentSibingFocusable) return parentSibingFocusable;
@@ -156,6 +169,8 @@ export function getPreviousFocusable(node, includeHidden) {
 }
 
 export function getNextFocusable(node, includeHidden, ignore, ignoreChildren) {
+
+	const focusableFixFlag = getFlag('GAUD-10260-get-focusable-fix', true);
 
 	if (!node) return null;
 
@@ -178,7 +193,7 @@ export function getNextFocusable(node, includeHidden, ignore, ignoreChildren) {
 			return null;
 		}
 
-		const nextParentSibling = getNextAncestorSibling(node);
+		const nextParentSibling = focusableFixFlag ? getComposedNextAncestorElementSibling(node) : getNextAncestorSibling(node);
 		if (nextParentSibling) {
 			const parentSibingFocusable = _getNextFocusable(nextParentSibling, false, false);
 			if (parentSibingFocusable) return parentSibingFocusable;

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -155,6 +155,7 @@ export function getPreviousFocusable(node, includeHidden) {
 			return null;
 		}
 
+		// Clean-up this next line when cleaning up GAUD-10260-get-focusable-fix
 		const previousAncestorSibling = focusableFixFlag ? getComposedPreviousAncestorElementSibling(node) : getPreviousAncestorSibling(node);
 		if (previousAncestorSibling) {
 			const parentSibingFocusable = _getPreviousFocusable(previousAncestorSibling, false, false);
@@ -193,6 +194,7 @@ export function getNextFocusable(node, includeHidden, ignore, ignoreChildren) {
 			return null;
 		}
 
+		// Clean-up this next line when cleaning up GAUD-10260-get-focusable-fix
 		const nextParentSibling = focusableFixFlag ? getComposedNextAncestorElementSibling(node) : getNextAncestorSibling(node);
 		if (nextParentSibling) {
 			const parentSibingFocusable = _getNextFocusable(nextParentSibling, false, false);

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -7,8 +7,6 @@ import {
 	getComposedPreviousAncestorElementSibling,
 	getComposedPreviousElementSibling,
 	getFirstVisibleAncestor,
-	getNextAncestorSibling,
-	getPreviousAncestorSibling,
 	isVisible
 } from './dom.js';
 import { getFlag } from './flags.js';
@@ -158,8 +156,7 @@ export function getPreviousFocusable(node, includeHidden) {
 			return null;
 		}
 
-		// Clean-up this next line when cleaning up GAUD-10260-get-focusable-fix
-		const previousAncestorSibling = focusableFixFlag ? getComposedPreviousAncestorElementSibling(node) : getPreviousAncestorSibling(node);
+		const previousAncestorSibling = getComposedPreviousAncestorElementSibling(node);
 		if (previousAncestorSibling) {
 			const parentSibingFocusable = _getPreviousFocusable(previousAncestorSibling, false, false);
 			if (parentSibingFocusable) return parentSibingFocusable;
@@ -198,8 +195,7 @@ export function getNextFocusable(node, includeHidden, ignore, ignoreChildren) {
 			return null;
 		}
 
-		// Clean-up this next line when cleaning up GAUD-10260-get-focusable-fix
-		const nextParentSibling = focusableFixFlag ? getComposedNextAncestorElementSibling(node) : getNextAncestorSibling(node);
+		const nextParentSibling = getComposedNextAncestorElementSibling(node);
 		if (nextParentSibling) {
 			const parentSibingFocusable = _getNextFocusable(nextParentSibling, false, false);
 			if (parentSibingFocusable) return parentSibingFocusable;

--- a/helpers/focus.js
+++ b/helpers/focus.js
@@ -2,8 +2,10 @@ import { css, unsafeCSS } from 'lit';
 import {
 	getComposedChildren,
 	getComposedNextAncestorElementSibling,
+	getComposedNextElementSibling,
 	getComposedParent,
 	getComposedPreviousAncestorElementSibling,
+	getComposedPreviousElementSibling,
 	getFirstVisibleAncestor,
 	getNextAncestorSibling,
 	getPreviousAncestorSibling,
@@ -148,7 +150,8 @@ export function getPreviousFocusable(node, includeHidden) {
 			if (focusable) return focusable;
 		}
 
-		const previousSibling = node.previousElementSibling;
+		// Clean-up this next line when cleaning up GAUD-10260-get-focusable-fix
+		const previousSibling = focusableFixFlag ? getComposedPreviousElementSibling(node) : node.previousElementSibling;
 		if (previousSibling) {
 			const siblingFocusable = _getPreviousFocusable(previousSibling, false, false);
 			if (siblingFocusable) return siblingFocusable;
@@ -187,7 +190,8 @@ export function getNextFocusable(node, includeHidden, ignore, ignoreChildren) {
 			if (focusable) return focusable;
 		}
 
-		const nextSibling = node.nextElementSibling;
+		// Clean-up this next line when cleaning up GAUD-10260-get-focusable-fix
+		const nextSibling = focusableFixFlag ? getComposedNextElementSibling(node) : node.nextElementSibling;
 		if (nextSibling) {
 			const siblingFocusable = _getNextFocusable(nextSibling, false, false);
 			if (siblingFocusable) return siblingFocusable;

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -7,8 +7,10 @@ import {
 	findComposedAncestor,
 	getBoundingAncestor,
 	getComposedChildren,
+	getComposedNextAncestorElementSibling,
 	getComposedNextElementSibling,
 	getComposedParent,
+	getComposedPreviousAncestorElementSibling,
 	getComposedPreviousElementSibling,
 	getFirstVisibleAncestor,
 	getNextAncestorSibling,
@@ -41,7 +43,7 @@ const testMultiSlotElemTag = defineCE(
 				text node before divider
 				<div id="divider"></div>
 				text node after divider
-				<slot id="slot2" name="slot1"></slot>
+				<slot id="slot2" name="slot2"></slot>
 			</div>`;
 		}
 		getContainer() {
@@ -95,9 +97,9 @@ const wcFixture = `
 `;
 const wcMultiSlotFixture = `
 	<${testMultiSlotElemTag}>
-		<div id="light1" slot="slot1"></div>
-		<div id="light2" slot="slot2"></div>
-		<div id="light3" slot="slot1"></div>
+		<div id="light1" slot="slot1">slot 1 text 1</div>
+		<div id="light2" slot="slot2">slot 2 text 1</div>
+		<div id="light3" slot="slot1">slot 1 text 2</div>
 	</${testMultiSlotElemTag}>
 `;
 const mixedFixture = `
@@ -477,6 +479,150 @@ describe('dom', () => {
 
 	});
 
+	describe('getComposedNextAncestorElementSibling', () => {
+
+		it('returns null when no ancestors have siblings in vanilla', async() => {
+			const elem = await fixture(simpleFixture);
+			const ancestorSibling = getComposedNextAncestorElementSibling(elem);
+			expect(ancestorSibling).to.be.null;
+		});
+
+		it('returns next ancestor sibling one level up in vanilla', async() => {
+			const elem = await fixture(html`
+				<div id="parent">
+					<div>
+						<div id="target"></div>
+					</div>
+					<div id="expected"></div>
+					<div></div>
+				</div>
+			`);
+			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns next ancestor sibling one level up after ignoring non-element nodes in vanilla', async() => {
+			const elem = await fixture(html`
+				<div id="parent">
+					<div>
+						<div id="target"></div>
+					</div>
+					birthday cake
+					<!-- birthday cake is yummy -->
+					<div id="expected"></div>
+					<div></div>
+				</div>
+			`);
+			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns next ancestor sibling two levels up in vanilla', async() => {
+			const elem = await fixture(html`
+				<div id="parent">
+					<div>
+						<div>
+							<div id="target"></div>
+						</div>
+					</div>
+					<div id="expected"></div>
+				</div>
+			`);
+			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns next ancestor sibling that fulfills predicate in vanilla', async() => {
+			const elem = await fixture(html`
+				<div id="parent">
+					<div>
+						<div id="target"></div>
+					</div>
+					<div></div>
+					<div id="expected"></div>
+				</div>
+			`);
+			const ancestorSibling = getComposedNextAncestorElementSibling(
+				elem.querySelector('#target'),
+				{ predicate: elem => elem.id === 'expected' }
+			);
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns next sibling of ancestor slot in custom element shadowDOM', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#light1'));
+			const expected = elem.getContainer().querySelector('#divider');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns next sibling of ancestor slot that fulfills predicate in custom element shadowDOM', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const ancestorSibling = getComposedNextAncestorElementSibling(
+				elem.querySelector('#light1'),
+				{ predicate: elem => elem.tagName === 'SLOT' }
+			);
+			const expected = elem.getContainer().querySelector('#slot2');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns null when there are no next ancestor siblings that fulfill predicate', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const ancestorSibling = getComposedNextAncestorElementSibling(
+				elem.querySelector('#light1'),
+				{ predicate: elem => elem.tagName === 'INVALID-TAG' }
+			);
+			expect(ancestorSibling).to.be.null;
+		});
+
+		it('returns null when no ancestors have next siblings in custom element', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#light2'));
+			expect(ancestorSibling).to.be.null;
+		});
+
+		it('returns next sibling of ancestor slot when text node is target', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#light1').childNodes[0]);
+			const expected = elem.querySelector('#light3');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns next ancestor sibling of custom element when target is child of slot and there are no other ancestor siblings in the shadowDOM', async() => {
+			const elem = await fixture(`
+				<div>
+					<${testElemTag}>
+						<div id="target"></div>
+					</${testElemTag}>
+					<div id="expected"></div>
+				</div>
+			`);
+			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns next ancestor sibling of custom element when target is in shadowDOM and there are no other ancestor siblings in the shadowDOM', async() => {
+			const elem = await fixture(`
+				<div>
+					<${testElemTag} id="wc">
+						<div id="target"></div>
+					</${testElemTag}>
+					<div id="expected"></div>
+				</div>
+			`);
+			const target = elem.querySelector('#wc').getContainer().querySelector('#slot1');
+			const ancestorSibling = getComposedNextAncestorElementSibling(target);
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+	});
+
 	describe('getComposedNextElementSibling', () => {
 
 		it('returns next element sibling in vanilla', async() => {
@@ -593,6 +739,138 @@ describe('dom', () => {
 		it('returns null as parent of document', async() => {
 			expect(getComposedParent(document))
 				.to.equal(null);
+		});
+
+	});
+
+	describe('getComposedPreviousAncestorElementSibling', () => {
+
+		it('returns previous ancestor sibling one level up in vanilla', async() => {
+			const elem = await fixture(html`
+				<div id="parent">
+					<div></div>
+					<div id="expected"></div>
+					<div>
+						<div id="target"></div>
+					</div>
+				</div>
+			`);
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(elem.querySelector('#target'));
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns previous ancestor sibling one level up after ignoring non-element nodes in vanilla', async() => {
+			const elem = await fixture(html`
+				<div id="parent">
+					<div></div>
+					<div id="expected"></div>
+					<!-- birthday cake is yummy -->
+					birthday cake
+					<div>
+						<div id="target"></div>
+					</div>
+				</div>
+			`);
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(elem.querySelector('#target'));
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns previous ancestor sibling two levels up in vanilla', async() => {
+			const elem = await fixture(html`
+				<div id="parent">
+					<div id="expected"></div>
+					<div>
+						<div>
+							<div id="target"></div>
+						</div>
+					</div>
+				</div>
+			`);
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(elem.querySelector('#target'));
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns previous ancestor sibling that fulfills predicate in vanilla', async() => {
+			const elem = await fixture(html`
+				<div id="parent">
+					<div id="expected"></div>
+					<div></div>
+					<div>
+						<div id="target"></div>
+					</div>
+				</div>
+			`);
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(
+				elem.querySelector('#target'),
+				{ predicate: elem => elem.id === 'expected' }
+			);
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns previous sibling of ancestor slot in custom element shadowDOM', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(elem.querySelector('#light2'));
+			const expected = elem.getContainer().querySelector('#divider');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns previous sibling of ancestor slot that fulfills predicate in custom element shadowDOM', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(
+				elem.querySelector('#light2'),
+				{ predicate: elem => elem.tagName === 'SLOT' }
+			);
+			const expected = elem.getContainer().querySelector('#slot1');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns null when there are no previous ancestor siblings that fulfill predicate', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(
+				elem.querySelector('#light2'),
+				{ predicate: elem => elem.tagName === 'INVALID-TAG' }
+			);
+			expect(ancestorSibling).to.be.null;
+		});
+
+		it('returns previous sibling of ancestor slot when text node is target', async() => {
+			const elem = await fixture(wcMultiSlotFixture);
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(elem.querySelector('#light3').childNodes[0]);
+			const expected = elem.querySelector('#light1');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns previous ancestor sibling of custom element when target is child of slot and there are no other ancestor siblings in the shadowDOM', async() => {
+			const elem = await fixture(`
+				<div>
+					<div id="expected"></div>
+					<${testElemTag}>
+						<div id="target"></div>
+					</${testElemTag}>
+				</div>
+			`);
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(elem.querySelector('#target'));
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
+		});
+
+		it('returns previous ancestor sibling of custom element when target is in shadowDOM and there are no other ancestor siblings in the shadowDOM', async() => {
+			const elem = await fixture(`
+				<div>
+					<div id="expected"></div>
+					<${testElemTag} id="wc">
+						<div id="target"></div>
+					</${testElemTag}>
+				</div>
+			`);
+			const target = elem.querySelector('#wc').getContainer().querySelector('#slot1');
+			const ancestorSibling = getComposedPreviousAncestorElementSibling(target);
+			const expected = elem.querySelector('#expected');
+			expect(ancestorSibling).to.be.equal(expected);
 		});
 
 	});
@@ -929,6 +1207,7 @@ describe('dom', () => {
 
 	});
 
+	// This block of tests can be removed when cleaning up getNextAncestorSibling as part of removing GAUD-10260-get-focusable-fix
 	describe('getNextAncestorSibling', () => {
 
 		it('returns null when no siblings', async() => {

--- a/helpers/test/dom.test.js
+++ b/helpers/test/dom.test.js
@@ -13,7 +13,6 @@ import {
 	getComposedPreviousAncestorElementSibling,
 	getComposedPreviousElementSibling,
 	getFirstVisibleAncestor,
-	getNextAncestorSibling,
 	getOffsetParent,
 	isComposedAncestor,
 	isVisible,
@@ -22,6 +21,7 @@ import {
 } from '../dom.js';
 import { css, html, LitElement } from 'lit';
 import { defineCE, expect, fixture } from '@brightspace-ui/testing';
+import { mockFlag, resetFlag } from '../flags.js';
 import sinon from 'sinon';
 
 const testElemTag = defineCE(
@@ -479,146 +479,159 @@ describe('dom', () => {
 
 	});
 
-	describe('getComposedNextAncestorElementSibling', () => {
+	// Remove this loop when cleaning up GAUD-10260-get-focusable-fix
+	[true, false].forEach(focusableFixFlag => {
 
-		it('returns null when no ancestors have siblings in vanilla', async() => {
-			const elem = await fixture(simpleFixture);
-			const ancestorSibling = getComposedNextAncestorElementSibling(elem);
-			expect(ancestorSibling).to.be.null;
-		});
+		describe('getComposedNextAncestorElementSibling', () => {
 
-		it('returns next ancestor sibling one level up in vanilla', async() => {
-			const elem = await fixture(html`
-				<div id="parent">
-					<div>
-						<div id="target"></div>
-					</div>
-					<div id="expected"></div>
-					<div></div>
-				</div>
-			`);
-			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
-			const expected = elem.querySelector('#expected');
-			expect(ancestorSibling).to.be.equal(expected);
-		});
+			before(() => mockFlag('GAUD-10260-get-focusable-fix', focusableFixFlag));
+			after(() => resetFlag('GAUD-10260-get-focusable-fix'));
 
-		it('returns next ancestor sibling one level up after ignoring non-element nodes in vanilla', async() => {
-			const elem = await fixture(html`
-				<div id="parent">
-					<div>
-						<div id="target"></div>
-					</div>
-					birthday cake
-					<!-- birthday cake is yummy -->
-					<div id="expected"></div>
-					<div></div>
-				</div>
-			`);
-			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
-			const expected = elem.querySelector('#expected');
-			expect(ancestorSibling).to.be.equal(expected);
-		});
+			it('returns null when no ancestors have siblings in vanilla', async() => {
+				const elem = await fixture(simpleFixture);
+				const ancestorSibling = getComposedNextAncestorElementSibling(elem);
+				expect(ancestorSibling).to.be.null;
+			});
 
-		it('returns next ancestor sibling two levels up in vanilla', async() => {
-			const elem = await fixture(html`
-				<div id="parent">
-					<div>
+			it('returns next ancestor sibling one level up in vanilla', async() => {
+				const elem = await fixture(html`
+					<div id="parent">
 						<div>
 							<div id="target"></div>
 						</div>
+						<div id="expected"></div>
+						<div></div>
 					</div>
-					<div id="expected"></div>
-				</div>
-			`);
-			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
-			const expected = elem.querySelector('#expected');
-			expect(ancestorSibling).to.be.equal(expected);
-		});
+				`);
+				const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
+				const expected = elem.querySelector('#expected');
+				expect(ancestorSibling).to.be.equal(expected);
+			});
 
-		it('returns next ancestor sibling that fulfills predicate in vanilla', async() => {
-			const elem = await fixture(html`
-				<div id="parent">
-					<div>
-						<div id="target"></div>
+			it('returns next ancestor sibling one level up after ignoring non-element nodes in vanilla', async() => {
+				const elem = await fixture(html`
+					<div id="parent">
+						<div>
+							<div id="target"></div>
+						</div>
+						birthday cake
+						<!-- birthday cake is yummy -->
+						<div id="expected"></div>
+						<div></div>
 					</div>
-					<div></div>
-					<div id="expected"></div>
-				</div>
-			`);
-			const ancestorSibling = getComposedNextAncestorElementSibling(
-				elem.querySelector('#target'),
-				{ predicate: elem => elem.id === 'expected' }
-			);
-			const expected = elem.querySelector('#expected');
-			expect(ancestorSibling).to.be.equal(expected);
-		});
+				`);
+				const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
+				const expected = elem.querySelector('#expected');
+				expect(ancestorSibling).to.be.equal(expected);
+			});
 
-		it('returns next sibling of ancestor slot in custom element shadowDOM', async() => {
-			const elem = await fixture(wcMultiSlotFixture);
-			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#light1'));
-			const expected = elem.getContainer().querySelector('#divider');
-			expect(ancestorSibling).to.be.equal(expected);
-		});
+			it('returns next ancestor sibling two levels up in vanilla', async() => {
+				const elem = await fixture(html`
+					<div id="parent">
+						<div>
+							<div>
+								<div id="target"></div>
+							</div>
+						</div>
+						<div id="expected"></div>
+					</div>
+				`);
+				const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
+				const expected = elem.querySelector('#expected');
+				expect(ancestorSibling).to.be.equal(expected);
+			});
 
-		it('returns next sibling of ancestor slot that fulfills predicate in custom element shadowDOM', async() => {
-			const elem = await fixture(wcMultiSlotFixture);
-			const ancestorSibling = getComposedNextAncestorElementSibling(
-				elem.querySelector('#light1'),
-				{ predicate: elem => elem.tagName === 'SLOT' }
-			);
-			const expected = elem.getContainer().querySelector('#slot2');
-			expect(ancestorSibling).to.be.equal(expected);
-		});
+			// Remove this if-check (keep the tests though!) when cleaning up GAUD-10260-get-focusable-fix
+			if (focusableFixFlag) {
 
-		it('returns null when there are no next ancestor siblings that fulfill predicate', async() => {
-			const elem = await fixture(wcMultiSlotFixture);
-			const ancestorSibling = getComposedNextAncestorElementSibling(
-				elem.querySelector('#light1'),
-				{ predicate: elem => elem.tagName === 'INVALID-TAG' }
-			);
-			expect(ancestorSibling).to.be.null;
-		});
+				it('returns next ancestor sibling that fulfills predicate in vanilla', async() => {
+					const elem = await fixture(html`
+						<div id="parent">
+							<div>
+								<div id="target"></div>
+							</div>
+							<div></div>
+							<div id="expected"></div>
+						</div>
+					`);
+					const ancestorSibling = getComposedNextAncestorElementSibling(
+						elem.querySelector('#target'),
+						{ predicate: elem => elem.id === 'expected' }
+					);
+					const expected = elem.querySelector('#expected');
+					expect(ancestorSibling).to.be.equal(expected);
+				});
 
-		it('returns null when no ancestors have next siblings in custom element', async() => {
-			const elem = await fixture(wcMultiSlotFixture);
-			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#light2'));
-			expect(ancestorSibling).to.be.null;
-		});
+				it('returns next sibling of ancestor slot in custom element shadowDOM', async() => {
+					const elem = await fixture(wcMultiSlotFixture);
+					const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#light1'));
+					const expected = elem.getContainer().querySelector('#divider');
+					expect(ancestorSibling).to.be.equal(expected);
+				});
 
-		it('returns next sibling of ancestor slot when text node is target', async() => {
-			const elem = await fixture(wcMultiSlotFixture);
-			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#light1').childNodes[0]);
-			const expected = elem.querySelector('#light3');
-			expect(ancestorSibling).to.be.equal(expected);
-		});
+				it('returns next sibling of ancestor slot that fulfills predicate in custom element shadowDOM', async() => {
+					const elem = await fixture(wcMultiSlotFixture);
+					const ancestorSibling = getComposedNextAncestorElementSibling(
+						elem.querySelector('#light1'),
+						{ predicate: elem => elem.tagName === 'SLOT' }
+					);
+					const expected = elem.getContainer().querySelector('#slot2');
+					expect(ancestorSibling).to.be.equal(expected);
+				});
 
-		it('returns next ancestor sibling of custom element when target is child of slot and there are no other ancestor siblings in the shadowDOM', async() => {
-			const elem = await fixture(`
-				<div>
-					<${testElemTag}>
-						<div id="target"></div>
-					</${testElemTag}>
-					<div id="expected"></div>
-				</div>
-			`);
-			const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
-			const expected = elem.querySelector('#expected');
-			expect(ancestorSibling).to.be.equal(expected);
-		});
+				it('returns null when there are no next ancestor siblings that fulfill predicate', async() => {
+					const elem = await fixture(wcMultiSlotFixture);
+					const ancestorSibling = getComposedNextAncestorElementSibling(
+						elem.querySelector('#light1'),
+						{ predicate: elem => elem.tagName === 'INVALID-TAG' }
+					);
+					expect(ancestorSibling).to.be.null;
+				});
 
-		it('returns next ancestor sibling of custom element when target is in shadowDOM and there are no other ancestor siblings in the shadowDOM', async() => {
-			const elem = await fixture(`
-				<div>
-					<${testElemTag} id="wc">
-						<div id="target"></div>
-					</${testElemTag}>
-					<div id="expected"></div>
-				</div>
-			`);
-			const target = elem.querySelector('#wc').getContainer().querySelector('#slot1');
-			const ancestorSibling = getComposedNextAncestorElementSibling(target);
-			const expected = elem.querySelector('#expected');
-			expect(ancestorSibling).to.be.equal(expected);
+				it('returns null when no ancestors have next siblings in custom element', async() => {
+					const elem = await fixture(wcMultiSlotFixture);
+					const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#light2'));
+					expect(ancestorSibling).to.be.null;
+				});
+
+				it('returns next sibling of ancestor slot when text node is target', async() => {
+					const elem = await fixture(wcMultiSlotFixture);
+					const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#light1').childNodes[0]);
+					const expected = elem.querySelector('#light3');
+					expect(ancestorSibling).to.be.equal(expected);
+				});
+
+				it('returns next ancestor sibling of custom element when target is child of slot and there are no other ancestor siblings in the shadowDOM', async() => {
+					const elem = await fixture(`
+						<div>
+							<${testElemTag}>
+								<div id="target"></div>
+							</${testElemTag}>
+							<div id="expected"></div>
+						</div>
+					`);
+					const ancestorSibling = getComposedNextAncestorElementSibling(elem.querySelector('#target'));
+					const expected = elem.querySelector('#expected');
+					expect(ancestorSibling).to.be.equal(expected);
+				});
+
+				it('returns next ancestor sibling of custom element when target is in shadowDOM and there are no other ancestor siblings in the shadowDOM', async() => {
+					const elem = await fixture(`
+						<div>
+							<${testElemTag} id="wc">
+								<div id="target"></div>
+							</${testElemTag}>
+							<div id="expected"></div>
+						</div>
+					`);
+					const target = elem.querySelector('#wc').getContainer().querySelector('#slot1');
+					const ancestorSibling = getComposedNextAncestorElementSibling(target);
+					const expected = elem.querySelector('#expected');
+					expect(ancestorSibling).to.be.equal(expected);
+				});
+
+			}
+
 		});
 
 	});
@@ -744,6 +757,9 @@ describe('dom', () => {
 	});
 
 	describe('getComposedPreviousAncestorElementSibling', () => {
+
+		before(() => mockFlag('GAUD-10260-get-focusable-fix', true));
+		after(() => resetFlag('GAUD-10260-get-focusable-fix'));
 
 		it('returns previous ancestor sibling one level up in vanilla', async() => {
 			const elem = await fixture(html`
@@ -1205,44 +1221,6 @@ describe('dom', () => {
 			expect(getOffsetParent(child)).to.equal(expected);
 		});
 
-	});
-
-	// This block of tests can be removed when cleaning up getNextAncestorSibling as part of removing GAUD-10260-get-focusable-fix
-	describe('getNextAncestorSibling', () => {
-
-		it('returns null when no siblings', async() => {
-			const elem = await fixture(simpleFixture);
-			expect(getNextAncestorSibling(elem)).to.be.null;
-		});
-
-		it('returns the ancestor sibling one level up', async() => {
-			const elem = await fixture(html`
-			<div id="parent">
-				<div>
-					<div id="target"></div>
-				</div>
-				<div id="expected"></div>
-				<div></div>
-			</div>
-			`);
-			expect(getNextAncestorSibling(elem.querySelector('#target')))
-				.to.be.equal(elem.querySelector('#expected'));
-		});
-
-		it('returns the ancestor sibling two levels up', async() => {
-			const elem = await fixture(html`
-			<div id="parent">
-				<div>
-					<div>
-						<div id="target"></div>
-					</div>
-				</div>
-				<div id="expected"></div>
-			</div>
-			`);
-			expect(getNextAncestorSibling(elem.querySelector('#target')))
-				.to.be.equal(elem.querySelector('#expected'));
-		});
 	});
 
 	describe('isComposedAncestor', () => {


### PR DESCRIPTION
[GAUD-10519](https://desire2learn.atlassian.net/browse/GAUD-10519)

This PR fixes `getNextFocusable` and `getPreviousFocusable` helpers by using composed DOM helpers for next/previous element siblings.

This fix addresses incorrect focus behaviour that was initially discovered while using `d2l-list` (in `grid` mode) as the last element in the `d2l-page`'s side/nav: the divider would be incorrectly skipped in the focus order.  

WIP:
* Need to add tests for the ancestor sibling helpers

[GAUD-10519]: https://desire2learn.atlassian.net/browse/GAUD-10519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ