### PR TITLE
GAUD-10486: delay scroll calculation

### DIFF
--- a/components/dropdown/dropdown-popover-mixin.js
+++ b/components/dropdown/dropdown-popover-mixin.js
@@ -394,8 +394,11 @@ export const DropdownPopoverMixin = superclass => class extends LocalizeCoreElem
 	}
 
 	#toggleScrollStyles() {
-		this._blockEndScroll = this.#contentElement.scrollHeight - (this.#contentElement.scrollTop + this.#contentElement.clientHeight) >= 5;
-		this._blockStartScroll = this.#contentElement.scrollTop !== 0;
+		// scrollHeight can sometimes not be updated right away
+		requestAnimationFrame(() => {
+			this._blockEndScroll = this.#contentElement.scrollHeight - (this.#contentElement.scrollTop + this.#contentElement.clientHeight) >= 5;
+			this._blockStartScroll = this.#contentElement.scrollTop !== 0;
+		});
 	}
 
 };


### PR DESCRIPTION
After #7321 merged, two filter vdiffs starting being very flaky, occasionally showing a shadow in the dropdown when there shouldn't have been one.

I dug into this pretty deeply, and what I was seeing was that the dropdown container's `scrollHeight` was sometimes `8px` taller than its `clientHeight` for a very brief period of time after the resize observer fired. This happened about 25% of the time for me locally. I can only assume that it sometimes takes some time for it to reflect reality.

This wasn't an issue before #7321 because the shadows were being calculated only once and it was happening way before any of the content in the dropdown had rendered.