### PR TITLE
GAUD-10255: use private handlers/variables and test fixtures

### DIFF
--- a/components/button/button-toggle.js
+++ b/components/button/button-toggle.js
@@ -39,16 +39,16 @@ class ButtonToggle extends LitElement {
 
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-		if (this._focusOnFirstRender) {
-			this._focusOnFirstRender = false;
+		if (this.#focusOnFirstRender) {
+			this.#focusOnFirstRender = false;
 			this.focus();
 		}
 	}
 
 	render() {
 		return html`
-			<slot @click="${this._handleNotPressedClick}" name="not-pressed"></slot>
-			<slot @click="${this._handlePressedClick}" name="pressed"></slot>
+			<slot @click="${this.#handleNotPressedClick}" name="not-pressed"></slot>
+			<slot @click="${this.#handlePressedClick}" name="pressed"></slot>
 		`;
 	}
 
@@ -63,7 +63,7 @@ class ButtonToggle extends LitElement {
 
 	focus() {
 		if (!this.hasUpdated) {
-			this._focusOnFirstRender = true;
+			this.#focusOnFirstRender = true;
 			return;
 		}
 
@@ -75,28 +75,30 @@ class ButtonToggle extends LitElement {
 		elem.focus();
 	}
 
-	async _handleClick(pressed) {
+	#focusOnFirstRender = false;
+
+	async #handleClick(pressed) {
 		const beforeToggleEvent = new CustomEvent('d2l-button-toggle-before-change', {
 			detail: {
-				update: (newPressed) => this._updatePressedState(newPressed)
+				update: (newPressed) => this.#updatePressedState(newPressed)
 			},
 			cancelable: true
 		});
 		this.dispatchEvent(beforeToggleEvent);
 		if (beforeToggleEvent.defaultPrevented) return;
 
-		this._updatePressedState(pressed);
+		this.#updatePressedState(pressed);
 	}
 
-	_handleNotPressedClick() {
-		this._handleClick(true);
+	#handleNotPressedClick() {
+		this.#handleClick(true);
 	}
 
-	_handlePressedClick() {
-		this._handleClick(false);
+	#handlePressedClick() {
+		this.#handleClick(false);
 	}
 
-	async _updatePressedState(newPressed) {
+	async #updatePressedState(newPressed) {
 		this.pressed = newPressed;
 		await this.updateComplete;
 		this.focus();

--- a/components/button/test/button-toggle-fixtures.js
+++ b/components/button/test/button-toggle-fixtures.js
@@ -1,0 +1,42 @@
+import '../button-icon.js';
+import '../button-toggle.js';
+import { html } from 'lit';
+
+export const buttonToggleFixtures = {
+	iconDisabled: html`
+		<d2l-button-toggle>
+			<d2l-button-icon slot="not-pressed" disabled icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon>
+			<d2l-button-icon slot="pressed" disabled icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon>
+		</d2l-button-toggle>
+	`,
+	iconNotPressed: html`
+		<d2l-button-toggle>
+			<d2l-button-icon slot="not-pressed" icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon>
+			<d2l-button-icon slot="pressed" icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon>
+		</d2l-button-toggle>
+	`,
+	iconPressed: html`
+		<d2l-button-toggle pressed>
+			<d2l-button-icon slot="not-pressed" icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon>
+			<d2l-button-icon slot="pressed" icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon>
+		</d2l-button-toggle>
+	`,
+	subtleDisabled: html`
+		<d2l-button-toggle>
+			<d2l-button-subtle slot="not-pressed" disabled icon="tier1:lock-unlock" text="Unlocked" description="Click to lock."></d2l-button-subtle>
+			<d2l-button-subtle slot="pressed" disabled icon="tier1:lock-locked" text="Locked" description="Click to unlock."></d2l-button-subtle>
+		</d2l-button-toggle>
+	`,
+	subtleNotPressed: html`
+		<d2l-button-toggle>
+			<d2l-button-subtle slot="not-pressed" icon="tier1:lock-unlock" text="Unlocked" description="Click to lock."></d2l-button-subtle>
+			<d2l-button-subtle slot="pressed" icon="tier1:lock-locked" text="Locked" description="Click to unlock."></d2l-button-subtle>
+		</d2l-button-toggle>
+	`,
+	subtlePressed: html`
+		<d2l-button-toggle pressed>
+			<d2l-button-subtle slot="not-pressed" icon="tier1:lock-unlock" text="Unlocked" description="Click to lock."></d2l-button-subtle>
+			<d2l-button-subtle slot="pressed" icon="tier1:lock-locked" text="Locked" description="Click to unlock."></d2l-button-subtle>
+		</d2l-button-toggle>
+	`
+};

--- a/components/button/test/button-toggle-fixtures.js
+++ b/components/button/test/button-toggle-fixtures.js
@@ -1,6 +1,15 @@
 import '../button-icon.js';
+import '../button-subtle.js';
 import '../button-toggle.js';
-import { html } from 'lit';
+import { clickElem, html } from '@brightspace-ui/testing';
+
+export async function clickActiveButton(elem) {
+	return clickElem(getActiveButton(elem));
+}
+
+export function getActiveButton(elem) {
+	return (elem.pressed) ? elem.querySelector('[slot="pressed"]') : elem.querySelector('[slot="not-pressed"]');
+}
 
 export const buttonToggleFixtures = {
 	iconDisabled: html`

--- a/components/button/test/button-toggle.axe.js
+++ b/components/button/test/button-toggle.axe.js
@@ -1,35 +1,20 @@
-import '../button-icon.js';
-import '../button-toggle.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
+import { expect, fixture } from '@brightspace-ui/testing';
+import { buttonToggleFixtures } from './button-toggle-fixtures.js';
 
 describe('d2l-button-toggle', () => {
 
-	const normalFixture = html`
-		<d2l-button-toggle>
-			<d2l-button-icon slot="not-pressed" icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon>
-			<d2l-button-icon slot="pressed" icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon>
-		</d2l-button-toggle>
-	`;
-
 	it('not pressed', async() => {
-		const el = await fixture(normalFixture);
+		const el = await fixture(buttonToggleFixtures.iconNotPressed);
 		await expect(el).to.be.accessible();
 	});
 
 	it('pressed', async() => {
-		const el = await fixture(normalFixture);
-		el.pressed = true;
-		await el.updateComplete;
+		const el = await fixture(buttonToggleFixtures.iconPressed);
 		await expect(el).to.be.accessible();
 	});
 
 	it('disabled', async() => {
-		const el = await fixture(html`
-			<d2l-button-toggle>
-				<d2l-button-icon slot="not-pressed" disabled icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon>
-				<d2l-button-icon slot="pressed" disabled icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon>
-			</d2l-button-toggle>
-		`);
+		const el = await fixture(buttonToggleFixtures.iconDisabled);
 		await expect(el).to.be.accessible();
 	});
 

--- a/components/button/test/button-toggle.test.js
+++ b/components/button/test/button-toggle.test.js
@@ -1,5 +1,5 @@
-import { clickElem, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
-import { buttonToggleFixtures } from './button-toggle-fixtures.js';
+import { buttonToggleFixtures, clickActiveButton } from './button-toggle-fixtures.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-button-toggle', () => {
 
@@ -15,14 +15,14 @@ describe('d2l-button-toggle', () => {
 
 		it('dispatches d2l-button-toggle-change event not-pressed is clicked', async() => {
 			const el = await fixture(buttonToggleFixtures.iconNotPressed);
-			clickElem(el.querySelector('[slot="not-pressed"]'));
+			clickActiveButton(el);
 			const e = await oneEvent(el, 'd2l-button-toggle-change');
 			expect(e.target.pressed).to.equal(true);
 		});
 
 		it('dispatches d2l-button-toggle-change event pressed is clicked', async() => {
 			const el = await fixture(buttonToggleFixtures.iconPressed);
-			clickElem(el.querySelector('[slot="pressed"]'));
+			clickActiveButton(el);
 			const e = await oneEvent(el, 'd2l-button-toggle-change');
 			expect(e.target.pressed).to.equal(false);
 		});
@@ -40,7 +40,7 @@ describe('d2l-button-toggle', () => {
 			const el = await fixture(buttonToggleFixtures.iconDisabled);
 			let dispatched = false;
 			el.addEventListener('d2l-button-toggle-change', () => dispatched = true);
-			await clickElem(el.querySelector('[slot="not-pressed"]'));
+			await clickActiveButton(el);
 			expect(el.pressed).to.equal(false);
 			expect(dispatched).to.be.false;
 		});
@@ -58,7 +58,7 @@ describe('d2l-button-toggle', () => {
 			el.addEventListener('d2l-button-toggle-before-change', (e) => {
 				e.preventDefault();
 			});
-			await clickElem(el.querySelector('[slot="not-pressed"]'));
+			await clickActiveButton(el);
 			expect(el.pressed).to.equal(false);
 		});
 
@@ -67,13 +67,13 @@ describe('d2l-button-toggle', () => {
 				e.preventDefault();
 				e.detail.update(!e.target.pressed);
 			});
-			clickElem(el.querySelector('[slot="not-pressed"]'));
+			clickActiveButton(el);
 			const e = await oneEvent(el, 'd2l-button-toggle-change');
 			expect(e.target.pressed).to.equal(true);
 		});
 
 		it('d2l-button-toggle-before-change event has correct detail structure', async() => {
-			clickElem(el.querySelector('[slot="not-pressed"]'));
+			clickActiveButton(el);
 			const e = await oneEvent(el, 'd2l-button-toggle-before-change');
 			expect(e.detail).to.have.property('update').that.is.a('function');
 		});

--- a/components/button/test/button-toggle.test.js
+++ b/components/button/test/button-toggle.test.js
@@ -1,6 +1,5 @@
-import '../button-icon.js';
-import '../button-toggle.js';
 import { clickElem, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { buttonToggleFixtures } from './button-toggle-fixtures.js';
 
 describe('d2l-button-toggle', () => {
 
@@ -15,24 +14,14 @@ describe('d2l-button-toggle', () => {
 	describe('events', () => {
 
 		it('dispatches d2l-button-toggle-change event not-pressed is clicked', async() => {
-			const el = await fixture(html`
-				<d2l-button-toggle>
-					<d2l-button-icon slot="not-pressed" icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon>
-					<d2l-button-icon slot="pressed" icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon>
-				</d2l-button-toggle>
-			`);
+			const el = await fixture(buttonToggleFixtures.iconNotPressed);
 			clickElem(el.querySelector('[slot="not-pressed"]'));
 			const e = await oneEvent(el, 'd2l-button-toggle-change');
 			expect(e.target.pressed).to.equal(true);
 		});
 
 		it('dispatches d2l-button-toggle-change event pressed is clicked', async() => {
-			const el = await fixture(html`
-				<d2l-button-toggle pressed>
-					<d2l-button-icon slot="not-pressed" icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon>
-					<d2l-button-icon slot="pressed" icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon>
-				</d2l-button-toggle>
-			`);
+			const el = await fixture(buttonToggleFixtures.iconPressed);
 			clickElem(el.querySelector('[slot="pressed"]'));
 			const e = await oneEvent(el, 'd2l-button-toggle-change');
 			expect(e.target.pressed).to.equal(false);
@@ -48,12 +37,7 @@ describe('d2l-button-toggle', () => {
 		});
 
 		it('does not dispatch d2l-button-toggle-change event if disabled buttons are clicked', async() => {
-			const el = await fixture(html`
-				<d2l-button-toggle>
-					<d2l-button-icon slot="not-pressed" disabled icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon>
-					<d2l-button-icon slot="pressed" disabled icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon>
-				</d2l-button-toggle>
-			`);
+			const el = await fixture(buttonToggleFixtures.iconDisabled);
 			let dispatched = false;
 			el.addEventListener('d2l-button-toggle-change', () => dispatched = true);
 			await clickElem(el.querySelector('[slot="not-pressed"]'));
@@ -67,12 +51,7 @@ describe('d2l-button-toggle', () => {
 
 		let el;
 		beforeEach(async() => {
-			el = await fixture(html`
-				<d2l-button-toggle>
-					<d2l-button-icon slot="not-pressed" icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon>
-					<d2l-button-icon slot="pressed" icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon>
-				</d2l-button-toggle>
-			`);
+			el = await fixture(buttonToggleFixtures.iconNotPressed);
 		});
 
 		it('click with no state management', async() => {

--- a/components/button/test/button-toggle.vdiff.js
+++ b/components/button/test/button-toggle.vdiff.js
@@ -1,16 +1,14 @@
-import '../button-icon.js';
-import '../button-subtle.js';
-import '../button-toggle.js';
-import { clickElem, expect, fixture, focusElem, hoverElem, html, sendKeysElem } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, focusElem, hoverElem, sendKeysElem } from '@brightspace-ui/testing';
+import { buttonToggleFixtures } from './button-toggle-fixtures.js';
 
 describe('button-toggle', () => {
 
 	[
-		{ category: 'button-icon', template: html`<d2l-button-toggle><d2l-button-icon slot="not-pressed" icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon><d2l-button-icon slot="pressed" icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon></d2l-button-toggle>` },
-		{ category: 'button-icon-pressed', template: html`<d2l-button-toggle pressed><d2l-button-icon slot="not-pressed" icon="tier1:pin-hollow" text="Unpinned, click to pin."></d2l-button-icon><d2l-button-icon slot="pressed" icon="tier1:pin-filled" text="Pinned, click to unpin."></d2l-button-icon></d2l-button-toggle>` },
-		{ category: 'button-subtle', template: html`<d2l-button-toggle><d2l-button-subtle slot="not-pressed" icon="tier1:lock-unlock" text="Unlocked" description="Click to lock."></d2l-button-subtle><d2l-button-subtle slot="pressed" icon="tier1:lock-locked" text="Locked" description="Click to unlock."></d2l-button-subtle></d2l-button-toggle>` },
-		{ category: 'button-subtle-pressed', template: html`<d2l-button-toggle pressed><d2l-button-subtle slot="not-pressed" icon="tier1:lock-unlock" text="Unlocked" description="Click to lock."></d2l-button-subtle><d2l-button-subtle slot="pressed" icon="tier1:lock-locked" text="Locked" description="Click to unlock."></d2l-button-subtle></d2l-button-toggle>` },
-		{ category: 'button-subtle-disabled', template: html`<d2l-button-toggle><d2l-button-subtle slot="not-pressed" disabled icon="tier1:lock-unlock" text="Unlocked" description="Click to lock."></d2l-button-subtle><d2l-button-subtle slot="pressed" disabled icon="tier1:lock-locked" text="Locked" description="Click to unlock."></d2l-button-subtle></d2l-button-toggle>` }
+		{ category: 'button-icon', template: buttonToggleFixtures.iconNotPressed },
+		{ category: 'button-icon-pressed', template: buttonToggleFixtures.iconPressed },
+		{ category: 'button-subtle', template: buttonToggleFixtures.subtleNotPressed },
+		{ category: 'button-subtle-pressed', template: buttonToggleFixtures.subtlePressed },
+		{ category: 'button-subtle-disabled', template: buttonToggleFixtures.subtleDisabled }
 	].forEach(({ category, template }) => {
 
 		const getActiveButton = elem => {

--- a/components/button/test/button-toggle.vdiff.js
+++ b/components/button/test/button-toggle.vdiff.js
@@ -1,8 +1,7 @@
-import { clickElem, expect, fixture, focusElem, hoverElem, sendKeysElem } from '@brightspace-ui/testing';
-import { buttonToggleFixtures } from './button-toggle-fixtures.js';
+import { buttonToggleFixtures, clickActiveButton, getActiveButton } from './button-toggle-fixtures.js';
+import { expect, fixture, focusElem, hoverElem, sendKeysElem } from '@brightspace-ui/testing';
 
 describe('button-toggle', () => {
-
 	[
 		{ category: 'button-icon', template: buttonToggleFixtures.iconNotPressed },
 		{ category: 'button-icon-pressed', template: buttonToggleFixtures.iconPressed },
@@ -10,18 +9,12 @@ describe('button-toggle', () => {
 		{ category: 'button-subtle-pressed', template: buttonToggleFixtures.subtlePressed },
 		{ category: 'button-subtle-disabled', template: buttonToggleFixtures.subtleDisabled }
 	].forEach(({ category, template }) => {
-
-		const getActiveButton = elem => {
-			if (elem.pressed) return elem.querySelector('[slot="pressed"]');
-			else return elem.querySelector('[slot="not-pressed"]');
-		};
-
 		describe(category, () => {
 			[
 				{ name: 'normal' },
 				{ name: 'hover', action: hoverElem },
 				{ name: 'focus', action: focusElem },
-				{ name: 'click', action: elem => clickElem(getActiveButton(elem)) },
+				{ name: 'click', action: elem => clickActiveButton(elem) },
 				{ name: 'enter', action: elem => sendKeysElem(getActiveButton(elem), 'press', 'Enter') }
 			].forEach(({ action, name }) => {
 				it(name, async() => {
@@ -31,7 +24,5 @@ describe('button-toggle', () => {
 				});
 			});
 		});
-
 	});
-
 });


### PR DESCRIPTION
Just a small bit of pre-work before fixing this issue: switch to `#privateHandlers`, `#privateVariables` and switch the tests to use shared fixtures.