### PR TITLE
GAUD-10269 - Refactor the panels in overlay mode to be their own panel state entries

### DIFF
--- a/components/page/demo/page-header-full.js
+++ b/components/page/demo/page-header-full.js
@@ -21,6 +21,11 @@ class PageHeaderFullDemo extends RequesterMixin(LitElement) {
 			gap: 5px;
 			height: 100%;
 		}
+		.full-nav-header-course {
+			align-items: center;
+			display: flex;
+			gap: 5px;
+		}
 		.full-nav-header-spacer {
 			flex: 1 1 auto;
 			min-width: 30px;
@@ -30,6 +35,14 @@ class PageHeaderFullDemo extends RequesterMixin(LitElement) {
 			display: flex;
 			flex: 0 0 auto;
 			height: 100%;
+		}
+		.full-nav-header-alerts {
+			align-items: center;
+			display: flex;
+			height: 100%;
+		}
+		.full-nav-header-alerts-combined {
+			display: none;
 		}
 		.full-nav-header-right d2l-page-header-button {
 			margin-inline: 15px;
@@ -45,8 +58,17 @@ class PageHeaderFullDemo extends RequesterMixin(LitElement) {
 		.full-nav-footer-inner {
 			align-items: center;
 			display: flex;
-			flex-wrap: wrap;
 			gap: 20px;
+		}
+		.full-nav-footer-links {
+			display: flex;
+			flex: 0 1 auto;
+			gap: 20px;
+			min-width: 0;
+			overflow: hidden;
+		}
+		.full-nav-footer-inner d2l-button-icon {
+			flex: 0 0 auto;
 		}
 		.full-nav-footer-link {
 			border-bottom: 4px solid transparent;
@@ -59,6 +81,19 @@ class PageHeaderFullDemo extends RequesterMixin(LitElement) {
 		.full-nav-footer-link:focus-visible {
 			border-bottom-color: var(--d2l-color-celestine);
 			color: var(--d2l-color-celestine);
+		}
+		@media (max-width: 615px) {
+			.full-nav-header-alerts {
+				display: none;
+			}
+			.full-nav-header-alerts-combined {
+				display: inline-flex;
+			}
+		}
+		@media (max-width: 400px) {
+			.full-nav-header-course {
+				display: none;
+			}
 		}
 	`;
 
@@ -76,25 +111,32 @@ class PageHeaderFullDemo extends RequesterMixin(LitElement) {
 				<div class="full-nav-header" slot="top">
 					<div class="full-nav-header-left">
 						<span class="full-nav-logo">Logo</span>
-						<d2l-page-header-separator></d2l-page-header-separator>
-						Course
+						<div class="full-nav-header-course">
+							<d2l-page-header-separator></d2l-page-header-separator>
+							Course
+						</div>
 					</div>
 					<div class="full-nav-header-spacer"></div>
 					<div class="full-nav-header-right">
 						<d2l-page-header-button icon="tier3:classes" text="Select a course..." text-hidden></d2l-page-header-button>
 						<d2l-page-header-separator></d2l-page-header-separator>
-						<d2l-page-header-button icon="tier3:email" text="Message alerts" text-hidden></d2l-page-header-button>
-						<d2l-page-header-button icon="tier3:discussions" text="Subscription alerts" text-hidden></d2l-page-header-button>
-						<d2l-page-header-button icon="tier3:notification-bell" text="Update alerts" text-hidden></d2l-page-header-button>
+						<div class="full-nav-header-alerts">
+							<d2l-page-header-button icon="tier3:email" text="Message alerts" text-hidden></d2l-page-header-button>
+							<d2l-page-header-button icon="tier3:discussions" text="Subscription alerts" text-hidden></d2l-page-header-button>
+							<d2l-page-header-button icon="tier3:notification-bell" text="Update alerts" text-hidden></d2l-page-header-button>
+						</div>
+						<d2l-page-header-button class="full-nav-header-alerts-combined" icon="tier3:notification-bell" text="Alerts" text-hidden></d2l-page-header-button>
 					</div>
 				</div>
 				<div class="full-nav-footer" slot="bottom">
 					<div class="full-nav-footer-inner">
-						<a class="full-nav-footer-link" href="javascript:void(0)">Content</a>
-						<a class="full-nav-footer-link" href="javascript:void(0)">Assignments</a>
-						<a class="full-nav-footer-link" href="javascript:void(0)">Quizzes</a>
-						<a class="full-nav-footer-link" href="javascript:void(0)">Grades</a>
-						<a class="full-nav-footer-link" href="javascript:void(0)">Classlist</a>
+						<div class="full-nav-footer-links">
+							<a class="full-nav-footer-link" href="javascript:void(0)">Content</a>
+							<a class="full-nav-footer-link" href="javascript:void(0)">Assignments</a>
+							<a class="full-nav-footer-link" href="javascript:void(0)">Quizzes</a>
+							<a class="full-nav-footer-link" href="javascript:void(0)">Grades</a>
+							<a class="full-nav-footer-link" href="javascript:void(0)">Classlist</a>
+						</div>
 						<d2l-button-icon icon="tier1:more" text="More" visible-on-ancestor></d2l-button-icon>
 					</div>
 				</div>

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -14,9 +14,18 @@ const DRAWER_MIN_HEIGHT = 200; // TO DO: Confirm
 export const MAIN_MIN_WIDTH = 600; // TO DO: Confirm
 export const PANEL_MIN_WIDTH = 320;
 
+const DIVIDER_GUTTER_WIDTH = 18;
+
 export const SIDE_NAV_DEFAULT_WIDTH = 334;
 export const supportingDefaultWidth = contentWidth => Math.floor(contentWidth / 3);
+export const supportingOverlayDefaultWidth = contentWidth => Math.min(400, Math.floor(0.9 * (contentWidth - DIVIDER_WIDTH - DIVIDER_GUTTER_WIDTH)));
 export const supportingMobileDefaultHeight = fullHeight => Math.floor(fullHeight / 2);
+
+const OVERLAY_MODE_BREAKPOINT = 929;
+const MOBILE_MODE_BREAKPOINT = 767;
+
+const overlayModeQuery = window.matchMedia(`(max-width: ${OVERLAY_MODE_BREAKPOINT}px)`);
+const mobileModeQuery = window.matchMedia(`(max-width: ${MOBILE_MODE_BREAKPOINT}px)`);
 
 class PanelStateController {
 	constructor(host, panelConfigs) {
@@ -25,7 +34,8 @@ class PanelStateController {
 		for (const [key, config] of Object.entries(panelConfigs)) {
 			this.#panels[key] = {
 				animate: false,
-				collapsed: false,
+				collapsed: config.collapsed,
+				restoreCollapsed: !config.collapsed,
 				size: 0,
 				minSize: config.minSize,
 				maxSize: config.minSize
@@ -56,7 +66,7 @@ class PanelStateController {
 			if (stored) {
 				const storedSize = parseInt(stored.size);
 				this.resize(key, isFinite(storedSize) ? storedSize : defaults[key]);
-				if (stored.collapsed) panel.collapsed = true;
+				if (panel.restoreCollapsed && stored.collapsed) panel.collapsed = true;
 			} else {
 				this.resize(key, defaults[key]);
 			}
@@ -92,7 +102,7 @@ class PanelStateController {
 		panel.maxSize = newMaxSize;
 
 		if (panel.size > newMaxSize) {
-			this.resize(key, panel.size);
+			this.resize(key, panel.size, { animate: true });
 		}
 	}
 
@@ -122,9 +132,11 @@ class PanelStateController {
 
 		try {
 			state[panelKey] = {
-				size: this.#panels[panelKey].size,
-				collapsed: this.#panels[panelKey].collapsed
+				size: this.#panels[panelKey].size
 			};
+			if (this.#panels[panelKey].restoreCollapsed) {
+				state[panelKey].collapsed = this.#panels[panelKey].collapsed;
+			}
 			localStorage.setItem(fullKey, JSON.stringify(state));
 		} catch {
 			// Do nothing if storage quota exceeded or using private browsing mode of an old Safari version
@@ -159,6 +171,8 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		_headerHeight: { state: true },
 		_headerIsSticky: { state: true },
 		_footerHeight: { state: true },
+		_inOverlayMode: { state: true },
+		_inMobileMode: { state: true },
 		_slotVisibility: { state: true }
 	};
 
@@ -183,12 +197,12 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 			--d2l-page-footer-max-width: 100%;
 		}
 
-		@media (max-width: 929px) {
+		@media (max-width: ${OVERLAY_MODE_BREAKPOINT}px) {
 			:host {
 				--d2l-page-padding: 24px;
 			}
 		}
-		@media (max-width: 767px) {
+		@media (max-width: ${MOBILE_MODE_BREAKPOINT}px) {
 			:host {
 				--d2l-page-padding: 18px;
 			}
@@ -262,10 +276,10 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		}
 
 		.side-nav-panel.collapsed {
-			padding-inline-end: 18px;
+			padding-inline-end: ${DIVIDER_GUTTER_WIDTH}px;
 		}
 		.supporting-panel.collapsed {
-			padding-inline-start: 18px;
+			padding-inline-start: ${DIVIDER_GUTTER_WIDTH}px;
 		}
 		.side-nav-panel.collapsed .side-nav-panel-content,
 		.supporting-panel.collapsed .supporting-panel-content {
@@ -315,9 +329,11 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		this._headerIsSticky = false;
 		this._footerHeight = 0;
 		this._panelState = new PanelStateController(this, {
-			'side-nav': { minSize: PANEL_MIN_WIDTH },
-			'supporting': { minSize: PANEL_MIN_WIDTH },
-			'supporting-mobile': { minSize: DRAWER_MIN_HEIGHT }
+			'side-nav': { collapsed: false, minSize: PANEL_MIN_WIDTH },
+			'supporting': { collapsed: false, minSize: PANEL_MIN_WIDTH },
+			'side-nav-overlay': { collapsed: true, minSize: PANEL_MIN_WIDTH },
+			'supporting-overlay': { collapsed: true, minSize: PANEL_MIN_WIDTH },
+			'supporting-mobile': { collapsed: false, minSize: DRAWER_MIN_HEIGHT }
 		});
 		this._slotVisibility = {};
 		this.#resizeObserver = new ResizeObserver(entries => {
@@ -341,7 +357,9 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 					this._panelState.updateMaxSize('side-nav', newMaxWidth);
 					this._panelState.updateMaxSize('supporting', newMaxWidth);
 
-					// TO DO: Collapse panel if needed
+					const newMaxOverlayWidth = this.#getMaxPanelOverlayWidth();
+					this._panelState.updateMaxSize('side-nav-overlay', newMaxOverlayWidth);
+					this._panelState.updateMaxSize('supporting-overlay', newMaxOverlayWidth);
 				}
 			}
 		});
@@ -363,12 +381,20 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 	connectedCallback() {
 		super.connectedCallback();
 		window.addEventListener('resize', this.#handleWindowResize);
+
+		this._inOverlayMode = overlayModeQuery.matches;
+		overlayModeQuery.addEventListener('change', this.#handleOverlayModeChange);
+		this._inMobileMode = mobileModeQuery.matches;
+		mobileModeQuery.addEventListener('change', this.#handleMobileModeChange);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.#resizeObserver.disconnect();
 		window.removeEventListener('resize', this.#handleWindowResize);
+
+		overlayModeQuery.removeEventListener('change', this.#handleOverlayModeChange);
+		mobileModeQuery.removeEventListener('change', this.#handleMobileModeChange);
 	}
 
 	firstUpdated() {
@@ -381,6 +407,9 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 	}
 
 	render() {
+		const sideNavPanelKey = this._inOverlayMode ? 'side-nav-overlay' : 'side-nav';
+		const supportingPanelKey = this._inMobileMode ? 'supporting-overlay' : (this._inOverlayMode ? 'supporting-overlay' : 'supporting'); // TO DO: Switch to supporting-mobile
+
 		const pageClasses = {
 			'page': true,
 			'header-sticky': this._headerIsSticky
@@ -394,9 +423,9 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 			<div class="${classMap(pageClasses)}">
 				${this.#renderHeader()}
 				<div class="${classMap(contentClasses)}">
-					${this.#renderSideNavPanel()}
+					${this.#renderSideNavPanel(sideNavPanelKey)}
 					<main><slot></slot></main>
-					${this.#renderSupportingPanel()}
+					${this.#renderSupportingPanel(supportingPanelKey)}
 				</div>
 				${this.#renderFooter()}
 			</div>
@@ -413,6 +442,16 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 	#resizeObserver;
 	#stateStorageKey;
 
+	#handleMobileModeChange = (e) => {
+		// TO DO: Collapse supporting panel if needed
+		this._inMobileMode = e.matches;
+	};
+
+	#handleOverlayModeChange = (e) => {
+		// TO DO: Collapse side-nav and supporting panel if needed
+		this._inOverlayMode = e.matches;
+	};
+
 	#handleWindowResize = () => {
 		this._panelState.updateMaxSize('supporting-mobile', this.#getMaxDrawerHeight());
 	};
@@ -420,6 +459,11 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 	#getMaxDrawerHeight() {
 		const reservedSpace = this._headerHeight + this._footerHeight + DIVIDER_WIDTH;
 		return Math.max(DRAWER_MIN_HEIGHT, window.innerHeight - reservedSpace);
+	}
+
+	#getMaxPanelOverlayWidth() {
+		const reservedSpace = MAIN_MIN_WIDTH + DIVIDER_WIDTH; // TO DO: Update when overlay styles added
+		return Math.max(PANEL_MIN_WIDTH, this._contentWidth - reservedSpace);
 	}
 
 	#getMaxPanelWidth() {
@@ -448,6 +492,8 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		this._panelState.initialize({
 			'side-nav': SIDE_NAV_DEFAULT_WIDTH,
 			'supporting': supportingDefaultWidth(this._contentWidth),
+			'side-nav-overlay': SIDE_NAV_DEFAULT_WIDTH,
+			'supporting-overlay': supportingOverlayDefaultWidth(this._contentWidth),
 			'supporting-mobile': supportingMobileDefaultHeight(window.innerHeight)
 		});
 	}
@@ -509,43 +555,43 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		`;
 	}
 
-	#renderSideNavPanel() {
+	#renderSideNavPanel(panelKey) {
 		const classes = {
 			'side-nav-panel': true,
-			'animate': this._panelState.getAnimate('side-nav'),
-			'collapsed': this._panelState.getCollapsed('side-nav')
+			'animate': this._panelState.getAnimate(panelKey),
+			'collapsed': this._panelState.getCollapsed(panelKey)
 		};
 		return html`
 			<nav class="side-nav" aria-label="${this.localize('components.page.side-nav-label')}">
 				<div
 					class="${classMap(classes)}"
-					style=${styleMap({ width: `${this._panelState.getSize('side-nav')}px` })}
+					style=${styleMap({ width: `${this._panelState.getSize(panelKey)}px` })}
 					?hidden="${!this._slotVisibility['side-nav']}">
-					<div class="side-nav-panel-content" style=${styleMap({ width: `${this._panelState.getTrueSize('side-nav')}px` })}>
+					<div class="side-nav-panel-content" style=${styleMap({ width: `${this._panelState.getTrueSize(panelKey)}px` })}>
 						<slot name="side-nav" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
 					</div>
 				</div>
 				${!this._slotVisibility['side-nav'] ? nothing :
-					this.#renderDivider('side-nav', this.localize('components.page.side-nav-divider-label'), 'start')}
+					this.#renderDivider(panelKey, this.localize('components.page.side-nav-divider-label'), 'start')}
 			</nav>
 		`;
 	}
 
-	#renderSupportingPanel() {
+	#renderSupportingPanel(panelKey) {
 		const classes = {
 			'supporting-panel': true,
-			'animate': this._panelState.getAnimate('supporting'),
-			'collapsed': this._panelState.getCollapsed('supporting')
+			'animate': this._panelState.getAnimate(panelKey),
+			'collapsed': this._panelState.getCollapsed(panelKey)
 		};
 		return html`
 			<aside class="supporting" aria-label="${this.localize('components.page.supporting-label')}">
 				${!this._slotVisibility['supporting'] ? nothing :
-					this.#renderDivider('supporting', this.localize('components.page.supporting-divider-label'), 'end')}
+					this.#renderDivider(panelKey, this.localize('components.page.supporting-divider-label'), 'end')}
 				<div
 					class="${classMap(classes)}"
-					style=${styleMap({ width: `${this._panelState.getSize('supporting')}px` })}
+					style=${styleMap({ width: `${this._panelState.getSize(panelKey)}px` })}
 					?hidden="${!this._slotVisibility['supporting']}">
-					<div class="supporting-panel-content" style=${styleMap({ width: `${this._panelState.getTrueSize('supporting')}px` })}>
+					<div class="supporting-panel-content" style=${styleMap({ width: `${this._panelState.getTrueSize(panelKey)}px` })}>
 						<slot name="supporting" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
 					</div>
 				</div>

--- a/components/page/page.js
+++ b/components/page/page.js
@@ -330,8 +330,8 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		this._footerHeight = 0;
 		this._panelState = new PanelStateController(this, {
 			'side-nav': { collapsed: false, minSize: PANEL_MIN_WIDTH },
-			'supporting': { collapsed: false, minSize: PANEL_MIN_WIDTH },
 			'side-nav-overlay': { collapsed: true, minSize: PANEL_MIN_WIDTH },
+			'supporting': { collapsed: false, minSize: PANEL_MIN_WIDTH },
 			'supporting-overlay': { collapsed: true, minSize: PANEL_MIN_WIDTH },
 			'supporting-mobile': { collapsed: false, minSize: DRAWER_MIN_HEIGHT }
 		});
@@ -491,8 +491,8 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 	#initializePanelSizes() {
 		this._panelState.initialize({
 			'side-nav': SIDE_NAV_DEFAULT_WIDTH,
-			'supporting': supportingDefaultWidth(this._contentWidth),
 			'side-nav-overlay': SIDE_NAV_DEFAULT_WIDTH,
+			'supporting': supportingDefaultWidth(this._contentWidth),
 			'supporting-overlay': supportingOverlayDefaultWidth(this._contentWidth),
 			'supporting-mobile': supportingMobileDefaultHeight(window.innerHeight)
 		});

--- a/components/page/test/page-divider-internal.axe.js
+++ b/components/page/test/page-divider-internal.axe.js
@@ -1,6 +1,6 @@
 import '../page-divider-internal.js';
-import { clearStoredPanelState, setStoredPanelState } from './page-fixtures.js';
-import { clickElem, expect, fixture, hoverElem, nextFrame } from '@brightspace-ui/testing';
+import { clearStoredPanelState, openPanel, setStoredPanelState } from './page-fixtures.js';
+import { clickElem, expect, fixture, focusElem, hoverElem, nextFrame } from '@brightspace-ui/testing';
 import { getDivider, getDividerArrow, getSlider, pageDividerFixtures } from './page-divider-internal-fixtures.js';
 
 const defaultFixtureOptions = { pagePadding: false, viewport: { width: 1300, height: 800 } };
@@ -66,6 +66,79 @@ describe('page-divider-internal', () => {
 		await clickElem(getSlider(divider));
 		await nextFrame();
 		await expect(elem).to.be.accessible();
+	});
+
+	describe('overlay', () => {
+		const overlayFixtureOptions = (panelKey) => ({ pagePadding: false, viewport: { width: panelKey === 'side-nav-overlay' ? 450 : 800, height: 500 } });
+
+		[
+			{ name: 'side-nav', key: 'side-nav-overlay', fixture: pageDividerFixtures.sideNavBothHeadersFooter },
+			{ name: 'supporting', key: 'supporting-overlay', fixture: pageDividerFixtures.supportingImmersiveFooter }
+		].forEach(panel => {
+
+			describe(panel.name, () => {
+				it('hover', async() => {
+					const elem = await fixture(panel.fixture, overlayFixtureOptions(panel.key));
+					await openPanel(elem, panel.key);
+					await hoverElem(getDivider(elem, panel.key));
+					await expect(elem).to.be.accessible();
+				});
+
+				it('hover handle', async() => {
+					const elem = await fixture(panel.fixture, overlayFixtureOptions(panel.key));
+					await openPanel(elem, panel.key);
+					const divider = getDivider(elem, panel.key);
+					await hoverElem(getSlider(divider));
+					await expect(elem).to.be.accessible();
+				});
+
+				it('focus', async() => {
+					const elem = await fixture(panel.fixture, overlayFixtureOptions(panel.key));
+					await openPanel(elem, panel.key);
+					await focusElem(getDivider(elem, panel.key));
+					await expect(elem).to.be.accessible();
+				});
+
+				// TO DO: Confirm this test is working once these arrows show up
+				it('focus then hover start arrow', async() => {
+					const elem = await fixture(panel.fixture, overlayFixtureOptions(panel.key));
+					await openPanel(elem, panel.key);
+
+					const divider = getDivider(elem, panel.key);
+					await clickElem(divider);
+					await nextFrame();
+					await hoverElem(getDividerArrow(divider, 'start'));
+					await expect(elem).to.be.accessible();
+				});
+
+				// TO DO: Confirm this test is working once these arrows show up
+				it('focus then hover end arrow', async() => {
+					const elem = await fixture(panel.fixture, overlayFixtureOptions(panel.key));
+					await openPanel(elem, panel.key);
+
+					const divider = getDivider(elem, panel.key);
+					await clickElem(divider);
+					await nextFrame();
+					await hoverElem(getDividerArrow(divider, 'end'));
+					await expect(elem).to.be.accessible();
+				});
+
+				it('collapsed', async() => {
+					const elem = await fixture(panel.fixture, overlayFixtureOptions(panel.key));
+					await expect(elem).to.be.accessible();
+				});
+
+				it('collapsed focused', async() => {
+					const elem = await fixture(panel.fixture, overlayFixtureOptions(panel.key));
+					await focusElem(getDivider(elem, panel.key));
+					await expect(elem).to.be.accessible();
+				});
+			});
+		});
+	});
+
+	describe('drawer', () => {
+		// TO DO
 	});
 
 });

--- a/components/page/test/page-divider-internal.vdiff.js
+++ b/components/page/test/page-divider-internal.vdiff.js
@@ -8,37 +8,37 @@ describe('page-divider-internal', () => {
 
 	describe('hover', () => {
 		[
-			{ name: 'side-nav', divider: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
-			{ name: 'supporting-immersive', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter }
+			{ name: 'side-nav', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
+			{ name: 'supporting-immersive', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter }
 		].forEach(test => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-				await hoverElem(getDivider(elem, test.divider));
+				await hoverElem(getDivider(elem, test.panelKey));
 				await expect(elem).to.be.golden({ margin: 0 });
 			});
 		});
 
 		[
-			{ name: 'handle-side-nav', divider: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
-			{ name: 'handle-supporting-immersive', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter }
+			{ name: 'handle-side-nav', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
+			{ name: 'handle-supporting-immersive', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter }
 		].forEach(test => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-				const divider = getDivider(elem, test.divider);
+				const divider = getDivider(elem, test.panelKey);
 				await hoverElem(getSlider(divider));
 				await expect(elem).to.be.golden({ margin: 0 });
 			});
 		});
 
 		[
-			{ name: 'arrow-start-side-nav', arrow: 'start', divider: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
-			{ name: 'arrow-end-side-nav', arrow: 'end', divider: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
-			{ name: 'arrow-start-supporting-immersive', arrow: 'start', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter },
-			{ name: 'arrow-end-supporting-immersive', arrow: 'end', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter }
+			{ name: 'arrow-start-side-nav', arrow: 'start', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
+			{ name: 'arrow-end-side-nav', arrow: 'end', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
+			{ name: 'arrow-start-supporting-immersive', arrow: 'start', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter },
+			{ name: 'arrow-end-supporting-immersive', arrow: 'end', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter }
 		].forEach(test => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-				const divider = getDivider(elem, test.divider);
+				const divider = getDivider(elem, test.panelKey);
 				await focusElem(divider);
 				await hoverElem(getDividerArrow(divider, test.arrow));
 				await expect(elem).to.be.golden({ margin: 0 });
@@ -52,25 +52,25 @@ describe('page-divider-internal', () => {
 		});
 
 		[
-			{ name: 'side-nav', divider: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeadersFooterStorageKey },
-			{ name: 'supporting-immersive', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveBothHeadersStorageKey }
+			{ name: 'side-nav', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeadersFooterStorageKey },
+			{ name: 'supporting-immersive', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveBothHeadersStorageKey }
 		].forEach(test => {
 			it(test.name, async() => {
-				setStoredPanelState({ [test.divider]: { size: 400, collapsed: true } });
+				setStoredPanelState({ [test.panelKey]: { size: 400, collapsed: true } });
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-				await hoverElem(getDivider(elem, test.divider));
+				await hoverElem(getDivider(elem, test.panelKey));
 				await expect(elem).to.be.golden({ margin: 0 });
 			});
 		});
 
 		[
-			{ name: 'handle-side-nav', divider: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeadersFooterStorageKey },
-			{ name: 'handle-supporting-immersive', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveBothHeadersStorageKey }
+			{ name: 'handle-side-nav', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeadersFooterStorageKey },
+			{ name: 'handle-supporting-immersive', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveBothHeadersStorageKey }
 		].forEach(test => {
 			it(test.name, async() => {
-				setStoredPanelState({ [test.divider]: { size: 400, collapsed: true } });
+				setStoredPanelState({ [test.panelKey]: { size: 400, collapsed: true } });
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-				const divider = getDivider(elem, test.divider);
+				const divider = getDivider(elem, test.panelKey);
 				await hoverElem(getSlider(divider));
 				await expect(elem).to.be.golden({ margin: 0 });
 			});
@@ -79,16 +79,16 @@ describe('page-divider-internal', () => {
 
 	describe('focus', () => {
 		[
-			{ name: 'side-nav', divider: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeadersFooter },
-			{ name: 'side-nav-immersive', divider: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveFooter },
-			{ name: 'side-nav-long-no-scroll', divider: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainBothHeaders },
-			{ name: 'supporting', divider: 'supporting', fixture: pageDividerFixtures.supportingLongFooter },
-			{ name: 'supporting-immersive', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveBothHeaders },
-			{ name: 'supporting-immersive-long-no-scroll', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMain }
+			{ name: 'side-nav', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeadersFooter },
+			{ name: 'side-nav-immersive', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveFooter },
+			{ name: 'side-nav-long-no-scroll', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainBothHeaders },
+			{ name: 'supporting', panelKey: 'supporting', fixture: pageDividerFixtures.supportingLongFooter },
+			{ name: 'supporting-immersive', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveBothHeaders },
+			{ name: 'supporting-immersive-long-no-scroll', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMain }
 		].forEach(test => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-				await focusElem(getDivider(elem, test.divider));
+				await focusElem(getDivider(elem, test.panelKey));
 				await expect(elem).to.be.golden({ margin: 0 });
 			});
 		});
@@ -96,16 +96,16 @@ describe('page-divider-internal', () => {
 
 	describe('focus-scrolled', () => {
 		[
-			{ name: 'main', divider: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainBothHeaders },
-			{ name: 'panel', divider: 'supporting', fixture: pageDividerFixtures.supportingLongFooter },
-			{ name: 'immersive-main', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMain },
-			{ name: 'immersive-panel', divider: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveLongFooter }
+			{ name: 'main', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainBothHeaders },
+			{ name: 'panel', panelKey: 'supporting', fixture: pageDividerFixtures.supportingLongFooter },
+			{ name: 'immersive-main', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMain },
+			{ name: 'immersive-panel', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveLongFooter }
 		].forEach(test => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-				await focusElem(getDivider(elem, test.divider));
+				await focusElem(getDivider(elem, test.panelKey));
 				scrollBody();
-				scrollPanel(elem, test.divider);
+				scrollPanel(elem, test.panelKey);
 				await expect(elem).to.be.golden({ margin: 0 });
 			});
 		});
@@ -113,16 +113,16 @@ describe('page-divider-internal', () => {
 
 	describe('focus-stay-scrolled', () => {
 		[
-			{ name: 'main', divider: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainBothHeaders },
-			{ name: 'panel', divider: 'supporting', fixture: pageDividerFixtures.supportingLongFooter },
-			{ name: 'immersive-main', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMain },
-			{ name: 'immersive-panel', divider: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveLongFooter }
+			{ name: 'main', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainBothHeaders },
+			{ name: 'panel', panelKey: 'supporting', fixture: pageDividerFixtures.supportingLongFooter },
+			{ name: 'immersive-main', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMain },
+			{ name: 'immersive-panel', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveLongFooter }
 		].forEach(test => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
 				scrollBody();
-				scrollPanel(elem, test.divider);
-				await focusElem(getDivider(elem, test.divider));
+				scrollPanel(elem, test.panelKey);
+				await focusElem(getDivider(elem, test.panelKey));
 				await expect(elem).to.be.golden({ margin: 0 });
 			});
 		});
@@ -130,13 +130,13 @@ describe('page-divider-internal', () => {
 
 	describe('collapse-stay-scrolled', () => {
 		[
-			{ name: 'main', divider: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainBothHeaders },
-			{ name: 'immersive-main', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMain }
+			{ name: 'main', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainBothHeaders },
+			{ name: 'immersive-main', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMain }
 		].forEach(test => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
 				scrollBody();
-				await sendKeysElem(getDivider(elem, test.divider), 'press', 'Enter');
+				await sendKeysElem(getDivider(elem, test.panelKey), 'press', 'Enter');
 				await expect(elem).to.be.golden({ margin: 0 });
 			});
 		});
@@ -144,17 +144,17 @@ describe('page-divider-internal', () => {
 
 	describe('expand-stay-scrolled', () => {
 		[
-			{ name: 'panel', divider: 'supporting', fixture: pageDividerFixtures.supportingLongFooter },
-			{ name: 'both', divider: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainLongFooter },
-			{ name: 'immersive-panel', divider: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveLongFooter },
-			{ name: 'immersive-both', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMainLongBothHeaders },
+			{ name: 'panel', panelKey: 'supporting', fixture: pageDividerFixtures.supportingLongFooter },
+			{ name: 'both', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainLongFooter },
+			{ name: 'immersive-panel', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveLongFooter },
+			{ name: 'immersive-both', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMainLongBothHeaders },
 		].forEach(test => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-				scrollPanel(elem, test.divider);
+				scrollPanel(elem, test.panelKey);
 				scrollBody();
 
-				const divider = getDivider(elem, test.divider);
+				const divider = getDivider(elem, test.panelKey);
 				await sendKeysElem(divider, 'press', 'Enter');
 				await nextFrame();
 
@@ -166,12 +166,12 @@ describe('page-divider-internal', () => {
 
 	describe('expand-not-scrolled', () => {
 		[
-			{ name: 'panel', divider: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainLongFooter },
-			{ name: 'immersive-panel', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMainLongBothHeaders }
+			{ name: 'panel', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavLongMainLongFooter },
+			{ name: 'immersive-panel', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveLongMainLongBothHeaders }
 		].forEach(test => {
 			it(test.name, async() => {
 				const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-				const divider = getDivider(elem, test.divider);
+				const divider = getDivider(elem, test.panelKey);
 				await clickElem(getSlider(divider));
 				await nextFrame();
 
@@ -193,10 +193,10 @@ describe('page-divider-internal', () => {
 		const supportingDefault = supportingDefaultWidth(width);
 
 		[
-			{ name: 'side-nav', position: 'start', fixture: pageDividerFixtures.sideNavBothHeadersWide, divider: 'side-nav', grow: 'ArrowRight', shrink: 'ArrowLeft', default: sideNavDefault },
-			{ name: 'supporting', position: 'end', fixture: pageDividerFixtures.supportingLongFooterWide, divider: 'supporting', grow: 'ArrowLeft', shrink: 'ArrowRight', default: supportingDefault },
-			{ name: 'rtl-side-nav', rtl: true, position: 'start', fixture: pageDividerFixtures.sideNavBothHeadersWide, divider: 'side-nav', grow: 'ArrowLeft', shrink: 'ArrowRight', default: sideNavDefault },
-			{ name: 'rtl-supporting', rtl: true, position: 'end', fixture: pageDividerFixtures.supportingLongFooterWide, divider: 'supporting', grow: 'ArrowRight', shrink: 'ArrowLeft', default: supportingDefault }
+			{ name: 'side-nav', position: 'start', fixture: pageDividerFixtures.sideNavBothHeadersWide, panelKey: 'side-nav', grow: 'ArrowRight', shrink: 'ArrowLeft', default: sideNavDefault },
+			{ name: 'supporting', position: 'end', fixture: pageDividerFixtures.supportingLongFooterWide, panelKey: 'supporting', grow: 'ArrowLeft', shrink: 'ArrowRight', default: supportingDefault },
+			{ name: 'rtl-side-nav', rtl: true, position: 'start', fixture: pageDividerFixtures.sideNavBothHeadersWide, panelKey: 'side-nav', grow: 'ArrowLeft', shrink: 'ArrowRight', default: sideNavDefault },
+			{ name: 'rtl-supporting', rtl: true, position: 'end', fixture: pageDividerFixtures.supportingLongFooterWide, panelKey: 'supporting', grow: 'ArrowRight', shrink: 'ArrowLeft', default: supportingDefault }
 		].forEach(test => {
 			describe(test.name, () => {
 				[
@@ -215,7 +215,7 @@ describe('page-divider-internal', () => {
 							...(requested !== expected ? [{ color: 'blue', size: requested }] : [])
 						]);
 
-						const divider = getDivider(elem, test.divider);
+						const divider = getDivider(elem, test.panelKey);
 						await sendKeysElem(divider, 'press', key);
 						await expect(elem).to.be.golden({ margin: 0 });
 					});
@@ -227,24 +227,24 @@ describe('page-divider-internal', () => {
 	describe('click', () => {
 		describe('handle', () => {
 			[
-				{ name: 'collapse-side-nav', divider: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
-				{ name: 'collapse-supporting-immersive', divider: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter }
+				{ name: 'collapse-side-nav', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavBothHeaders },
+				{ name: 'collapse-supporting-immersive', panelKey: 'supporting', fixture: pageDividerFixtures.supportingImmersiveFooter }
 			].forEach(test => {
 				it(test.name, async() => {
 					const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-					const divider = getDivider(elem, test.divider);
+					const divider = getDivider(elem, test.panelKey);
 					await clickElem(getSlider(divider));
 					await expect(elem).to.be.golden({ margin: 0 });
 				});
 			});
 
 			[
-				{ name: 'expand-side-nav-immersive', divider: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveFooter },
-				{ name: 'expand-supporting', divider: 'supporting', fixture: pageDividerFixtures.supportingLongFooter }
+				{ name: 'expand-side-nav-immersive', panelKey: 'side-nav', fixture: pageDividerFixtures.sideNavImmersiveFooter },
+				{ name: 'expand-supporting', panelKey: 'supporting', fixture: pageDividerFixtures.supportingLongFooter }
 			].forEach(test => {
 				it(test.name, async() => {
 					const elem = await fixture(test.fixture, { pagePadding: false, viewport: { width: 1000, height: 400 } });
-					const divider = getDivider(elem, test.divider);
+					const divider = getDivider(elem, test.panelKey);
 					await clickElem(getSlider(divider));
 					await clickElem(getSlider(divider));
 					await expect(elem).to.be.golden({ margin: 0 });
@@ -279,20 +279,20 @@ describe('page-divider-internal', () => {
 			});
 
 			[
-				{ name: 'side-nav', position: 'start', fixture: pageDividerFixtures.sideNavBothHeadersStorageKey, divider: 'side-nav', grow: 'end', shrink: 'start' },
-				{ name: 'supporting', position: 'end', fixture: pageDividerFixtures.supportingLongFooterStorageKey, divider: 'supporting', grow: 'start', shrink: 'end' },
-				{ name: 'rtl-side-nav', rtl: true, position: 'start', fixture: pageDividerFixtures.sideNavBothHeadersStorageKey, divider: 'side-nav', grow: 'end', shrink: 'start' },
-				{ name: 'rtl-supporting', rtl: true, position: 'end', fixture: pageDividerFixtures.supportingLongFooterStorageKey, divider: 'supporting', grow: 'start', shrink: 'end' }
+				{ name: 'side-nav', position: 'start', fixture: pageDividerFixtures.sideNavBothHeadersStorageKey, panelKey: 'side-nav', grow: 'end', shrink: 'start' },
+				{ name: 'supporting', position: 'end', fixture: pageDividerFixtures.supportingLongFooterStorageKey, panelKey: 'supporting', grow: 'start', shrink: 'end' },
+				{ name: 'rtl-side-nav', rtl: true, position: 'start', fixture: pageDividerFixtures.sideNavBothHeadersStorageKey, panelKey: 'side-nav', grow: 'end', shrink: 'start' },
+				{ name: 'rtl-supporting', rtl: true, position: 'end', fixture: pageDividerFixtures.supportingLongFooterStorageKey, panelKey: 'supporting', grow: 'start', shrink: 'end' }
 			].forEach(test => {
 				describe(test.name, () => {
 					[
-						{ action: 'grow', arrow: test.grow, collapsed: false, startingSize: stored, expected: stored + KEYBOARD_STEP },
-						{ action: 'shrink', arrow: test.shrink, collapsed: false, startingSize: stored, expected: stored - KEYBOARD_STEP }
-					].forEach(({ action, arrow, collapsed, startingSize, expected }) => {
+						{ action: 'grow', arrow: test.grow, startingSize: stored, expected: stored + KEYBOARD_STEP },
+						{ action: 'shrink', arrow: test.shrink, startingSize: stored, expected: stored - KEYBOARD_STEP }
+					].forEach(({ action, arrow, startingSize, expected }) => {
 						it(action, async() => {
 							setStoredPanelState({
-								'side-nav': { collapsed: collapsed, size: stored },
-								'supporting': { collapsed: collapsed, size: stored }
+								'side-nav': { collapsed: false, size: stored },
+								'supporting': { collapsed: false, size: stored }
 							});
 							const elem = await fixture(test.fixture, { pagePadding: false, rtl: test.rtl, viewport: { height: 325, width: 1100 } });
 							addMarkers(elem, test.position, [
@@ -300,7 +300,7 @@ describe('page-divider-internal', () => {
 								{ color: 'green', size: expected }
 							]);
 
-							const divider = getDivider(elem, test.divider);
+							const divider = getDivider(elem, test.panelKey);
 							await focusElem(divider);
 							await clickElem(getDividerArrow(divider, arrow));
 							await expect(elem).to.be.golden({ margin: 0 });

--- a/components/page/test/page-fixtures.js
+++ b/components/page/test/page-fixtures.js
@@ -6,6 +6,7 @@ import '../page-side-nav.js';
 import '../page-supporting.js';
 import { html, nothing, render } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { nextFrame } from '@brightspace-ui/testing';
 import { panelStateStorageKey } from '../page.js';
 
 export function scrollBody() {
@@ -17,7 +18,13 @@ export function scrollPanel(elem, panel) {
 	panelElem.scrollTop = panelElem.scrollHeight;
 }
 
-const TEST_STATE_STORAGE_KEY = 'test-page';
+export async function openPanel(elem, panelKey) {
+	const divider = elem.shadowRoot.querySelector(`d2l-page-divider-internal[data-panel-key="${panelKey}"]`);
+	divider.dispatchEvent(new CustomEvent('d2l-page-divider-toggle'));
+	await nextFrame();
+}
+
+export const TEST_STATE_STORAGE_KEY = 'test-page';
 const panelStorageKey = panelStateStorageKey(TEST_STATE_STORAGE_KEY);
 export function getStoredPanelState() {
 	const stored = localStorage.getItem(panelStorageKey);

--- a/components/page/test/page.axe.js
+++ b/components/page/test/page.axe.js
@@ -1,43 +1,98 @@
 import '../page.js';
+import { clearStoredPanelState, openPanel, setStoredPanelState, TEST_STATE_STORAGE_KEY } from './page-fixtures.js';
 import { expect, fixture, html } from '@brightspace-ui/testing';
 
 // TO DO: See if we can remove once we are handling <h1> and page title setting
 const rulesToIgnore = ['document-title', 'page-has-heading-one'];
 
+const singlePanel = html`
+	<d2l-page>
+		<div slot="header">Header</div>
+		<div>Content</div>
+		<div slot="footer">Footer</div>
+	</d2l-page>
+`;
+
+const sideNavPanel = html`
+	<d2l-page state-storage-key="${TEST_STATE_STORAGE_KEY}">
+		<div slot="header">Header</div>
+		<div>Content</div>
+		<div slot="side-nav">Side Nav</div>
+		<div slot="footer">Footer</div>
+	</d2l-page>
+`;
+
+const supportingPanel = html`
+	<d2l-page state-storage-key="${TEST_STATE_STORAGE_KEY}">
+		<div slot="header">Header</div>
+		<div>Content</div>
+		<div slot="supporting">Supporting</div>
+		<div slot="footer">Footer</div>
+	</d2l-page>
+`;
+
 describe('page', () => {
+	afterEach(() => {
+		clearStoredPanelState();
+	});
 
 	it('single panel', async() => {
-		await fixture(html`
-			<d2l-page>
-				<div slot="header">Header</div>
-				<div>Content</div>
-				<div slot="footer">Footer</div>
-			</d2l-page>
-		`);
+		await fixture(singlePanel, { viewport: { width: 1300 } });
 		await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
 	});
 
 	it('with side-nav panel', async() => {
-		await fixture(html`
-			<d2l-page>
-				<div slot="header">Header</div>
-				<div>Content</div>
-				<div slot="side-nav">Side Nav</div>
-				<div slot="footer">Footer</div>
-			</d2l-page>
-		`);
+		await fixture(sideNavPanel, { viewport: { width: 1300 } });
+		await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
+	});
+
+	it('with side-nav panel collapsed', async() => {
+		setStoredPanelState({ 'side-nav': { size: 400, collapsed: true } });
+		await fixture(sideNavPanel, { viewport: { width: 1300 } });
 		await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
 	});
 
 	it('with supporting panel', async() => {
-		await fixture(html`
-			<d2l-page>
-				<div slot="header">Header</div>
-				<div>Content</div>
-				<div slot="supporting">Supporting</div>
-				<div slot="footer">Footer</div>
-			</d2l-page>
-		`);
+		await fixture(supportingPanel, { viewport: { width: 1300 } });
 		await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
+	});
+
+	it('with supporting panel collapsed', async() => {
+		setStoredPanelState({ 'supporting': { size: 400, collapsed: true } });
+		await fixture(supportingPanel, { viewport: { width: 1300 } });
+		await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
+	});
+
+	describe('overlay mode', () => {
+		it('single panel', async() => {
+			await fixture(singlePanel, { viewport: { width: 800 } });
+			await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
+		});
+
+		it('with side-nav panel', async() => {
+			await fixture(sideNavPanel, { viewport: { width: 800 } });
+			await openPanel(document.querySelector('d2l-page'), 'side-nav-overlay');
+			await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
+		});
+
+		it('with side-nav panel collapsed', async() => {
+			await fixture(sideNavPanel, { viewport: { width: 800 } });
+			await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
+		});
+
+		it('with supporting panel', async() => {
+			await fixture(supportingPanel, { viewport: { width: 800 } });
+			await openPanel(document.querySelector('d2l-page'), 'supporting-overlay');
+			await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
+		});
+
+		it('with supporting panel collapsed', async() => {
+			await fixture(supportingPanel, { viewport: { width: 800 } });
+			await expect(document).to.be.accessible({ ignoredRules: rulesToIgnore });
+		});
+	});
+
+	describe('mobile mode', () => {
+		// TO DO
 	});
 });

--- a/components/page/test/page.test.js
+++ b/components/page/test/page.test.js
@@ -56,8 +56,24 @@ describe('page', () => {
 				expect(elem._panelState.getTrueSize('side-nav')).to.equal(450);
 			});
 
+			it('does not apply a stored collapsed state for side-nav-overlay', async() => {
+				setStoredPanelState({ 'side-nav-overlay': { size: 450, collapsed: false } });
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getCollapsed('side-nav-overlay')).to.be.true;
+				expect(elem._panelState.getSize('side-nav-overlay')).to.equal(0);
+				expect(elem._panelState.getTrueSize('side-nav-overlay')).to.equal(450);
+			});
+
+			it('does not apply a stored collapsed state for supporting-overlay', async() => {
+				setStoredPanelState({ 'supporting-overlay': { size: 350, collapsed: false } });
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getCollapsed('supporting-overlay')).to.be.true;
+				expect(elem._panelState.getSize('supporting-overlay')).to.equal(0);
+				expect(elem._panelState.getTrueSize('supporting-overlay')).to.equal(350);
+			});
+
 			it('falls back to the default when no storage key set', async() => {
-				const elem = await fixture(pageFixtures.sideNavHeader, defaultFixtureOptions);
+				const elem = await fixture(pageFixtures.mainStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getTrueSize('side-nav')).to.equal(SIDE_NAV_DEFAULT_WIDTH);
 				expect(elem._panelState.getCollapsed('side-nav')).to.be.false;
 			});
@@ -141,6 +157,22 @@ describe('page', () => {
 				expect(stored['side-nav'].size).to.equal(SIDE_NAV_DEFAULT_WIDTH);
 			});
 
+			it('does not persist the collapsed state for side-nav-overlay', async() => {
+				const elem = await fixture(pageFixtures.sideNavHeaderStorageKey, { pagePadding: false, viewport: { width: 450, height: fixtureHeight } });
+				getDivider(elem, 'side-nav-overlay').dispatchEvent(new CustomEvent('d2l-page-divider-toggle'));
+				const stored = getStoredPanelState();
+				expect(stored['side-nav-overlay'].collapsed).to.be.undefined;
+				expect(stored['side-nav-overlay'].size).to.equal(320); // TO DO: Should be SIDE_NAV_DEFAULT_WIDTH once overlay styles applied
+			});
+
+			it('does not persist the collapsed state for supporting-overlay', async() => {
+				const elem = await fixture(pageFixtures.supportingFooterStorageKey, { pagePadding: false, viewport: { width: 800, height: fixtureHeight } });
+				getDivider(elem, 'supporting-overlay').dispatchEvent(new CustomEvent('d2l-page-divider-toggle'));
+				const stored = getStoredPanelState();
+				expect(stored['supporting-overlay'].collapsed).to.be.undefined;
+				expect(stored['supporting-overlay'].size).to.equal(320); // TO DO: Should be supportingOverlayDefaultWidth(800) once overlay styles applied
+			});
+
 			it('persists each panel under its own key', async() => {
 				setStoredPanelState({ 'side-nav': { size: 450, collapsed: true } });
 				const elem = await fixture(pageFixtures.supportingFooterStorageKey, defaultFixtureOptions);
@@ -167,16 +199,28 @@ describe('page', () => {
 				expect(stored['supporting'].size).to.equal(9999);
 			});
 
-			it('does not update when size adjusted by window resize', async() => {
+			it('does not update when size adjusted by window width resize', async() => {
 				setStoredPanelState({ 'supporting': { size: 500, collapsed: false } });
 				const elem = await fixture(pageFixtures.supportingFooterStorageKey, defaultFixtureOptions);
 				expect(elem._panelState.getTrueSize('supporting')).to.equal(500);
 
-				await setViewport({ width: 1000, height: fixtureHeight });
+				await setViewport({ width: 1000 });
 				await waitUntil(() => elem._panelState.getTrueSize('supporting') !== 500);
 
 				const stored = getStoredPanelState();
 				expect(stored['supporting'].size).to.equal(500);
+			});
+
+			it('does not update when size adjusted by window height resize', async() => {
+				setStoredPanelState({ 'supporting-mobile': { size: 600, collapsed: false } });
+				const elem = await fixture(pageFixtures.supportingFooterStorageKey, defaultFixtureOptions);
+				expect(elem._panelState.getTrueSize('supporting-mobile')).to.equal(600);
+
+				await setViewport({ height: 650 });
+				await waitUntil(() => elem._panelState.getTrueSize('supporting-mobile') !== 600);
+
+				const stored = getStoredPanelState();
+				expect(stored['supporting-mobile'].size).to.equal(600);
 			});
 		});
 	});


### PR DESCRIPTION
So this PR doesn't have any visual changes (aside from the demo page header changes), but it _sets up_ everything we need for overlay mode. It:
- Adds the event listeners for determining when we've entered overlay mode and mobile mode
- Breaks out the overlay values as their own panel state, and uses them if we're in overlay mode
- Does not store collapsed state for overlay, and defaults to overlay panels always being closed
- Adds unit tests for this, enhances the axe test coverage, and tweaks the wording in the vdiffs to prep for the overlay ones
- "Enhances" the demo full header to be more responsive so we can actually test small screen sizes in the demo

More comments inline. 