### PR TITLE
GAUD-10255: don't dispatch change event when property updates

### DIFF
--- a/components/button/button-toggle.js
+++ b/components/button/button-toggle.js
@@ -1,4 +1,5 @@
 import { css, html, LitElement } from 'lit';
+import { getFlag } from '../../helpers/flags.js';
 
 /**
  * A button container component for button toggles.
@@ -52,13 +53,16 @@ class ButtonToggle extends LitElement {
 		`;
 	}
 
+	// remove with "button-toggle-no-change-event-on-prop-update" flag
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
 		if (changedProperties.get('pressed') === undefined) return;
 
-		/** Dispatched when the pressed state changes */
-		this.dispatchEvent(new CustomEvent('d2l-button-toggle-change'));
+		if (!getFlag('button-toggle-no-change-event-on-prop-update', true)) {
+			/** Dispatched when the pressed state changes */
+			this.dispatchEvent(new CustomEvent('d2l-button-toggle-change'));
+		}
 	}
 
 	focus() {
@@ -102,6 +106,10 @@ class ButtonToggle extends LitElement {
 		this.pressed = newPressed;
 		await this.updateComplete;
 		this.focus();
+		if (getFlag('button-toggle-no-change-event-on-prop-update', true)) {
+			/** Dispatched when the pressed state changes */
+			this.dispatchEvent(new CustomEvent('d2l-button-toggle-change'));
+		}
 	}
 
 }

--- a/components/button/test/button-toggle.test.js
+++ b/components/button/test/button-toggle.test.js
@@ -1,7 +1,13 @@
 import { buttonToggleFixtures, clickActiveButton } from './button-toggle-fixtures.js';
 import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
+import { mockFlag, resetFlag } from '../../../helpers/flags.js';
 
 describe('d2l-button-toggle', () => {
+
+	// remove with "button-toggle-no-change-event-on-prop-update" flag
+	afterEach(() => {
+		resetFlag('button-toggle-no-change-event-on-prop-update');
+	});
 
 	describe('constructor', () => {
 
@@ -13,21 +19,42 @@ describe('d2l-button-toggle', () => {
 
 	describe('events', () => {
 
-		it('dispatches d2l-button-toggle-change event not-pressed is clicked', async() => {
+		it('dispatches "d2l-button-toggle-change" event not-pressed is clicked', async() => {
 			const el = await fixture(buttonToggleFixtures.iconNotPressed);
 			clickActiveButton(el);
 			const e = await oneEvent(el, 'd2l-button-toggle-change');
 			expect(e.target.pressed).to.equal(true);
 		});
 
-		it('dispatches d2l-button-toggle-change event pressed is clicked', async() => {
+		it('dispatches "d2l-button-toggle-change" event pressed is clicked', async() => {
 			const el = await fixture(buttonToggleFixtures.iconPressed);
 			clickActiveButton(el);
 			const e = await oneEvent(el, 'd2l-button-toggle-change');
 			expect(e.target.pressed).to.equal(false);
 		});
 
-		it('does not dispatch d2l-button-toggle-change event initially', async() => {
+		it('does not dispatch "d2l-button-toggle-change" event when "pressed" property is updated', async() => {
+			const el = await fixture(buttonToggleFixtures.iconPressed);
+			let dispatched = false;
+			el.addEventListener('d2l-button-toggle-change', () => dispatched = true);
+			el.pressed = false;
+			await el.updateComplete;
+			expect(dispatched).to.equal(false);
+		});
+
+		// remove with "button-toggle-no-change-event-on-prop-update" flag
+		it('dispatches "d2l-button-toggle-change" event when "pressed" property is updated and flag is OFF', async() => {
+			mockFlag('button-toggle-no-change-event-on-prop-update', false);
+			const el = await fixture(buttonToggleFixtures.iconPressed);
+			let dispatched = false;
+			el.addEventListener('d2l-button-toggle-change', () => dispatched = true);
+			el.pressed = false;
+			await el.updateComplete;
+			expect(dispatched).to.equal(true);
+		});
+
+		// remove test with "button-toggle-no-change-event-on-prop-update" flag
+		it('does not dispatch "d2l-button-toggle-change" event initially', async() => {
 			let dispatched = false;
 			const el = document.createElement('d2l-button-toggle');
 			el.addEventListener('d2l-button-toggle-change', () => dispatched = true);
@@ -36,7 +63,7 @@ describe('d2l-button-toggle', () => {
 			expect(dispatched).to.equal(false);
 		});
 
-		it('does not dispatch d2l-button-toggle-change event if disabled buttons are clicked', async() => {
+		it('does not dispatch "d2l-button-toggle-change" event if disabled buttons are clicked', async() => {
 			const el = await fixture(buttonToggleFixtures.iconDisabled);
 			let dispatched = false;
 			el.addEventListener('d2l-button-toggle-change', () => dispatched = true);


### PR DESCRIPTION
The `<d2l-button-toggle>` component was dispatching its change event whenever the property was updated, not just when the user interacted with it.

This isn't what we normally do, since we expect consumer components that update the property to already be aware of the change and therefore not need to be notified of it via an event. Dispatching on update can actually cause consumers to handle the event (sometimes by doing a `fetch` or running other logic) duplicate times for the same change.