### PR TITLE
GAUD-10255: downgrade terser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11226,8 +11226,8 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.49.1",
-      "integrity": "sha512-7A2xlQ5EnGT8KPA92dUh6RbRYTVw8hEaEN9L1K68l4UOXFuV511NnAqObGoRqGOQofQcMypisu1s3xawCEHrvA==",
+      "version": "5.49.0",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {


### PR DESCRIPTION
We had to remove `5.49.1` from the proxy as it had a defect, but core upgraded to it in the meantime. This downgrades to the last working version.