### PR TITLE
GAUD-10544 - Some d2l-page a11y fixes

### DIFF
--- a/components/page/page.js
+++ b/components/page/page.js
@@ -238,6 +238,10 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		.supporting {
 			display: contents;
 		}
+		.side-nav[hidden],
+		.supporting[hidden] {
+			display: none;
+		}
 
 		.side-nav-panel,
 		.supporting-panel {
@@ -562,11 +566,10 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 			'collapsed': this._panelState.getCollapsed(panelKey)
 		};
 		return html`
-			<nav class="side-nav" aria-label="${this.localize('components.page.side-nav-label')}">
+			<nav class="side-nav" ?hidden="${!this._slotVisibility['side-nav']}" aria-label="${this.localize('components.page.side-nav-label')}">
 				<div
 					class="${classMap(classes)}"
-					style=${styleMap({ width: `${this._panelState.getSize(panelKey)}px` })}
-					?hidden="${!this._slotVisibility['side-nav']}">
+					style=${styleMap({ width: `${this._panelState.getSize(panelKey)}px` })}>
 					<div class="side-nav-panel-content" style=${styleMap({ width: `${this._panelState.getTrueSize(panelKey)}px` })}>
 						<slot name="side-nav" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
 					</div>
@@ -584,13 +587,12 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 			'collapsed': this._panelState.getCollapsed(panelKey)
 		};
 		return html`
-			<aside class="supporting" aria-label="${this.localize('components.page.supporting-label')}">
+			<aside class="supporting" ?hidden="${!this._slotVisibility['supporting']}" aria-label="${this.localize('components.page.supporting-label')}">
 				${!this._slotVisibility['supporting'] ? nothing :
 					this.#renderDivider(panelKey, this.localize('components.page.supporting-divider-label'), 'end')}
 				<div
 					class="${classMap(classes)}"
-					style=${styleMap({ width: `${this._panelState.getSize(panelKey)}px` })}
-					?hidden="${!this._slotVisibility['supporting']}">
+					style=${styleMap({ width: `${this._panelState.getSize(panelKey)}px` })}>
 					<div class="supporting-panel-content" style=${styleMap({ width: `${this._panelState.getTrueSize(panelKey)}px` })}>
 						<slot name="supporting" @slotchange="${this.#handleSlotVisibilityChange}"></slot>
 					</div>

--- a/components/page/test/page.test.js
+++ b/components/page/test/page.test.js
@@ -13,6 +13,28 @@ describe('page', () => {
 		runConstructor('d2l-page');
 	});
 
+	describe('accessibility', () => {
+		describe('hides panels with no content', () => {
+			it('single panel', async() => {
+				const elem = await fixture(pageFixtures.mainHeaderFooter, defaultFixtureOptions);
+				expect(elem.shadowRoot.querySelector('.side-nav').hasAttribute('hidden')).to.be.true;
+				expect(elem.shadowRoot.querySelector('.supporting').hasAttribute('hidden')).to.be.true;
+			});
+			it('side-nav', async() => {
+				const elem = await fixture(pageFixtures.sideNavHeader, defaultFixtureOptions);
+				expect(elem.shadowRoot.querySelector('.side-nav').getAttribute('aria-label')).to.equal('Side');
+				expect(elem.shadowRoot.querySelector('.side-nav').hasAttribute('hidden')).to.be.false;
+				expect(elem.shadowRoot.querySelector('.supporting').hasAttribute('hidden')).to.be.true;
+			});
+			it('supporting', async() => {
+				const elem = await fixture(pageFixtures.supportingImmersiveBothHeaders, defaultFixtureOptions);
+				expect(elem.shadowRoot.querySelector('.supporting').getAttribute('aria-label')).to.equal('Supporting');
+				expect(elem.shadowRoot.querySelector('.supporting').hasAttribute('hidden')).to.be.false;
+				expect(elem.shadowRoot.querySelector('.side-nav').hasAttribute('hidden')).to.be.true;
+			});
+		});
+	});
+
 	describe('storing panel state', () => {
 		afterEach(() => {
 			clearStoredPanelState();

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "مقسّم التنقل الجانبي",
 	"components.page.side-nav-label": "جانبية",
 	"components.page.supporting-divider-label": "فاصل اللوحة الداعمة",
-	"components.page.supporting-panel-label": "داعمة",
+	"components.page.supporting-label": "داعمة",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} مادة واحد}

--- a/lang/ca.js
+++ b/lang/ca.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Separador de la navegació lateral",
 	"components.page.side-nav-label": "Lateral",
 	"components.page.supporting-divider-label": "Divisor del panell de suport",
-	"components.page.supporting-panel-label": "Suport",
+	"components.page.supporting-label": "Suport",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} element}

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Raniwr Llywio Ochr",
 	"components.page.side-nav-label": "Ochr",
 	"components.page.supporting-divider-label": "Raniwr Panel Cymorth",
-	"components.page.supporting-panel-label": "Cefnogi",
+	"components.page.supporting-label": "Cefnogi",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} eitem}

--- a/lang/da.js
+++ b/lang/da.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Skillelinje i sidemenu",
 	"components.page.side-nav-label": "Side",
 	"components.page.supporting-divider-label": "Skillelinje i sidepanel",
-	"components.page.supporting-panel-label": "Understøttende",
+	"components.page.supporting-label": "Understøttende",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} element}

--- a/lang/de.js
+++ b/lang/de.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Trennung für Seitennavigation",
 	"components.page.side-nav-label": "Seiten-",
 	"components.page.supporting-divider-label": "Trennung für Unterstützungsbereich",
-	"components.page.supporting-panel-label": "Unterstützung",
+	"components.page.supporting-label": "Unterstützung",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} Element}

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Side Navigation Divider",
 	"components.page.side-nav-label": "Side",
 	"components.page.supporting-divider-label": "Supporting Panel Divider",
-	"components.page.supporting-panel-label": "Supporting",
+	"components.page.supporting-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/en.js
+++ b/lang/en.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Side Navigation Divider",
 	"components.page.side-nav-label": "Side",
 	"components.page.supporting-divider-label": "Supporting Panel Divider",
-	"components.page.supporting-panel-label": "Supporting",
+	"components.page.supporting-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Separador de navegación lateral",
 	"components.page.side-nav-label": "Lateral",
 	"components.page.supporting-divider-label": "Separador del panel complementario",
-	"components.page.supporting-panel-label": "Complementario",
+	"components.page.supporting-label": "Complementario",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} elemento}

--- a/lang/es.js
+++ b/lang/es.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Divisor de navegación lateral",
 	"components.page.side-nav-label": "Lateral",
 	"components.page.supporting-divider-label": "Divisor de panel de soporte",
-	"components.page.supporting-panel-label": "Soporte",
+	"components.page.supporting-label": "Soporte",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} elemento}

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Séparateur de navigation latérale",
 	"components.page.side-nav-label": "Côté",
 	"components.page.supporting-divider-label": "Séparateur de panneau d’aide",
-	"components.page.supporting-panel-label": "Pris en charge",
+	"components.page.supporting-label": "Pris en charge",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} élément}

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Séparateur de navigation latéral",
 	"components.page.side-nav-label": "Côté",
 	"components.page.supporting-divider-label": "Séparateur de panneau de support",
-	"components.page.supporting-panel-label": "Support",
+	"components.page.supporting-label": "Support",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} élément}

--- a/lang/haw.js
+++ b/lang/haw.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Māhele Hoʻokele ʻAoʻao",
 	"components.page.side-nav-label": "ʻaoʻao",
 	"components.page.supporting-divider-label": "Mea Hoʻokaʻawale Panel Kākoʻo",
-	"components.page.supporting-panel-label": "Ke kākoʻo nei",
+	"components.page.supporting-label": "Ke kākoʻo nei",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} mea}

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "साइड नेविगेशन डिवाइडर",
 	"components.page.side-nav-label": "साइड",
 	"components.page.supporting-divider-label": "सपोर्टिंग पैनल डिवाइडर",
-	"components.page.supporting-panel-label": "सपोर्टिंग",
+	"components.page.supporting-label": "सपोर्टिंग",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} आइटम}

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -156,7 +156,7 @@ export default {
 	"components.page.side-nav-divider-label": "サイドナビゲーション区切り",
 	"components.page.side-nav-label": "サイド",
 	"components.page.supporting-divider-label": "サポートパネル区切り",
-	"components.page.supporting-panel-label": "サポート",
+	"components.page.supporting-label": "サポート",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 個の項目}

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -156,7 +156,7 @@ export default {
 	"components.page.side-nav-divider-label": "측면 탐색 구분선",
 	"components.page.side-nav-label": "사이드",
 	"components.page.supporting-divider-label": "보조 패널 구분선",
-	"components.page.supporting-panel-label": "지원",
+	"components.page.supporting-label": "지원",
 	"components.pageable.info":
 		`{count, plural,
 			other {해당 항목 수 {countFormatted}개}

--- a/lang/mi.js
+++ b/lang/mi.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Wehewehenga Whakatere Taha",
 	"components.page.side-nav-label": "Taha",
 	"components.page.supporting-divider-label": "Te Wehewehe Paewhiri Tautoko",
-	"components.page.supporting-panel-label": "Te tautoko",
+	"components.page.supporting-label": "Te tautoko",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} Tūemi}

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Scheidingslijn zijmenu",
 	"components.page.side-nav-label": "Zij",
 	"components.page.supporting-divider-label": "Scheidingslijn ondersteunend paneel",
-	"components.page.supporting-panel-label": "Ondersteuning",
+	"components.page.supporting-label": "Ondersteuning",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -171,7 +171,7 @@ export default {
 	"components.page.side-nav-divider-label": "Separator nawigacji bocznej",
 	"components.page.side-nav-label": "Strona boczna",
 	"components.page.supporting-divider-label": "Separator panelu pomocniczego",
-	"components.page.supporting-panel-label": "Wsparcie",
+	"components.page.supporting-label": "Wsparcie",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} element}

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Divisor de Navegação Lateral",
 	"components.page.side-nav-label": "Lateral",
 	"components.page.supporting-divider-label": "Divisor do Painel de Suporte",
-	"components.page.supporting-panel-label": "Suporte",
+	"components.page.supporting-label": "Suporte",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -171,7 +171,7 @@ export default {
 	"components.page.side-nav-divider-label": "Боковой навигационный разделитель",
 	"components.page.side-nav-label": "Сторона",
 	"components.page.supporting-divider-label": "Опорный разделитель панелей",
-	"components.page.supporting-panel-label": "Поддерживающий",
+	"components.page.supporting-label": "Поддерживающий",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} элемент}

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Avgränsare för sidnavigering",
 	"components.page.side-nav-label": "Sida",
 	"components.page.supporting-divider-label": "Avgränsare för supportpanel",
-	"components.page.supporting-panel-label": "Support",
+	"components.page.supporting-label": "Support",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} objekt}

--- a/lang/th.js
+++ b/lang/th.js
@@ -157,7 +157,7 @@ export default {
 	"components.page.side-nav-divider-label": "ตัวแบ่งในแถบนำทางด้านข้าง",
 	"components.page.side-nav-label": "ด้านข้าง",
 	"components.page.supporting-divider-label": "ตัวแบ่งในแผงส่วนเสริม",
-	"components.page.supporting-panel-label": "ส่วนเสริม",
+	"components.page.supporting-label": "ส่วนเสริม",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} รายการ}

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Yan Navigasyon Ayırıcı",
 	"components.page.side-nav-label": "Yan",
 	"components.page.supporting-divider-label": "Destekleyici Panel Ayırıcı",
-	"components.page.supporting-panel-label": "Destekleyici",
+	"components.page.supporting-label": "Destekleyici",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} öğe}

--- a/lang/ur.js
+++ b/lang/ur.js
@@ -161,7 +161,7 @@ export default {
 	"components.page.side-nav-divider-label": "Side Navigation Divider",
 	"components.page.side-nav-label": "Side",
 	"components.page.supporting-divider-label": "Supporting Panel Divider",
-	"components.page.supporting-panel-label": "Supporting",
+	"components.page.supporting-label": "Supporting",
 	"components.pageable.info":
 		`{count, plural,
 			one {{countFormatted} item}

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -155,7 +155,7 @@ export default {
 	"components.page.side-nav-divider-label": "Phân cách điều hướng bên",
 	"components.page.side-nav-label": "Bên",
 	"components.page.supporting-divider-label": "Bộ phân cách bảng hỗ trợ",
-	"components.page.supporting-panel-label": "Hỗ trợ",
+	"components.page.supporting-label": "Hỗ trợ",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} mục}

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -156,7 +156,7 @@ export default {
 	"components.page.side-nav-divider-label": "侧边导航分隔条",
 	"components.page.side-nav-label": "侧面",
 	"components.page.supporting-divider-label": "辅助面板分隔条",
-	"components.page.supporting-panel-label": "辅助",
+	"components.page.supporting-label": "辅助",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 项}

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -157,7 +157,7 @@ export default {
 	"components.page.side-nav-divider-label": "側邊導覽分隔線",
 	"components.page.side-nav-label": "側邊",
 	"components.page.supporting-divider-label": "支援面板分隔線",
-	"components.page.supporting-panel-label": "支援",
+	"components.page.supporting-label": "支援",
 	"components.pageable.info":
 		`{count, plural,
 			other {{countFormatted} 個項目}


### PR DESCRIPTION
Few things I noticed testing the overlay scrim a11y.

1. Had the wrong langterm name for the `aside` so it's `aria-label` was empty 🤦‍♀️ 
2. Moving the `hidden` up a level so the landmark is fully hidden from the screenreader, rather than having an empty landmark.