### PR TITLE
GAUD-10529 broken filter demo in daylight

### DIFF
--- a/components/filter/README.md
+++ b/components/filter/README.md
@@ -360,7 +360,8 @@ e.detail.loadMoreCompleteCallback({ displayAllKeys: true });
 ### Selection and manual search/paging
 
 The filter component depends entirely on the consumer to include the selected filter values in order for the selected counts and `d2l-filter-tags` to display the correct values. Ideally, all values should be loaded into the dimensions and the event callbacks should be leveraged to set the visibility on those values. However, in the cases where this is not possible and new values are being added/removed manually from the dimension, then selection should be persisted. This means that selected items should always be loaded and included in the dimension and they should not be removed in order to maintain the functionality of counts and filter tags.
-<!-- docs: demo -->
+
+<!-- docs: demo align:start autoOpen:true autoSize:false size:large -->
 ```html
 <script type="module">
   import '@brightspace-ui/core/components/filter/demo/filter-load-more-demo.js'

--- a/components/filter/demo/filter-load-more-demo.js
+++ b/components/filter/demo/filter-load-more-demo.js
@@ -70,6 +70,7 @@ const FullData = [
 class FilterLoadMoreDemo extends LitElement {
 
 	static properties = {
+		opened: { type: Boolean, reflect: true },
 		useOverflowGroup: { type: Boolean, attribute: 'use-overflow-group' }
 	};
 
@@ -89,6 +90,7 @@ class FilterLoadMoreDemo extends LitElement {
 		</d2l-filter-overflow-group>`;
 		return html`
 			<d2l-filter
+				?opened="${this.opened}"
 				@d2l-filter-change="${this._handleFilterChange}"
 				@d2l-filter-dimension-load-more=${this._handleLoadMore}
 				@d2l-filter-dimension-search=${this._handleSearch}>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "!test",
     "/components/demo",
     "/components/description-list/demo",
+    "/components/filter/demo/",
     "/components/selection/demo",
     "/components/table/demo",
     "!/components/demo/demo"


### PR DESCRIPTION
## Jira
 
[GAUD-10529](https://desire2learn.atlassian.net/browse/GAUD-10529)

## Description

The block of code in the README that is being used in Daylight, is not being displayed for the [Search and Paging section](https://daylight.d2l.dev/components/filters/#search-and-paging). The root cause was that Daylight needs to have access to the component that is going to be rendered. That means that in the Daylight project, the relative path has to be included in the `components-pagedata.js`. That part is being addressed in [this other PR](https://github.com/BrightspaceUI/documentation/pull/2307).

This PR makes the `demo/` folder from the filter component to be accessible by Daylight. It also adds the open attribute to the component so it is open by default in Daylight when loaded.

[GAUD-10529]: https://desire2learn.atlassian.net/browse/GAUD-10529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ