### PR TITLE
Remove obsolete dirty state properties and event

### DIFF
--- a/components/backdrop/test/backdrop.vdiff.js
+++ b/components/backdrop/test/backdrop.vdiff.js
@@ -5,7 +5,7 @@ const template = html`
 	<div style="background-color: orange; height: 100px; padding: 1rem; width: 300px;">
 		Background content
 		<div id="target" style="position: relative; z-index: 1000;">Target content</div>
-		<d2l-backdrop for="target" dirtyText="some text" dirtyButtonText="action"></d2l-backdrop>
+		<d2l-backdrop for="target"></d2l-backdrop>
 	</div>
 `;
 

--- a/components/table/table-wrapper.js
+++ b/components/table/table-wrapper.js
@@ -269,21 +269,6 @@ export class TableWrapper extends FreshnessMixin(PageableMixin(SelectionMixin(Li
 
 	static properties = {
 		/**
-		 * Todo: remove once consumers are updated to freshness. Use freshness instead.
-		 * @ignore
-		 */
-		dataState: { reflect: true, type: String },
-		/**
-		 * Todo: remove once consumers are updated to freshness-stale-text. Use freshness-stale-text instead.
-		 * @ignore
-		 */
-		dirtyText: { reflect: true, attribute: 'dirty-text', type: String },
-		/**
-		 * Todo: remove once consumers are updated to freshness-stale-button-text. Use freshness-stale-button-text instead.
-		 * @ignore
-		 */
-		dirtyButtonText: { reflect: true, attribute: 'dirty-button-text', type: String },
-		/**
 		 * Hides the column borders on "default" table type
 		 * @type {boolean}
 		 */
@@ -448,19 +433,6 @@ export class TableWrapper extends FreshnessMixin(PageableMixin(SelectionMixin(Li
 		}
 	}
 
-	willUpdate(changedProperties) {
-		super.willUpdate(changedProperties);
-
-		// Todo: remove these once consumers are updated to freshness properties
-		if (this.dataState) {
-			if (this.dataState === 'clean') this.freshness = freshness.fresh;
-			else if (this.dataState === 'dirty') this.freshness = freshness.stale;
-			else if (this.dataState === 'loading') this.freshness = freshness.loading;
-		}
-		if (this.dirtyText) this.freshnessStaleText = this.dirtyText;
-		if (this.dirtyButtonText) this.freshnessStaleButtonText = this.dirtyButtonText;
-	}
-
 	#hasIntersected = false;
 
 	#noScrollWidthTimeout = null;
@@ -620,9 +592,6 @@ export class TableWrapper extends FreshnessMixin(PageableMixin(SelectionMixin(Li
 	_handleStaleButton() {
 		/** Dispatched when the action button on the stale overlay is clicked */
 		this.dispatchEvent(new CustomEvent('d2l-table-stale-button-click'));
-
-		/** @ignore Todo: remove once consumers are updated to d2l-table-stale-button-click */
-		this.dispatchEvent(new CustomEvent('d2l-table-dirty-button-clicked'));
 	}
 
 	async _handleTableChange(mutationRecords) {


### PR DESCRIPTION
[GAUD-10566](https://desire2learn.atlassian.net/browse/GAUD-10566)

Remove the old `dataState`, `dirtyText`, and `dirtyButtonText` from `d2l-table-wrapper`. These were kept briefly to avoid breakage until we were able to update Insights to use the new properties from the `FreshnessMixin`.

[GAUD-10566]: https://desire2learn.atlassian.net/browse/GAUD-10566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ