### PR TITLE
GAUD-10553: safety check for missing dropdown content

### DIFF
--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -226,7 +226,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		}
 	}
 
-	async __onMouseEnter() {
+	__onMouseEnter() {
 		const dropdownContent = this.__getContentElement();
 		if (!dropdownContent) return;
 
@@ -237,10 +237,17 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 
 		if (!this.openOnHover) return;
 
+		const afterOpen = () => {
+			this._closeTimerStop();
+			if (!this._isOpenedViaClick) this._isHovering = true;
+		};
+
 		clearTimeout(this._dismissTimerId);
-		if (!this.dropdownOpened) await this.openDropdown(false);
-		this._closeTimerStop();
-		if (!this._isOpenedViaClick) this._isHovering = true;
+		if (!this.dropdownOpened) {
+			this.openDropdown(false).then(afterOpen);
+		} else {
+			afterOpen();
+		}
 	}
 
 	async __onMouseLeave() {

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -228,6 +228,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 
 	async __onMouseEnter() {
 		const dropdownContent = this.__getContentElement();
+		if (!dropdownContent) return;
 
 		// do not respond to hover events on mobile screens
 		if (dropdownContent._mobile) return;

--- a/components/dropdown/dropdown-opener-mixin.js
+++ b/components/dropdown/dropdown-opener-mixin.js
@@ -254,6 +254,7 @@ export const DropdownOpenerMixin = superclass => class extends superclass {
 		if (!this.openOnHover) return;
 		// do not respond to hover events on mobile screens
 		const dropdownContent = this.__getContentElement();
+		if (!dropdownContent) return;
 
 		if (dropdownContent._mobile) return;
 

--- a/components/dropdown/test/dropdown-openers.test.js
+++ b/components/dropdown/test/dropdown-openers.test.js
@@ -72,4 +72,10 @@ describe('d2l-dropdown-openers', () => {
 
 	});
 
+	it('should not throw when hovering and content is missing', async() => {
+		const elem = await fixture(html`<d2l-dropdown><button class="d2l-dropdown-opener">Open</button></d2l-dropdown>`);
+		const opener = elem.querySelector('.d2l-dropdown-opener');
+		await hoverElem(opener);
+	});
+
 });


### PR DESCRIPTION
This started causing JavaScript errors in Grades. Apparently the LMS's dropdowns add/remove the dropdown content dynamically when it opens/closes. So `__getDropdownContent` in the mouseover code doesn't find anything.

This was likely always a bug lurking in the background, but because this method used to return immediately if `openOnHover` was `false`, it was never getting hit.