### PR TITLE
GAUD-10313 - Fix jitter if pulling the panel backwards when collapsed

### DIFF
--- a/components/page/page.js
+++ b/components/page/page.js
@@ -81,7 +81,7 @@ class PanelStateController {
 		const panel = this.#panels[key];
 		// Clamp requested size to min and max bounds
 		panel.size = Math.max(panel.minSize, Math.min(requestedSize, panel.maxSize));
-		panel.animate = animate;
+		panel.animate = panel.collapsed ? false : animate; // Don't animate re-close if not dragged far enough to open
 		panel.dragSize = null;
 		this.#host.requestUpdate();
 		if (storeState) this.#storePanelState(key);


### PR DESCRIPTION
This may be a Windows-only thing, as I can only make it happen on certain screen sizes/monitors. But if you try to pull the divider backwards while collapsed, you get this jittering:
<img width="699" height="520" alt="panel-jitter" src="https://github.com/user-attachments/assets/9ce9db07-a917-453d-91f4-c94aaa289457" />

You also get the big Windows scrollbar appearing, and then animating away.
<img width="699" height="520" alt="scrollbar-jitter" src="https://github.com/user-attachments/assets/cfcaa879-8225-48ad-bfc6-cff9356b5349" />

It's really complicated to not have the scrollbar appear at all, since we need it there as we start dragging open.

The easiest way to fix this is to turn off animating until you're actually opening the panel. I think this looks better, but it does mean you "snap back" to closed if you didn't pull the panel far enough to open:
<img width="699" height="520" alt="panel-no-jitter" src="https://github.com/user-attachments/assets/e68d7738-e3ba-49a6-b571-7bd3a5579bf1" />

And here it is with a scrollbar:
<img width="699" height="520" alt="scrollbar-no-jitter" src="https://github.com/user-attachments/assets/b5eaaf09-464e-4b9b-9b1c-2ce6feef1dfe" />

If this solution is not acceptable, I can go back to the drawing board, but this is the cleanest I've found so far.