### PR TITLE
fix: GAUD-10313 - Fix pixel jumping after dragging

### DIFF
--- a/components/page/page.js
+++ b/components/page/page.js
@@ -87,11 +87,11 @@ class PanelStateController {
 		if (storeState) this.#storePanelState(key);
 	}
 
-	setCollapsed(key, collapsed) {
+	setCollapsed(key, collapsed, { animate = true } = {}) {
 		const panel = this.#panels[key];
 		panel.collapsed = collapsed;
 		panel.dragSize = null;
-		panel.animate = true;
+		panel.animate = animate;
 		this.#host.requestUpdate();
 		this.#storePanelState(key);
 	}
@@ -542,7 +542,9 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 
 	#handleDividerResize(e) {
 		const panelKey = e.target.dataset.panelKey;
-		this._panelState.resize(panelKey, e.detail.requestedSize, { animate: true, storeState: true });
+		// Do not animate if dragging past closed size
+		const animate = this._panelState.getSize(panelKey) > DIVIDER_GUTTER_WIDTH;
+		this._panelState.resize(panelKey, e.detail.requestedSize, { animate, storeState: true });
 	};
 
 	#handleDividerResizeLive(e) {
@@ -552,8 +554,10 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 
 	#handleDividerToggle(e) {
 		const panelKey = e.target.dataset.panelKey;
-		const collapsed = !this._panelState.getCollapsed(panelKey);
-		this._panelState.setCollapsed(panelKey, collapsed);
+		const collapsed = this._panelState.getCollapsed(panelKey);
+		// Do not animate if dragged to fully closed
+		const animate = collapsed || this._panelState.getSize(panelKey) > DIVIDER_GUTTER_WIDTH;
+		this._panelState.setCollapsed(panelKey, !collapsed, { animate });
 	};
 
 	#handleScrimClick() {
@@ -578,13 +582,9 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 	}
 
 	#renderDivider(panelKey, label, panelPosition) {
-		const classes = {
-			'divider': true,
-			'animate': this._panelState.getAnimate(panelKey)
-		};
 		return html`
 			<d2l-page-divider-internal
-				class="${classMap(classes)}"
+				class="divider"
 				data-panel-key="${panelKey}"
 				label="${label}"
 				?collapsed="${this._panelState.getCollapsed(panelKey)}"


### PR DESCRIPTION
There are two scenarios this PR is fixing, caused by animating from a width of 18px to 0px (without visually moving, resulting in a weird jitter). It may be a Windows only thing, and it doesn't happen at all screen sizes. Also only happens for the Side Nav. 🤷‍♀️ 

Dragging backwards while closed:
<img width="643" height="520" alt="drag-backwards" src="https://github.com/user-attachments/assets/65bed427-8168-4074-b245-02163e0fdc84" />

Dragging from open to fully closed:
<img width="699" height="520" alt="drag-closed" src="https://github.com/user-attachments/assets/604fac0e-9819-48a9-97d3-c654e01d2d8f" />

Basically, I turn off animating in these two scenarios.