### PR TITLE
fix: GAUD-10313 - Fix divider dragging on mobile

### DIFF
--- a/components/page/page-divider-internal.js
+++ b/components/page/page-divider-internal.js
@@ -109,6 +109,7 @@ class PageDivider extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 			cursor: ew-resize;
 			height: 100%;
 			position: relative;
+			touch-action: none;
 			width: ${DIVIDER_WIDTH}px;
 		}
 		.divider:hover {


### PR DESCRIPTION
Had this, removed it to confirm it was important, forgot to add it back 🤦‍♀️ 

We need this to tell touchscreens/mobile browsers we're not trying to pinch, zoom, or scroll when we're dragging the divider.