### PR TITLE
GAUD-10633: ignore case

### DIFF
--- a/components/demo/demo-snippet.js
+++ b/components/demo/demo-snippet.js
@@ -168,9 +168,9 @@ class DemoSnippet extends LitElement {
 
 		// fix script whitespace
 		text = setIndent(text.replace(/\t/g, '  '))
-			.replace(/( *)<script( type="module")?>([^\n]+?)<\/script>/g, '$1<script$2>\n$1  $3\n$1</script>') // convert single line scripts to multi-line
-			.replace(/( *)<\/script>/g, '\n$1</script>')
-			.replace(/<script( type="module")?>/g, '<script$1>\n')
+			.replace(/( *)<script( type="module")?>([^\n]+?)<\/script>/gi, '$1<script$2>\n$1  $3\n$1</script>') // convert single line scripts to multi-line
+			.replace(/( *)<\/script>/gi, '\n$1</script>')
+			.replace(/<script( type="module")?>/gi, '<script$1>\n')
 			.replace(/(\n *)?<script data-demo-hide(.+?)<\/script>/gis, '');
 
 		const startTags = new Set([...text.matchAll(/<[^/](.*?)>/g)].map(m => m[0]));


### PR DESCRIPTION
We've got a couple code scanning alerts for using regular expressions to do HTML things, which obviously isn't amazing. I'm not super worried since this is our demo snippet and it's not being used to do any filtering, but it'd be nice to not have the warnings.

- https://github.com/BrightspaceUI/core/security/code-scanning/12
- https://github.com/BrightspaceUI/core/security/code-scanning/13

I'm not sure if just ignoring case in the regex is actually going to dismiss them... but that's what they're complaining about so worth a shot!