### PR TITLE
GAUD-10635 - Add workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 on: pull_request
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -79,6 +83,9 @@ jobs:
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/setup-node@main

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -1,5 +1,9 @@
 name: License Checker
 on: pull_request
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: License Checker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
       - main
       - '[0-9]+.x'
       - '[0-9]+.[0-9]+.x'
+
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -4,6 +4,12 @@ on:
     paths:
       - 'lang/**'
 
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   format:
     timeout-minutes: 5

--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "30 12 * * 1-5" # Mon-Fri 8:30AM EDT. 7:30AM EST.
   workflow_dispatch: # manual trigger
+
+permissions:
+  pull-requests: write
+
 jobs:
   update:
     name: Update

--- a/.github/workflows/vdiff.yml
+++ b/.github/workflows/vdiff.yml
@@ -1,5 +1,12 @@
 name: vdiff
 on: pull_request
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   vdiff:
     timeout-minutes: 30


### PR DESCRIPTION
Looking to remove the 10 code scanning alerts for "Workflow does not contain permissions" ([example](https://github.com/BrightspaceUI/core/security/code-scanning/6)).

These are all educated guesses for what we need, looking through all the consuming actions and what they all use `GITHUB_TOKEN` for. Added comments inline.

After these seem good, we can carry these across all our repos, add them to `create` and docs, etc.