### PR TITLE
Only console.warn resolveLoadingComplete if still connected to DOM

### DIFF
--- a/mixins/loading-complete/loading-complete-mixin.js
+++ b/mixins/loading-complete/loading-complete-mixin.js
@@ -26,6 +26,7 @@ export const LoadingCompleteMixin = dedupeMixin((superclass) => class extends su
 	#loadingCompletePromise = !Object.prototype.hasOwnProperty.call(this.constructor.prototype, 'getLoadingComplete')
 		? new Promise(resolve => {
 			const timeout = setTimeout(() => {
+				if (!this.isConnected) return;
 				console.warn(`Failed to load ${this.localName} in ${timeoutMs}ms: resolveLoadingComplete was not called`);
 			}, timeoutMs);
 

--- a/mixins/loading-complete/test/loading-complete-mixin.test.js
+++ b/mixins/loading-complete/test/loading-complete-mixin.test.js
@@ -1,4 +1,5 @@
-import { aTimeout, defineCE, fixture } from '@brightspace-ui/testing';
+import { aTimeout, defineCE, expect, fixture, nextFrame } from '@brightspace-ui/testing';
+import { stub, useFakeTimers } from 'sinon';
 import { LitElement } from 'lit';
 import { LoadingCompleteMixin } from '../loading-complete-mixin.js';
 
@@ -43,6 +44,12 @@ const componentLevelOverrideTag = defineCE(
 	}
 );
 
+const noResolveTag = defineCE(
+	class extends LoadingCompleteMixin(DummyMixin(LitElement)) {
+
+	}
+);
+
 describe('LoadingCompleteMixin', () => {
 
 	it('inherits existing getLoadingComplete', async() => {
@@ -61,6 +68,40 @@ describe('LoadingCompleteMixin', () => {
 		await fixture(`
 			<${componentLevelOverrideTag}></${componentLevelOverrideTag}>
 		`);
+	});
+
+	describe('console behaviour', () => {
+
+		let clock, warnStub;
+		beforeEach(() => {
+			clock = useFakeTimers({ toFake: ['setTimeout'] });
+			warnStub = stub(console, 'warn');
+
+		});
+
+		afterEach(() => {
+			clock?.restore();
+			warnStub?.restore();
+		});
+
+		it('logs a console warning when resolveLoadingComplete is not called', async() => {
+			fixture(`<${noResolveTag}></${noResolveTag}>`);
+
+			await nextFrame();
+			clock.tick(30000);
+			expect(warnStub).to.be.calledOnce;
+		});
+
+		it('does not log a console warning when resolveLoadingComplete if the element is disconnected', async() => {
+			fixture(`<${noResolveTag}></${noResolveTag}>`);
+
+			await nextFrame();
+			const elem = document.querySelector(noResolveTag);
+			elem.remove();
+			clock.tick(30000);
+			expect(warnStub).to.not.be.called;
+		});
+
 	});
 
 });


### PR DESCRIPTION
[GAUD-10634](https://desire2learn.atlassian.net/browse/GAUD-10634)

Only `console.warn` if the component is still connected to the DOM.

[GAUD-10634]: https://desire2learn.atlassian.net/browse/GAUD-10634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ