### PR TITLE
Update d2l-input-date-range and d2l-input-date-time-range to use PropertyRequiredMixin

### DIFF
--- a/components/inputs/input-date-range.js
+++ b/components/inputs/input-date-range.js
@@ -10,6 +10,7 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { InteractiveMixin } from '../../mixins/interactive/interactive-mixin.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
+import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 export function getShiftedEndDate(startValue, endValue, prevStartValue, inclusive) {
@@ -32,7 +33,7 @@ export function getShiftedEndDate(startValue, endValue, prevStartValue, inclusiv
  * @slot inline-help - Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
  * @fires change - Dispatched when there is a change to selected start date or selected end date. `start-value` and `end-value` correspond to the selected values and are formatted in ISO 8601 calendar date format (`YYYY-MM-DD`).
  */
-class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
+class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormElementMixin(PropertyRequiredMixin(LocalizeCoreElement(LitElement)))))) {
 
 	static properties = {
 		/**
@@ -75,7 +76,7 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 		 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date inputs
 		 * @type {string}
 		 */
-		label: { type: String, reflect: true },
+		label: { type: String, reflect: true, required: true },
 		/**
 		 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 		 * @type {boolean}
@@ -156,10 +157,6 @@ class InputDateRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormEleme
 
 	async firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-
-		if (!this.label) {
-			console.warn('d2l-input-date-range component requires label text');
-		}
 		this.shadowRoot.querySelector('d2l-input-date-time-range-to').setParentNode(this);
 	}
 

--- a/components/inputs/input-date-time-range.js
+++ b/components/inputs/input-date-time-range.js
@@ -11,6 +11,7 @@ import { getUniqueId } from '../../helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { InteractiveMixin } from '../../mixins/interactive/interactive-mixin.js';
 import { LocalizeCoreElement } from '../../helpers/localize-core-element.js';
+import { PropertyRequiredMixin } from '../../mixins/property-required/property-required-mixin.js';
 import { SkeletonMixin } from '../skeleton/skeleton-mixin.js';
 
 function _isSameDate(date1, date2) {
@@ -65,7 +66,7 @@ export function getShiftedEndDateTime(startValue, endValue, prevStartValue, incl
  * @slot inline-help - Help text that will appear below the input. Use this only when other helpful cues are not sufficient, such as a carefully-worded label.
  * @fires change - Dispatched when there is a change to selected start date-time or selected end date-time. `start-value` and `end-value` correspond to the selected values and are formatted in ISO 8601 combined date and time format (`YYYY-MM-DDTHH:mm:ss.sssZ`).
  */
-class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormElementMixin(LocalizeCoreElement(LitElement))))) {
+class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormElementMixin(PropertyRequiredMixin(LocalizeCoreElement(LitElement)))))) {
 
 	static properties = {
 		/**
@@ -108,7 +109,7 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 		 * ACCESSIBILITY: REQUIRED: Label for the input fieldset that wraps the date-time inputs
 		 * @type {string}
 		 */
-		label: { type: String, reflect: true },
+		label: { type: String, reflect: true, required: true },
 		/**
 		 * Hides the fieldset label visually. Hidden labels are still read by screen readers so make sure to set an appropriate label.
 		 * @type {boolean}
@@ -211,11 +212,6 @@ class InputDateTimeRange extends InteractiveMixin(FocusMixin(SkeletonMixin(FormE
 
 	async firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
-
-		if (!this.label) {
-			console.warn('d2l-input-date-time-range component requires label text');
-		}
-
 		this.shadowRoot.querySelector('d2l-input-date-time-range-to').setParentNode(this);
 	}
 

--- a/mixins/loading-complete/test/loading-complete-mixin.test.js
+++ b/mixins/loading-complete/test/loading-complete-mixin.test.js
@@ -93,10 +93,7 @@ describe('LoadingCompleteMixin', () => {
 		});
 
 		it('does not log a console warning when resolveLoadingComplete if the element is disconnected', async() => {
-			fixture(`<${noResolveTag}></${noResolveTag}>`);
-
-			await nextFrame();
-			const elem = document.querySelector(noResolveTag);
+			const elem = await fixture(`<${noResolveTag}></${noResolveTag}>`, { awaitLoadingComplete: false });
 			elem.remove();
 			clock.tick(30000);
 			expect(warnStub).to.not.be.called;


### PR DESCRIPTION
[GAUD-10531](https://desire2learn.atlassian.net/browse/GAUD-10531)

This PR updates `d2l-input-date-range` and `d2l-input-date-time-range` to use `PropertyRequiredMixin` instead of logging a warning in `firstUpdated`. This avoids logging console warnings when there is a delay assigning the label.

[GAUD-10531]: https://desire2learn.atlassian.net/browse/GAUD-10531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ