### PR TITLE
fix: GAUD-10626 - Fix mobile height calculations

### DIFF
--- a/components/page/page.js
+++ b/components/page/page.js
@@ -234,6 +234,7 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		}
 		.content.has-panels {
 			min-height: calc(100vh - var(--d2l-page-header-height-measured, 0px));
+			min-height: calc(100dvh - var(--d2l-page-header-height-measured, 0px));
 		}
 
 		main {
@@ -274,6 +275,7 @@ class Page extends ProviderMixin(LocalizeCoreElement(LitElement)) {
 		.supporting-panel-content,
 		.divider {
 			max-height: calc(100vh - var(--d2l-page-header-height, 0) - var(--d2l-page-footer-height, 0));
+			max-height: calc(100dvh - var(--d2l-page-header-height, 0) - var(--d2l-page-footer-height, 0));
 		}
 
 		.side-nav-panel-content,


### PR DESCRIPTION
Noticed that calculations are slightly off on my phone, so things weren't sticking at the right spot. Mainly, the divider handle could be scrolled away at the bottom of the screen.

`dvh` isn't supported in everything we need, so we fallback to `vh`. This is temporary - once I add Legacy Browser Mode, it'll replace these two values anyways (POC [here](https://github.com/BrightspaceUI/core/pull/7235)). Legacy Browser Mode will turn on for browsers that don't support Popover, and [Popover](https://caniuse.com/mdn-api_htmlelement_popover) support was added _after_ [Dynamic Viewport Units](https://caniuse.com/viewport-unit-variants). So we should be covered there.